### PR TITLE
Remove test coverage for color2 type

### DIFF
--- a/resources/Materials/TestSuite/stdlib/adjustment/smoothstep.mtlx
+++ b/resources/Materials/TestSuite/stdlib/adjustment/smoothstep.mtlx
@@ -20,22 +20,6 @@
     </smoothstep>
     <output name="out" type="float" nodename="smoothstep1" />
   </nodegraph>
-  <nodegraph name="smoothstep_color2">
-    <smoothstep name="smoothstep1" type="vector2">
-      <input name="in" type="vector2" value="0.6000, 0.5000" />
-      <input name="low" type="vector2" value="0.2000, 0.2000" />
-      <input name="high" type="vector2" value="0.8000, 0.8000" />
-    </smoothstep>
-    <output name="out" type="vector2" nodename="smoothstep1" />
-  </nodegraph>
-  <nodegraph name="smoothstep_color2FA">
-    <smoothstep name="smoothstep1" type="vector2">
-      <input name="in" type="vector2" value="0.6000, 0.5000" />
-      <input name="low" type="float" value="0.2000" />
-      <input name="high" type="float" value="0.8000" />
-    </smoothstep>
-    <output name="out" type="vector2" nodename="smoothstep1" />
-  </nodegraph>
   <nodegraph name="smoothstep_color3">
     <smoothstep name="smoothstep1" type="color3">
       <input name="in" type="color3" value="0.6000, 0.5000, 0.2000" />

--- a/resources/Materials/TestSuite/stdlib/channel/channel.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/channel.mtlx
@@ -1,12 +1,5 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="combine_color2">
-    <combine2 name="combine1" type="vector2">
-      <input name="in1" type="float" value="0.5000" />
-      <input name="in2" type="float" value="1.0000" />
-    </combine2>
-    <output name="out" type="vector2" nodename="combine1" />
-  </nodegraph>
   <nodegraph name="combine_vector2">
     <combine2 name="combine1" type="vector2">
       <input name="in1" type="float" value="0.5000" />
@@ -69,13 +62,6 @@
     </combine2>
     <output name="out" type="vector4" nodename="combine1" />
   </nodegraph>
-  <nodegraph name="extract_color2">
-    <extract name="extract1" type="float">
-      <input name="in" type="vector2" value="0.5000, 1.0" />
-      <input name="index" type="integer" value="1" />
-    </extract>
-    <output name="out" type="float" nodename="extract1" />
-  </nodegraph>
   <nodegraph name="extract_color3">
     <extract name="extract1" type="float">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
@@ -110,16 +96,6 @@
       <input name="index" type="integer" value="1" />
     </extract>
     <output name="out" type="float" nodename="extract1" />
-  </nodegraph>
-  <nodegraph name="separate_color2" type="vector2">
-    <separate2 name="separate1" type="multioutput">
-      <input name="in" type="vector2" value="0.42, 0.77" />
-    </separate2>
-    <combine2 name="combine1" type="vector2">
-      <input name="in1" type="float" nodename="separate1" output="outy" />
-      <input name="in2" type="float" nodename="separate1" output="outx" />
-    </combine2>
-    <output name="out" type="vector2" nodename="combine1" />
   </nodegraph>
   <nodegraph name="separate_color3" type="color3">
     <separate3 name="separate1" type="multioutput">

--- a/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/channels_attribute.mtlx
@@ -5,12 +5,6 @@
     Output test
 
     -->
-  <nodegraph name="image4_to_color2_ra_out">
-    <image name="image4" type="color4">
-      <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
-    </image>
-    <output name="out" type="vector2" nodename="image4" channels="rr" />
-  </nodegraph>
   <nodegraph name="image4_to_color3_bgr_out">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
@@ -29,12 +23,6 @@
     </constant>
     <output name="out" type="color4" nodename="constant1" channels="rrrr" />
   </nodegraph>
-  <nodegraph name="color2_to_color4_arar_out">
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="1.0, 0.5" />
-    </constant>
-    <output name="out" type="color4" nodename="constant1" channels="yxyx" />
-  </nodegraph>
   <nodegraph name="color3_to_color4_bgr1_out">
     <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.5, 0.7, 1.0" />
@@ -46,12 +34,6 @@
       <input name="value" type="color4" value="0.5, 0.7, 0.9, 1.0" />
     </constant>
     <output name="out" type="color3" nodename="constant1" channels="bgr" />
-  </nodegraph>
-  <nodegraph name="color4_to_color2_bg_out">
-    <constant name="constant1" type="color4">
-      <input name="value" type="color4" value="0.5, 0.7, 0.9, 1.0" />
-    </constant>
-    <output name="out" type="vector2" nodename="constant1" channels="bg" />
   </nodegraph>
   <nodegraph name="color4_to_float_g_out">
     <constant name="constant1" type="color4">
@@ -76,18 +58,6 @@
     </add>
     <output name="out" type="color3" nodename="add1" />
   </nodegraph>
-  <nodegraph name="image4_to_color2_ga_in">
-    <image name="image4" type="color4">
-      <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
-      <input name="uaddressmode" type="string" value="constant" />
-      <input name="vaddressmode" type="string" value="clamp" />
-    </image>
-    <add name="add1" type="vector2">
-      <input name="in1" type="vector2" nodename="image4" channels="gg" />
-      <input name="in2" type="vector2" value="0.5, 0.0" />
-    </add>
-    <output name="out" type="vector2" nodename="add1" />
-  </nodegraph>
   <nodegraph name="image4_to_float_g_in">
     <image name="image4" type="color4">
       <input name="file" type="filename" value="resources/Lights/san_giuseppe_bridge.hdr" />
@@ -110,16 +80,6 @@
     </add>
     <output name="out" type="color4" nodename="add1" />
   </nodegraph>
-  <nodegraph name="color2_to_color4_arar_in">
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="1.0, 0.5" />
-    </constant>
-    <add name="add1" type="color4">
-      <input name="in1" type="color4" nodename="constant1" channels="yxyx" />
-      <input name="in2" type="color4" value="0.1, 0.1, 0.1, 0.0" />
-    </add>
-    <output name="out" type="color4" nodename="add1" />
-  </nodegraph>
   <nodegraph name="color3_to_color4_bgr1_in">
     <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.5, 0.7, 1.0" />
@@ -139,16 +99,6 @@
       <input name="in2" type="color3" value="0.5, 0.5, 0.5" />
     </add>
     <output name="out" type="color3" nodename="add1" />
-  </nodegraph>
-  <nodegraph name="color4_to_color2_rg_in">
-    <constant name="constant1" type="color4">
-      <input name="value" type="color4" value="0.0, 0.5, 0.75, 1.0" />
-    </constant>
-    <add name="add1" type="vector2">
-      <input name="in1" type="vector2" nodename="constant1" channels="rg" />
-      <input name="in2" type="vector2" value="0.5, 0.5" />
-    </add>
-    <output name="out" type="vector2" nodename="add1" />
   </nodegraph>
   <nodegraph name="color4_to_float_g_in">
     <constant name="constant1" type="color4">

--- a/resources/Materials/TestSuite/stdlib/channel/swizzle.mtlx
+++ b/resources/Materials/TestSuite/stdlib/channel/swizzle.mtlx
@@ -1,12 +1,5 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="swizzle_float_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="float" value="0.5000" />
-      <input name="channels" type="string" value="rr" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
-  </nodegraph>
   <nodegraph name="swizzle_float_color3">
     <swizzle name="swizzle1" type="color3">
       <input name="in" type="float" value="0.5000" />
@@ -42,68 +35,12 @@
     </swizzle>
     <output name="out" type="vector4" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color2_float">
-    <swizzle name="swizzle1" type="float">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <output name="out" type="float" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color2_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="yx" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color2_color3">
-    <swizzle name="swizzle1" type="color3">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="yxy" />
-    </swizzle>
-    <output name="out" type="color3" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color2_color4">
-    <swizzle name="swizzle1" type="color4">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="xyxy" />
-    </swizzle>
-    <output name="out" type="color4" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color2_vector2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="yx" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color2_vector3">
-    <swizzle name="swizzle1" type="vector3">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="yxy" />
-    </swizzle>
-    <output name="out" type="vector3" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color2_vector4">
-    <swizzle name="swizzle1" type="vector4">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="channels" type="string" value="xyxy" />
-    </swizzle>
-    <output name="out" type="vector4" nodename="swizzle1" />
-  </nodegraph>
   <nodegraph name="swizzle_color3_float">
     <swizzle name="swizzle1" type="float">
       <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
       <input name="channels" type="string" value="g" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_color3_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="color3" value="0.0, 0.5000, 1.0000" />
-      <input name="channels" type="string" value="br" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
   <nodegraph name="swizzle_color3_color3">
     <swizzle name="swizzle1" type="color3">
@@ -147,13 +84,6 @@
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_color4_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
-      <input name="channels" type="string" value="ab" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
-  </nodegraph>
   <nodegraph name="swizzle_color4_color3">
     <swizzle name="swizzle1" type="color3">
       <input name="in" type="color4" value="0.0, 0.2500, 0.7500, 1.0" />
@@ -195,13 +125,6 @@
       <input name="channels" type="string" value="y" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_vector2_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="vector2" value="0.0, 1.0000" />
-      <input name="channels" type="string" value="yx" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
   <nodegraph name="swizzle_vector2_color3">
     <swizzle name="swizzle1" type="color3">
@@ -245,13 +168,6 @@
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
   </nodegraph>
-  <nodegraph name="swizzle_vector3_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
-      <input name="channels" type="string" value="zx" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
-  </nodegraph>
   <nodegraph name="swizzle_vector3_color3">
     <swizzle name="swizzle1" type="color3">
       <input name="in" type="vector3" value="0.0, 0.5000, 1.0000" />
@@ -293,13 +209,6 @@
       <input name="channels" type="string" value="w" />
     </swizzle>
     <output name="out" type="float" nodename="swizzle1" />
-  </nodegraph>
-  <nodegraph name="swizzle_vector4_color2">
-    <swizzle name="swizzle1" type="vector2">
-      <input name="in" type="vector4" value="0.0, 0.2500, 0.7500, 1.0" />
-      <input name="channels" type="string" value="wz" />
-    </swizzle>
-    <output name="out" type="vector2" nodename="swizzle1" />
   </nodegraph>
   <nodegraph name="swizzle_vector4_color3">
     <swizzle name="swizzle1" type="color3">

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_if_float.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_if_float.mtlx
@@ -13,15 +13,6 @@
     </ifgreater>
     <output name="out" type="float" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color2">
-    <ifgreater name="ifgreater1" type="vector2">
-      <input name="value1" type="float" value="0.8000" />
-      <input name="value2" type="float" value="0.6000" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifgreater>
-    <output name="out" type="vector2" nodename="ifgreater1" />
-  </nodegraph>
   <nodegraph name="ifgreater_color3">
     <ifgreater name="ifgreater1" type="color3">
       <input name="value1" type="float" value="0.8000" />
@@ -76,15 +67,6 @@
     </ifequal>
     <output name="out" type="float" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequal_color2">
-    <ifequal name="ifequal1" type="vector2">
-      <input name="value1" type="float" value="0.8000" />
-      <input name="value2" type="float" value="0.8000" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifequal>
-    <output name="out" type="vector2" nodename="ifequal1" />
-  </nodegraph>
   <nodegraph name="ifequal_color3">
     <ifequal name="ifequal1" type="color3">
       <input name="value1" type="float" value="0.8000" />
@@ -138,15 +120,6 @@
       <input name="in2" type="float" value="0.0" />
     </ifgreatereq>
     <output name="out" type="float" nodename="ifgreatereq1" />
-  </nodegraph>
-  <nodegraph name="ifgreatereq_color2">
-    <ifgreatereq name="ifgreatereq1" type="vector2">
-      <input name="value1" type="float" value="0.8000" />
-      <input name="value2" type="float" value="0.6000" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifgreatereq>
-    <output name="out" type="vector2" nodename="ifgreatereq1" />
   </nodegraph>
   <nodegraph name="ifgreatereq_color3">
     <ifgreatereq name="ifgreatereq1" type="color3">

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_if_int.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_if_int.mtlx
@@ -15,15 +15,6 @@
     </ifgreater>
     <output name="out" type="float" nodename="ifgreater1" />
   </nodegraph>
-  <nodegraph name="ifgreater_color2">
-    <ifgreater name="ifgreater1" type="vector2">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" value="6" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifgreater>
-    <output name="out" type="vector2" nodename="ifgreater1" />
-  </nodegraph>
   <nodegraph name="ifgreater_color3">
     <ifgreater name="ifgreater1" type="color3">
       <input name="value1" type="integer" value="8" />
@@ -79,15 +70,6 @@
       <input name="in2" type="float" value="0.0" />
     </ifequal>
     <output name="out" type="float" nodename="ifequal1" />
-  </nodegraph>
-  <nodegraph name="ifequal_color2">
-    <ifequal name="ifequal1" type="vector2">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" value="8" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifequal>
-    <output name="out" type="vector2" nodename="ifequal1" />
   </nodegraph>
   <nodegraph name="ifequal_color3">
     <ifequal name="ifequal1" type="color3">
@@ -145,15 +127,6 @@
     </ifequal>
     <output name="out" type="float" nodename="ifequal1" />
   </nodegraph>
-  <nodegraph name="ifequalB_color2">
-    <ifequal name="ifequal1" type="vector2">
-      <input name="value1" type="boolean" value="true" />
-      <input name="value2" type="boolean" value="true" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifequal>
-    <output name="out" type="vector2" nodename="ifequal1" />
-  </nodegraph>
   <nodegraph name="ifequalB_color3">
     <ifequal name="ifequal1" type="color3">
       <input name="value1" type="boolean" value="true" />
@@ -209,15 +182,6 @@
       <input name="in2" type="float" value="0.0" />
     </ifgreatereq>
     <output name="out" type="float" nodename="ifgreatereq1" />
-  </nodegraph>
-  <nodegraph name="ifgreatereq_color2">
-    <ifgreatereq name="ifgreatereq1" type="vector2">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" value="6" />
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.0, 0.0000" />
-    </ifgreatereq>
-    <output name="out" type="vector2" nodename="ifgreatereq1" />
   </nodegraph>
   <nodegraph name="ifgreatereq_color3">
     <ifgreatereq name="ifgreatereq1" type="color3">

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_switch.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_switch.mtlx
@@ -14,17 +14,6 @@
     </switch>
     <output name="out" type="float" nodename="switch1" />
   </nodegraph>
-  <nodegraph name="switch_color2">
-    <switch name="switch1" type="vector2">
-      <input name="in1" type="vector2" value="0.0, 0.0" />
-      <input name="in2" type="vector2" value="0.3000, 0.3000" />
-      <input name="in3" type="vector2" value="0.5000, 0.5000" />
-      <input name="in4" type="vector2" value="0.7000, 0.7000" />
-      <input name="in5" type="vector2" value="1.0000, 1.0000" />
-      <input name="which" type="float" value="1.0000" />
-    </switch>
-    <output name="out" type="vector2" nodename="switch1" />
-  </nodegraph>
   <nodegraph name="switch_color3">
     <switch name="switch1" type="color3">
       <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
@@ -90,17 +79,6 @@
       <input name="which" type="integer" value="0" />
     </switch>
     <output name="out" type="float" nodename="switch1" />
-  </nodegraph>
-  <nodegraph name="switch_color2I">
-    <switch name="switch1" type="vector2">
-      <input name="in1" type="vector2" value="0.0000, 0.0000" />
-      <input name="in2" type="vector2" value="0.3000, 0.3000" />
-      <input name="in3" type="vector2" value="0.5000, 0.5000" />
-      <input name="in4" type="vector2" value="0.7000, 0.7000" />
-      <input name="in5" type="vector2" value="1.0000, 1.0000" />
-      <input name="which" type="integer" value="1" />
-    </switch>
-    <output name="out" type="vector2" nodename="switch1" />
   </nodegraph>
   <nodegraph name="switch_color3I">
     <switch name="switch1" type="color3">

--- a/resources/Materials/TestSuite/stdlib/geometric/geompropvalue.mtlx
+++ b/resources/Materials/TestSuite/stdlib/geometric/geompropvalue.mtlx
@@ -34,10 +34,6 @@
   <geompropvalue name="geompropvalue_float" type="float">
     <input name="geomprop" type="string" value="geompropvalue_float" />
   </geompropvalue>
-  <output name="geompropvalue_color2_out" type="vector2" nodename="geompropvalue_color2" />
-  <geompropvalue name="geompropvalue_color2" type="vector2">
-    <input name="geomprop" type="string" value="geompropvalue_color2" />
-  </geompropvalue>
   <output name="geompropvalue_color3_out" type="color3" nodename="geompropvalue_color3" />
   <geompropvalue name="geompropvalue_color3" type="color3">
     <input name="geomprop" type="string" value="geompropvalue_color3" />

--- a/resources/Materials/TestSuite/stdlib/math/math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math.mtlx
@@ -153,15 +153,6 @@
     </constant>
     <output name="out" type="vector4" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="ceil_color2_nodegraph">
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="-0.5000, 0.5000" />
-    </constant>
-    <ceil name="ceil1" type="vector2">
-      <input name="in" type="vector2" nodename="constant1" />
-    </ceil>
-    <output name="out" type="vector2" nodename="ceil1" />
-  </nodegraph>
   <nodegraph name="ceil_color3_nodegraph">
     <constant name="constant1" type="color3">
       <input name="value" type="color3" value="-0.5000, 0.5000, 0.0" />
@@ -207,15 +198,6 @@
     </constant>
     <output name="out" type="vector4" nodename="floor1" />
   </nodegraph>
-  <nodegraph name="floor_color2_nodegraph">
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="0.5000, 1.5000" />
-    </constant>
-    <floor name="floor1" type="vector2">
-      <input name="in" type="vector2" nodename="constant1" />
-    </floor>
-    <output name="out" type="vector2" nodename="floor1" />
-  </nodegraph>
   <nodegraph name="floor_color3_nodegraph">
     <constant name="constant1" type="color3">
       <input name="value" type="color3" value="0.5000, 1.5000, 0.0" />
@@ -242,15 +224,6 @@
       <input name="in" type="float" nodename="constant1" />
     </sign>
     <output name="out" type="float" nodename="sign1" />
-  </nodegraph>
-  <nodegraph name="sign_color2">
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="0.0, 1.0" />
-    </constant>
-    <sign name="sign1" type="vector2">
-      <input name="in" type="vector2" nodename="constant1" />
-    </sign>
-    <output name="out" type="vector2" nodename="sign1" />
   </nodegraph>
   <nodegraph name="sign_color3">
     <constant name="constant1" type="color3">
@@ -331,12 +304,6 @@
     </absval>
     <output name="out" type="float" nodename="absval1" />
   </nodegraph>
-  <nodegraph name="absval_color2">
-    <absval name="absval1" type="vector2">
-      <input name="in" type="vector2" value="-0.5000, -0.2500" />
-    </absval>
-    <output name="out" type="vector2" nodename="absval1" />
-  </nodegraph>
   <nodegraph name="absval_color3">
     <absval name="absval1" type="color3">
       <input name="in" type="color3" value="-0.5000, -0.2500, 0.5000" />
@@ -416,20 +383,6 @@
     </invert>
     <output name="out" type="vector4" nodename="invert1" />
   </nodegraph>
-  <nodegraph name="invert_color2">
-    <invert name="invert1" type="vector2">
-      <input name="in" type="vector2" value="0.5000, 0.5000" />
-      <input name="amount" type="vector2" value="1.0, 0.5000" />
-    </invert>
-    <output name="out" type="vector2" nodename="invert1" />
-  </nodegraph>
-  <nodegraph name="invert_color2FA">
-    <invert name="invert1" type="vector2">
-      <input name="in" type="vector2" value="0.5000, 1.0" />
-      <input name="amount" type="float" value="1.0" />
-    </invert>
-    <output name="out" type="vector2" nodename="invert1" />
-  </nodegraph>
   <nodegraph name="invert_color3">
     <invert name="invert1" type="color3">
       <input name="in" type="color3" value="0.5000, 0.5000, 0.0" />
@@ -465,22 +418,6 @@
       <input name="high" type="float" value="0.5000" />
     </clamp>
     <output name="out" type="float" nodename="clamp1" />
-  </nodegraph>
-  <nodegraph name="clamp_color2">
-    <clamp name="clamp1" type="vector2">
-      <input name="in" type="vector2" value="1.0000, 0.0000" />
-      <input name="low" type="vector2" value="0.0000, 0.5000" />
-      <input name="high" type="vector2" value="0.5000, 1.0" />
-    </clamp>
-    <output name="out" type="vector2" nodename="clamp1" />
-  </nodegraph>
-  <nodegraph name="clamp_color2FA">
-    <clamp name="clamp1" type="vector2">
-      <input name="in" type="vector2" value="0.0, 1.0" />
-      <input name="low" type="float" value="0.5000" />
-      <input name="high" type="float" value="0.5000" />
-    </clamp>
-    <output name="out" type="vector2" nodename="clamp1" />
   </nodegraph>
   <nodegraph name="clamp_color3">
     <clamp name="clamp1" type="color3">
@@ -569,20 +506,6 @@
     </min>
     <output name="out" type="float" nodename="min1" />
   </nodegraph>
-  <nodegraph name="min_color2">
-    <min name="min1" type="vector2">
-      <input name="in1" type="vector2" value="0.5000, 1.0" />
-      <input name="in2" type="vector2" value="1.0000, 0.5000" />
-    </min>
-    <output name="out" type="vector2" nodename="min1" />
-  </nodegraph>
-  <nodegraph name="min_color2FA">
-    <min name="min1" type="vector2">
-      <input name="in1" type="vector2" value="0.0, 1.0" />
-      <input name="in2" type="float" value="0.5000" />
-    </min>
-    <output name="out" type="vector2" nodename="min1" />
-  </nodegraph>
   <nodegraph name="min_color3">
     <min name="min1" type="color3">
       <input name="in1" type="color3" value="0.5000, 1.0000, 0.5000" />
@@ -659,20 +582,6 @@
       <input name="in2" type="float" value="1.0000" />
     </max>
     <output name="out" type="float" nodename="max1" />
-  </nodegraph>
-  <nodegraph name="max_color2">
-    <max name="max1" type="vector2">
-      <input name="in1" type="vector2" value="0.5000, 1.0" />
-      <input name="in2" type="vector2" value="1.0000, 0.5000" />
-    </max>
-    <output name="out" type="vector2" nodename="max1" />
-  </nodegraph>
-  <nodegraph name="max_color2FA">
-    <max name="max1" type="vector2">
-      <input name="in1" type="vector2" value="0.0, 1.0" />
-      <input name="in2" type="float" value="0.5000" />
-    </max>
-    <output name="out" type="vector2" nodename="max1" />
   </nodegraph>
   <nodegraph name="max_color3">
     <max name="max1" type="color3">

--- a/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
@@ -7,20 +7,6 @@
     </add>
     <output name="out" type="float" nodename="add1" />
   </nodegraph>
-  <nodegraph name="add_color2">
-    <add name="add1" type="vector2">
-      <input name="in1" type="vector2" value="0.2000, 0.0000" />
-      <input name="in2" type="vector2" value="0.3000, 1.0" />
-    </add>
-    <output name="out" type="vector2" nodename="add1" />
-  </nodegraph>
-  <nodegraph name="add_color2FA">
-    <add name="add1" type="vector2">
-      <input name="in1" type="vector2" value="0.2000, 0.4500" />
-      <input name="in2" type="float" value="0.3000" />
-    </add>
-    <output name="out" type="vector2" nodename="add1" />
-  </nodegraph>
   <nodegraph name="add_color3">
     <add name="add1" type="color3">
       <input name="in1" type="color3" value="0.2000, 0.3000, 0.0" />
@@ -97,20 +83,6 @@
       <input name="in2" type="float" value="0.5000" />
     </subtract>
     <output name="out" type="float" nodename="subtract1" />
-  </nodegraph>
-  <nodegraph name="subtract_color2">
-    <subtract name="subtract1" type="vector2">
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="0.5000, 0.0000" />
-    </subtract>
-    <output name="out" type="vector2" nodename="subtract1" />
-  </nodegraph>
-  <nodegraph name="subtract_color2FA">
-    <subtract name="subtract1" type="vector2">
-      <input name="in1" type="vector2" value="1.0000, 0.5000" />
-      <input name="in2" type="float" value="0.5000" />
-    </subtract>
-    <output name="out" type="vector2" nodename="subtract1" />
   </nodegraph>
   <nodegraph name="subtract_color3">
     <subtract name="subtract1" type="color3">
@@ -189,20 +161,6 @@
     </multiply>
     <output name="out" type="float" nodename="multiply1" />
   </nodegraph>
-  <nodegraph name="multiply_color2">
-    <multiply name="multiply1" type="vector2">
-      <input name="in1" type="vector2" value="1.0000, 0.5000" />
-      <input name="in2" type="vector2" value="0.5000, 0.5000" />
-    </multiply>
-    <output name="out" type="vector2" nodename="multiply1" />
-  </nodegraph>
-  <nodegraph name="multiply_color2FA">
-    <multiply name="multiply1" type="vector2">
-      <input name="in1" type="vector2" value="1.0000, 0.5000" />
-      <input name="in2" type="float" value="0.5000" />
-    </multiply>
-    <output name="out" type="vector2" nodename="multiply1" />
-  </nodegraph>
   <nodegraph name="multiply_color3">
     <multiply name="multiply1" type="color3">
       <input name="in1" type="color3" value="1.0000, 0.5000, 0.0000" />
@@ -279,20 +237,6 @@
       <input name="in2" type="float" value="2.0000" />
     </divide>
     <output name="out" type="float" nodename="divide1" />
-  </nodegraph>
-  <nodegraph name="divide_color2">
-    <divide name="divide1" type="vector2">
-      <input name="in1" type="vector2" value="1.0000, 1.0" />
-      <input name="in2" type="vector2" value="2.0000, 4.0000" />
-    </divide>
-    <output name="out" type="vector2" nodename="divide1" />
-  </nodegraph>
-  <nodegraph name="divide_color2FA">
-    <divide name="divide1" type="vector2">
-      <input name="in1" type="vector2" value="2.0000, 1.0" />
-      <input name="in2" type="float" value="4.0000" />
-    </divide>
-    <output name="out" type="vector2" nodename="divide1" />
   </nodegraph>
   <nodegraph name="divide_color3">
     <divide name="divide1" type="color3">
@@ -371,20 +315,6 @@
     </modulo>
     <output name="out" type="float" nodename="modulo1" />
   </nodegraph>
-  <nodegraph name="modulo_color2">
-    <modulo name="modulo1" type="vector2">
-      <input name="in1" type="vector2" value="1.5000, 1.0" />
-      <input name="in2" type="vector2" value="1.0000, 1.0000" />
-    </modulo>
-    <output name="out" type="vector2" nodename="modulo1" />
-  </nodegraph>
-  <nodegraph name="modulo_color2FA">
-    <modulo name="modulo1" type="vector2">
-      <input name="in1" type="vector2" value="1.5000, 1.0" />
-      <input name="in2" type="float" value="1.0000" />
-    </modulo>
-    <output name="out" type="vector2" nodename="modulo1" />
-  </nodegraph>
   <nodegraph name="modulo_color3">
     <modulo name="modulo1" type="color3">
       <input name="in1" type="color3" value="1.5000, 1.0000, 0.0" />
@@ -461,20 +391,6 @@
       <input name="in2" type="float" value="2.0000" />
     </power>
     <output name="out" type="float" nodename="power1" />
-  </nodegraph>
-  <nodegraph name="power_color2">
-    <power name="power1" type="vector2">
-      <input name="in1" type="vector2" value="0.5000, 1.0" />
-      <input name="in2" type="vector2" value="2.0000, 1.0" />
-    </power>
-    <output name="out" type="vector2" nodename="power1" />
-  </nodegraph>
-  <nodegraph name="power_color2FA">
-    <power name="power1" type="vector2">
-      <input name="in1" type="vector2" value="0.5000, 1.0000" />
-      <input name="in2" type="float" value="2.0000" />
-    </power>
-    <output name="out" type="vector2" nodename="power1" />
   </nodegraph>
   <nodegraph name="power_color3">
     <power name="power1" type="color3">

--- a/resources/Materials/TestSuite/stdlib/organization/organization.mtlx
+++ b/resources/Materials/TestSuite/stdlib/organization/organization.mtlx
@@ -10,16 +10,6 @@
       <input name="value" type="float" value="0.5000" />
     </constant>
   </nodegraph>
-  <nodegraph name="dot_color2">
-    <dot name="dot1" type="vector2">
-      <input name="in" type="vector2" nodename="constant1" />
-      <input name="note" type="string" value="" />
-    </dot>
-    <output name="out" type="vector2" nodename="dot1" />
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="0.5000, 1.0" />
-    </constant>
-  </nodegraph>
   <nodegraph name="dot_color3">
     <dot name="dot1" type="color3">
       <input name="in" type="color3" nodename="constant1" />

--- a/resources/Materials/TestSuite/stdlib/texture/image.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image.mtlx
@@ -11,10 +11,6 @@
     <input name="file" type="filename" value="resources/Images/grid.png" />
   </image>
   <output name="image_color3_output" type="color3" nodename="image_color3" />
-  <image name="image_color2" type="vector2">
-    <input name="file" type="filename" value="resources/Images/grid.png" />
-  </image>
-  <output name="image_color2_output" type="vector2" nodename="image_color2" />
   <image name="image_vector4" type="vector4">
     <input name="file" type="filename" value="resources/Images/grid.png" />
   </image>


### PR DESCRIPTION
This changelist removes legacy test coverage for the color2 data type, which is no longer present in MaterialX 1.38.