### PR TITLE
Upgrade to Xcode 12.5.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
         - name: MacOS_Xcode_12_Python37
           os: macos-11
           compiler: xcode
-          compiler_version: "12.5"
+          compiler_version: "12.5.1"
           python: 3.7
 
         - name: MacOS_Xcode_13_Python38


### PR DESCRIPTION
This changelist upgrades GitHub Actions builds to Xcode 12.5.1, as Xcode 12.5 has been removed from the MacOS 11 virtual environment.