### PR TITLE
Add function templates toValueString and fromValueString

### DIFF
--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXCore/Types.h>
 
-#include <MaterialXCore/Util.h>
-
 namespace MaterialX
 {
 
@@ -21,25 +19,5 @@ const string VALUE_STRING_FALSE = "false";
 const string NAME_PATH_SEPARATOR = "/";
 const string ARRAY_VALID_SEPARATORS = ", ";
 const string ARRAY_PREFERRED_SEPARATOR = ", ";
-
-std::istream& operator>>(std::istream& is, vector<string>& v)
-{
-    string str(std::istreambuf_iterator<char>(is), { });
-    v = splitString(str, ARRAY_VALID_SEPARATORS);
-    return is;
-}
-
-std::ostream& operator<<(std::ostream& os, const vector<string>& v)
-{
-    for (size_t i = 0; i < v.size(); i++)
-    {
-        os << v[i];
-        if (i < v.size() - (size_t) 1)
-        {
-            os << ARRAY_PREFERRED_SEPARATOR;
-        }
-    }
-    return os;
-}
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -12,8 +12,6 @@
 #include <MaterialXCore/Library.h>
 
 #include <array>
-#include <istream>
-#include <ostream>
 
 namespace MaterialX
 {
@@ -116,27 +114,10 @@ class Color4 : public Vector4
     using Vector4::Vector4;
 };
 
-template <std::size_t N> std::istream& operator>>(std::istream& is, VectorN<N>& v)
-{
-    for (size_t i = 0; i < N; i++)
-    {
-        is >> v[i];
-    }
-    return is;
-}
-
-template <std::size_t N> std::ostream& operator<<(std::ostream& os, const VectorN<N>& v)
-{
-    for (size_t i = 0; i < N - (size_t) 1; i++)
-    {
-        os << v[i] << ARRAY_PREFERRED_SEPARATOR;
-    }
-    os << v[N - (size_t) 1];
-    return os;
-}
-
-std::istream& operator>>(std::istream& is, vector<string>& v);
-std::ostream& operator<<(std::ostream& os, const vector<string>& v);
+// Standard vector aliases
+using IntVec = vector<int>;
+using BoolVec = vector<bool>;
+using FloatVec = vector<float>;
 
 } // namespace MaterialX
 

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -5,74 +5,94 @@
 
 #include <MaterialXCore/Value.h>
 
+#include <MaterialXCore/Util.h>
+
 #include <sstream>
-#include <type_traits>
 
 namespace MaterialX
 {
 
 Value::CreatorMap Value::_creatorMap;
 
+namespace {
+
+//
+// Stream operators
+//
+
+template <size_t N> std::istream& operator>>(std::istream& is, VectorN<N>& v)
+{
+    string str(std::istreambuf_iterator<char>(is), { });
+    vector<string> values = splitString(str, ARRAY_VALID_SEPARATORS);
+    if (values.size() == N)
+    {
+        for (size_t i = 0; i < N; i++)
+        {
+            v[i] = fromValueString<float>(values[i]);
+        }
+    }
+    else
+    {
+        is.setstate(std::ios::failbit);
+    }
+    return is;
+}
+
+template <size_t N> std::ostream& operator<<(std::ostream& os, const VectorN<N>& v)
+{
+    for (size_t i = 0; i < N; i++)
+    {
+        os << v[i];
+        if (i + 1 < N)
+        {
+            os << ARRAY_PREFERRED_SEPARATOR;
+        }
+    }
+    return os;
+}
+
+template <class T> std::istream& operator>>(std::istream& is, vector<T>& v)
+{
+    string str(std::istreambuf_iterator<char>(is), { });
+    for (const string& value : splitString(str, ARRAY_VALID_SEPARATORS))
+    {
+        v.push_back(fromValueString<T>(value));
+    }
+    return is;
+}
+
+template <class T> std::ostream& operator<<(std::ostream& os, const vector<T>& v)
+{
+    for (size_t i = 0; i < v.size(); i++)
+    {
+        os << toValueString<T>(v[i]);
+        if (i + 1 < v.size())
+        {
+            os << ARRAY_PREFERRED_SEPARATOR;
+        }
+    }
+    return os;
+}
+
+} // anonymous namespace
+
 //
 // TypedValue methods
 //
-
-template <> string TypedValue<string>::getValueString() const
-{
-    return _data;
-}
-
-template <> string TypedValue<bool>::getValueString() const
-{
-    return _data ? VALUE_STRING_TRUE : VALUE_STRING_FALSE;
-}
-
-template <class T> string TypedValue<T>::getValueString() const
-{
-    std::stringstream ss;
-    if (!(ss << _data))
-        throw Exception("Unsupported value in getValueString");
-    return ss.str();
-}
 
 template <class T> const string& TypedValue<T>::getTypeString() const
 {
     return TYPE;
 }
 
-template <> ValuePtr TypedValue<string>::createFromString(const string& value)
+template <class T> string TypedValue<T>::getValueString() const
 {
-    return Value::createValue<string>(value);
-}
-
-template <> ValuePtr TypedValue<bool>::createFromString(const string& value)
-{
-    if (value == VALUE_STRING_TRUE)
-        return Value::createValue<bool>(true);
-    else if (value == VALUE_STRING_FALSE)
-        return Value::createValue<bool>(false);
-    return nullptr;
+    return toValueString<T>(_data);
 }
 
 template <class T> ValuePtr TypedValue<T>::createFromString(const string& value)
 {
-    std::stringstream ss;
-    if (std::is_base_of<VectorBase, T>::value)
-    {
-        string fmt = value;
-        fmt.erase(std::remove(fmt.begin(), fmt.end(), ' '), fmt.end());
-        std::replace(fmt.begin(), fmt.end(), ',', ' ');
-        ss << fmt;
-    }
-    else
-    {
-        ss << value;
-    }
-
-    T data;
-    if (ss >> data)
-        return Value::createValue<T>(data);
-    return nullptr;
+    return Value::createValue<T>(fromValueString<T>(value));
 }
 
 //
@@ -112,6 +132,46 @@ template<class T> const string& getTypeString()
     return TypedValue<T>::TYPE;
 }
 
+template <> string toValueString(const bool& data)
+{
+    return data ? VALUE_STRING_TRUE : VALUE_STRING_FALSE;
+}
+
+template <> string toValueString(const string& data)
+{
+    return data;
+}
+
+template <class T> string toValueString(const T& data)
+{
+    std::stringstream ss;
+    ss << data;
+    return ss.str();
+}
+
+template <> bool fromValueString(const string& value)
+{
+    if (value == VALUE_STRING_TRUE)
+        return true;
+    if (value == VALUE_STRING_FALSE)
+        return false;
+    throw Exception("Type mismatch in boolean fromValueString: " + value);
+}
+
+template <> string fromValueString(const string& value)
+{
+    return value;
+}
+
+template <class T> T fromValueString(const string& value)
+{
+    std::stringstream ss(value);
+    T data;
+    if (ss >> data)
+        return data;
+    throw Exception("Type mismatch in fromValueString: " + value);
+}
+
 //
 // Value registry class
 //
@@ -121,7 +181,10 @@ template <class T> class ValueRegistry
   public:
     ValueRegistry()
     {
-        Value::_creatorMap[TypedValue<T>::TYPE] = TypedValue<T>::createFromString;
+        if (!Value::_creatorMap.count(TypedValue<T>::TYPE))
+        {
+            Value::_creatorMap[TypedValue<T>::TYPE] = TypedValue<T>::createFromString;
+        }
     }
     ~ValueRegistry() { }
 };
@@ -137,6 +200,7 @@ template T Value::asA<T>() const;                       \
 template const string& getTypeString<T>();              \
 ValueRegistry<T> registry##T;
 
+// Base types
 INSTANTIATE_TYPE(int, "integer")
 INSTANTIATE_TYPE(bool, "boolean")
 INSTANTIATE_TYPE(float, "float")
@@ -149,6 +213,15 @@ INSTANTIATE_TYPE(Vector4, "vector4")
 INSTANTIATE_TYPE(Matrix3x3, "matrix33")
 INSTANTIATE_TYPE(Matrix4x4, "matrix44")
 INSTANTIATE_TYPE(string, "string")
+
+// Array types
+INSTANTIATE_TYPE(IntVec, "integerarray")
+INSTANTIATE_TYPE(BoolVec, "booleanarray")
+INSTANTIATE_TYPE(FloatVec, "floatarray")
 INSTANTIATE_TYPE(StringVec, "stringarray")
+
+// Alias types
+INSTANTIATE_TYPE(long, "integer")
+INSTANTIATE_TYPE(double, "float")
 
 } // namespace MaterialX

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -33,9 +33,9 @@ class Value
     virtual ~Value() { }
 
     /// Create a new value from an object of any valid MaterialX type.
-    template<class T> static ValuePtr createValue(const T& value)
+    template<class T> static ValuePtr createValue(const T& data)
     {
-        return std::make_shared< TypedValue<T> >(value);
+        return std::make_shared< TypedValue<T> >(data);
     }
 
     /// Create a new value from value and type strings.
@@ -132,6 +132,13 @@ template <class T> class TypedValue : public Value
 
 /// Return the type string associated with the given data type.
 template<class T> const string& getTypeString();
+
+/// Return the value string associated with the given data value.
+template <class T> string toValueString(const T& data);
+
+/// Convert the given value string to a data value of the given type.
+/// @throws Exception if the string cannot be converted to the given type.
+template <class T> T fromValueString(const string& value);
 
 } // namespace MaterialX
 

--- a/source/MaterialXTest/Value.cpp
+++ b/source/MaterialXTest/Value.cpp
@@ -40,8 +40,29 @@ template<class T> void testTypedValue(const T& v1, const T& v2)
     REQUIRE(newValue2->asA<T>() == v2);
 }
 
+TEST_CASE("Value strings", "[value]")
+{
+    REQUIRE(mx::toValueString(1) == "1");
+    REQUIRE(mx::toValueString(0.0f) == "0");
+    REQUIRE(mx::toValueString(true) == "true");
+    REQUIRE(mx::toValueString(false) == "false");
+    REQUIRE(mx::toValueString(mx::Color3(1.0f)) == "1, 1, 1");
+    REQUIRE(mx::toValueString(mx::Vector4(0.5f)) == "0.5, 0.5, 0.5, 0.5");
+
+    REQUIRE(mx::fromValueString<int>("1") == 1);
+    REQUIRE(mx::fromValueString<float>("0") == 0.0f);
+    REQUIRE(mx::fromValueString<bool>("true") == true);
+    REQUIRE(mx::fromValueString<bool>("false") == false);
+    REQUIRE(mx::fromValueString<std::string>("1") == "1");
+    REQUIRE_THROWS_AS(mx::fromValueString<mx::Color3>("1"), mx::Exception);
+
+    REQUIRE(mx::fromValueString<std::string>("text") == "text");
+    REQUIRE_THROWS_AS(mx::fromValueString<int>("text"), mx::Exception);
+}
+
 TEST_CASE("Typed values", "[value]")
 {
+    // Base types
     testTypedValue<int>(1, 2);
     testTypedValue<bool>(false, true);
     testTypedValue<float>(1.0f, 2.0f);
@@ -63,6 +84,18 @@ TEST_CASE("Typed values", "[value]")
                    mx::Matrix4x4(1.0f));
     testTypedValue(std::string("first_value"),
                    std::string("second_value"));
-    testTypedValue(std::vector<std::string>{"one", "two", "three"},
-                   std::vector<std::string>{"four", "five", "six"});
+
+    // Array types
+    testTypedValue(mx::IntVec{1, 2, 3},
+                   mx::IntVec{4, 5, 6});
+    testTypedValue(mx::BoolVec{false, false, false},
+                   mx::BoolVec{true, true, true});
+    testTypedValue(mx::FloatVec{1.0f, 2.0f, 3.0f},
+                   mx::FloatVec{4.0f, 5.0f, 6.0f});
+    testTypedValue(mx::StringVec{"one", "two", "three"},
+                   mx::StringVec{"four", "five", "six"});
+
+    // Alias types
+    testTypedValue<long>(1l, 2l);
+    testTypedValue<double>(1.0, 2.0);
 }

--- a/source/PyMaterialX/PyTypes.cpp
+++ b/source/PyMaterialX/PyTypes.cpp
@@ -7,6 +7,8 @@
 
 #include <MaterialXCore/Types.h>
 
+#include <MaterialXCore/Value.h>
+
 #include <sstream>
 
 namespace py = pybind11;
@@ -31,13 +33,7 @@ void bindPyTypes(py::module& mod)
         .def("__setitem__", [](mx::Vector2& vec, size_t i, float value) { vec[i] = value; } )
         .def("__iter__", [](const mx::Vector2& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
             py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Vector2 &vec)
-            {
-                std::ostringstream output;
-                output << vec;
-                return output.str();
-            }
-        )
+        .def("__str__", [](const mx::Vector2& vec) { return mx::toValueString(vec); })
         .def_static("__len__", &mx::Vector2::length);
 
     py::class_<mx::Vector3, mx::VectorBase>(mod, "Vector3")
@@ -55,13 +51,7 @@ void bindPyTypes(py::module& mod)
         .def("__setitem__", [](mx::Vector3& vec, size_t i, float value) { vec[i] = value; } )
         .def("__iter__", [](const mx::Vector3& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
             py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Vector3 &vec)
-            {
-                std::ostringstream output;
-                output << vec;
-                return output.str();
-            }
-        )
+        .def("__str__", [](const mx::Vector3& vec) { return mx::toValueString(vec); })
         .def_static("__len__", &mx::Vector3::length);
 
     py::class_<mx::Vector4, mx::VectorBase>(mod, "Vector4")
@@ -79,13 +69,7 @@ void bindPyTypes(py::module& mod)
         .def("__setitem__", [](mx::Vector4& vec, size_t i, float value) { vec[i] = value; } )
         .def("__iter__", [](const mx::Vector4& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
             py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Vector4 &vec)
-            {
-                std::ostringstream output;
-                output << vec;
-                return output.str();
-            }
-        )
+        .def("__str__", [](const mx::Vector4& vec) { return mx::toValueString(vec); })
         .def_static("__len__", &mx::Vector4::length);
 
     py::class_<mx::Matrix3x3, mx::VectorBase>(mod, "Matrix3x3")
@@ -101,13 +85,7 @@ void bindPyTypes(py::module& mod)
         .def("__setitem__", [](mx::Matrix3x3& vec, size_t i, float value) { vec[i] = value; } )
         .def("__iter__", [](const mx::Matrix3x3& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
             py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Matrix3x3 &vec)
-            {
-                std::ostringstream output;
-                output << vec;
-                return output.str();
-            }
-        )
+        .def("__str__", [](const mx::Matrix3x3& vec) { return mx::toValueString(vec); })
         .def_static("__len__", &mx::Matrix3x3::length);
 
     py::class_<mx::Matrix4x4, mx::VectorBase>(mod, "Matrix4x4")
@@ -123,13 +101,7 @@ void bindPyTypes(py::module& mod)
         .def("__setitem__", [](mx::Matrix4x4& vec, size_t i, float value) { vec[i] = value; } )
         .def("__iter__", [](const mx::Matrix4x4& vec) { return py::make_iterator(vec.data.begin(), vec.data.end()); },
             py::keep_alive<0, 1>())
-        .def("__str__", [](const mx::Matrix4x4 &vec)
-            {
-                std::ostringstream output;
-                output << vec;
-                return output.str();
-            }
-        )
+        .def("__str__", [](const mx::Matrix4x4& vec) { return mx::toValueString(vec); })
         .def_static("__len__", &mx::Matrix4x4::length);
 
     py::class_<mx::Color2, mx::Vector2>(mod, "Color2")


### PR DESCRIPTION
This changelist adds two function templates, MaterialX::toValueString and MaterialX::fromValueString, allowing conversion between data values and strings without the intermediate creation of a TypedValue<T> instance.

Also:

- Add support for the MaterialX data types "intarray", "boolarray", and "floatarray".
- Add support for long and double as alternative representations of "integer" and "float" data.
- Clarify the edge case behavior of ValueElement accessors.