### PR TITLE
Add version defines to MaterialXCore

### DIFF
--- a/source/MaterialXCore/.gitignore
+++ b/source/MaterialXCore/.gitignore
@@ -1,0 +1,1 @@
+Version.h

--- a/source/MaterialXCore/CMakeLists.txt
+++ b/source/MaterialXCore/CMakeLists.txt
@@ -1,11 +1,10 @@
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Version.h.in ${CMAKE_CURRENT_SOURCE_DIR}/Version.h)
+
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
-file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
+file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
 add_library(MaterialXCore ${materialx_source} ${materialx_headers})
 
-add_definitions(-DMATERIALX_MAJOR_VERSION=${MATERIALX_MAJOR_VERSION})
-add_definitions(-DMATERIALX_MINOR_VERSION=${MATERIALX_MINOR_VERSION})
-add_definitions(-DMATERIALX_BUILD_VERSION=${MATERIALX_BUILD_VERSION})
 add_definitions(-DMATERIALX_CORE_EXPORTS)
 
 set_target_properties(

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -6,6 +6,7 @@
 #include <MaterialXCore/Document.h>
 
 #include <MaterialXCore/Util.h>
+#include <MaterialXCore/Version.h>
 
 #include <mutex>
 

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <MaterialXCore/Types.h>
+#include <MaterialXCore/Version.h>
 
 #include <cctype>
 

--- a/source/MaterialXCore/Version.h.in
+++ b/source/MaterialXCore/Version.h.in
@@ -1,0 +1,15 @@
+//
+// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_VERSION_H
+#define MATERIALX_VERSION_H
+
+#include <MaterialXCore/Library.h>
+
+#define MATERIALX_MAJOR_VERSION @MATERIALX_MAJOR_VERSION@
+#define MATERIALX_MINOR_VERSION @MATERIALX_MINOR_VERSION@
+#define MATERIALX_BUILD_VERSION @MATERIALX_BUILD_VERSION@
+
+#endif


### PR DESCRIPTION
This changelist adds preprocessor definitions for the API version to MaterialXCore, allowing applications to detect version details at compile time.

The new preprocessor definitions are accessed through a Version.h file that is generated at MaterialX build time.