### PR TITLE
Update mxdoc node definition script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,8 +189,8 @@ jobs:
         python MaterialXTest/genshader.py
         python Scripts/mxupdate.py ../resources/Materials/TestSuite/stdlib/upgrade --yes
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
-        python Scripts/mxdoc.py ../libraries/pbrlib/pbrlib_defs.mtlx
-        python Scripts/mxdoc.py --docType="html" ../libraries/bxdf/standard_surface.mtlx
+        python Scripts/mxdoc.py --docType md ../libraries/pbrlib/pbrlib_defs.mtlx
+        python Scripts/mxdoc.py --docType html ../libraries/bxdf/standard_surface.mtlx
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_gold.mtlx --path .. --target glsl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_copper.mtlx --path .. --target osl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx --path .. --target mdl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,7 +190,7 @@ jobs:
         python Scripts/mxupdate.py ../resources/Materials/TestSuite/stdlib/upgrade --yes
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
         python Scripts/mxdoc.py ../libraries/pbrlib/pbrlib_defs.mtlx
-        python Scripts/mxdoc.py --docType="html" ../../libraries/bxdf/standard_surface.mtlx
+        python Scripts/mxdoc.py --docType="html" ../libraries/bxdf/standard_surface.mtlx
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_gold.mtlx --path .. --target glsl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_copper.mtlx --path .. --target osl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx --path .. --target mdl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,6 +190,7 @@ jobs:
         python Scripts/mxupdate.py ../resources/Materials/TestSuite/stdlib/upgrade --yes
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
         python Scripts/mxdoc.py ../libraries/pbrlib/pbrlib_defs.mtlx
+        python Scripts/mxdoc.py --docType="html" ../../libraries/bxdf/standard_surface.mtlx
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_gold.mtlx --path .. --target glsl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_copper.mtlx --path .. --target osl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx --path .. --target mdl

--- a/python/Scripts/mxdoc.py
+++ b/python/Scripts/mxdoc.py
@@ -12,8 +12,9 @@ HEADERS = ('Name', 'Type', 'Default Value',
 ATTR_NAMES = ('uniform', 'uimin', 'uimax', 'uisoftmin', 'uisoftmax', 'uistep', 'uifolder', 'uiadvanced')
 
 def main():
-    parser = argparse.ArgumentParser(description="Print markdown documentation for each nodedef in the given document.")
+    parser = argparse.ArgumentParser(description="Print documentation for each nodedef in the given document.")
     parser.add_argument(dest="inputFilename", help="Filename of the input MaterialX document.")
+    parser.add_argument('--docType', dest='documentType', default='md', help='Document type. Default is "md" (markdown). "html" is also supported')
     opts = parser.parse_args()
 
     doc = mx.createDocument()
@@ -24,22 +25,53 @@ def main():
         sys.exit(0)
 
     for nd in doc.getNodeDefs():
-        print('- *Nodedef*: %s' % nd.getName())
-        print('- *Type*: %s' % nd.getType())
-        print('- *Doc*: %s\n' % nd.getAttribute('doc'))
-        print('| ' + ' | '.join(HEADERS) + ' |')
-        print('|' + ' ---- |' * len(HEADERS) + '')
-        for inp in nd.getInputs():
-            infos = []
-            infos.append(inp.getName())
-            infos.append(inp.getType())
-            val = inp.getValue()
-            if inp.getType() == "float":
-                val = round(val, 6)
-            infos.append(str(val))
-            for attrname in ATTR_NAMES:
-                infos.append(inp.getAttribute(attrname))
-            print('| ' + " | ".join(infos) + ' |')
+        if opts.documentType == "html":
+            print('<head><style>')
+            print('table, th, td {')
+            print('   border-bottom: 1px solid; border-collapse: collapse; padding: 1%;')
+            print('}')
+            print('</style></head>')
+            print('<ul>')
+            print('<li> <em>Nodedef</em>: %s' % nd.getName())
+            print('<li> <em>Type</em>: %s' % nd.getType())
+            print('<li> <em>Doc</em>: %s\n' % nd.getAttribute('doc'))
+            print('</ul>')
+            print('<table border-collapse=collapse><tr>')
+            for h in HEADERS:
+                print('<th>' + h + '</th>')
+            print('</tr>')
+            for inp in nd.getInputs():
+                print('<tr>')
+                infos = []
+                infos.append(inp.getName())
+                infos.append(inp.getType())
+                val = inp.getValue()
+                if inp.getType() == "float":
+                    val = round(val, 6)
+                infos.append(str(val))
+                for attrname in ATTR_NAMES:
+                    infos.append(inp.getAttribute(attrname))
+                for info in infos:
+                    print('<td>' + info + '</td>')
+                print('</tr>')
+            print('</table>')
+        else:
+            print('- *Nodedef*: %s' % nd.getName())
+            print('- *Type*: %s' % nd.getType())
+            print('- *Doc*: %s\n' % nd.getAttribute('doc'))
+            print('| ' + ' | '.join(HEADERS) + ' |')
+            print('|' + ' ---- |' * len(HEADERS) + '')
+            for inp in nd.getInputs():
+                infos = []
+                infos.append(inp.getName())
+                infos.append(inp.getType())
+                val = inp.getValue()
+                if inp.getType() == "float":
+                    val = round(val, 6)
+                infos.append(str(val))
+                for attrname in ATTR_NAMES:
+                    infos.append(inp.getAttribute(attrname))
+                print('| ' + " | ".join(infos) + ' |')
 
 if __name__ == '__main__':
     main()

--- a/python/Scripts/mxdoc.py
+++ b/python/Scripts/mxdoc.py
@@ -7,14 +7,15 @@ import sys, os, argparse
 import MaterialX as mx
 
 HEADERS = ('Name', 'Type', 'Default Value',
-           'Uniform', 'UI min', 'UI max', 'UI Soft Min', 'UI Soft Max', 'UI step', 'UI group', 'UI Advanced')
+           'UI name', 'UI min', 'UI max', 'UI Soft Min', 'UI Soft Max', 'UI step', 'UI group', 'UI Advanced', 'Doc', 'Uniform')
 
-ATTR_NAMES = ('uniform', 'uimin', 'uimax', 'uisoftmin', 'uisoftmax', 'uistep', 'uifolder', 'uiadvanced')
+ATTR_NAMES = ('uiname', 'uimin', 'uimax', 'uisoftmin', 'uisoftmax', 'uistep', 'uifolder', 'uiadvanced', 'doc', 'uniform' )
 
 def main():
     parser = argparse.ArgumentParser(description="Print documentation for each nodedef in the given document.")
     parser.add_argument(dest="inputFilename", help="Filename of the input MaterialX document.")
-    parser.add_argument('--docType', dest='documentType', default='md', help='Document type. Default is "md" (markdown). "html" is also supported')
+    parser.add_argument('--docType', dest='documentType', default='md', help='Document type. Default is "md" (Markdown). Specify "html" for HTML output')
+    parser.add_argument('--showInherited', default=False, action='store_true', help='Show inherited inputs. Default is False')
     opts = parser.parse_args()
 
     doc = mx.createDocument()
@@ -25,52 +26,81 @@ def main():
         sys.exit(0)
 
     for nd in doc.getNodeDefs():
+        # HTML output
         if opts.documentType == "html":
             print('<head><style>')
             print('table, th, td {')
-            print('   border-bottom: 1px solid; border-collapse: collapse; padding: 1%;')
+            print('   border-bottom: 1px solid; border-collapse: collapse; padding: 10px;')
             print('}')
             print('</style></head>')
             print('<ul>')
             print('<li> <em>Nodedef</em>: %s' % nd.getName())
             print('<li> <em>Type</em>: %s' % nd.getType())
+            if len(nd.getVersionString()) > 0:
+                print('<li> <em>Version</em>: %s. Is default: %s' % (nd.getVersionString(), nd.getDefaultVersion()))
+            if len(nd.getInheritString()) > 0:
+                print('<li> <em>Inherits From</em>: %s' % nd.getInheritString())
             print('<li> <em>Doc</em>: %s\n' % nd.getAttribute('doc'))
             print('</ul>')
-            print('<table border-collapse=collapse><tr>')
+            print('<table><tr>')
             for h in HEADERS:
                 print('<th>' + h + '</th>')
             print('</tr>')
-            for inp in nd.getInputs():
+            inputList = nd.getActiveInputs() if opts.showInherited  else nd.getInputs()            
+            tokenList = nd.getActiveTokens() if opts.showInherited  else nd.getTokens()
+            outputList = nd.getActiveOutputs() if opts.showInherited  else nd.getOutputs()
+            totalList = inputList + tokenList + outputList;
+            for port in totalList:
                 print('<tr>')
                 infos = []
-                infos.append(inp.getName())
-                infos.append(inp.getType())
-                val = inp.getValue()
-                if inp.getType() == "float":
+                if port in outputList:
+                    infos.append('<em>'+ port.getName() + '</em>')
+                elif port in tokenList:
+                    infos.append(port.getName())
+                else:
+                    infos.append('<b>'+ port.getName() + '</b>')
+                infos.append(port.getType())
+                val = port.getValue()
+                if port.getType() == "float":
                     val = round(val, 6)
                 infos.append(str(val))
                 for attrname in ATTR_NAMES:
-                    infos.append(inp.getAttribute(attrname))
+                    infos.append(port.getAttribute(attrname))
                 for info in infos:
                     print('<td>' + info + '</td>')
                 print('</tr>')
             print('</table>')
+
+        # Markdown output
         else:
             print('- *Nodedef*: %s' % nd.getName())
             print('- *Type*: %s' % nd.getType())
+            if len(nd.getVersionString()) > 0:
+                print('- *Version*: %s. Is default: %s' % (nd.getVersionString(), nd.getDefaultVersion()))
+            if len(nd.getInheritString()) > 0:
+                print('- *Inherits From*: %s' % nd.getInheritString())
             print('- *Doc*: %s\n' % nd.getAttribute('doc'))
             print('| ' + ' | '.join(HEADERS) + ' |')
             print('|' + ' ---- |' * len(HEADERS) + '')
-            for inp in nd.getInputs():
+            inputList = nd.getActiveInputs() if opts.showInherited  else nd.getInputs()
+            tokenList = nd.getActiveTokens() if opts.showInherited  else nd.getTokens()
+            outputList = nd.getActiveOutputs() if opts.showInherited  else nd.getOutputs()
+            totalList = inputList + tokenList + outputList;
+            for port in totalList:
                 infos = []
-                infos.append(inp.getName())
-                infos.append(inp.getType())
-                val = inp.getValue()
-                if inp.getType() == "float":
+                if port in outputList:
+                    infos.append('*'+ port.getName() + '*')
+                elif port in tokenList:
+                    infos.append(port.getName())
+                else:
+                    infos.append('**'+ port.getName() + '**')
+                infos.append(port.getType())
+                val = port.getValue()
+                if port.getType() == "float":
                     val = round(val, 6)
                 infos.append(str(val))
                 for attrname in ATTR_NAMES:
-                    infos.append(inp.getAttribute(attrname))
+                    infos.append(port.getAttribute(attrname))
                 print('| ' + " | ".join(infos) + ' |')
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Script Updates 

- Add support for `html` output as an option in addition to `Markdown`
- Add in additional attributes not currently output per attribute: `doc`, `ui name`
- Add in `output` and `token` port attribute support
- Add in `version`, `isdefaultversion`, and `inherit`. For inheritance, allow to emit inherited attributes as an option.
- For testing: add in html output for python tests as part of CI actions.

The formatting for html attempts to mimic that of Markdown as much as possible. 
(Note that it's possible an convert markdown pretty easily using the [markdown package for python ](https://pypi.org/project/Markdown/) but the markdown tables produced by this script don't parse properly).

## Examples 

### New Properties
Following is example output (run for CI action). It shows some of the additions include showing inheritance
![image](https://user-images.githubusercontent.com/49369885/156052100-2996ec31-6c71-40ea-b923-631778687cb1.png)

### HTML Output Comparison
![image](https://user-images.githubusercontent.com/49369885/156053909-d9ea953f-dec9-4536-a738-33919d0734f2.png)
### Markdown Output Comparison
![image](https://user-images.githubusercontent.com/49369885/156054303-2ba182bb-e327-4fac-a3a0-057cc2d695e4.png)

#### Generated HTML (For comparison example)
```html
<head><style>
table, th, td {
   border-bottom: 1px solid; border-collapse: collapse; padding: 10px;
}
</style></head>
<ul>
<li> <em>Nodedef</em>: ND_lama_conductor
<li> <em>Type</em>: BSDF
<li> <em>Version</em>: 1.0. Is default: True
<li> <em>Doc</em>: Lama conductor

</ul>
<table><tr>
<th>Name</th>
<th>Type</th>
<th>Default Value</th>
<th>UI name</th>
<th>UI min</th>
<th>UI max</th>
<th>UI Soft Min</th>
<th>UI Soft Max</th>
<th>UI step</th>
<th>UI group</th>
<th>UI Advanced</th>
<th>Doc</th>
<th>Uniform</th>
</tr>
<tr>
<td><b>tint</b></td>
<td>color3</td>
<td>1, 1, 1</td>
<td>Tint</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Overall color multiplier. It should be used with parcimony, as a non-white value breaks physicality. The prefered way to define the color of a conductor is through the Fresnel attributes right below.</td>
<td></td>
</tr>
<tr>
<td><b>fresnelMode</b></td>
<td>integer</td>
<td>0</td>
<td>Fresnel Mode</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Fresnel mode</td>
<td>true</td>
</tr>
<tr>
<td><b>IOR</b></td>
<td>vector3</td>
<td>0.18, 0.42, 1.37</td>
<td>IOR</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Index of refraction (often denoted by eta), defining the color reflected by the surface in the normal direction.</td>
<td></td>
</tr>
<tr>
<td><b>extinction</b></td>
<td>vector3</td>
<td>3.42, 2.35, 1.77</td>
<td>Extinction</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Extinction coefficient (often denoted by kappa), influencing how the reflected color curve evolves between its value in the normal direction (or 0 degree), and 1 when reaching 90 degrees. A null value does not deviate the curve at all.</td>
<td></td>
</tr>
<tr>
<td><b>reflectivity</b></td>
<td>color3</td>
<td>0.945, 0.7772, 0.3737</td>
<td>Reflectivity</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Color reflected by the surface in the normal direction.</td>
<td></td>
</tr>
<tr>
<td><b>edgeColor</b></td>
<td>color3</td>
<td>0.9979, 0.9813, 0.7523</td>
<td>Edge Color</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Indicates how the reflected color curve evolves between its value in the normal direction (or 0 degree), and 1 when reaching 90 degrees. Note that this color is unlikely to be reached, and just bends the curve towards it when reaching grazing angles. A null value does not deviate the curve at all.</td>
<td></td>
</tr>
<tr>
<td><b>roughness</b></td>
<td>float</td>
<td>0.1</td>
<td>Roughness</td>
<td>0.0</td>
<td>1.0</td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Micro-facet distribution roughness.</td>
<td></td>
</tr>
<tr>
<td><b>normal</b></td>
<td>vector3</td>
<td>None</td>
<td>Normal</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Main</td>
<td></td>
<td>Shading normal, typically defined by bump or normal mapping. Defaults to the smooth surface normal if not set.</td>
<td></td>
</tr>
<tr>
<td><b>anisotropy</b></td>
<td>float</td>
<td>0.0</td>
<td>Anisotropy</td>
<td>-1.0</td>
<td>1.0</td>
<td></td>
<td></td>
<td></td>
<td>Anisotropy</td>
<td></td>
<td>Defines the amount of anisotropy, changing the co-tangent axis roughness from the original value to 1 (or to 0 with a negative value).</td>
<td></td>
</tr>
<tr>
<td><b>anisotropyDirection</b></td>
<td>vector3</td>
<td>None</td>
<td>Direction</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Anisotropy</td>
<td></td>
<td>Overrides the surface tangent as the anisotropy direction.</td>
<td></td>
</tr>
<tr>
<td><b>anisotropyRotation</b></td>
<td>float</td>
<td>0.0</td>
<td>Rotation</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td>Anisotropy</td>
<td></td>
<td>Rotates the anisotropy direction (possibly overriden by the previous attribute) around the normal, from 0 to 360 degrees.</td>
<td></td>
</tr>
<tr>
<td><b>iridescenceThickness</b></td>
<td>float</td>
<td>0.0</td>
<td>Thickness</td>
<td>0.0</td>
<td></td>
<td></td>
<td>200.0</td>
<td></td>
<td>Iridescence</td>
<td></td>
<td>Thin film thickness in nanometers, driving the iridescent effect.</td>
<td></td>
</tr>
<tr>
<td><b>iridescenceIOR</b></td>
<td>float</td>
<td>1.5</td>
<td>IOR</td>
<td>1.0</td>
<td>3.0</td>
<td></td>
<td></td>
<td></td>
<td>Iridescence</td>
<td></td>
<td>Thin film index of refraction, driving the iridescent effect.</td>
<td></td>
</tr>
<tr>
<td><b>exteriorIOR</b></td>
<td>float</td>
<td>1.0</td>
<td>Exterior IOR</td>
<td>1.0</td>
<td>3.0</td>
<td></td>
<td></td>
<td></td>
<td>Advanced</td>
<td></td>
<td>Defines what the IOR of the exterior medium is (can be either the outside medium, eg. air or water, or in case of a layered material, the top layer medium, like plexiglass or varnish).</td>
<td></td>
</tr>
<tr>
<td><em>out</em></td>
<td>BSDF</td>
<td>None</td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
<td></td>
</tr>
</table>

```
