### PR TITLE
Fix typo in MDL thin_surface

### DIFF
--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -47,7 +47,7 @@
   <implementation name="IM_surface_genmdl" nodedef="ND_surface" target="genmdl" />
 
   <!-- <thin_surface> -->
-  <implementation name="IM_thin_surface_genmdl" nodedef="ND_thin_surface" sourcecode="mx::pbrlib::mx_thin_surface(mxp_front_bsdf:{{front_bsdf}}, mxp_front_edf:{{front_edf}}, (mxp_back_bsdf:{{back_bsdf}}, mxp_back_edf:{{back_edf}}, mxp_opacity:{{opacity}})" target="genmdl" />
+  <implementation name="IM_thin_surface_genmdl" nodedef="ND_thin_surface" sourcecode="mx::pbrlib::mx_thin_surface(mxp_front_bsdf:{{front_bsdf}}, mxp_front_edf:{{front_edf}}, mxp_back_bsdf:{{back_bsdf}}, mxp_back_edf:{{back_edf}}, mxp_opacity:{{opacity}})" target="genmdl" />
 
   <!-- <volume> -->
   <implementation name="IM_volume_genmdl" nodedef="ND_volume" sourcecode="mx::pbrlib::mx_volume(mxp_vdf:{{vdf}}, mxp_edf:{{edf}})" target="genmdl" />


### PR DESCRIPTION
This PR fixes a typo in the MDL shader generation.