### PR TITLE
Improvements to Linux Clang support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,24 @@ jobs:
           python: 3.7
           test_render: ON
 
+        - name: Linux_Clang_9_Python36
+          os: ubuntu-18.04
+          compiler: clang
+          compiler_version: "9"
+          python: 3.6
+
+        - name: Linux_Clang_11_Python37
+          os: ubuntu-20.04
+          compiler: clang
+          compiler_version: "11"
+          python: 3.7
+
+        - name: Linux_Clang_12_Python38
+          os: ubuntu-20.04
+          compiler: clang
+          compiler_version: "12"
+          python: 3.8
+
         - name: MacOS_Xcode_10_Python27
           os: macos-10.15
           compiler: xcode
@@ -92,7 +110,7 @@ jobs:
           echo "CC=gcc-${{ matrix.compiler_version }}" >> $GITHUB_ENV
           echo "CXX=g++-${{ matrix.compiler_version }}" >> $GITHUB_ENV
         else
-          sudo apt-get install -y clang-${{ matrix.compiler_version }} g++-multilib
+          sudo apt-get install -y clang-${{ matrix.compiler_version }} libc++-${{ matrix.compiler_version }}-dev libc++abi-${{ matrix.compiler_version }}-dev
           echo "CC=clang-${{ matrix.compiler_version }}" >> $GITHUB_ENV
           echo "CXX=clang++-${{ matrix.compiler_version }}" >> $GITHUB_ENV
         fi
@@ -111,7 +129,7 @@ jobs:
           echo "CXX=clang++" >> $GITHUB_ENV
         fi
 
-    - name: Build GLSlangValidator (Windows)
+    - name: Install GLSlangValidator (Windows)
       if: matrix.test_validate == 'ON' && runner.os == 'Windows'
       run: |
         git clone https://github.com/Microsoft/vcpkg
@@ -164,17 +182,16 @@ jobs:
         python Scripts/mxupdate.py ../resources/Materials/TestSuite/stdlib/upgrade --yes
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
         python Scripts/mxdoc.py ../libraries/pbrlib/pbrlib_defs.mtlx
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path ".." --target "glsl" 
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path ".." --target "osl"
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path ".." --target "mdl"
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path ".." --target "essl" 
+        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_gold.mtlx --path .. --target glsl
+        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_copper.mtlx --path .. --target osl
+        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx --path .. --target mdl
       working-directory: python
 
     - name: Generation Validation Tests
       if: matrix.test_validate == 'ON' && runner.os == 'Windows'
       run: |
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path "." --target "glsl" --validator "vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe"
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path "." --target "essl" --validator "vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe"
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target essl --validator vcpkg/packages/glslang_x64-windows/tools/glslang/glslangValidator.exe
 
     - name: Render Tests
       if: matrix.test_render == 'ON'

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -16,42 +16,46 @@ if(APPLE)
     set_source_files_properties(${materialx_source_oc} PROPERTIES
         COMPILE_FLAGS "-x objective-c++")
     set(materialx_source ${materialx_source} ${materialx_source_oc})
-    add_compile_options(-Wno-deprecated-declarations -DGL_SILENCE_DEPRECATION)
+    add_compile_options(-DGL_SILENCE_DEPRECATION)
 elseif(UNIX)
     find_package(X11 REQUIRED)
     find_package(OpenGL REQUIRED)
     if(NOT X11_Xt_FOUND)
-        message("Error in building MaterialXRender: Xt was not found")
+        message("Error in building MaterialXRenderGlsl: Xt was not found")
     endif()
     include_directories(${X11_INCLUDE_DIR})
+endif()
+
+# Disable deprecation warnings for GLew source on Clang.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wno-deprecated-declarations)
 endif()
 
 add_library(MaterialXRenderGlsl ${materialx_source} ${materialx_headers})
 
 add_definitions(-DMATERIALX_RENDERGLSL_EXPORTS)
 
+set(COMMON_LIBRARIES
+    MaterialXRenderHw
+    MaterialXGenGlsl
+    ${CMAKE_DL_LIBS})
+
 if(MSVC)
     target_link_libraries(
         MaterialXRenderGlsl
-        MaterialXRenderHw
-        MaterialXGenGlsl
-        Opengl32
-        ${CMAKE_DL_LIBS})
+        ${COMMON_LIBRARIES}
+        Opengl32)
 elseif(APPLE)
     target_link_libraries(
         MaterialXRenderGlsl
-        MaterialXRenderHw
-        MaterialXGenGlsl
-        ${CMAKE_DL_LIBS}
+        ${COMMON_LIBRARIES}
         ${OPENGL_LIBRARIES}
         "-framework Foundation"
         "-framework Cocoa")
 elseif(UNIX)
     target_link_libraries(
         MaterialXRenderGlsl
-        MaterialXRenderHw
-        MaterialXGenGlsl
-        ${CMAKE_DL_LIBS}
+        ${COMMON_LIBRARIES}
         ${OPENGL_LIBRARIES}
         ${X11_LIBRARIES}
         ${X11_Xt_LIB})

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -36,12 +36,21 @@ else()
     set(PREV_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
     if(MSVC)
         add_compile_options(-wd4389 -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -DEIGEN_DONT_VECTORIZE)
-    elseif(APPLE)
-        add_compile_options(-Wno-objc-multiple-method-names -Wno-deprecated -DGL_SILENCE_DEPRECATION)
-    elseif(UNIX AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        add_compile_options(-Wno-deprecated)
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         add_compile_options(-Wno-format-truncation -Wno-implicit-fallthrough -Wno-int-in-bool-context
                             -Wno-maybe-uninitialized -Wno-misleading-indentation)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-copy")
+    endif()
+    if(APPLE)
+        add_compile_options(-Wno-objc-multiple-method-names -DGL_SILENCE_DEPRECATION)
+    endif()
+
+    # Disable NanoGUI compiler modifications for Clang
+    set(PREV_COMPILER_ID CMAKE_CXX_COMPILER_ID)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT APPLE)
+        set(CMAKE_CXX_COMPILER_ID "None")
     endif()
 
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/NanoGUI external/NanoGUI)
@@ -53,6 +62,9 @@ else()
     # Restore warnings for MaterialXView
     set(CMAKE_C_FLAGS ${PREV_CMAKE_C_FLAGS})
     set(CMAKE_CXX_FLAGS ${PREV_CMAKE_CXX_FLAGS})
+
+    # Restore compiler ID for MaterialXView
+    set(CMAKE_CXX_COMPILER_ID PREV_COMPILER_ID)
 endif()
 
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
@@ -62,21 +74,21 @@ add_definitions(${NANOGUI_EXTRA_DEFS})
 
 add_executable(MaterialXView ${materialx_source} ${materialx_headers})
 
-set(LIBS
-    MaterialXView
+set(MATERIALX_LIBRARIES
     MaterialXFormat
     MaterialXGenGlsl
     MaterialXRenderGlsl)
 
 if (MATERIALX_BUILD_GEN_OSL)
-    LIST(APPEND LIBS MaterialXGenOsl)
+    LIST(APPEND MATERIALX_LIBRARIES MaterialXGenOsl)
 endif()
 if (MATERIALX_BUILD_GEN_MDL)
-    LIST(APPEND LIBS MaterialXGenMdl)
+    LIST(APPEND MATERIALX_LIBRARIES MaterialXGenMdl)
 endif()
 
 target_link_libraries(
-    ${LIBS}
+    MaterialXView
+    ${MATERIALX_LIBRARIES}
     ${NANOGUI_LIBRARIES}
     ${NANOGUI_EXTRA_LIBS})
 


### PR DESCRIPTION
- Add Linux Clang 9, 11, and 12 builds to the GitHub Actions matrix.
- Improve compiler handling in MaterialXRenderGlsl and MaterialXView.
- Minor refinements to generateshader.py testing.