### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -284,7 +284,7 @@ class MX_CORE_API Vector2 : public VectorN<Vector2, float, 2>
 {
   public:
     using VectorN<Vector2, float, 2>::VectorN;
-    Vector2() { }
+    Vector2() = default;
     Vector2(float x, float y) : VectorN(Uninit{})
     {
         _arr = {x, y};
@@ -303,7 +303,7 @@ class MX_CORE_API Vector3 : public VectorN<Vector3, float, 3>
 {
   public:
     using VectorN<Vector3, float, 3>::VectorN;
-    Vector3() { }
+    Vector3() = default;
     Vector3(float x, float y, float z) : VectorN(Uninit{})
     {
         _arr = {x, y, z};
@@ -324,7 +324,7 @@ class MX_CORE_API Vector4 : public VectorN<Vector4, float, 4>
 {
   public:
     using VectorN<Vector4, float, 4>::VectorN;
-    Vector4() { }
+    Vector4() = default;
     Vector4(float x, float y, float z, float w) : VectorN(Uninit{})
     {
         _arr = {x, y, z, w};
@@ -337,7 +337,7 @@ class MX_CORE_API Quaternion : public VectorN<Vector4, float, 4>
 {
   public:
     using VectorN<Vector4, float, 4>::VectorN;
-    Quaternion() { }
+    Quaternion() = default;
     Quaternion(float x, float y, float z, float w) : VectorN(Uninit{})
     {
         _arr = {x, y, z, w};
@@ -376,7 +376,7 @@ class MX_CORE_API Color3 : public VectorN<Color3, float, 3>
 {
   public:
     using VectorN<Color3, float, 3>::VectorN;
-    Color3() { }
+    Color3() = default;
     Color3(float r, float g, float b) : VectorN(Uninit{})
     {
         _arr = {r, g, b};
@@ -389,7 +389,7 @@ class MX_CORE_API Color4 : public VectorN<Color4, float, 4>
 {
   public:
     using VectorN<Color4, float, 4>::VectorN;
-    Color4() { }
+    Color4() = default;
     Color4(float r, float g, float b, float a) : VectorN(Uninit{})
     {
         _arr = {r, g, b, a};
@@ -625,7 +625,7 @@ class MX_CORE_API Matrix33 : public MatrixN<Matrix33, float, 3>
 {
   public:
     using MatrixN<Matrix33, float, 3>::MatrixN;
-    Matrix33() { }
+    Matrix33() = default;
     Matrix33(float m00, float m01, float m02,
              float m10, float m11, float m12,
              float m20, float m21, float m22) :
@@ -676,7 +676,7 @@ class MX_CORE_API Matrix44 : public MatrixN<Matrix44, float, 4>
 {
   public:
     using MatrixN<Matrix44, float, 4>::MatrixN;
-    Matrix44() { }
+    Matrix44() = default;
     Matrix44(float m00, float m01, float m02, float m03,
              float m10, float m11, float m12, float m13,
              float m20, float m21, float m22, float m23,

--- a/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
@@ -15,7 +15,7 @@ namespace MaterialX
 
 ShaderNodeImplPtr BlurNodeGlsl::create()
 {
-    return std::shared_ptr<BlurNodeGlsl>(new BlurNodeGlsl());
+    return std::make_shared<BlurNodeGlsl>();
 }
 
 void BlurNodeGlsl::emitSamplingFunctionDefinition(const ShaderNode& /*node*/, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -27,13 +27,9 @@ namespace
     const float filterOffset = 0.0;
 }
 
-HeightToNormalNodeGlsl::HeightToNormalNodeGlsl()
-{
-}
-
 ShaderNodeImplPtr HeightToNormalNodeGlsl::create()
 {
-    return std::shared_ptr<HeightToNormalNodeGlsl>(new HeightToNormalNodeGlsl());
+    return std::make_shared<HeightToNormalNodeGlsl>();
 }
 
 void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
@@ -23,9 +23,6 @@ class HeightToNormalNodeGlsl : public ConvolutionNode
     const string& getTarget() const override;
 
   protected:
-    /// Constructor
-    HeightToNormalNodeGlsl();
-
     /// Return if given type is an acceptible input
     bool acceptsInputType(const TypeDesc* type) const override;
 

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
@@ -13,14 +13,9 @@
 namespace MaterialX
 {
 
-BlurNodeMdl::BlurNodeMdl() :
-    BlurNode()
-{
-}
-
 ShaderNodeImplPtr BlurNodeMdl::create()
 {
-    return std::shared_ptr<BlurNodeMdl>(new BlurNodeMdl());
+    return std::make_shared<BlurNodeMdl>();
 }
 
 void BlurNodeMdl::outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& stage, const TypeDesc* inputType, 

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
@@ -20,8 +20,6 @@ class BlurNodeMdl : public BlurNode
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   protected:
-    /// Constructor
-    BlurNodeMdl();
     void emitSamplingFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
     /// Output sample array

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -30,7 +30,7 @@ namespace
 
 ShaderNodeImplPtr HeightToNormalNodeMdl::create()
 {
-    return std::shared_ptr<HeightToNormalNodeMdl>(new HeightToNormalNodeMdl());
+    return std::make_shared<HeightToNormalNodeMdl>();
 }
 
 void HeightToNormalNodeMdl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 

--- a/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
@@ -15,7 +15,7 @@ namespace MaterialX
 
 ShaderNodeImplPtr BlurNodeOsl::create()
 {
-    return std::shared_ptr<BlurNodeOsl>(new BlurNodeOsl());
+    return std::make_shared<BlurNodeOsl>();
 }
 
 void BlurNodeOsl::emitSamplingFunctionDefinition(const ShaderNode& /*node*/, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -248,7 +248,6 @@ bool isTransparentSurface(ElementPtr element, const string& target)
                 const OutputPtr& output = outputs[0];
                 if (output->getType() == SURFACE_SHADER_TYPE_STRING)
                 {
-                    OpaqueTestPairList opaqueInputList;
                     if (isTransparentShaderGraph(output, target, node))
                     {
                         return true;

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -21,7 +21,7 @@ class MX_RENDER_API Vector3d : public VectorN<Vector3d, double, 3>
 {
   public:
     using VectorN<Vector3d, double, 3>::VectorN;
-    Vector3d() { }
+    Vector3d() = default;
     Vector3d(double x, double y, double z) : VectorN(Uninit{})
     {
         _arr = {x, y, z};
@@ -34,7 +34,7 @@ class MX_RENDER_API Vector4d : public VectorN<Vector4d, double, 4>
 {
   public:
     using VectorN<Vector4d, double, 4>::VectorN;
-    Vector4d() { }
+    Vector4d() = default;
     Vector4d(double x, double y, double z, double w) : VectorN(Uninit{})
     {
         _arr = {x, y, z, w};
@@ -47,7 +47,7 @@ class MX_RENDER_API Color3d : public VectorN<Color3d, double, 3>
 {
   public:
     using VectorN<Color3d, double, 3>::VectorN;
-    Color3d() { }
+    Color3d() = default;
     Color3d(double r, double g, double b) : VectorN(Uninit{})
     {
         _arr = {r, g, b};

--- a/source/MaterialXRenderGlsl/GLContext.cpp
+++ b/source/MaterialXRenderGlsl/GLContext.cpp
@@ -20,7 +20,7 @@ namespace MaterialX
 
 #if defined(_WIN32)
 
-GLContext::GLContext(const SimpleWindowPtr window, HardwareContextHandle sharedWithContext) :
+GLContext::GLContext(SimpleWindowPtr window, HardwareContextHandle sharedWithContext) :
     _window(window),
     _contextHandle(nullptr),
     _isValid(false)

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -181,7 +181,7 @@ int GLTextureHandler::getNextAvailableTextureLocation()
 
 int GLTextureHandler::mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum)
 {
-    const vector<int> addressModes
+    const std::array<int, 4> ADDRESS_MODES
     {
         // Constant color. Use clamp to border
         // with border color to achieve this
@@ -200,7 +200,7 @@ int GLTextureHandler::mapAddressModeToGL(ImageSamplingProperties::AddressMode ad
     int addressMode = GL_REPEAT;
     if (addressModeEnum != ImageSamplingProperties::AddressMode::UNSPECIFIED)
     {
-        addressMode = addressModes[static_cast<int>(addressModeEnum)];
+        addressMode = ADDRESS_MODES[static_cast<int>(addressModeEnum)];
     }
     return addressMode;
 }

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -46,7 +46,7 @@ class MX_RENDERGLSL_API GlslRenderer : public ShaderRenderer
     static GlslRendererPtr create(unsigned int width = 512, unsigned int height = 512, Image::BaseType baseType = Image::BaseType::UINT8);
 
     /// Destructor
-    virtual ~GlslRenderer() { };
+    virtual ~GlslRenderer() { }
 
     /// @name Setup
     /// @{

--- a/source/MaterialXView/Camera.h
+++ b/source/MaterialXView/Camera.h
@@ -19,7 +19,7 @@ class Camera
         _speedFactor(2.f)
     {
     }
-    ~Camera() { };
+    ~Camera() { }
 
     // Set the size of a virtual window for click-drag interaction.
     void setSize(const mx::Vector2& size)

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -2,13 +2,8 @@
 
 #include <MaterialXView/Viewer.h>
 
-#include <nanogui/button.h>
-#include <nanogui/colorpicker.h>
 #include <nanogui/colorwheel.h>
-#include <nanogui/combobox.h>
-#include <nanogui/layout.h>
 #include <nanogui/slider.h>
-#include <nanogui/textbox.h>
 #include <nanogui/vscrollpanel.h>
 
 namespace {
@@ -41,10 +36,10 @@ class EditorColorPicker : public ng::ColorPicker
         layout->setSpacing(1, 1);
         floatGroup->setLayout(layout);
 
-        const std::vector<std::string> colorLabels = { "Red", "Green", "Blue", "Alpha" };
-        for (size_t i = 0; i < colorLabels.size(); i++)
+        const std::array<std::string, 4> COLOR_LABELS = { "Red", "Green", "Blue", "Alpha" };
+        for (size_t i = 0; i < COLOR_LABELS.size(); i++)
         {
-            new ng::Label(floatGroup, colorLabels[i]);
+            new ng::Label(floatGroup, COLOR_LABELS[i]);
             _colorWidgets[i] = new ng::FloatBox<float>(floatGroup, color[i]);
             _colorWidgets[i]->setEditable(true);
             _colorWidgets[i]->setAlignment(ng::TextBox::Alignment::Right);
@@ -211,13 +206,16 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             comboBox->setCallback([path, viewer, enumeration, enumValues](int index)
             {
                 MaterialPtr material = viewer->getSelectedMaterial();
-                if (index >= 0 && static_cast<size_t>(index) < enumValues.size())
+                if (material)
                 {
-                    material->modifyUniform(path, enumValues[index]);
-                }
-                else if (index >= 0 && static_cast<size_t>(index) < enumeration.size())
-                {
-                    material->modifyUniform(path, mx::Value::createValue(index), enumeration[index]);
+                    if (index >= 0 && static_cast<size_t>(index) < enumValues.size())
+                    {
+                        material->modifyUniform(path, enumValues[index]);
+                    }
+                    else if (index >= 0 && static_cast<size_t>(index) < enumeration.size())
+                    {
+                        material->modifyUniform(path, mx::Value::createValue(index), enumeration[index]);
+                    }
                 }
             });
         }
@@ -340,11 +338,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         else
         {
             mx::Color3 v = value->asA<mx::Color3>();
-            ng::Color c;
-            c.r() = v[0];
-            c.g() = v[1];
-            c.b() = v[2];
-            c.w() = 1.0;
+            ng::Color c(v[0], v[1], v[2], 1.0);
             
             new ng::Label(twoColumns, label);
             auto colorVar = new EditorColorPicker(twoColumns, c);
@@ -353,11 +347,11 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             colorVar->setFinalCallback([path, viewer](const ng::Color &c)
             {
                 MaterialPtr material = viewer->getSelectedMaterial();
-                mx::Vector3 v;
-                v[0] = c.r();
-                v[1] = c.g();
-                v[2] = c.b();
-                material->modifyUniform(path, mx::Value::createValue(v));
+                if (material)
+                {
+                    mx::Vector3 v(c.r(), c.g(), c.b());
+                    material->modifyUniform(path, mx::Value::createValue(v));
+                }
             });
         }
     }
@@ -370,11 +364,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
 
         new ng::Label(twoColumns, label);
         mx::Color4 v = value->asA<mx::Color4>();
-        ng::Color c;
-        c.r() = v[0];
-        c.g() = v[1];
-        c.b() = v[2];
-        c.w() = v[3];
+        ng::Color c(v[0], v[1], v[2], v[3]);
         auto colorVar = new EditorColorPicker(twoColumns, c);
         colorVar->setFixedSize({ 100, 20 });
         colorVar->setFontSize(15);
@@ -383,11 +373,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector4 v;
-                v[0] = c.r();
-                v[1] = c.g();
-                v[2] = c.b();
-                v[3] = c.w();
+                mx::Vector4 v(c.r(), c.g(), c.b(), c.w());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -413,9 +399,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector2 v;
-                v[0] = f;
-                v[1] = v2->value();
+                mx::Vector2 v(f, v2->value());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -426,9 +410,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector2 v;
-                v[0] = v1->value();
-                v[1] = f;
+                mx::Vector2 v(v1->value(), f);
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -461,10 +443,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector3 v;
-                v[0] = f;
-                v[1] = v2->value();
-                v[2] = v3->value();
+                mx::Vector3 v(f, v2->value(), v3->value());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -475,10 +454,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector3 v;
-                v[0] = v1->value();
-                v[1] = f;
-                v[2] = v3->value();
+                mx::Vector3 v(v1->value(), f, v3->value());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -489,10 +465,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector3 v;
-                v[0] = v1->value();
-                v[1] = v2->value();
-                v[2] = f;
+                mx::Vector3 v(v1->value(), v2->value(), f);
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -529,11 +502,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector4 v;
-                v[0] = f;
-                v[1] = v2->value();
-                v[2] = v3->value();
-                v[3] = v4->value();
+                mx::Vector4 v(f, v2->value(), v3->value(), v4->value());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -543,11 +512,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector4 v;
-                v[0] = v1->value();
-                v[1] = f;
-                v[2] = v3->value();
-                v[3] = v4->value();
+                mx::Vector4 v(v1->value(), f, v3->value(), v4->value());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -558,11 +523,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector4 v;
-                v[0] = v1->value();
-                v[1] = v2->value();
-                v[2] = f;
-                v[3] = v4->value();
+                mx::Vector4 v(v1->value(), v2->value(), f, v4->value());
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });
@@ -573,11 +534,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector4 v;
-                v[0] = v1->value();
-                v[1] = v2->value();
-                v[2] = v3->value();
-                v[3] = f;
+                mx::Vector4 v(v1->value(), v2->value(), v3->value(), f);
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });


### PR DESCRIPTION
- Assign explicitly-defaulted constructors to vector and matrix classes.
- Use std::make_shared in node creation methods.
- Prefer std::array to std::vector for immutable data.
- Add null checks for missing viewer materials.
- Additional minor simplifications to code.