### PR TITLE
Fix skipped inputs in createUIPropertyGroups

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -676,18 +676,6 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @endcode
     InheritanceIterator traverseInheritance() const;
 
-    /// Return the breadth-first index of this element within the document tree.
-    int getTreeIndex() const
-    {
-        ConstElementPtr parent = getParent();
-        if (!parent)
-        {
-            return 0;
-        }
-        return parent->getTreeIndex() * (int) (parent->getChildren().size() + 1) +
-               parent->getChildIndex(getName()) + 1;
-    }
-
     /// @}
     /// @name Source URI
     /// @{

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -241,6 +241,14 @@ unsigned int getUIProperties(InputPtr input, const string& target, UIProperties&
 void createUIPropertyGroups(DocumentPtr doc, const VariableBlock& block, UIPropertyGroup& groups,
                             UIPropertyGroup& unnamedGroups, const string& pathSeparator, bool showAllInputs)
 {
+    // Assign a depth-first index to each element in the document.
+    std::unordered_map<ConstElementPtr, int> indexMap;
+    int curIndex = 0;
+    for (ConstElementPtr elem : doc->traverseTree())
+    {
+        indexMap[elem] = curIndex++;
+    }
+
     // Generated an ordered map of shader inputs.
     using ShaderInputPair = std::pair<InputPtr, ShaderPort*>;
     std::map<int, ShaderInputPair> shaderInputMap;
@@ -284,7 +292,7 @@ void createUIPropertyGroups(DocumentPtr doc, const VariableBlock& block, UIPrope
         // Add the shader input if unique.
         if (input)
         {
-            int treeIndex = input->getTreeIndex();
+            int treeIndex = indexMap[input];
             if (shaderInputMap.count(treeIndex))
             {
                 continue;
@@ -293,7 +301,7 @@ void createUIPropertyGroups(DocumentPtr doc, const VariableBlock& block, UIPrope
         }
     }
 
-    // Generate UI properties for each shader input
+    // Generate UI properties for each shader input in order.
     for (const auto& it : shaderInputMap)
     {
         // Retrieve the shader input pair.

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -85,7 +85,6 @@ void bindPyElement(py::module& mod)
         .def("getUpstreamElement", &mx::Element::getUpstreamElement,
             py::arg("index") = 0)
         .def("traverseInheritance", &mx::Element::traverseInheritance)
-        .def("getTreeIndex", &mx::Element::getTreeIndex)
         .def("setSourceUri", &mx::Element::setSourceUri)
         .def("hasSourceUri", &mx::Element::hasSourceUri)
         .def("getSourceUri", &mx::Element::getSourceUri)


### PR DESCRIPTION
This changelist fixes a bug that caused shader inputs to be skipped in createUIPropertyGroups.

Instead of computing breadth-first indices in a dedicated (and inaccurate) method, we now compute exact depth-first indices by traversing the document tree in advance.

The original inaccurate method has been removed, as it is otherwise unused in the MaterialX codebase.