### PR TITLE
Initial clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,16 @@
+AllowShortBlocksOnASingleLine: true
+AllowShortLambdasOnASingleLine: false
+AlwaysBreakTemplateDeclarations: No
+BreakBeforeBraces: Allman
+BreakConstructorInitializers: AfterColon
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit: 0
+Cpp11BracedListStyle: false
+IndentCaseLabels: true
+IndentWidth: 4
+LambdaBodyIndentation: OuterScope
+PointerAlignment: Left
+SortIncludes: false
+SpaceAfterCStyleCast: true
+SpaceInEmptyBlock: true
+UseTab: Never


### PR DESCRIPTION
This changelist adds an initial clang-format file to the MaterialX project, allowing developers to align their code to its conventions on demand.

For now, the use of Clang formatting is optional, and we should consider its integration into automated testing as we gain more experience with its usage.

The new clang-format file requires Clang 13 or newer, as it leverages newly-added formatting options for lambdas (https://clang.llvm.org/docs/ClangFormatStyleOptions.html).