### PR TITLE
Clarify interface of getGeometryBindings

### DIFF
--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -21,7 +21,7 @@ const string Visibility::VISIBLE_ATTRIBUTE = "visible";
 const string LookGroup::LOOKS_ATTRIBUTE = "looks";
 const string LookGroup::ACTIVE_ATTRIBUTE = "active";
 
-vector<MaterialAssignPtr> getGeometryBindings(const NodePtr& materialNode, const string& geom)
+vector<MaterialAssignPtr> getGeometryBindings(ConstNodePtr materialNode, const string& geom)
 {
     vector<MaterialAssignPtr> matAssigns;
     for (LookPtr look : materialNode->getDocument()->getLooks())

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -492,7 +492,7 @@ class MX_CORE_API Visibility : public GeomElement
 ///             By default, this argument is the universal geometry string "/",
 ///             and all material bindings are returned.
 /// @return Vector of MaterialAssign elements
-MX_CORE_API vector<MaterialAssignPtr> getGeometryBindings(const NodePtr& materialNode, const string& geom);
+MX_CORE_API vector<MaterialAssignPtr> getGeometryBindings(ConstNodePtr materialNode, const string& geom = UNIVERSAL_GEOM_NAME);
 
 } // namespace MaterialX
 

--- a/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
@@ -80,5 +80,6 @@ void bindPyLook(py::module& mod)
         .def("getVisible", &mx::Visibility::getVisible)
         .def_readonly_static("CATEGORY", &mx::Visibility::CATEGORY);
 
-    mod.def("getGeometryBindings", &mx::getGeometryBindings);
+    mod.def("getGeometryBindings", &mx::getGeometryBindings,
+        py::arg("materialNode") , py::arg("geom") = mx::UNIVERSAL_GEOM_NAME);
 }


### PR DESCRIPTION
This changelist clarifies the interface of the getGeometryBindings function, expressing its first argument more precisely as a ConstNodePtr, and adding a missing default value for its second argument.