### PR TITLE
Additional color space updates

### DIFF
--- a/libraries/README.md
+++ b/libraries/README.md
@@ -60,7 +60,7 @@ This folder contains the standard data libraries for MaterialX, providing declar
 - OSL target support is for version 1.9.10 or higher.
 - MDL target support is for version 1.6.
 - "Default" color management support includes OSL, GLSL, and MDL implementations for the following color spaces:
-    - lin_rec709, g18_rec709, g22_rec709, g24_rec709, lin_ap1/acescg, g22_ap1, srgb_texture
+    - lin_rec709, g18_rec709, g22_rec709, rec709_display, acescg (lin_ap1), g22_ap1, srgb_texture
 - Basic GLSL `lightshader` node definitions and implementations are provided for the following light types:
     - point, directional, spot
 - Code generation does not currently support:

--- a/libraries/stdlib/genglsl/stdlib_genglsl_cm_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_cm_impl.mtlx
@@ -9,11 +9,11 @@
   <implementation name="IM_g18_rec709_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma18_to_linear_color4.glsl" function="mx_gamma18_to_linear_color4" target="genglsl" />
   <implementation name="IM_g22_rec709_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_gamma22_to_linear_color3.glsl" function="mx_gamma22_to_linear_color3" target="genglsl" />
   <implementation name="IM_g22_rec709_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma22_to_linear_color4.glsl" function="mx_gamma22_to_linear_color4" target="genglsl" />
-  <implementation name="IM_g24_rec709_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_gamma24_to_linear_color3.glsl" function="mx_gamma24_to_linear_color3" target="genglsl" />
-  <implementation name="IM_g24_rec709_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma24_to_linear_color4.glsl" function="mx_gamma24_to_linear_color4" target="genglsl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_gamma24_to_linear_color3.glsl" function="mx_gamma24_to_linear_color3" target="genglsl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma24_to_linear_color4.glsl" function="mx_gamma24_to_linear_color4" target="genglsl" />
 
-  <implementation name="IM_lin_ap1_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_ap1_to_rec709_color3.glsl" function="mx_ap1_to_rec709_color3" target="genglsl" />
-  <implementation name="IM_lin_ap1_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_ap1_to_rec709_color4.glsl" function="mx_ap1_to_rec709_color4" target="genglsl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_ap1_to_rec709_color3.glsl" function="mx_ap1_to_rec709_color3" target="genglsl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_ap1_to_rec709_color4.glsl" function="mx_ap1_to_rec709_color4" target="genglsl" />
 
   <implementation name="IM_g22_ap1_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl" function="mx_g22_ap1_to_lin_rec709_color3" target="genglsl" />
   <implementation name="IM_g22_ap1_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl" function="mx_g22_ap1_to_lin_rec709_color4" target="genglsl" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_cm_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_cm_impl.mtlx
@@ -9,11 +9,11 @@
   <implementation name="IM_g18_rec709_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_gamma18_to_linear_color4({{in}})" target="genmdl" />
   <implementation name="IM_g22_rec709_to_lin_rec709_color3_genmdl" sourcecode="mx::cm::mx_gamma22_to_linear_color3({{in}})" target="genmdl" />
   <implementation name="IM_g22_rec709_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_gamma22_to_linear_color4({{in}})" target="genmdl" />
-  <implementation name="IM_g24_rec709_to_lin_rec709_color3_genmdl" sourcecode="mx::cm::mx_gamma24_to_linear_color3({{in}})" target="genmdl" />
-  <implementation name="IM_g24_rec709_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_gamma24_to_linear_color4({{in}})" target="genmdl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genmdl" sourcecode="mx::cm::mx_gamma24_to_linear_color3({{in}})" target="genmdl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_gamma24_to_linear_color4({{in}})" target="genmdl" />
 
-  <implementation name="IM_lin_ap1_to_lin_rec709_color3_genmdl" sourcecode="mx::cm::mx_ap1_to_rec709_color3({{in}})" target="genmdl" />
-  <implementation name="IM_lin_ap1_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_ap1_to_rec709_color4({{in}})" target="genmdl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genmdl" sourcecode="mx::cm::mx_ap1_to_rec709_color3({{in}})" target="genmdl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_ap1_to_rec709_color4({{in}})" target="genmdl" />
 
   <implementation name="IM_srgb_texture_to_lin_rec709_color3_genmdl" sourcecode="mx::cm::mx_srgb_texture_to_lin_rec709_color3({{in}})" target="genmdl" />
   <implementation name="IM_srgb_texture_to_lin_rec709_color4_genmdl" sourcecode="mx::cm::mx_srgb_texture_to_lin_rec709_color4({{in}})" target="genmdl" />

--- a/libraries/stdlib/genosl/stdlib_genosl_cm_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_cm_impl.mtlx
@@ -9,11 +9,11 @@
   <implementation name="IM_g18_rec709_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma18_to_linear_color4.osl" function="mx_gamma18_to_linear_color4" target="genosl" />
   <implementation name="IM_g22_rec709_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_gamma22_to_linear_color3.osl" function="mx_gamma22_to_linear_color3" target="genosl" />
   <implementation name="IM_g22_rec709_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma22_to_linear_color4.osl" function="mx_gamma22_to_linear_color4" target="genosl" />
-  <implementation name="IM_g24_rec709_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_gamma24_to_linear_color3.osl" function="mx_gamma24_to_linear_color3" target="genosl" />
-  <implementation name="IM_g24_rec709_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma24_to_linear_color4.osl" function="mx_gamma24_to_linear_color4" target="genosl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_gamma24_to_linear_color3.osl" function="mx_gamma24_to_linear_color3" target="genosl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma24_to_linear_color4.osl" function="mx_gamma24_to_linear_color4" target="genosl" />
 
-  <implementation name="IM_lin_ap1_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_ap1_to_rec709_color3.osl" function="mx_ap1_to_rec709_color3" target="genosl" />
-  <implementation name="IM_lin_ap1_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_ap1_to_rec709_color4.osl" function="mx_ap1_to_rec709_color4" target="genosl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_ap1_to_rec709_color3.osl" function="mx_ap1_to_rec709_color3" target="genosl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_ap1_to_rec709_color4.osl" function="mx_ap1_to_rec709_color4" target="genosl" />
 
   <implementation name="IM_g22_ap1_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_g22_ap1_to_lin_rec709_color3.osl" function="mx_g22_ap1_to_lin_rec709_color3" target="genosl" />
   <implementation name="IM_g22_ap1_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_g22_ap1_to_lin_rec709_color4.osl" function="mx_g22_ap1_to_lin_rec709_color4" target="genosl" />

--- a/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
@@ -19,8 +19,8 @@ const StringMap COLOR_SPACE_REMAP =
 {
     { "gamma18", "g18_rec709" },
     { "gamma22", "g22_rec709" },
-    { "gamma24", "g24_rec709" },
-    { "acescg", "lin_ap1" }
+    { "gamma24", "rec709_display" },
+    { "lin_ap1", "acescg" }
 };
 
 } // anonymous namespace


### PR DESCRIPTION
This changelist makes two additional updates to the default color space names, based on feedback from Doug Walker:
- Use the standard "rec709_display" instead of "g24_rec709".
- Use the standard "acescg" as the preferred name, with "lin_ap1" being a supported alias.