### PR TITLE
Remove hardcoded search path string

### DIFF
--- a/libraries/lights/genglsl/lights_genglsl_impl.mtlx
+++ b/libraries/lights/genglsl/lights_genglsl_impl.mtlx
@@ -2,12 +2,12 @@
 <materialx version="1.37">
 
   <!-- <point_light> -->
-  <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="lights/genglsl/mx_point_light.glsl" function="mx_point_light" target="genglsl"/>
+  <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="libraries/lights/genglsl/mx_point_light.glsl" function="mx_point_light" target="genglsl"/>
 
   <!-- <directional_light> -->
-  <implementation name="IM_directional_light_genglsl" nodedef="ND_directional_light" file="lights/genglsl/mx_directional_light.glsl" function="mx_directional_light" target="genglsl"/>
+  <implementation name="IM_directional_light_genglsl" nodedef="ND_directional_light" file="libraries/lights/genglsl/mx_directional_light.glsl" function="mx_directional_light" target="genglsl"/>
 
   <!-- <spot_light> -->
-  <implementation name="IM_spot_light_genglsl" nodedef="ND_spot_light" file="lights/genglsl/mx_spot_light.glsl" function="mx_spot_light" target="genglsl"/>
+  <implementation name="IM_spot_light_genglsl" nodedef="ND_spot_light" file="libraries/lights/genglsl/mx_spot_light.glsl" function="mx_spot_light" target="genglsl"/>
 
 </materialx>

--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
 // Section 20.4 Equation 13

--- a/libraries/pbrlib/genglsl/lib/mx_environment_none.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_none.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution, FresnelData fd)
 {

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 float mx_latlong_compute_lod(float alpha)
 {

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet.glsl"
 
 // Based on the OSL implementation of Oren-Nayar diffuse, which is in turn
 // based on https://mimosa-pudica.net/improved-oren-nayar.html.

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet.glsl"
 
 // http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 // Equation 2

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet.glsl"
 
 // Fresnel model options.
 const int FRESNEL_MODEL_DIELECTRIC = 0;

--- a/libraries/pbrlib/genglsl/lib/mx_table.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_table.glsl
@@ -1,5 +1,5 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 vec3 mx_generate_dir_albedo_table()
 {

--- a/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
 
 void mx_burley_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 ior_n, vec3 ior_k, vec2 roughness, vec3 N, vec3 X, int distribution, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
 
 void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
 
 void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
+#include "libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
 
 void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl
@@ -1,4 +1,4 @@
-﻿#include "pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+﻿#include "libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
 
 void mx_subsurface_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -2,31 +2,31 @@
 <materialx version="1.38">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genglsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genglsl" />
+  <implementation name="IM_oren_nayar_diffuse_bsdf_genglsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genglsl" />
 
   <!-- <burley_diffuse_bsdf> -->
-  <implementation name="IM_burley_diffuse_bsdf_genglsl" nodedef="ND_burley_diffuse_bsdf" file="pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl" function="mx_burley_diffuse_bsdf" target="genglsl" />
+  <implementation name="IM_burley_diffuse_bsdf_genglsl" nodedef="ND_burley_diffuse_bsdf" file="libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl" function="mx_burley_diffuse_bsdf" target="genglsl" />
 
   <!-- <translucent_bsdf> -->
-  <implementation name="IM_translucent_bsdf_genglsl" nodedef="ND_translucent_bsdf" file="pbrlib/genglsl/mx_translucent_bsdf.glsl" function="mx_translucent_bsdf" target="genglsl" />
+  <implementation name="IM_translucent_bsdf_genglsl" nodedef="ND_translucent_bsdf" file="libraries/pbrlib/genglsl/mx_translucent_bsdf.glsl" function="mx_translucent_bsdf" target="genglsl" />
 
   <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genglsl" nodedef="ND_dielectric_bsdf" file="pbrlib/genglsl/mx_dielectric_bsdf.glsl" function="mx_dielectric_bsdf" target="genglsl" />
+  <implementation name="IM_dielectric_bsdf_genglsl" nodedef="ND_dielectric_bsdf" file="libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl" function="mx_dielectric_bsdf" target="genglsl" />
 
   <!-- <conductor_bsdf> -->
-  <implementation name="IM_conductor_bsdf_genglsl" nodedef="ND_conductor_bsdf" file="pbrlib/genglsl/mx_conductor_bsdf.glsl" function="mx_conductor_bsdf" target="genglsl" />
+  <implementation name="IM_conductor_bsdf_genglsl" nodedef="ND_conductor_bsdf" file="libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl" function="mx_conductor_bsdf" target="genglsl" />
 
   <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genglsl" nodedef="ND_generalized_schlick_bsdf" file="pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl" function="mx_generalized_schlick_bsdf" target="genglsl" />
+  <implementation name="IM_generalized_schlick_bsdf_genglsl" nodedef="ND_generalized_schlick_bsdf" file="libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl" function="mx_generalized_schlick_bsdf" target="genglsl" />
 
   <!-- <subsurface_bsdf> -->
-  <implementation name="IM_subsurface_bsdf_genglsl" nodedef="ND_subsurface_bsdf" file="pbrlib/genglsl/mx_subsurface_bsdf.glsl" function="mx_subsurface_bsdf" target="genglsl" />
+  <implementation name="IM_subsurface_bsdf_genglsl" nodedef="ND_subsurface_bsdf" file="libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl" function="mx_subsurface_bsdf" target="genglsl" />
 
   <!-- <sheen_bsdf> -->
-  <implementation name="IM_sheen_bsdf_genglsl" nodedef="ND_sheen_bsdf" file="pbrlib/genglsl/mx_sheen_bsdf.glsl" function="mx_sheen_bsdf" target="genglsl" />
+  <implementation name="IM_sheen_bsdf_genglsl" nodedef="ND_sheen_bsdf" file="libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl" function="mx_sheen_bsdf" target="genglsl" />
 
   <!-- <anisotropic_vdf> -->
-  <implementation name="IM_anisotropic_vdf_genglsl" nodedef="ND_anisotropic_vdf" file="pbrlib/genglsl/mx_anisotropic_vdf.glsl" function="mx_anisotropic_vdf" target="genglsl" />
+  <implementation name="IM_anisotropic_vdf_genglsl" nodedef="ND_anisotropic_vdf" file="libraries/pbrlib/genglsl/mx_anisotropic_vdf.glsl" function="mx_anisotropic_vdf" target="genglsl" />
 
   <!-- <thin_film_bsdf> -->
   <implementation name="IM_thin_film_bsdf_genglsl" nodedef="ND_thin_film_bsdf" target="genglsl" />
@@ -50,7 +50,7 @@
   <implementation name="IM_multiply_edfF_genglsl" nodedef="ND_multiply_edfF" target="genglsl" />
 
   <!-- <uniform_edf> -->
-  <implementation name="IM_uniform_edf_genglsl" nodedef="ND_uniform_edf" file="pbrlib/genglsl/mx_uniform_edf.glsl" function="mx_uniform_edf" target="genglsl" />
+  <implementation name="IM_uniform_edf_genglsl" nodedef="ND_uniform_edf" file="libraries/pbrlib/genglsl/mx_uniform_edf.glsl" function="mx_uniform_edf" target="genglsl" />
 
   <!-- <surface> -->
   <implementation name="IM_surface_genglsl" nodedef="ND_surface" target="genglsl" />
@@ -59,12 +59,12 @@
   <implementation name="IM_light_genglsl" nodedef="ND_light" target="genglsl" />
 
   <!-- <roughness_anisotropy> -->
-  <implementation name="IM_roughness_anisotropy_genglsl" nodedef="ND_roughness_anisotropy" file="pbrlib/genglsl/mx_roughness_anisotropy.glsl" function="mx_roughness_anisotropy" target="genglsl" />
+  <implementation name="IM_roughness_anisotropy_genglsl" nodedef="ND_roughness_anisotropy" file="libraries/pbrlib/genglsl/mx_roughness_anisotropy.glsl" function="mx_roughness_anisotropy" target="genglsl" />
 
   <!-- <roughness_dual> -->
-  <implementation name="IM_roughness_dual_genglsl" nodedef="ND_roughness_dual" file="pbrlib/genglsl/mx_roughness_dual.glsl" function="mx_roughness_dual" target="genglsl" />
+  <implementation name="IM_roughness_dual_genglsl" nodedef="ND_roughness_dual" file="libraries/pbrlib/genglsl/mx_roughness_dual.glsl" function="mx_roughness_dual" target="genglsl" />
 
   <!-- <artistic_ior> -->
-  <implementation name="IM_artistic_ior_genglsl" nodedef="ND_artistic_ior" file="pbrlib/genglsl/mx_artistic_ior.glsl" function="mx_artistic_ior" target="genglsl" />
+  <implementation name="IM_artistic_ior_genglsl" nodedef="ND_artistic_ior" file="libraries/pbrlib/genglsl/mx_artistic_ior.glsl" function="mx_artistic_ior" target="genglsl" />
 
 </materialx>

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
@@ -1,4 +1,4 @@
-#include "pbrlib/genosl/lib/mx_microfacet.osl"
+#include "libraries/pbrlib/genosl/lib/mx_microfacet.osl"
 
 // Rational curve fit approximation for the directional albedo of Imageworks sheen.
 float mx_imageworks_sheen_dir_albedo_analytic(float NdotV, float roughness)

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
@@ -1,4 +1,4 @@
-#include "pbrlib/genosl/lib/mx_microfacet.osl"
+#include "libraries/pbrlib/genosl/lib/mx_microfacet.osl"
 
 // Compute the average of an anisotropic alpha pair.
 float mx_average_alpha(vector2 alpha)

--- a/libraries/pbrlib/genosl/mx_conductor_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_conductor_bsdf.osl
@@ -1,4 +1,4 @@
-#include "pbrlib/genosl/lib/mx_microfacet_specular.osl"
+#include "libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl"
 
 void mx_conductor_bsdf(float weight, color ior_n, color ior_k, vector2 roughness, normal N, vector U, string distribution, output BSDF bsdf)
 {

--- a/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
@@ -1,4 +1,4 @@
-#include "pbrlib/genosl/lib/mx_microfacet_specular.osl"
+#include "libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl"
 
 void mx_dielectric_bsdf(float weight, color tint, float ior, vector2 roughness, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {

--- a/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
@@ -1,4 +1,4 @@
-#include "pbrlib/genosl/lib/mx_microfacet_specular.osl"
+#include "libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl"
 
 void mx_generalized_schlick_bsdf(float weight, color color0, color color90, float exponent, vector2 roughness, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {

--- a/libraries/pbrlib/genosl/mx_sheen_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_sheen_bsdf.osl
@@ -1,4 +1,4 @@
-#include "pbrlib/genosl/lib/mx_microfacet_sheen.osl"
+#include "libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl"
 
 // TODO: Vanilla OSL doesn't have a proper sheen closure,
 // so use 'diffuse' scaled by sheen directional albedo for now.

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -2,37 +2,37 @@
 <materialx version="1.38">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" file="pbrlib/genosl/mx_oren_nayar_diffuse_bsdf.osl" function="mx_oren_nayar_diffuse_bsdf" target="genosl" />
+  <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" file="libraries/pbrlib/genosl/mx_oren_nayar_diffuse_bsdf.osl" function="mx_oren_nayar_diffuse_bsdf" target="genosl" />
 
   <!-- <burley_diffuse_bsdf> -->
-  <implementation name="IM_burley_diffuse_bsdf_genosl" nodedef="ND_burley_diffuse_bsdf" file="pbrlib/genosl/mx_burley_diffuse_bsdf.osl" function="mx_burley_diffuse_bsdf" target="genosl" />
+  <implementation name="IM_burley_diffuse_bsdf_genosl" nodedef="ND_burley_diffuse_bsdf" file="libraries/pbrlib/genosl/mx_burley_diffuse_bsdf.osl" function="mx_burley_diffuse_bsdf" target="genosl" />
 
   <!-- <translucent_bsdf> -->
-  <implementation name="IM_translucent_bsdf_genosl" nodedef="ND_translucent_bsdf" file="pbrlib/genosl/mx_translucent_bsdf.osl" function="mx_translucent_bsdf" target="genosl" />
+  <implementation name="IM_translucent_bsdf_genosl" nodedef="ND_translucent_bsdf" file="libraries/pbrlib/genosl/mx_translucent_bsdf.osl" function="mx_translucent_bsdf" target="genosl" />
 
   <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genosl" nodedef="ND_dielectric_bsdf" file="pbrlib/genosl/mx_dielectric_bsdf.osl" function="mx_dielectric_bsdf" target="genosl" />
+  <implementation name="IM_dielectric_bsdf_genosl" nodedef="ND_dielectric_bsdf" file="libraries/pbrlib/genosl/mx_dielectric_bsdf.osl" function="mx_dielectric_bsdf" target="genosl" />
 
   <!-- <conductor_bsdf> -->
-  <implementation name="IM_conductor_bsdf_genosl" nodedef="ND_conductor_bsdf" file="pbrlib/genosl/mx_conductor_bsdf.osl" function="mx_conductor_bsdf" target="genosl" />
+  <implementation name="IM_conductor_bsdf_genosl" nodedef="ND_conductor_bsdf" file="libraries/pbrlib/genosl/mx_conductor_bsdf.osl" function="mx_conductor_bsdf" target="genosl" />
 
   <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genosl" nodedef="ND_generalized_schlick_bsdf" file="pbrlib/genosl/mx_generalized_schlick_bsdf.osl" function="mx_generalized_schlick_bsdf" target="genosl" />
+  <implementation name="IM_generalized_schlick_bsdf_genosl" nodedef="ND_generalized_schlick_bsdf" file="libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl" function="mx_generalized_schlick_bsdf" target="genosl" />
 
   <!-- <subsurface_bsdf> -->
-  <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="pbrlib/genosl/mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
+  <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="libraries/pbrlib/genosl/mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
 
   <!-- <sheen_bsdf> -->
-  <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" file="pbrlib/genosl/mx_sheen_bsdf.osl" function="mx_sheen_bsdf" target="genosl" />
+  <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" file="libraries/pbrlib/genosl/mx_sheen_bsdf.osl" function="mx_sheen_bsdf" target="genosl" />
 
   <!-- <anisotropic_vdf> -->
-  <implementation name="IM_anisotropic_vdf_genosl" nodedef="ND_anisotropic_vdf" file="pbrlib/genosl/mx_anisotropic_vdf.osl" function="mx_anisotropic_vdf" target="genosl" />
+  <implementation name="IM_anisotropic_vdf_genosl" nodedef="ND_anisotropic_vdf" file="libraries/pbrlib/genosl/mx_anisotropic_vdf.osl" function="mx_anisotropic_vdf" target="genosl" />
 
   <!-- <thin_film_bsdf> -->
   <implementation name="IM_thin_film_bsdf_genosl" nodedef="ND_thin_film_bsdf" target="genosl" />
 
   <!-- <uniform_edf> -->
-  <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" file="pbrlib/genosl/mx_uniform_edf.inline" target="genosl" />
+  <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" file="libraries/pbrlib/genosl/mx_uniform_edf.inline" target="genosl" />
 
   <!-- <layer> -->
   <implementation name="IM_layer_bsdf_genosl" nodedef="ND_layer_bsdf" target="genosl" />
@@ -53,19 +53,19 @@
   <implementation name="IM_multiply_edfF_genosl" nodedef="ND_multiply_edfF" target="genosl" />
 
   <!-- <surface> -->
-  <implementation name="IM_surface_genosl" nodedef="ND_surface" file="pbrlib/genosl/mx_surface.osl" function="mx_surface" target="genosl" />
+  <implementation name="IM_surface_genosl" nodedef="ND_surface" file="libraries/pbrlib/genosl/mx_surface.osl" function="mx_surface" target="genosl" />
 
   <!-- <displacement> -->
-  <implementation name="IM_displacement_float_genosl" nodedef="ND_displacement_float" file="pbrlib/genosl/mx_displacement_float.osl" function="mx_displacement_float" target="genosl" />
-  <implementation name="IM_displacement_vector3_genosl" nodedef="ND_displacement_vector3" file="pbrlib/genosl/mx_displacement_vector3.osl" function="mx_displacement_vector3" target="genosl" />
+  <implementation name="IM_displacement_float_genosl" nodedef="ND_displacement_float" file="libraries/pbrlib/genosl/mx_displacement_float.osl" function="mx_displacement_float" target="genosl" />
+  <implementation name="IM_displacement_vector3_genosl" nodedef="ND_displacement_vector3" file="libraries/pbrlib/genosl/mx_displacement_vector3.osl" function="mx_displacement_vector3" target="genosl" />
 
   <!-- <roughness_anisotropy> -->
-  <implementation name="IM_roughness_anisotropy_genosl" nodedef="ND_roughness_anisotropy" file="pbrlib/genosl/mx_roughness_anisotropy.osl" function="mx_roughness_anisotropy" target="genosl" />
+  <implementation name="IM_roughness_anisotropy_genosl" nodedef="ND_roughness_anisotropy" file="libraries/pbrlib/genosl/mx_roughness_anisotropy.osl" function="mx_roughness_anisotropy" target="genosl" />
 
   <!-- <roughness_dual> -->
-  <implementation name="IM_roughness_dual_genosl" nodedef="ND_roughness_dual" file="pbrlib/genosl/mx_roughness_dual.osl" function="mx_roughness_dual" target="genosl" />
+  <implementation name="IM_roughness_dual_genosl" nodedef="ND_roughness_dual" file="libraries/pbrlib/genosl/mx_roughness_dual.osl" function="mx_roughness_dual" target="genosl" />
 
   <!-- <artistic_ior> -->
-  <implementation name="IM_artistic_ior_genosl" nodedef="ND_artistic_ior" file="pbrlib/genosl/mx_artistic_ior.osl" function="mx_artistic_ior" target="genosl" />
+  <implementation name="IM_artistic_ior_genosl" nodedef="ND_artistic_ior" file="libraries/pbrlib/genosl/mx_artistic_ior.osl" function="mx_artistic_ior" target="genosl" />
 
 </materialx>

--- a/libraries/stdlib/genglsl/mx_ap1_to_rec709_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_ap1_to_rec709_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
 
 void mx_ap1_to_rec709_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_ap1_to_rec709_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_ap1_to_rec709_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
 
 void mx_ap1_to_rec709_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_burn_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_burn_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_burn_float.glsl"
+#include "libraries/stdlib/genglsl/mx_burn_float.glsl"
 
 void mx_burn_color3(vec3 fg, vec3 bg, float mixval, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_burn_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_burn_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_burn_float.glsl"
+#include "libraries/stdlib/genglsl/mx_burn_float.glsl"
 
 void mx_burn_color4(vec4 fg, vec4 bg, float mixval, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_cellnoise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_cellnoise2d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_cellnoise2d_float(vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_cellnoise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_cellnoise3d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_cellnoise3d_float(vec3 position, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_dodge_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_dodge_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_dodge_float.glsl"
+#include "libraries/stdlib/genglsl/mx_dodge_float.glsl"
 
 void mx_dodge_color3(vec3 fg, vec3 bg, float mixval, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_dodge_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_dodge_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_dodge_float.glsl"
+#include "libraries/stdlib/genglsl/mx_dodge_float.glsl"
 
 void mx_dodge_color4(vec4 fg , vec4 bg , float mixval, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_fa_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_fa_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_fa_vector2(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_fa_vector3(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_fa_vector4(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_float(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_vector2(vec2 amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_vector3(vec3 amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_fractal3d_vector4(vec4 amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
 
 void mx_g22_ap1_to_lin_rec709_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
 
 void mx_g22_ap1_to_lin_rec709_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_hsvtorgb_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_hsvtorgb_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_hsv.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
 
 void mx_hsvtorgb_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_hsv.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
 
 void mx_hsvtorgb_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_fa_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_fa_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_fa_vector2(float amplitude, float pivot, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_fa_vector3(float amplitude, float pivot, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_fa_vector4(float amplitude, float pivot, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_float(float amplitude, float pivot, vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_vector2(vec2 amplitude, float pivot, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_vector3(vec3 amplitude, float pivot, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise2d_vector4(vec4 amplitude, float pivot, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_fa_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_fa_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_fa_vector2(float amplitude, float pivot, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_fa_vector3(float amplitude, float pivot, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_fa_vector4(float amplitude, float pivot, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_float(float amplitude, float pivot, vec3 position, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_vector2(vec2 amplitude, float pivot, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_vector3(vec3 amplitude, float pivot, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_noise3d_vector4(vec4 amplitude, float pivot, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_overlay_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_overlay_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_overlay.glsl"
+#include "libraries/stdlib/genglsl/mx_overlay.glsl"
 
 void mx_overlay_color3(vec3 fg, vec3 bg, float mix, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_overlay_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_overlay_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_overlay.glsl"
+#include "libraries/stdlib/genglsl/mx_overlay.glsl"
 
 void mx_overlay_color4(vec4 fg, vec4 bg, float mix, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_rgbtohsv_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_rgbtohsv_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_hsv.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
 
 void mx_rgbtohsv_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_hsv.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
 
 void mx_rgbtohsv_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec2.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec2(vec2 val, vec2 low, vec2 high, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec2FA.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec2FA.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec2FA(vec2 val, float low, float high, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec3(vec3 val, vec3 low, vec3 high, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec3FA(vec3 val, float low, float high, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec4(vec4 val, vec4 low, vec4 high, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec4FA(vec4 val, float low, float high, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_float.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splitlr_float(float valuel, float valuer, float center, vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splitlr_vector2(vec2 valuel, vec2 valuer, float center, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splitlr_vector3(vec3 valuel, vec3 valuer, float center, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splitlr_vector4(vec4 valuel, vec4 valuer, float center, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_float.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splittb_float(float valuet, float valueb, float center, vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splittb_vector2(vec2 valuet, vec2 valueb, float center, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splittb_vector3(vec3 valuet, vec3 valueb, float center, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/mx_aastep.glsl"
+#include "libraries/stdlib/genglsl/mx_aastep.glsl"
 
 void mx_splittb_vector4(vec4 valuet, vec4 valueb, float center, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
 
 void mx_srgb_texture_to_lin_rec709_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
 
 void mx_srgb_texture_to_lin_rec709_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_worleynoise2d_float(vec2 texcoord, float jitter, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_worleynoise2d_vector2(vec2 texcoord, float jitter, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_worleynoise2d_vector3(vec2 texcoord, float jitter, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_worleynoise3d_float(vec3 position, float jitter, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_worleynoise3d_vector2(vec3 position, float jitter, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "stdlib/genglsl/lib/mx_noise.glsl"
+#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
 
 void mx_worleynoise3d_vector3(vec3 position, float jitter, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/stdlib_genglsl_cm_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_cm_impl.mtlx
@@ -5,20 +5,20 @@
   <!-- Color Management System Implementations -->
   <!-- ======================================================================== -->
 
-  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_gamma18_to_linear_color3.glsl" function="mx_gamma18_to_linear_color3" target="genglsl" />
-  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma18_to_linear_color4.glsl" function="mx_gamma18_to_linear_color4" target="genglsl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_gamma22_to_linear_color3.glsl" function="mx_gamma22_to_linear_color3" target="genglsl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma22_to_linear_color4.glsl" function="mx_gamma22_to_linear_color4" target="genglsl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_gamma24_to_linear_color3.glsl" function="mx_gamma24_to_linear_color3" target="genglsl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_gamma24_to_linear_color4.glsl" function="mx_gamma24_to_linear_color4" target="genglsl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_gamma18_to_linear_color3.glsl" function="mx_gamma18_to_linear_color3" target="genglsl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_gamma18_to_linear_color4.glsl" function="mx_gamma18_to_linear_color4" target="genglsl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_gamma22_to_linear_color3.glsl" function="mx_gamma22_to_linear_color3" target="genglsl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_gamma22_to_linear_color4.glsl" function="mx_gamma22_to_linear_color4" target="genglsl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_gamma24_to_linear_color3.glsl" function="mx_gamma24_to_linear_color3" target="genglsl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_gamma24_to_linear_color4.glsl" function="mx_gamma24_to_linear_color4" target="genglsl" />
 
-  <implementation name="IM_acescg_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_ap1_to_rec709_color3.glsl" function="mx_ap1_to_rec709_color3" target="genglsl" />
-  <implementation name="IM_acescg_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_ap1_to_rec709_color4.glsl" function="mx_ap1_to_rec709_color4" target="genglsl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_ap1_to_rec709_color3.glsl" function="mx_ap1_to_rec709_color3" target="genglsl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_ap1_to_rec709_color4.glsl" function="mx_ap1_to_rec709_color4" target="genglsl" />
 
-  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl" function="mx_g22_ap1_to_lin_rec709_color3" target="genglsl" />
-  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl" function="mx_g22_ap1_to_lin_rec709_color4" target="genglsl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl" function="mx_g22_ap1_to_lin_rec709_color3" target="genglsl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl" function="mx_g22_ap1_to_lin_rec709_color4" target="genglsl" />
 
-  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genglsl" file="stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl" function="mx_srgb_texture_to_lin_rec709_color3" target="genglsl" />
-  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genglsl" file="stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl" function="mx_srgb_texture_to_lin_rec709_color4" target="genglsl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl" function="mx_srgb_texture_to_lin_rec709_color3" target="genglsl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl" function="mx_srgb_texture_to_lin_rec709_color4" target="genglsl" />
 
 </materialx>

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -19,132 +19,132 @@
   <!-- ======================================================================== -->
 
   <!-- <image> -->
-  <implementation name="IM_image_float_genglsl" nodedef="ND_image_float" file="stdlib/genglsl/mx_image_float.glsl" function="mx_image_float" target="genglsl">
+  <implementation name="IM_image_float_genglsl" nodedef="ND_image_float" file="libraries/stdlib/genglsl/mx_image_float.glsl" function="mx_image_float" target="genglsl">
     <input name="default" type="float" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color3_genglsl" nodedef="ND_image_color3" file="stdlib/genglsl/mx_image_color3.glsl" function="mx_image_color3" target="genglsl">
+  <implementation name="IM_image_color3_genglsl" nodedef="ND_image_color3" file="libraries/stdlib/genglsl/mx_image_color3.glsl" function="mx_image_color3" target="genglsl">
     <input name="default" type="color3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color4_genglsl" nodedef="ND_image_color4" file="stdlib/genglsl/mx_image_color4.glsl" function="mx_image_color4" target="genglsl">
+  <implementation name="IM_image_color4_genglsl" nodedef="ND_image_color4" file="libraries/stdlib/genglsl/mx_image_color4.glsl" function="mx_image_color4" target="genglsl">
     <input name="default" type="color4" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector2_genglsl" nodedef="ND_image_vector2" file="stdlib/genglsl/mx_image_vector2.glsl" function="mx_image_vector2" target="genglsl">
+  <implementation name="IM_image_vector2_genglsl" nodedef="ND_image_vector2" file="libraries/stdlib/genglsl/mx_image_vector2.glsl" function="mx_image_vector2" target="genglsl">
     <input name="default" type="vector2" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector3_genglsl" nodedef="ND_image_vector3" file="stdlib/genglsl/mx_image_vector3.glsl" function="mx_image_vector3" target="genglsl">
+  <implementation name="IM_image_vector3_genglsl" nodedef="ND_image_vector3" file="libraries/stdlib/genglsl/mx_image_vector3.glsl" function="mx_image_vector3" target="genglsl">
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector4_genglsl" nodedef="ND_image_vector4" file="stdlib/genglsl/mx_image_vector4.glsl" function="mx_image_vector4" target="genglsl">
+  <implementation name="IM_image_vector4_genglsl" nodedef="ND_image_vector4" file="libraries/stdlib/genglsl/mx_image_vector4.glsl" function="mx_image_vector4" target="genglsl">
     <input name="default" type="vector4" implname="default_value" />
   </implementation>
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_genglsl" nodedef="ND_normalmap" file="stdlib/genglsl/mx_normalmap.glsl" function="mx_normalmap" target="genglsl" />
+  <implementation name="IM_normalmap_genglsl" nodedef="ND_normalmap" file="libraries/stdlib/genglsl/mx_normalmap.glsl" function="mx_normalmap" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->
   <!-- ======================================================================== -->
 
   <!-- <constant> -->
-  <implementation name="IM_constant_float_genglsl" nodedef="ND_constant_float" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_color3_genglsl" nodedef="ND_constant_color3" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_color4_genglsl" nodedef="ND_constant_color4" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_vector2_genglsl" nodedef="ND_constant_vector2" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_vector3_genglsl" nodedef="ND_constant_vector3" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_vector4_genglsl" nodedef="ND_constant_vector4" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_boolean_genglsl" nodedef="ND_constant_boolean" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_integer_genglsl" nodedef="ND_constant_integer" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_matrix33_genglsl" nodedef="ND_constant_matrix33" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_matrix44_genglsl" nodedef="ND_constant_matrix44" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_string_genglsl" nodedef="ND_constant_string" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_filename_genglsl" nodedef="ND_constant_filename" file="stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_float_genglsl" nodedef="ND_constant_float" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_color3_genglsl" nodedef="ND_constant_color3" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_color4_genglsl" nodedef="ND_constant_color4" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_vector2_genglsl" nodedef="ND_constant_vector2" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_vector3_genglsl" nodedef="ND_constant_vector3" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_vector4_genglsl" nodedef="ND_constant_vector4" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_boolean_genglsl" nodedef="ND_constant_boolean" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_integer_genglsl" nodedef="ND_constant_integer" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_matrix33_genglsl" nodedef="ND_constant_matrix33" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_matrix44_genglsl" nodedef="ND_constant_matrix44" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_string_genglsl" nodedef="ND_constant_string" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_filename_genglsl" nodedef="ND_constant_filename" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
 
   <!-- <ramplr> -->
-  <implementation name="IM_ramplr_float_genglsl" nodedef="ND_ramplr_float" file="stdlib/genglsl/mx_ramplr_float.glsl" function="mx_ramplr_float" target="genglsl" />
-  <implementation name="IM_ramplr_color3_genglsl" nodedef="ND_ramplr_color3" file="stdlib/genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
-  <implementation name="IM_ramplr_color4_genglsl" nodedef="ND_ramplr_color4" file="stdlib/genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
-  <implementation name="IM_ramplr_vector2_genglsl" nodedef="ND_ramplr_vector2" file="stdlib/genglsl/mx_ramplr_vector2.glsl" function="mx_ramplr_vector2" target="genglsl" />
-  <implementation name="IM_ramplr_vector3_genglsl" nodedef="ND_ramplr_vector3" file="stdlib/genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
-  <implementation name="IM_ramplr_vector4_genglsl" nodedef="ND_ramplr_vector4" file="stdlib/genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
+  <implementation name="IM_ramplr_float_genglsl" nodedef="ND_ramplr_float" file="libraries/stdlib/genglsl/mx_ramplr_float.glsl" function="mx_ramplr_float" target="genglsl" />
+  <implementation name="IM_ramplr_color3_genglsl" nodedef="ND_ramplr_color3" file="libraries/stdlib/genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
+  <implementation name="IM_ramplr_color4_genglsl" nodedef="ND_ramplr_color4" file="libraries/stdlib/genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
+  <implementation name="IM_ramplr_vector2_genglsl" nodedef="ND_ramplr_vector2" file="libraries/stdlib/genglsl/mx_ramplr_vector2.glsl" function="mx_ramplr_vector2" target="genglsl" />
+  <implementation name="IM_ramplr_vector3_genglsl" nodedef="ND_ramplr_vector3" file="libraries/stdlib/genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
+  <implementation name="IM_ramplr_vector4_genglsl" nodedef="ND_ramplr_vector4" file="libraries/stdlib/genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
 
   <!-- <ramptb> -->
-  <implementation name="IM_ramptb_float_genglsl" nodedef="ND_ramptb_float" file="stdlib/genglsl/mx_ramptb_float.glsl" function="mx_ramptb_float" target="genglsl" />
-  <implementation name="IM_ramptb_color3_genglsl" nodedef="ND_ramptb_color3" file="stdlib/genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
-  <implementation name="IM_ramptb_color4_genglsl" nodedef="ND_ramptb_color4" file="stdlib/genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
-  <implementation name="IM_ramptb_vector2_genglsl" nodedef="ND_ramptb_vector2" file="stdlib/genglsl/mx_ramptb_vector2.glsl" function="mx_ramptb_vector2" target="genglsl" />
-  <implementation name="IM_ramptb_vector3_genglsl" nodedef="ND_ramptb_vector3" file="stdlib/genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
-  <implementation name="IM_ramptb_vector4_genglsl" nodedef="ND_ramptb_vector4" file="stdlib/genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
+  <implementation name="IM_ramptb_float_genglsl" nodedef="ND_ramptb_float" file="libraries/stdlib/genglsl/mx_ramptb_float.glsl" function="mx_ramptb_float" target="genglsl" />
+  <implementation name="IM_ramptb_color3_genglsl" nodedef="ND_ramptb_color3" file="libraries/stdlib/genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
+  <implementation name="IM_ramptb_color4_genglsl" nodedef="ND_ramptb_color4" file="libraries/stdlib/genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
+  <implementation name="IM_ramptb_vector2_genglsl" nodedef="ND_ramptb_vector2" file="libraries/stdlib/genglsl/mx_ramptb_vector2.glsl" function="mx_ramptb_vector2" target="genglsl" />
+  <implementation name="IM_ramptb_vector3_genglsl" nodedef="ND_ramptb_vector3" file="libraries/stdlib/genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
+  <implementation name="IM_ramptb_vector4_genglsl" nodedef="ND_ramptb_vector4" file="libraries/stdlib/genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
 
   <!-- <splitlr> -->
-  <implementation name="IM_splitlr_float_genglsl" nodedef="ND_splitlr_float" file="stdlib/genglsl/mx_splitlr_float.glsl" function="mx_splitlr_float" target="genglsl" />
-  <implementation name="IM_splitlr_color3_genglsl" nodedef="ND_splitlr_color3" file="stdlib/genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
-  <implementation name="IM_splitlr_color4_genglsl" nodedef="ND_splitlr_color4" file="stdlib/genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
-  <implementation name="IM_splitlr_vector2_genglsl" nodedef="ND_splitlr_vector2" file="stdlib/genglsl/mx_splitlr_vector2.glsl" function="mx_splitlr_vector2" target="genglsl" />
-  <implementation name="IM_splitlr_vector3_genglsl" nodedef="ND_splitlr_vector3" file="stdlib/genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
-  <implementation name="IM_splitlr_vector4_genglsl" nodedef="ND_splitlr_vector4" file="stdlib/genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
+  <implementation name="IM_splitlr_float_genglsl" nodedef="ND_splitlr_float" file="libraries/stdlib/genglsl/mx_splitlr_float.glsl" function="mx_splitlr_float" target="genglsl" />
+  <implementation name="IM_splitlr_color3_genglsl" nodedef="ND_splitlr_color3" file="libraries/stdlib/genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
+  <implementation name="IM_splitlr_color4_genglsl" nodedef="ND_splitlr_color4" file="libraries/stdlib/genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
+  <implementation name="IM_splitlr_vector2_genglsl" nodedef="ND_splitlr_vector2" file="libraries/stdlib/genglsl/mx_splitlr_vector2.glsl" function="mx_splitlr_vector2" target="genglsl" />
+  <implementation name="IM_splitlr_vector3_genglsl" nodedef="ND_splitlr_vector3" file="libraries/stdlib/genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
+  <implementation name="IM_splitlr_vector4_genglsl" nodedef="ND_splitlr_vector4" file="libraries/stdlib/genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
 
   <!-- <splittb> -->
-  <implementation name="IM_splittb_float_genglsl" nodedef="ND_splittb_float" file="stdlib/genglsl/mx_splittb_float.glsl" function="mx_splittb_float" target="genglsl" />
-  <implementation name="IM_splittb_color3_genglsl" nodedef="ND_splittb_color3" file="stdlib/genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
-  <implementation name="IM_splittb_color4_genglsl" nodedef="ND_splittb_color4" file="stdlib/genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
-  <implementation name="IM_splittb_vector2_genglsl" nodedef="ND_splittb_vector2" file="stdlib/genglsl/mx_splittb_vector2.glsl" function="mx_splittb_vector2" target="genglsl" />
-  <implementation name="IM_splittb_vector3_genglsl" nodedef="ND_splittb_vector3" file="stdlib/genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
-  <implementation name="IM_splittb_vector4_genglsl" nodedef="ND_splittb_vector4" file="stdlib/genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
+  <implementation name="IM_splittb_float_genglsl" nodedef="ND_splittb_float" file="libraries/stdlib/genglsl/mx_splittb_float.glsl" function="mx_splittb_float" target="genglsl" />
+  <implementation name="IM_splittb_color3_genglsl" nodedef="ND_splittb_color3" file="libraries/stdlib/genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
+  <implementation name="IM_splittb_color4_genglsl" nodedef="ND_splittb_color4" file="libraries/stdlib/genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
+  <implementation name="IM_splittb_vector2_genglsl" nodedef="ND_splittb_vector2" file="libraries/stdlib/genglsl/mx_splittb_vector2.glsl" function="mx_splittb_vector2" target="genglsl" />
+  <implementation name="IM_splittb_vector3_genglsl" nodedef="ND_splittb_vector3" file="libraries/stdlib/genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
+  <implementation name="IM_splittb_vector4_genglsl" nodedef="ND_splittb_vector4" file="libraries/stdlib/genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
 
   <!-- <noise2d> -->
-  <implementation name="IM_noise2d_float_genglsl" nodedef="ND_noise2d_float" file="stdlib/genglsl/mx_noise2d_float.glsl" function="mx_noise2d_float" target="genglsl" />
-  <implementation name="IM_noise2d_color3_genglsl" nodedef="ND_noise2d_color3" file="stdlib/genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_color4_genglsl" nodedef="ND_noise2d_color4" file="stdlib/genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
-  <implementation name="IM_noise2d_color3FA_genglsl" nodedef="ND_noise2d_color3FA" file="stdlib/genglsl/mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_color4FA_genglsl" nodedef="ND_noise2d_color4FA" file="stdlib/genglsl/mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
-  <implementation name="IM_noise2d_vector2_genglsl" nodedef="ND_noise2d_vector2" file="stdlib/genglsl/mx_noise2d_vector2.glsl" function="mx_noise2d_vector2" target="genglsl" />
-  <implementation name="IM_noise2d_vector3_genglsl" nodedef="ND_noise2d_vector3" file="stdlib/genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_vector4_genglsl" nodedef="ND_noise2d_vector4" file="stdlib/genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
-  <implementation name="IM_noise2d_vector2FA_genglsl" nodedef="ND_noise2d_vector2FA" file="stdlib/genglsl/mx_noise2d_fa_vector2.glsl" function="mx_noise2d_fa_vector2" target="genglsl" />
-  <implementation name="IM_noise2d_vector3FA_genglsl" nodedef="ND_noise2d_vector3FA" file="stdlib/genglsl/mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_vector4FA_genglsl" nodedef="ND_noise2d_vector4FA" file="stdlib/genglsl/mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_float_genglsl" nodedef="ND_noise2d_float" file="libraries/stdlib/genglsl/mx_noise2d_float.glsl" function="mx_noise2d_float" target="genglsl" />
+  <implementation name="IM_noise2d_color3_genglsl" nodedef="ND_noise2d_color3" file="libraries/stdlib/genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_color4_genglsl" nodedef="ND_noise2d_color4" file="libraries/stdlib/genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_color3FA_genglsl" nodedef="ND_noise2d_color3FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_color4FA_genglsl" nodedef="ND_noise2d_color4FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_vector2_genglsl" nodedef="ND_noise2d_vector2" file="libraries/stdlib/genglsl/mx_noise2d_vector2.glsl" function="mx_noise2d_vector2" target="genglsl" />
+  <implementation name="IM_noise2d_vector3_genglsl" nodedef="ND_noise2d_vector3" file="libraries/stdlib/genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_vector4_genglsl" nodedef="ND_noise2d_vector4" file="libraries/stdlib/genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_vector2FA_genglsl" nodedef="ND_noise2d_vector2FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector2.glsl" function="mx_noise2d_fa_vector2" target="genglsl" />
+  <implementation name="IM_noise2d_vector3FA_genglsl" nodedef="ND_noise2d_vector3FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_vector4FA_genglsl" nodedef="ND_noise2d_vector4FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
 
   <!-- <noise3d> -->
-  <implementation name="IM_noise3d_float_genglsl" nodedef="ND_noise3d_float" file="stdlib/genglsl/mx_noise3d_float.glsl" function="mx_noise3d_float" target="genglsl" />
-  <implementation name="IM_noise3d_color3_genglsl" nodedef="ND_noise3d_color3" file="stdlib/genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_color4_genglsl" nodedef="ND_noise3d_color4" file="stdlib/genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
-  <implementation name="IM_noise3d_color3FA_genglsl" nodedef="ND_noise3d_color3FA" file="stdlib/genglsl/mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_color4FA_genglsl" nodedef="ND_noise3d_color4FA" file="stdlib/genglsl/mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
-  <implementation name="IM_noise3d_vector2_genglsl" nodedef="ND_noise3d_vector2" file="stdlib/genglsl/mx_noise3d_vector2.glsl" function="mx_noise3d_vector2" target="genglsl" />
-  <implementation name="IM_noise3d_vector3_genglsl" nodedef="ND_noise3d_vector3" file="stdlib/genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_vector4_genglsl" nodedef="ND_noise3d_vector4" file="stdlib/genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
-  <implementation name="IM_noise3d_vector2FA_genglsl" nodedef="ND_noise3d_vector2FA" file="stdlib/genglsl/mx_noise3d_fa_vector2.glsl" function="mx_noise3d_fa_vector2" target="genglsl" />
-  <implementation name="IM_noise3d_vector3FA_genglsl" nodedef="ND_noise3d_vector3FA" file="stdlib/genglsl/mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_vector4FA_genglsl" nodedef="ND_noise3d_vector4FA" file="stdlib/genglsl/mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_float_genglsl" nodedef="ND_noise3d_float" file="libraries/stdlib/genglsl/mx_noise3d_float.glsl" function="mx_noise3d_float" target="genglsl" />
+  <implementation name="IM_noise3d_color3_genglsl" nodedef="ND_noise3d_color3" file="libraries/stdlib/genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_color4_genglsl" nodedef="ND_noise3d_color4" file="libraries/stdlib/genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_color3FA_genglsl" nodedef="ND_noise3d_color3FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_color4FA_genglsl" nodedef="ND_noise3d_color4FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_vector2_genglsl" nodedef="ND_noise3d_vector2" file="libraries/stdlib/genglsl/mx_noise3d_vector2.glsl" function="mx_noise3d_vector2" target="genglsl" />
+  <implementation name="IM_noise3d_vector3_genglsl" nodedef="ND_noise3d_vector3" file="libraries/stdlib/genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_vector4_genglsl" nodedef="ND_noise3d_vector4" file="libraries/stdlib/genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_vector2FA_genglsl" nodedef="ND_noise3d_vector2FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector2.glsl" function="mx_noise3d_fa_vector2" target="genglsl" />
+  <implementation name="IM_noise3d_vector3FA_genglsl" nodedef="ND_noise3d_vector3FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_vector4FA_genglsl" nodedef="ND_noise3d_vector4FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
 
   <!-- <fractal3d> -->
-  <implementation name="IM_fractal3d_float_genglsl" nodedef="ND_fractal3d_float" file="stdlib/genglsl/mx_fractal3d_float.glsl" function="mx_fractal3d_float" target="genglsl" />
-  <implementation name="IM_fractal3d_color3_genglsl" nodedef="ND_fractal3d_color3" file="stdlib/genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_color4_genglsl" nodedef="ND_fractal3d_color4" file="stdlib/genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
-  <implementation name="IM_fractal3d_color3FA_genglsl" nodedef="ND_fractal3d_color3FA" file="stdlib/genglsl/mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_color4FA_genglsl" nodedef="ND_fractal3d_color4FA" file="stdlib/genglsl/mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
-  <implementation name="IM_fractal3d_vector2_genglsl" nodedef="ND_fractal3d_vector2" file="stdlib/genglsl/mx_fractal3d_vector2.glsl" function="mx_fractal3d_vector2" target="genglsl" />
-  <implementation name="IM_fractal3d_vector3_genglsl" nodedef="ND_fractal3d_vector3" file="stdlib/genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_vector4_genglsl" nodedef="ND_fractal3d_vector4" file="stdlib/genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
-  <implementation name="IM_fractal3d_vector2FA_genglsl" nodedef="ND_fractal3d_vector2FA" file="stdlib/genglsl/mx_fractal3d_fa_vector2.glsl" function="mx_fractal3d_fa_vector2" target="genglsl" />
-  <implementation name="IM_fractal3d_vector3FA_genglsl" nodedef="ND_fractal3d_vector3FA" file="stdlib/genglsl/mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_vector4FA_genglsl" nodedef="ND_fractal3d_vector4FA" file="stdlib/genglsl/mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_float_genglsl" nodedef="ND_fractal3d_float" file="libraries/stdlib/genglsl/mx_fractal3d_float.glsl" function="mx_fractal3d_float" target="genglsl" />
+  <implementation name="IM_fractal3d_color3_genglsl" nodedef="ND_fractal3d_color3" file="libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_color4_genglsl" nodedef="ND_fractal3d_color4" file="libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_color3FA_genglsl" nodedef="ND_fractal3d_color3FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_color4FA_genglsl" nodedef="ND_fractal3d_color4FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_vector2_genglsl" nodedef="ND_fractal3d_vector2" file="libraries/stdlib/genglsl/mx_fractal3d_vector2.glsl" function="mx_fractal3d_vector2" target="genglsl" />
+  <implementation name="IM_fractal3d_vector3_genglsl" nodedef="ND_fractal3d_vector3" file="libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_vector4_genglsl" nodedef="ND_fractal3d_vector4" file="libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_vector2FA_genglsl" nodedef="ND_fractal3d_vector2FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector2.glsl" function="mx_fractal3d_fa_vector2" target="genglsl" />
+  <implementation name="IM_fractal3d_vector3FA_genglsl" nodedef="ND_fractal3d_vector3FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_vector4FA_genglsl" nodedef="ND_fractal3d_vector4FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
 
   <!-- <cellnoise2d> -->
-  <implementation name="IM_cellnoise2d_float_genglsl" nodedef="ND_cellnoise2d_float" file="stdlib/genglsl/mx_cellnoise2d_float.glsl" function="mx_cellnoise2d_float" target="genglsl" />
+  <implementation name="IM_cellnoise2d_float_genglsl" nodedef="ND_cellnoise2d_float" file="libraries/stdlib/genglsl/mx_cellnoise2d_float.glsl" function="mx_cellnoise2d_float" target="genglsl" />
 
   <!-- <cellnoise3d> -->
-  <implementation name="IM_cellnoise3d_float_genglsl" nodedef="ND_cellnoise3d_float" file="stdlib/genglsl/mx_cellnoise3d_float.glsl" function="mx_cellnoise3d_float" target="genglsl" />
+  <implementation name="IM_cellnoise3d_float_genglsl" nodedef="ND_cellnoise3d_float" file="libraries/stdlib/genglsl/mx_cellnoise3d_float.glsl" function="mx_cellnoise3d_float" target="genglsl" />
 
   <!-- <worleynoise2d> -->
-  <implementation name="IM_worleynoise2d_float_genglsl" nodedef="ND_worleynoise2d_float" file="stdlib/genglsl/mx_worleynoise2d_float.glsl" function="mx_worleynoise2d_float" target="genglsl" />
-  <implementation name="IM_worleynoise2d_vector2_genglsl" nodedef="ND_worleynoise2d_vector2" file="stdlib/genglsl/mx_worleynoise2d_vector2.glsl" function="mx_worleynoise2d_vector2" target="genglsl" />
-  <implementation name="IM_worleynoise2d_vector3_genglsl" nodedef="ND_worleynoise2d_vector3" file="stdlib/genglsl/mx_worleynoise2d_vector3.glsl" function="mx_worleynoise2d_vector3" target="genglsl" />
+  <implementation name="IM_worleynoise2d_float_genglsl" nodedef="ND_worleynoise2d_float" file="libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl" function="mx_worleynoise2d_float" target="genglsl" />
+  <implementation name="IM_worleynoise2d_vector2_genglsl" nodedef="ND_worleynoise2d_vector2" file="libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl" function="mx_worleynoise2d_vector2" target="genglsl" />
+  <implementation name="IM_worleynoise2d_vector3_genglsl" nodedef="ND_worleynoise2d_vector3" file="libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl" function="mx_worleynoise2d_vector3" target="genglsl" />
 
   <!-- <worleynoise3d> -->
-  <implementation name="IM_worleynoise3d_float_genglsl" nodedef="ND_worleynoise3d_float" file="stdlib/genglsl/mx_worleynoise3d_float.glsl" function="mx_worleynoise3d_float" target="genglsl" />
-  <implementation name="IM_worleynoise3d_vector2_genglsl" nodedef="ND_worleynoise3d_vector2" file="stdlib/genglsl/mx_worleynoise3d_vector2.glsl" function="mx_worleynoise3d_vector2" target="genglsl" />
-  <implementation name="IM_worleynoise3d_vector3_genglsl" nodedef="ND_worleynoise3d_vector3" file="stdlib/genglsl/mx_worleynoise3d_vector3.glsl" function="mx_worleynoise3d_vector3" target="genglsl" />
+  <implementation name="IM_worleynoise3d_float_genglsl" nodedef="ND_worleynoise3d_float" file="libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl" function="mx_worleynoise3d_float" target="genglsl" />
+  <implementation name="IM_worleynoise3d_vector2_genglsl" nodedef="ND_worleynoise3d_vector2" file="libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl" function="mx_worleynoise3d_vector2" target="genglsl" />
+  <implementation name="IM_worleynoise3d_vector3_genglsl" nodedef="ND_worleynoise3d_vector3" file="libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl" function="mx_worleynoise3d_vector3" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
@@ -204,242 +204,242 @@
   <!-- ======================================================================== -->
 
   <!-- <add> -->
-  <implementation name="IM_add_float_genglsl" nodedef="ND_add_float" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color3_genglsl" nodedef="ND_add_color3" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color3FA_genglsl" nodedef="ND_add_color3FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color4_genglsl" nodedef="ND_add_color4" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color4FA_genglsl" nodedef="ND_add_color4FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector2_genglsl" nodedef="ND_add_vector2" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector2FA_genglsl" nodedef="ND_add_vector2FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector3_genglsl" nodedef="ND_add_vector3" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector3FA_genglsl" nodedef="ND_add_vector3FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector4_genglsl" nodedef="ND_add_vector4" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector4FA_genglsl" nodedef="ND_add_vector4FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix33_genglsl" nodedef="ND_add_matrix33" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix33FA_genglsl" nodedef="ND_add_matrix33FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix44_genglsl" nodedef="ND_add_matrix44" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix44FA_genglsl" nodedef="ND_add_matrix44FA" file="stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_surfaceshader_genglsl" nodedef="ND_add_surfaceshader" function="mx_add_surfaceshader" file="stdlib/genglsl/mx_add_surfaceshader.glsl" target="genglsl" />
+  <implementation name="IM_add_float_genglsl" nodedef="ND_add_float" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color3_genglsl" nodedef="ND_add_color3" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color3FA_genglsl" nodedef="ND_add_color3FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color4_genglsl" nodedef="ND_add_color4" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color4FA_genglsl" nodedef="ND_add_color4FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector2_genglsl" nodedef="ND_add_vector2" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector2FA_genglsl" nodedef="ND_add_vector2FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector3_genglsl" nodedef="ND_add_vector3" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector3FA_genglsl" nodedef="ND_add_vector3FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector4_genglsl" nodedef="ND_add_vector4" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector4FA_genglsl" nodedef="ND_add_vector4FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix33_genglsl" nodedef="ND_add_matrix33" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix33FA_genglsl" nodedef="ND_add_matrix33FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix44_genglsl" nodedef="ND_add_matrix44" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix44FA_genglsl" nodedef="ND_add_matrix44FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_surfaceshader_genglsl" nodedef="ND_add_surfaceshader" function="mx_add_surfaceshader" file="libraries/stdlib/genglsl/mx_add_surfaceshader.glsl" target="genglsl" />
 
   <!-- <subtract> -->
-  <implementation name="IM_subtract_float_genglsl" nodedef="ND_subtract_float" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color3_genglsl" nodedef="ND_subtract_color3" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color3FA_genglsl" nodedef="ND_subtract_color3FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color4_genglsl" nodedef="ND_subtract_color4" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color4FA_genglsl" nodedef="ND_subtract_color4FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector2_genglsl" nodedef="ND_subtract_vector2" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector2FA_genglsl" nodedef="ND_subtract_vector2FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector3_genglsl" nodedef="ND_subtract_vector3" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector3FA_genglsl" nodedef="ND_subtract_vector3FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector4_genglsl" nodedef="ND_subtract_vector4" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector4FA_genglsl" nodedef="ND_subtract_vector4FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix33_genglsl" nodedef="ND_subtract_matrix33" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix33FA_genglsl" nodedef="ND_subtract_matrix33FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix44_genglsl" nodedef="ND_subtract_matrix44" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix44FA_genglsl" nodedef="ND_subtract_matrix44FA" file="stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_float_genglsl" nodedef="ND_subtract_float" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color3_genglsl" nodedef="ND_subtract_color3" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color3FA_genglsl" nodedef="ND_subtract_color3FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color4_genglsl" nodedef="ND_subtract_color4" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color4FA_genglsl" nodedef="ND_subtract_color4FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector2_genglsl" nodedef="ND_subtract_vector2" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector2FA_genglsl" nodedef="ND_subtract_vector2FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector3_genglsl" nodedef="ND_subtract_vector3" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector3FA_genglsl" nodedef="ND_subtract_vector3FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector4_genglsl" nodedef="ND_subtract_vector4" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector4FA_genglsl" nodedef="ND_subtract_vector4FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix33_genglsl" nodedef="ND_subtract_matrix33" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix33FA_genglsl" nodedef="ND_subtract_matrix33FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix44_genglsl" nodedef="ND_subtract_matrix44" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix44FA_genglsl" nodedef="ND_subtract_matrix44FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
 
   <!-- <multiply> -->
-  <implementation name="IM_multiply_float_genglsl" nodedef="ND_multiply_float" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color3_genglsl" nodedef="ND_multiply_color3" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color3FA_genglsl" nodedef="ND_multiply_color3FA" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color4_genglsl" nodedef="ND_multiply_color4" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color4FA_genglsl" nodedef="ND_multiply_color4FA" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector2_genglsl" nodedef="ND_multiply_vector2" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector2FA_genglsl" nodedef="ND_multiply_vector2FA" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector3_genglsl" nodedef="ND_multiply_vector3" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector3FA_genglsl" nodedef="ND_multiply_vector3FA" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector4_genglsl" nodedef="ND_multiply_vector4" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector4FA_genglsl" nodedef="ND_multiply_vector4FA" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_matrix33_genglsl" nodedef="ND_multiply_matrix33" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_matrix44_genglsl" nodedef="ND_multiply_matrix44" file="stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_surfaceshaderF_genglsl" nodedef="ND_multiply_surfaceshaderF" function="mx_multiply_surfaceshader_float" file="stdlib/genglsl/mx_multiply_surfaceshader_float.glsl" target="genglsl" />
-  <implementation name="IM_multiply_surfaceshaderC_genglsl" nodedef="ND_multiply_surfaceshaderC" function="mx_multiply_surfaceshader_color3" file="stdlib/genglsl/mx_multiply_surfaceshader_color3.glsl" target="genglsl" />
+  <implementation name="IM_multiply_float_genglsl" nodedef="ND_multiply_float" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color3_genglsl" nodedef="ND_multiply_color3" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color3FA_genglsl" nodedef="ND_multiply_color3FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color4_genglsl" nodedef="ND_multiply_color4" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color4FA_genglsl" nodedef="ND_multiply_color4FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector2_genglsl" nodedef="ND_multiply_vector2" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector2FA_genglsl" nodedef="ND_multiply_vector2FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector3_genglsl" nodedef="ND_multiply_vector3" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector3FA_genglsl" nodedef="ND_multiply_vector3FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector4_genglsl" nodedef="ND_multiply_vector4" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector4FA_genglsl" nodedef="ND_multiply_vector4FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_matrix33_genglsl" nodedef="ND_multiply_matrix33" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_matrix44_genglsl" nodedef="ND_multiply_matrix44" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_surfaceshaderF_genglsl" nodedef="ND_multiply_surfaceshaderF" function="mx_multiply_surfaceshader_float" file="libraries/stdlib/genglsl/mx_multiply_surfaceshader_float.glsl" target="genglsl" />
+  <implementation name="IM_multiply_surfaceshaderC_genglsl" nodedef="ND_multiply_surfaceshaderC" function="mx_multiply_surfaceshader_color3" file="libraries/stdlib/genglsl/mx_multiply_surfaceshader_color3.glsl" target="genglsl" />
 
   <!-- <divide> -->
-  <implementation name="IM_divide_float_genglsl" nodedef="ND_divide_float" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color3_genglsl" nodedef="ND_divide_color3" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color3FA_genglsl" nodedef="ND_divide_color3FA" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color4_genglsl" nodedef="ND_divide_color4" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color4FA_genglsl" nodedef="ND_divide_color4FA" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector2_genglsl" nodedef="ND_divide_vector2" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector2FA_genglsl" nodedef="ND_divide_vector2FA" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector3_genglsl" nodedef="ND_divide_vector3" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector3FA_genglsl" nodedef="ND_divide_vector3FA" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector4_genglsl" nodedef="ND_divide_vector4" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector4FA_genglsl" nodedef="ND_divide_vector4FA" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_matrix33_genglsl" nodedef="ND_divide_matrix33" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_matrix44_genglsl" nodedef="ND_divide_matrix44" file="stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_float_genglsl" nodedef="ND_divide_float" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color3_genglsl" nodedef="ND_divide_color3" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color3FA_genglsl" nodedef="ND_divide_color3FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color4_genglsl" nodedef="ND_divide_color4" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color4FA_genglsl" nodedef="ND_divide_color4FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector2_genglsl" nodedef="ND_divide_vector2" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector2FA_genglsl" nodedef="ND_divide_vector2FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector3_genglsl" nodedef="ND_divide_vector3" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector3FA_genglsl" nodedef="ND_divide_vector3FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector4_genglsl" nodedef="ND_divide_vector4" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector4FA_genglsl" nodedef="ND_divide_vector4FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_matrix33_genglsl" nodedef="ND_divide_matrix33" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_matrix44_genglsl" nodedef="ND_divide_matrix44" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
 
   <!-- <modulo> -->
-  <implementation name="IM_modulo_float_genglsl" nodedef="ND_modulo_float" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color3_genglsl" nodedef="ND_modulo_color3" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color3FA_genglsl" nodedef="ND_modulo_color3FA" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color4_genglsl" nodedef="ND_modulo_color4" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color4FA_genglsl" nodedef="ND_modulo_color4FA" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector2_genglsl" nodedef="ND_modulo_vector2" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector2FA_genglsl" nodedef="ND_modulo_vector2FA" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector3_genglsl" nodedef="ND_modulo_vector3" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector3FA_genglsl" nodedef="ND_modulo_vector3FA" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector4_genglsl" nodedef="ND_modulo_vector4" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector4FA_genglsl" nodedef="ND_modulo_vector4FA" file="stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_float_genglsl" nodedef="ND_modulo_float" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color3_genglsl" nodedef="ND_modulo_color3" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color3FA_genglsl" nodedef="ND_modulo_color3FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color4_genglsl" nodedef="ND_modulo_color4" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color4FA_genglsl" nodedef="ND_modulo_color4FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector2_genglsl" nodedef="ND_modulo_vector2" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector2FA_genglsl" nodedef="ND_modulo_vector2FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector3_genglsl" nodedef="ND_modulo_vector3" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector3FA_genglsl" nodedef="ND_modulo_vector3FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector4_genglsl" nodedef="ND_modulo_vector4" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector4FA_genglsl" nodedef="ND_modulo_vector4FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
 
   <!-- <invert> -->
-  <implementation name="IM_invert_float_genglsl" nodedef="ND_invert_float" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color3_genglsl" nodedef="ND_invert_color3" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color3FA_genglsl" nodedef="ND_invert_color3FA" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color4_genglsl" nodedef="ND_invert_color4" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color4FA_genglsl" nodedef="ND_invert_color4FA" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector2_genglsl" nodedef="ND_invert_vector2" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector2FA_genglsl" nodedef="ND_invert_vector2FA" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector3_genglsl" nodedef="ND_invert_vector3" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector3FA_genglsl" nodedef="ND_invert_vector3FA" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector4_genglsl" nodedef="ND_invert_vector4" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector4FA_genglsl" nodedef="ND_invert_vector4FA" file="stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_float_genglsl" nodedef="ND_invert_float" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color3_genglsl" nodedef="ND_invert_color3" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color3FA_genglsl" nodedef="ND_invert_color3FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color4_genglsl" nodedef="ND_invert_color4" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color4FA_genglsl" nodedef="ND_invert_color4FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector2_genglsl" nodedef="ND_invert_vector2" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector2FA_genglsl" nodedef="ND_invert_vector2FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector3_genglsl" nodedef="ND_invert_vector3" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector3FA_genglsl" nodedef="ND_invert_vector3FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector4_genglsl" nodedef="ND_invert_vector4" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector4FA_genglsl" nodedef="ND_invert_vector4FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
 
   <!-- <absval> -->
-  <implementation name="IM_absval_float_genglsl" nodedef="ND_absval_float" file="stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_color3_genglsl" nodedef="ND_absval_color3" file="stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_color4_genglsl" nodedef="ND_absval_color4" file="stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_vector2_genglsl" nodedef="ND_absval_vector2" file="stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_vector3_genglsl" nodedef="ND_absval_vector3" file="stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_vector4_genglsl" nodedef="ND_absval_vector4" file="stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_float_genglsl" nodedef="ND_absval_float" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_color3_genglsl" nodedef="ND_absval_color3" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_color4_genglsl" nodedef="ND_absval_color4" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_vector2_genglsl" nodedef="ND_absval_vector2" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_vector3_genglsl" nodedef="ND_absval_vector3" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_vector4_genglsl" nodedef="ND_absval_vector4" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
 
   <!-- <floor> -->
-  <implementation name="IM_floor_float_genglsl" nodedef="ND_floor_float" file="stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_color3_genglsl" nodedef="ND_floor_color3" file="stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_color4_genglsl" nodedef="ND_floor_color4" file="stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_vector2_genglsl" nodedef="ND_floor_vector2" file="stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_vector3_genglsl" nodedef="ND_floor_vector3" file="stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_vector4_genglsl" nodedef="ND_floor_vector4" file="stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_float_genglsl" nodedef="ND_floor_float" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_color3_genglsl" nodedef="ND_floor_color3" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_color4_genglsl" nodedef="ND_floor_color4" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_vector2_genglsl" nodedef="ND_floor_vector2" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_vector3_genglsl" nodedef="ND_floor_vector3" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_vector4_genglsl" nodedef="ND_floor_vector4" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
   <!-- <ceil> -->
-  <implementation name="IM_ceil_float_genglsl" nodedef="ND_ceil_float" file="stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_color3_genglsl" nodedef="ND_ceil_color3" file="stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_color4_genglsl" nodedef="ND_ceil_color4" file="stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_vector2_genglsl" nodedef="ND_ceil_vector2" file="stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_vector3_genglsl" nodedef="ND_ceil_vector3" file="stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_vector4_genglsl" nodedef="ND_ceil_vector4" file="stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_float_genglsl" nodedef="ND_ceil_float" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_color3_genglsl" nodedef="ND_ceil_color3" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_color4_genglsl" nodedef="ND_ceil_color4" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_vector2_genglsl" nodedef="ND_ceil_vector2" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_vector3_genglsl" nodedef="ND_ceil_vector3" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_vector4_genglsl" nodedef="ND_ceil_vector4" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
 
   <!-- <power> -->
-  <implementation name="IM_power_float_genglsl" nodedef="ND_power_float" file="stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_color3_genglsl" nodedef="ND_power_color3" file="stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_color3FA_genglsl" nodedef="ND_power_color3FA" file="stdlib/genglsl/mx_power_color3_float.inline" target="genglsl" />
-  <implementation name="IM_power_color4_genglsl" nodedef="ND_power_color4" file="stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_color4FA_genglsl" nodedef="ND_power_color4FA" file="stdlib/genglsl/mx_power_color4_float.inline" target="genglsl" />
-  <implementation name="IM_power_vector2_genglsl" nodedef="ND_power_vector2" file="stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_vector2FA_genglsl" nodedef="ND_power_vector2FA" file="stdlib/genglsl/mx_power_vector2_float.inline" target="genglsl" />
-  <implementation name="IM_power_vector3_genglsl" nodedef="ND_power_vector3" file="stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_vector3FA_genglsl" nodedef="ND_power_vector3FA" file="stdlib/genglsl/mx_power_vector3_float.inline" target="genglsl" />
-  <implementation name="IM_power_vector4_genglsl" nodedef="ND_power_vector4" file="stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_vector4FA_genglsl" nodedef="ND_power_vector4FA" file="stdlib/genglsl/mx_power_vector4_float.inline" target="genglsl" />
+  <implementation name="IM_power_float_genglsl" nodedef="ND_power_float" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_color3_genglsl" nodedef="ND_power_color3" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_color3FA_genglsl" nodedef="ND_power_color3FA" file="libraries/stdlib/genglsl/mx_power_color3_float.inline" target="genglsl" />
+  <implementation name="IM_power_color4_genglsl" nodedef="ND_power_color4" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_color4FA_genglsl" nodedef="ND_power_color4FA" file="libraries/stdlib/genglsl/mx_power_color4_float.inline" target="genglsl" />
+  <implementation name="IM_power_vector2_genglsl" nodedef="ND_power_vector2" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_vector2FA_genglsl" nodedef="ND_power_vector2FA" file="libraries/stdlib/genglsl/mx_power_vector2_float.inline" target="genglsl" />
+  <implementation name="IM_power_vector3_genglsl" nodedef="ND_power_vector3" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_vector3FA_genglsl" nodedef="ND_power_vector3FA" file="libraries/stdlib/genglsl/mx_power_vector3_float.inline" target="genglsl" />
+  <implementation name="IM_power_vector4_genglsl" nodedef="ND_power_vector4" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_vector4FA_genglsl" nodedef="ND_power_vector4FA" file="libraries/stdlib/genglsl/mx_power_vector4_float.inline" target="genglsl" />
 
   <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genglsl" nodedef="ND_sin_float" file="stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_float_genglsl" nodedef="ND_cos_float" file="stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" file="stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" file="stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" file="stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" file="stdlib/genglsl/mx_atan2.inline" target="genglsl" />
-  <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" file="stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" file="stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" file="stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" file="stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" file="stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" file="stdlib/genglsl/mx_atan2.inline" target="genglsl" />
-  <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" file="stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" file="stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" file="stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" file="stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" file="stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" file="stdlib/genglsl/mx_atan2.inline" target="genglsl" />
-  <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" file="stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" file="stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" file="stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" file="stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" file="stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" file="stdlib/genglsl/mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_float_genglsl" nodedef="ND_sin_float" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_float_genglsl" nodedef="ND_cos_float" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
 
   <!-- <sqrt> -->
-  <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" file="stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
-  <implementation name="IM_sqrt_vector2_genglsl" nodedef="ND_sqrt_vector2" file="stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
-  <implementation name="IM_sqrt_vector3_genglsl" nodedef="ND_sqrt_vector3" file="stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
-  <implementation name="IM_sqrt_vector4_genglsl" nodedef="ND_sqrt_vector4" file="stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_vector2_genglsl" nodedef="ND_sqrt_vector2" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_vector3_genglsl" nodedef="ND_sqrt_vector3" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_vector4_genglsl" nodedef="ND_sqrt_vector4" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
 
   <!-- <ln> -->
-  <implementation name="IM_ln_float_genglsl" nodedef="ND_ln_float" file="stdlib/genglsl/mx_ln.inline" target="genglsl" />
-  <implementation name="IM_ln_vector2_genglsl" nodedef="ND_ln_vector2" file="stdlib/genglsl/mx_ln.inline" target="genglsl" />
-  <implementation name="IM_ln_vector3_genglsl" nodedef="ND_ln_vector3" file="stdlib/genglsl/mx_ln.inline" target="genglsl" />
-  <implementation name="IM_ln_vector4_genglsl" nodedef="ND_ln_vector4" file="stdlib/genglsl/mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_float_genglsl" nodedef="ND_ln_float" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_vector2_genglsl" nodedef="ND_ln_vector2" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_vector3_genglsl" nodedef="ND_ln_vector3" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_vector4_genglsl" nodedef="ND_ln_vector4" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
 
   <!-- <exp> -->
-  <implementation name="IM_exp_float_genglsl" nodedef="ND_exp_float" file="stdlib/genglsl/mx_exp.inline" target="genglsl" />
-  <implementation name="IM_exp_vector2_genglsl" nodedef="ND_exp_vector2" file="stdlib/genglsl/mx_exp.inline" target="genglsl" />
-  <implementation name="IM_exp_vector3_genglsl" nodedef="ND_exp_vector3" file="stdlib/genglsl/mx_exp.inline" target="genglsl" />
-  <implementation name="IM_exp_vector4_genglsl" nodedef="ND_exp_vector4" file="stdlib/genglsl/mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_float_genglsl" nodedef="ND_exp_float" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_vector2_genglsl" nodedef="ND_exp_vector2" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_vector3_genglsl" nodedef="ND_exp_vector3" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_vector4_genglsl" nodedef="ND_exp_vector4" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
 
   <!-- sign -->
-  <implementation name="IM_sign_float_genglsl" nodedef="ND_sign_float" file="stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_color3_genglsl" nodedef="ND_sign_color3" file="stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_color4_genglsl" nodedef="ND_sign_color4" file="stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_vector2_genglsl" nodedef="ND_sign_vector2" file="stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_vector3_genglsl" nodedef="ND_sign_vector3" file="stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_vector4_genglsl" nodedef="ND_sign_vector4" file="stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_float_genglsl" nodedef="ND_sign_float" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_color3_genglsl" nodedef="ND_sign_color3" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_color4_genglsl" nodedef="ND_sign_color4" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_vector2_genglsl" nodedef="ND_sign_vector2" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_vector3_genglsl" nodedef="ND_sign_vector3" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_vector4_genglsl" nodedef="ND_sign_vector4" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
 
   <!-- <clamp> -->
-  <implementation name="IM_clamp_float_genglsl" nodedef="ND_clamp_float" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color3_genglsl" nodedef="ND_clamp_color3" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color3FA_genglsl" nodedef="ND_clamp_color3FA" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color4_genglsl" nodedef="ND_clamp_color4" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color4FA_genglsl" nodedef="ND_clamp_color4FA" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector2_genglsl" nodedef="ND_clamp_vector2" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector2FA_genglsl" nodedef="ND_clamp_vector2FA" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector3_genglsl" nodedef="ND_clamp_vector3" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector3FA_genglsl" nodedef="ND_clamp_vector3FA" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector4_genglsl" nodedef="ND_clamp_vector4" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector4FA_genglsl" nodedef="ND_clamp_vector4FA" file="stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_float_genglsl" nodedef="ND_clamp_float" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color3_genglsl" nodedef="ND_clamp_color3" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color3FA_genglsl" nodedef="ND_clamp_color3FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color4_genglsl" nodedef="ND_clamp_color4" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color4FA_genglsl" nodedef="ND_clamp_color4FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector2_genglsl" nodedef="ND_clamp_vector2" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector2FA_genglsl" nodedef="ND_clamp_vector2FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector3_genglsl" nodedef="ND_clamp_vector3" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector3FA_genglsl" nodedef="ND_clamp_vector3FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector4_genglsl" nodedef="ND_clamp_vector4" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector4FA_genglsl" nodedef="ND_clamp_vector4FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
 
   <!-- <min> -->
-  <implementation name="IM_min_float_genglsl" nodedef="ND_min_float" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color3_genglsl" nodedef="ND_min_color3" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color3FA_genglsl" nodedef="ND_min_color3FA" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color4_genglsl" nodedef="ND_min_color4" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color4FA_genglsl" nodedef="ND_min_color4FA" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector2_genglsl" nodedef="ND_min_vector2" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector2FA_genglsl" nodedef="ND_min_vector2FA" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector3_genglsl" nodedef="ND_min_vector3" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector3FA_genglsl" nodedef="ND_min_vector3FA" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector4_genglsl" nodedef="ND_min_vector4" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector4FA_genglsl" nodedef="ND_min_vector4FA" file="stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_float_genglsl" nodedef="ND_min_float" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color3_genglsl" nodedef="ND_min_color3" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color3FA_genglsl" nodedef="ND_min_color3FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color4_genglsl" nodedef="ND_min_color4" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color4FA_genglsl" nodedef="ND_min_color4FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector2_genglsl" nodedef="ND_min_vector2" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector2FA_genglsl" nodedef="ND_min_vector2FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector3_genglsl" nodedef="ND_min_vector3" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector3FA_genglsl" nodedef="ND_min_vector3FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector4_genglsl" nodedef="ND_min_vector4" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector4FA_genglsl" nodedef="ND_min_vector4FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
 
   <!-- <max> -->
-  <implementation name="IM_max_float_genglsl" nodedef="ND_max_float" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color3_genglsl" nodedef="ND_max_color3" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color3FA_genglsl" nodedef="ND_max_color3FA" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color4_genglsl" nodedef="ND_max_color4" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color4FA_genglsl" nodedef="ND_max_color4FA" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector2_genglsl" nodedef="ND_max_vector2" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector2FA_genglsl" nodedef="ND_max_vector2FA" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector3_genglsl" nodedef="ND_max_vector3" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector3FA_genglsl" nodedef="ND_max_vector3FA" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector4_genglsl" nodedef="ND_max_vector4" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector4FA_genglsl" nodedef="ND_max_vector4FA" file="stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_float_genglsl" nodedef="ND_max_float" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color3_genglsl" nodedef="ND_max_color3" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color3FA_genglsl" nodedef="ND_max_color3FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color4_genglsl" nodedef="ND_max_color4" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color4FA_genglsl" nodedef="ND_max_color4FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector2_genglsl" nodedef="ND_max_vector2" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector2FA_genglsl" nodedef="ND_max_vector2FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector3_genglsl" nodedef="ND_max_vector3" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector3FA_genglsl" nodedef="ND_max_vector3FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector4_genglsl" nodedef="ND_max_vector4" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector4FA_genglsl" nodedef="ND_max_vector4FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
 
   <!-- <normalize> -->
-  <implementation name="IM_normalize_vector2_genglsl" nodedef="ND_normalize_vector2" file="stdlib/genglsl/mx_normalize.inline" target="genglsl" />
-  <implementation name="IM_normalize_vector3_genglsl" nodedef="ND_normalize_vector3" file="stdlib/genglsl/mx_normalize.inline" target="genglsl" />
-  <implementation name="IM_normalize_vector4_genglsl" nodedef="ND_normalize_vector4" file="stdlib/genglsl/mx_normalize.inline" target="genglsl" />
+  <implementation name="IM_normalize_vector2_genglsl" nodedef="ND_normalize_vector2" file="libraries/stdlib/genglsl/mx_normalize.inline" target="genglsl" />
+  <implementation name="IM_normalize_vector3_genglsl" nodedef="ND_normalize_vector3" file="libraries/stdlib/genglsl/mx_normalize.inline" target="genglsl" />
+  <implementation name="IM_normalize_vector4_genglsl" nodedef="ND_normalize_vector4" file="libraries/stdlib/genglsl/mx_normalize.inline" target="genglsl" />
 
   <!-- <magnitude> -->
-  <implementation name="IM_magnitude_vector2_genglsl" nodedef="ND_magnitude_vector2" file="stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
-  <implementation name="IM_magnitude_vector3_genglsl" nodedef="ND_magnitude_vector3" file="stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
-  <implementation name="IM_magnitude_vector4_genglsl" nodedef="ND_magnitude_vector4" file="stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
+  <implementation name="IM_magnitude_vector2_genglsl" nodedef="ND_magnitude_vector2" file="libraries/stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
+  <implementation name="IM_magnitude_vector3_genglsl" nodedef="ND_magnitude_vector3" file="libraries/stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
+  <implementation name="IM_magnitude_vector4_genglsl" nodedef="ND_magnitude_vector4" file="libraries/stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
 
   <!-- <dotproduct> -->
-  <implementation name="IM_dotproduct_vector2_genglsl" nodedef="ND_dotproduct_vector2" file="stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
-  <implementation name="IM_dotproduct_vector3_genglsl" nodedef="ND_dotproduct_vector3" file="stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
-  <implementation name="IM_dotproduct_vector4_genglsl" nodedef="ND_dotproduct_vector4" file="stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
+  <implementation name="IM_dotproduct_vector2_genglsl" nodedef="ND_dotproduct_vector2" file="libraries/stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
+  <implementation name="IM_dotproduct_vector3_genglsl" nodedef="ND_dotproduct_vector3" file="libraries/stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
+  <implementation name="IM_dotproduct_vector4_genglsl" nodedef="ND_dotproduct_vector4" file="libraries/stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
 
   <!-- <crossproduct> -->
-  <implementation name="IM_crossproduct_vector3_genglsl" nodedef="ND_crossproduct_vector3" file="stdlib/genglsl/mx_crossproduct.inline" target="genglsl" />
+  <implementation name="IM_crossproduct_vector3_genglsl" nodedef="ND_crossproduct_vector3" file="libraries/stdlib/genglsl/mx_crossproduct.inline" target="genglsl" />
 
   <!-- <transformpoint> -->
   <implementation name="IM_transformpoint_vector3_genglsl" nodedef="ND_transformpoint_vector3" target="genglsl" />
@@ -451,28 +451,28 @@
   <implementation name="IM_transformnormal_vector3_genglsl" nodedef="ND_transformnormal_vector3" target="genglsl" />
 
   <!-- <transformmatrix> -->
-  <implementation name="IM_transformmatrix_vector2M3_genglsl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="stdlib/genglsl/mx_transformmatrix_vector2M3.glsl" target="genglsl" />
-  <implementation name="IM_transformmatrix_vector3_genglsl" nodedef="ND_transformmatrix_vector3" file="stdlib/genglsl/mx_transformmatrix.inline" target="genglsl" />
-  <implementation name="IM_transformmatrix_vector3M4_genglsl" nodedef="ND_transformmatrix_vector3M4" function="mx_transformmatrix_vector3M4" file="stdlib/genglsl/mx_transformmatrix_vector3M4.glsl" target="genglsl" />
-  <implementation name="IM_transformmatrix_vector4_genglsl" nodedef="ND_transformmatrix_vector4" file="stdlib/genglsl/mx_transformmatrix.inline" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector2M3_genglsl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="libraries/stdlib/genglsl/mx_transformmatrix_vector2M3.glsl" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector3_genglsl" nodedef="ND_transformmatrix_vector3" file="libraries/stdlib/genglsl/mx_transformmatrix.inline" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector3M4_genglsl" nodedef="ND_transformmatrix_vector3M4" function="mx_transformmatrix_vector3M4" file="libraries/stdlib/genglsl/mx_transformmatrix_vector3M4.glsl" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector4_genglsl" nodedef="ND_transformmatrix_vector4" file="libraries/stdlib/genglsl/mx_transformmatrix.inline" target="genglsl" />
 
   <!-- <transpose> -->
-  <implementation name="IM_transpose_matrix33_genglsl" nodedef="ND_transpose_matrix33" file="stdlib/genglsl/mx_transpose.inline" target="genglsl" />
-  <implementation name="IM_transpose_matrix44_genglsl" nodedef="ND_transpose_matrix44" file="stdlib/genglsl/mx_transpose.inline" target="genglsl" />
+  <implementation name="IM_transpose_matrix33_genglsl" nodedef="ND_transpose_matrix33" file="libraries/stdlib/genglsl/mx_transpose.inline" target="genglsl" />
+  <implementation name="IM_transpose_matrix44_genglsl" nodedef="ND_transpose_matrix44" file="libraries/stdlib/genglsl/mx_transpose.inline" target="genglsl" />
 
   <!-- <determinant> -->
-  <implementation name="IM_determinant_matrix33_genglsl" nodedef="ND_determinant_matrix33" file="stdlib/genglsl/mx_determinant.inline" target="genglsl" />
-  <implementation name="IM_determinant_matrix44_genglsl" nodedef="ND_determinant_matrix44" file="stdlib/genglsl/mx_determinant.inline" target="genglsl" />
+  <implementation name="IM_determinant_matrix33_genglsl" nodedef="ND_determinant_matrix33" file="libraries/stdlib/genglsl/mx_determinant.inline" target="genglsl" />
+  <implementation name="IM_determinant_matrix44_genglsl" nodedef="ND_determinant_matrix44" file="libraries/stdlib/genglsl/mx_determinant.inline" target="genglsl" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genglsl" nodedef="ND_invertmatrix_matrix33" file="stdlib/genglsl/mx_invertM.inline" target="genglsl" />
-  <implementation name="IM_invertmatrix_matrix44_genglsl" nodedef="ND_invertmatrix_matrix44" file="stdlib/genglsl/mx_invertM.inline" target="genglsl" />
+  <implementation name="IM_invertmatrix_matrix33_genglsl" nodedef="ND_invertmatrix_matrix33" file="libraries/stdlib/genglsl/mx_invertM.inline" target="genglsl" />
+  <implementation name="IM_invertmatrix_matrix44_genglsl" nodedef="ND_invertmatrix_matrix44" file="libraries/stdlib/genglsl/mx_invertM.inline" target="genglsl" />
 
   <!-- <rotate2d> -->
-  <implementation name="IM_rotate2d_vector2_genglsl" nodedef="ND_rotate2d_vector2" file="stdlib/genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genglsl" />
+  <implementation name="IM_rotate2d_vector2_genglsl" nodedef="ND_rotate2d_vector2" file="libraries/stdlib/genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genglsl" />
 
   <!-- <rotate3d> -->
-  <implementation name="IM_rotate3d_vector3_genglsl" nodedef="ND_rotate3d_vector3" file="stdlib/genglsl/mx_rotate_vector3.glsl" function="mx_rotate_vector3" target="genglsl" />
+  <implementation name="IM_rotate3d_vector3_genglsl" nodedef="ND_rotate3d_vector3" file="libraries/stdlib/genglsl/mx_rotate_vector3.glsl" function="mx_rotate_vector3" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
@@ -481,124 +481,124 @@
   <!-- <contrast> -->
 
   <!-- <remap> -->
-  <implementation name="IM_remap_float_genglsl" nodedef="ND_remap_float" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color3_genglsl" nodedef="ND_remap_color3" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color3FA_genglsl" nodedef="ND_remap_color3FA" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color4_genglsl" nodedef="ND_remap_color4" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color4FA_genglsl" nodedef="ND_remap_color4FA" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector2_genglsl" nodedef="ND_remap_vector2" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector2FA_genglsl" nodedef="ND_remap_vector2FA" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector3_genglsl" nodedef="ND_remap_vector3" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector3FA_genglsl" nodedef="ND_remap_vector3FA" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector4_genglsl" nodedef="ND_remap_vector4" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector4FA_genglsl" nodedef="ND_remap_vector4FA" file="stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_float_genglsl" nodedef="ND_remap_float" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color3_genglsl" nodedef="ND_remap_color3" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color3FA_genglsl" nodedef="ND_remap_color3FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color4_genglsl" nodedef="ND_remap_color4" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color4FA_genglsl" nodedef="ND_remap_color4FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector2_genglsl" nodedef="ND_remap_vector2" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector2FA_genglsl" nodedef="ND_remap_vector2FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector3_genglsl" nodedef="ND_remap_vector3" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector3FA_genglsl" nodedef="ND_remap_vector3FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector4_genglsl" nodedef="ND_remap_vector4" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector4FA_genglsl" nodedef="ND_remap_vector4FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
 
   <!-- <smoothstep> -->
-  <implementation name="IM_smoothstep_float_genglsl" nodedef="ND_smoothstep_float" file="stdlib/genglsl/mx_smoothstep_float.glsl" function="mx_smoothstep_float" target="genglsl" />
-  <implementation name="IM_smoothstep_color3_genglsl" nodedef="ND_smoothstep_color3" file="stdlib/genglsl/mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
-  <implementation name="IM_smoothstep_color3FA_genglsl" nodedef="ND_smoothstep_color3FA" file="stdlib/genglsl/mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
-  <implementation name="IM_smoothstep_color4_genglsl" nodedef="ND_smoothstep_color4" file="stdlib/genglsl/mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
-  <implementation name="IM_smoothstep_color4FA_genglsl" nodedef="ND_smoothstep_color4FA" file="stdlib/genglsl/mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
-  <implementation name="IM_smoothstep_vector2_genglsl" nodedef="ND_smoothstep_vector2" file="stdlib/genglsl/mx_smoothstep_vec2.glsl" function="mx_smoothstep_vec2" target="genglsl" />
-  <implementation name="IM_smoothstep_vector2FA_genglsl" nodedef="ND_smoothstep_vector2FA" file="stdlib/genglsl/mx_smoothstep_vec2FA.glsl" function="mx_smoothstep_vec2FA" target="genglsl" />
-  <implementation name="IM_smoothstep_vector3_genglsl" nodedef="ND_smoothstep_vector3" file="stdlib/genglsl/mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
-  <implementation name="IM_smoothstep_vector3FA_genglsl" nodedef="ND_smoothstep_vector3FA" file="stdlib/genglsl/mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
-  <implementation name="IM_smoothstep_vector4_genglsl" nodedef="ND_smoothstep_vector4" file="stdlib/genglsl/mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
-  <implementation name="IM_smoothstep_vector4FA_genglsl" nodedef="ND_smoothstep_vector4FA" file="stdlib/genglsl/mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
+  <implementation name="IM_smoothstep_float_genglsl" nodedef="ND_smoothstep_float" file="libraries/stdlib/genglsl/mx_smoothstep_float.glsl" function="mx_smoothstep_float" target="genglsl" />
+  <implementation name="IM_smoothstep_color3_genglsl" nodedef="ND_smoothstep_color3" file="libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
+  <implementation name="IM_smoothstep_color3FA_genglsl" nodedef="ND_smoothstep_color3FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
+  <implementation name="IM_smoothstep_color4_genglsl" nodedef="ND_smoothstep_color4" file="libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
+  <implementation name="IM_smoothstep_color4FA_genglsl" nodedef="ND_smoothstep_color4FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
+  <implementation name="IM_smoothstep_vector2_genglsl" nodedef="ND_smoothstep_vector2" file="libraries/stdlib/genglsl/mx_smoothstep_vec2.glsl" function="mx_smoothstep_vec2" target="genglsl" />
+  <implementation name="IM_smoothstep_vector2FA_genglsl" nodedef="ND_smoothstep_vector2FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec2FA.glsl" function="mx_smoothstep_vec2FA" target="genglsl" />
+  <implementation name="IM_smoothstep_vector3_genglsl" nodedef="ND_smoothstep_vector3" file="libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
+  <implementation name="IM_smoothstep_vector3FA_genglsl" nodedef="ND_smoothstep_vector3FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
+  <implementation name="IM_smoothstep_vector4_genglsl" nodedef="ND_smoothstep_vector4" file="libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
+  <implementation name="IM_smoothstep_vector4FA_genglsl" nodedef="ND_smoothstep_vector4FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
 
   <!-- <luminance> -->
-  <implementation name="IM_luminance_color3_genglsl" nodedef="ND_luminance_color3" file="stdlib/genglsl/mx_luminance_color3.glsl" function="mx_luminance_color3" target="genglsl" />
-  <implementation name="IM_luminance_color4_genglsl" nodedef="ND_luminance_color4" file="stdlib/genglsl/mx_luminance_color4.glsl" function="mx_luminance_color4" target="genglsl" />
+  <implementation name="IM_luminance_color3_genglsl" nodedef="ND_luminance_color3" file="libraries/stdlib/genglsl/mx_luminance_color3.glsl" function="mx_luminance_color3" target="genglsl" />
+  <implementation name="IM_luminance_color4_genglsl" nodedef="ND_luminance_color4" file="libraries/stdlib/genglsl/mx_luminance_color4.glsl" function="mx_luminance_color4" target="genglsl" />
 
   <!-- <rgbtohsv> -->
-  <implementation name="IM_rgbtohsv_color3_genglsl" nodedef="ND_rgbtohsv_color3" file="stdlib/genglsl/mx_rgbtohsv_color3.glsl" function="mx_rgbtohsv_color3" target="genglsl" />
-  <implementation name="IM_rgbtohsv_color4_genglsl" nodedef="ND_rgbtohsv_color4" file="stdlib/genglsl/mx_rgbtohsv_color4.glsl" function="mx_rgbtohsv_color4" target="genglsl" />
+  <implementation name="IM_rgbtohsv_color3_genglsl" nodedef="ND_rgbtohsv_color3" file="libraries/stdlib/genglsl/mx_rgbtohsv_color3.glsl" function="mx_rgbtohsv_color3" target="genglsl" />
+  <implementation name="IM_rgbtohsv_color4_genglsl" nodedef="ND_rgbtohsv_color4" file="libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl" function="mx_rgbtohsv_color4" target="genglsl" />
 
   <!-- <hsvtorgb> -->
-  <implementation name="IM_hsvtorgb_color3_genglsl" nodedef="ND_hsvtorgb_color3" file="stdlib/genglsl/mx_hsvtorgb_color3.glsl" function="mx_hsvtorgb_color3" target="genglsl" />
-  <implementation name="IM_hsvtorgb_color4_genglsl" nodedef="ND_hsvtorgb_color4" file="stdlib/genglsl/mx_hsvtorgb_color4.glsl" function="mx_hsvtorgb_color4" target="genglsl" />
+  <implementation name="IM_hsvtorgb_color3_genglsl" nodedef="ND_hsvtorgb_color3" file="libraries/stdlib/genglsl/mx_hsvtorgb_color3.glsl" function="mx_hsvtorgb_color3" target="genglsl" />
+  <implementation name="IM_hsvtorgb_color4_genglsl" nodedef="ND_hsvtorgb_color4" file="libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl" function="mx_hsvtorgb_color4" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->
   <!-- ======================================================================== -->
 
   <!-- <premult> -->
-  <implementation name="IM_premult_color4_genglsl" nodedef="ND_premult_color4" file="stdlib/genglsl/mx_premult_color4.glsl" function="mx_premult_color4" target="genglsl" />
+  <implementation name="IM_premult_color4_genglsl" nodedef="ND_premult_color4" file="libraries/stdlib/genglsl/mx_premult_color4.glsl" function="mx_premult_color4" target="genglsl" />
 
   <!-- <unpremult> -->
-  <implementation name="IM_unpremult_color4_genglsl" nodedef="ND_unpremult_color4" file="stdlib/genglsl/mx_unpremult_color4.glsl" function="mx_unpremult_color4" target="genglsl" />
+  <implementation name="IM_unpremult_color4_genglsl" nodedef="ND_unpremult_color4" file="libraries/stdlib/genglsl/mx_unpremult_color4.glsl" function="mx_unpremult_color4" target="genglsl" />
 
   <!-- <plus> -->
-  <implementation name="IM_plus_float_genglsl" nodedef="ND_plus_float" file="stdlib/genglsl/mx_plus.inline" target="genglsl" />
-  <implementation name="IM_plus_color3_genglsl" nodedef="ND_plus_color3" file="stdlib/genglsl/mx_plus.inline" target="genglsl" />
-  <implementation name="IM_plus_color4_genglsl" nodedef="ND_plus_color4" file="stdlib/genglsl/mx_plus.inline" target="genglsl" />
+  <implementation name="IM_plus_float_genglsl" nodedef="ND_plus_float" file="libraries/stdlib/genglsl/mx_plus.inline" target="genglsl" />
+  <implementation name="IM_plus_color3_genglsl" nodedef="ND_plus_color3" file="libraries/stdlib/genglsl/mx_plus.inline" target="genglsl" />
+  <implementation name="IM_plus_color4_genglsl" nodedef="ND_plus_color4" file="libraries/stdlib/genglsl/mx_plus.inline" target="genglsl" />
 
   <!-- <minus> -->
-  <implementation name="IM_minus_float_genglsl" nodedef="ND_minus_float" file="stdlib/genglsl/mx_minus.inline" target="genglsl" />
-  <implementation name="IM_minus_color3_genglsl" nodedef="ND_minus_color3" file="stdlib/genglsl/mx_minus.inline" target="genglsl" />
-  <implementation name="IM_minus_color4_genglsl" nodedef="ND_minus_color4" file="stdlib/genglsl/mx_minus.inline" target="genglsl" />
+  <implementation name="IM_minus_float_genglsl" nodedef="ND_minus_float" file="libraries/stdlib/genglsl/mx_minus.inline" target="genglsl" />
+  <implementation name="IM_minus_color3_genglsl" nodedef="ND_minus_color3" file="libraries/stdlib/genglsl/mx_minus.inline" target="genglsl" />
+  <implementation name="IM_minus_color4_genglsl" nodedef="ND_minus_color4" file="libraries/stdlib/genglsl/mx_minus.inline" target="genglsl" />
 
   <!-- <difference> -->
-  <implementation name="IM_difference_float_genglsl" nodedef="ND_difference_float" file="stdlib/genglsl/mx_difference.inline" target="genglsl" />
-  <implementation name="IM_difference_color3_genglsl" nodedef="ND_difference_color3" file="stdlib/genglsl/mx_difference.inline" target="genglsl" />
-  <implementation name="IM_difference_color4_genglsl" nodedef="ND_difference_color4" file="stdlib/genglsl/mx_difference.inline" target="genglsl" />
+  <implementation name="IM_difference_float_genglsl" nodedef="ND_difference_float" file="libraries/stdlib/genglsl/mx_difference.inline" target="genglsl" />
+  <implementation name="IM_difference_color3_genglsl" nodedef="ND_difference_color3" file="libraries/stdlib/genglsl/mx_difference.inline" target="genglsl" />
+  <implementation name="IM_difference_color4_genglsl" nodedef="ND_difference_color4" file="libraries/stdlib/genglsl/mx_difference.inline" target="genglsl" />
 
   <!-- <burn> -->
-  <implementation name="IM_burn_float_genglsl" nodedef="ND_burn_float" file="stdlib/genglsl/mx_burn_float.glsl" function="mx_burn_float" target="genglsl" />
-  <implementation name="IM_burn_color3_genglsl" nodedef="ND_burn_color3" file="stdlib/genglsl/mx_burn_color3.glsl" function="mx_burn_color3" target="genglsl" />
-  <implementation name="IM_burn_color4_genglsl" nodedef="ND_burn_color4" file="stdlib/genglsl/mx_burn_color4.glsl" function="mx_burn_color4" target="genglsl" />
+  <implementation name="IM_burn_float_genglsl" nodedef="ND_burn_float" file="libraries/stdlib/genglsl/mx_burn_float.glsl" function="mx_burn_float" target="genglsl" />
+  <implementation name="IM_burn_color3_genglsl" nodedef="ND_burn_color3" file="libraries/stdlib/genglsl/mx_burn_color3.glsl" function="mx_burn_color3" target="genglsl" />
+  <implementation name="IM_burn_color4_genglsl" nodedef="ND_burn_color4" file="libraries/stdlib/genglsl/mx_burn_color4.glsl" function="mx_burn_color4" target="genglsl" />
 
   <!-- <dodge> -->
-  <implementation name="IM_dodge_float_genglsl" nodedef="ND_dodge_float" file="stdlib/genglsl/mx_dodge_float.glsl" function="mx_dodge_float" target="genglsl" />
-  <implementation name="IM_dodge_color3_genglsl" nodedef="ND_dodge_color3" file="stdlib/genglsl/mx_dodge_color3.glsl" function="mx_dodge_color3" target="genglsl" />
-  <implementation name="IM_dodge_color4_genglsl" nodedef="ND_dodge_color4" file="stdlib/genglsl/mx_dodge_color4.glsl" function="mx_dodge_color4" target="genglsl" />
+  <implementation name="IM_dodge_float_genglsl" nodedef="ND_dodge_float" file="libraries/stdlib/genglsl/mx_dodge_float.glsl" function="mx_dodge_float" target="genglsl" />
+  <implementation name="IM_dodge_color3_genglsl" nodedef="ND_dodge_color3" file="libraries/stdlib/genglsl/mx_dodge_color3.glsl" function="mx_dodge_color3" target="genglsl" />
+  <implementation name="IM_dodge_color4_genglsl" nodedef="ND_dodge_color4" file="libraries/stdlib/genglsl/mx_dodge_color4.glsl" function="mx_dodge_color4" target="genglsl" />
 
   <!-- <screen> -->
-  <implementation name="IM_screen_float_genglsl" nodedef="ND_screen_float" file="stdlib/genglsl/mx_screen.inline" target="genglsl" />
-  <implementation name="IM_screen_color3_genglsl" nodedef="ND_screen_color3" file="stdlib/genglsl/mx_screen.inline" target="genglsl" />
-  <implementation name="IM_screen_color4_genglsl" nodedef="ND_screen_color4" file="stdlib/genglsl/mx_screen.inline" target="genglsl" />
+  <implementation name="IM_screen_float_genglsl" nodedef="ND_screen_float" file="libraries/stdlib/genglsl/mx_screen.inline" target="genglsl" />
+  <implementation name="IM_screen_color3_genglsl" nodedef="ND_screen_color3" file="libraries/stdlib/genglsl/mx_screen.inline" target="genglsl" />
+  <implementation name="IM_screen_color4_genglsl" nodedef="ND_screen_color4" file="libraries/stdlib/genglsl/mx_screen.inline" target="genglsl" />
 
   <!-- <overlay> -->
-  <implementation name="IM_overlay_float_genglsl" nodedef="ND_overlay_float" file="stdlib/genglsl/mx_overlay_float.inline" target="genglsl" />
-  <implementation name="IM_overlay_color3_genglsl" nodedef="ND_overlay_color3" file="stdlib/genglsl/mx_overlay_color3.glsl" function="mx_overlay_color3" target="genglsl" />
-  <implementation name="IM_overlay_color4_genglsl" nodedef="ND_overlay_color4" file="stdlib/genglsl/mx_overlay_color4.glsl" function="mx_overlay_color4" target="genglsl" />
+  <implementation name="IM_overlay_float_genglsl" nodedef="ND_overlay_float" file="libraries/stdlib/genglsl/mx_overlay_float.inline" target="genglsl" />
+  <implementation name="IM_overlay_color3_genglsl" nodedef="ND_overlay_color3" file="libraries/stdlib/genglsl/mx_overlay_color3.glsl" function="mx_overlay_color3" target="genglsl" />
+  <implementation name="IM_overlay_color4_genglsl" nodedef="ND_overlay_color4" file="libraries/stdlib/genglsl/mx_overlay_color4.glsl" function="mx_overlay_color4" target="genglsl" />
 
   <!-- <disjointover> -->
-  <implementation name="IM_disjointover_color4_genglsl" nodedef="ND_disjointover_color4" file="stdlib/genglsl/mx_disjointover_color4.glsl" function="mx_disjointover_color4" target="genglsl" />
+  <implementation name="IM_disjointover_color4_genglsl" nodedef="ND_disjointover_color4" file="libraries/stdlib/genglsl/mx_disjointover_color4.glsl" function="mx_disjointover_color4" target="genglsl" />
 
   <!-- <in> -->
-  <implementation name="IM_in_color4_genglsl" nodedef="ND_in_color4" file="stdlib/genglsl/mx_in_color4.inline" target="genglsl" />
+  <implementation name="IM_in_color4_genglsl" nodedef="ND_in_color4" file="libraries/stdlib/genglsl/mx_in_color4.inline" target="genglsl" />
 
   <!-- <mask> -->
-  <implementation name="IM_mask_color4_genglsl" nodedef="ND_mask_color4" file="stdlib/genglsl/mx_mask_color4.inline" target="genglsl" />
+  <implementation name="IM_mask_color4_genglsl" nodedef="ND_mask_color4" file="libraries/stdlib/genglsl/mx_mask_color4.inline" target="genglsl" />
 
   <!-- <matte> -->
-  <implementation name="IM_matte_color4_genglsl" nodedef="ND_matte_color4" file="stdlib/genglsl/mx_matte_color4.inline" target="genglsl" />
+  <implementation name="IM_matte_color4_genglsl" nodedef="ND_matte_color4" file="libraries/stdlib/genglsl/mx_matte_color4.inline" target="genglsl" />
 
   <!-- <out> -->
-  <implementation name="IM_out_color4_genglsl" nodedef="ND_out_color4" file="stdlib/genglsl/mx_out_color4.inline" target="genglsl" />
+  <implementation name="IM_out_color4_genglsl" nodedef="ND_out_color4" file="libraries/stdlib/genglsl/mx_out_color4.inline" target="genglsl" />
 
   <!-- <over> -->
-  <implementation name="IM_over_color4_genglsl" nodedef="ND_over_color4" file="stdlib/genglsl/mx_over_color4.inline" target="genglsl" />
+  <implementation name="IM_over_color4_genglsl" nodedef="ND_over_color4" file="libraries/stdlib/genglsl/mx_over_color4.inline" target="genglsl" />
 
   <!-- <inside> -->
-  <implementation name="IM_inside_float_genglsl" nodedef="ND_inside_float" file="stdlib/genglsl/mx_inside.inline" target="genglsl" />
-  <implementation name="IM_inside_color3_genglsl" nodedef="ND_inside_color3" file="stdlib/genglsl/mx_inside.inline" target="genglsl" />
-  <implementation name="IM_inside_color4_genglsl" nodedef="ND_inside_color4" file="stdlib/genglsl/mx_inside.inline" target="genglsl" />
+  <implementation name="IM_inside_float_genglsl" nodedef="ND_inside_float" file="libraries/stdlib/genglsl/mx_inside.inline" target="genglsl" />
+  <implementation name="IM_inside_color3_genglsl" nodedef="ND_inside_color3" file="libraries/stdlib/genglsl/mx_inside.inline" target="genglsl" />
+  <implementation name="IM_inside_color4_genglsl" nodedef="ND_inside_color4" file="libraries/stdlib/genglsl/mx_inside.inline" target="genglsl" />
 
   <!-- <outside> -->
-  <implementation name="IM_outside_float_genglsl" nodedef="ND_outside_float" file="stdlib/genglsl/mx_outside.inline" target="genglsl" />
-  <implementation name="IM_outside_color3_genglsl" nodedef="ND_outside_color3" file="stdlib/genglsl/mx_outside.inline" target="genglsl" />
-  <implementation name="IM_outside_color4_genglsl" nodedef="ND_outside_color4" file="stdlib/genglsl/mx_outside.inline" target="genglsl" />
+  <implementation name="IM_outside_float_genglsl" nodedef="ND_outside_float" file="libraries/stdlib/genglsl/mx_outside.inline" target="genglsl" />
+  <implementation name="IM_outside_color3_genglsl" nodedef="ND_outside_color3" file="libraries/stdlib/genglsl/mx_outside.inline" target="genglsl" />
+  <implementation name="IM_outside_color4_genglsl" nodedef="ND_outside_color4" file="libraries/stdlib/genglsl/mx_outside.inline" target="genglsl" />
 
   <!-- <mix> -->
-  <implementation name="IM_mix_float_genglsl" nodedef="ND_mix_float" file="stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_color3_genglsl" nodedef="ND_mix_color3" file="stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_color4_genglsl" nodedef="ND_mix_color4" file="stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_vector2_genglsl" nodedef="ND_mix_vector2" file="stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_vector3_genglsl" nodedef="ND_mix_vector3" file="stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_vector4_genglsl" nodedef="ND_mix_vector4" file="stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_surfaceshader_genglsl" nodedef="ND_mix_surfaceshader" function="mx_mix_surfaceshader" file="stdlib/genglsl/mx_mix_surfaceshader.glsl" target="genglsl" />
+  <implementation name="IM_mix_float_genglsl" nodedef="ND_mix_float" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_color3_genglsl" nodedef="ND_mix_color3" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_color4_genglsl" nodedef="ND_mix_color4" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_vector2_genglsl" nodedef="ND_mix_vector2" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_vector3_genglsl" nodedef="ND_mix_vector3" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_vector4_genglsl" nodedef="ND_mix_vector4" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_surfaceshader_genglsl" nodedef="ND_mix_surfaceshader" function="mx_mix_surfaceshader" file="libraries/stdlib/genglsl/mx_mix_surfaceshader.glsl" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
@@ -766,21 +766,21 @@
   <!-- ======================================================================== -->
 
   <!-- <dot> -->
-  <implementation name="IM_dot_float_genglsl" nodedef="ND_dot_float" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_color3_genglsl" nodedef="ND_dot_color3" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_color4_genglsl" nodedef="ND_dot_color4" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_vector2_genglsl" nodedef="ND_dot_vector2" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_vector3_genglsl" nodedef="ND_dot_vector3" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_vector4_genglsl" nodedef="ND_dot_vector4" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_integer_genglsl" nodedef="ND_dot_integer" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_boolean_genglsl" nodedef="ND_dot_boolean" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_matrix33_genglsl" nodedef="ND_dot_matrix33" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_matrix44_genglsl" nodedef="ND_dot_matrix44" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_string_genglsl" nodedef="ND_dot_string" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_filename_genglsl" nodedef="ND_dot_filename" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_surfaceshader_genglsl" nodedef="ND_dot_surfaceshader" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_displacementshader_genglsl" nodedef="ND_dot_displacementshader" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_volumeshader_genglsl" nodedef="ND_dot_volumeshader" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_lightshader_genglsl" nodedef="ND_dot_lightshader" file="stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_float_genglsl" nodedef="ND_dot_float" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_color3_genglsl" nodedef="ND_dot_color3" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_color4_genglsl" nodedef="ND_dot_color4" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_vector2_genglsl" nodedef="ND_dot_vector2" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_vector3_genglsl" nodedef="ND_dot_vector3" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_vector4_genglsl" nodedef="ND_dot_vector4" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_integer_genglsl" nodedef="ND_dot_integer" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_boolean_genglsl" nodedef="ND_dot_boolean" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_matrix33_genglsl" nodedef="ND_dot_matrix33" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_matrix44_genglsl" nodedef="ND_dot_matrix44" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_string_genglsl" nodedef="ND_dot_string" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_filename_genglsl" nodedef="ND_dot_filename" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_surfaceshader_genglsl" nodedef="ND_dot_surfaceshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_displacementshader_genglsl" nodedef="ND_dot_displacementshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_volumeshader_genglsl" nodedef="ND_dot_volumeshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_lightshader_genglsl" nodedef="ND_dot_lightshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
 
 </materialx>

--- a/libraries/stdlib/genosl/mx_burn_color3.osl
+++ b/libraries/stdlib/genosl/mx_burn_color3.osl
@@ -1,4 +1,4 @@
-#include "stdlib/genosl/mx_burn_float.osl"
+#include "libraries/stdlib/genosl/mx_burn_float.osl"
 
 void mx_burn_color3(color fg, color bg, float mix, output color result)
 {

--- a/libraries/stdlib/genosl/mx_burn_color4.osl
+++ b/libraries/stdlib/genosl/mx_burn_color4.osl
@@ -1,4 +1,4 @@
-#include "stdlib/genosl/mx_burn_float.osl"
+#include "libraries/stdlib/genosl/mx_burn_float.osl"
 
 void mx_burn_color4(color4 fg, color4 bg, float mix, output color4 result)
 {

--- a/libraries/stdlib/genosl/mx_dodge_color3.osl
+++ b/libraries/stdlib/genosl/mx_dodge_color3.osl
@@ -1,4 +1,4 @@
-#include "stdlib/genosl/mx_dodge_float.osl"
+#include "libraries/stdlib/genosl/mx_dodge_float.osl"
 
 void mx_dodge_color3(color fg, color bg, float mix, output color result)
 {

--- a/libraries/stdlib/genosl/mx_dodge_color4.osl
+++ b/libraries/stdlib/genosl/mx_dodge_color4.osl
@@ -1,4 +1,4 @@
-#include "stdlib/genosl/mx_dodge_float.osl"
+#include "libraries/stdlib/genosl/mx_dodge_float.osl"
 
 void mx_dodge_color4(color4 fg , color4 bg , float mix , output color4 result)
 {

--- a/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl
+++ b/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl
@@ -1,4 +1,4 @@
-#include "stdlib/genosl/lib/mx_transform_color.osl"
+#include "libraries/stdlib/genosl/lib/mx_transform_color.osl"
 
 void mx_srgb_texture_to_lin_rec709_color3(color _in, output color result)
 {

--- a/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl
+++ b/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl
@@ -1,4 +1,4 @@
-#include "stdlib/genosl/lib/mx_transform_color.osl"
+#include "libraries/stdlib/genosl/lib/mx_transform_color.osl"
 
 void mx_srgb_texture_to_lin_rec709_color4(color4 _in, output color4 result)
 {

--- a/libraries/stdlib/genosl/stdlib_genosl_cm_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_cm_impl.mtlx
@@ -5,20 +5,20 @@
   <!-- Color Management System Implementations -->
   <!-- ======================================================================== -->
 
-  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_gamma18_to_linear_color3.osl" function="mx_gamma18_to_linear_color3" target="genosl" />
-  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma18_to_linear_color4.osl" function="mx_gamma18_to_linear_color4" target="genosl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_gamma22_to_linear_color3.osl" function="mx_gamma22_to_linear_color3" target="genosl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma22_to_linear_color4.osl" function="mx_gamma22_to_linear_color4" target="genosl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_gamma24_to_linear_color3.osl" function="mx_gamma24_to_linear_color3" target="genosl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_gamma24_to_linear_color4.osl" function="mx_gamma24_to_linear_color4" target="genosl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_gamma18_to_linear_color3.osl" function="mx_gamma18_to_linear_color3" target="genosl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_gamma18_to_linear_color4.osl" function="mx_gamma18_to_linear_color4" target="genosl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_gamma22_to_linear_color3.osl" function="mx_gamma22_to_linear_color3" target="genosl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_gamma22_to_linear_color4.osl" function="mx_gamma22_to_linear_color4" target="genosl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_gamma24_to_linear_color3.osl" function="mx_gamma24_to_linear_color3" target="genosl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_gamma24_to_linear_color4.osl" function="mx_gamma24_to_linear_color4" target="genosl" />
 
-  <implementation name="IM_acescg_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_ap1_to_rec709_color3.osl" function="mx_ap1_to_rec709_color3" target="genosl" />
-  <implementation name="IM_acescg_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_ap1_to_rec709_color4.osl" function="mx_ap1_to_rec709_color4" target="genosl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_ap1_to_rec709_color3.osl" function="mx_ap1_to_rec709_color3" target="genosl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_ap1_to_rec709_color4.osl" function="mx_ap1_to_rec709_color4" target="genosl" />
 
-  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_g22_ap1_to_lin_rec709_color3.osl" function="mx_g22_ap1_to_lin_rec709_color3" target="genosl" />
-  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_g22_ap1_to_lin_rec709_color4.osl" function="mx_g22_ap1_to_lin_rec709_color4" target="genosl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color3.osl" function="mx_g22_ap1_to_lin_rec709_color3" target="genosl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color4.osl" function="mx_g22_ap1_to_lin_rec709_color4" target="genosl" />
 
-  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genosl" file="stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl" function="mx_srgb_texture_to_lin_rec709_color3" target="genosl" />
-  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genosl" file="stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl" function="mx_srgb_texture_to_lin_rec709_color4" target="genosl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl" function="mx_srgb_texture_to_lin_rec709_color3" target="genosl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl" function="mx_srgb_texture_to_lin_rec709_color4" target="genosl" />
 
 </materialx>

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -12,141 +12,141 @@
   <!-- ======================================================================== -->
 
   <!-- <surface> -->
-  <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="stdlib/genosl/mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl" />
+  <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="libraries/stdlib/genosl/mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Texture nodes                                                            -->
   <!-- ======================================================================== -->
 
   <!-- <image> -->
-  <implementation name="IM_image_float_genosl" nodedef="ND_image_float" file="stdlib/genosl/mx_image_float.osl" function="mx_image_float" target="genosl">
+  <implementation name="IM_image_float_genosl" nodedef="ND_image_float" file="libraries/stdlib/genosl/mx_image_float.osl" function="mx_image_float" target="genosl">
     <input name="default" type="float" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color3_genosl" nodedef="ND_image_color3" file="stdlib/genosl/mx_image_color3.osl" function="mx_image_color3" target="genosl">
+  <implementation name="IM_image_color3_genosl" nodedef="ND_image_color3" file="libraries/stdlib/genosl/mx_image_color3.osl" function="mx_image_color3" target="genosl">
     <input name="default" type="color3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color4_genosl" nodedef="ND_image_color4" file="stdlib/genosl/mx_image_color4.osl" function="mx_image_color4" target="genosl">
+  <implementation name="IM_image_color4_genosl" nodedef="ND_image_color4" file="libraries/stdlib/genosl/mx_image_color4.osl" function="mx_image_color4" target="genosl">
     <input name="default" type="color4" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector2_genosl" nodedef="ND_image_vector2" file="stdlib/genosl/mx_image_vector2.osl" function="mx_image_vector2" target="genosl">
+  <implementation name="IM_image_vector2_genosl" nodedef="ND_image_vector2" file="libraries/stdlib/genosl/mx_image_vector2.osl" function="mx_image_vector2" target="genosl">
     <input name="default" type="vector2" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector3_genosl" nodedef="ND_image_vector3" file="stdlib/genosl/mx_image_vector3.osl" function="mx_image_vector3" target="genosl">
+  <implementation name="IM_image_vector3_genosl" nodedef="ND_image_vector3" file="libraries/stdlib/genosl/mx_image_vector3.osl" function="mx_image_vector3" target="genosl">
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector4_genosl" nodedef="ND_image_vector4" file="stdlib/genosl/mx_image_vector4.osl" function="mx_image_vector4" target="genosl">
+  <implementation name="IM_image_vector4_genosl" nodedef="ND_image_vector4" file="libraries/stdlib/genosl/mx_image_vector4.osl" function="mx_image_vector4" target="genosl">
     <input name="default" type="vector4" implname="default_value" />
   </implementation>
 
   <!-- <triplanarprojection> -->
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_genosl" nodedef="ND_normalmap" file="stdlib/genosl/mx_normalmap.osl" function="mx_normalmap" target="genosl" />
+  <implementation name="IM_normalmap_genosl" nodedef="ND_normalmap" file="libraries/stdlib/genosl/mx_normalmap.osl" function="mx_normalmap" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->
   <!-- ======================================================================== -->
 
   <!-- <constant> -->
-  <implementation name="IM_constant_float_genosl" nodedef="ND_constant_float" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_color3_genosl" nodedef="ND_constant_color3" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_color4_genosl" nodedef="ND_constant_color4" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_vector2_genosl" nodedef="ND_constant_vector2" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_vector3_genosl" nodedef="ND_constant_vector3" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_vector4_genosl" nodedef="ND_constant_vector4" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_boolean_genosl" nodedef="ND_constant_boolean" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_integer_genosl" nodedef="ND_constant_integer" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_matrix33_genosl" nodedef="ND_constant_matrix33" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_matrix44_genosl" nodedef="ND_constant_matrix44" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_string_genosl" nodedef="ND_constant_string" file="stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_filename_genosl" nodedef="ND_constant_filename" file="stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_float_genosl" nodedef="ND_constant_float" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_color3_genosl" nodedef="ND_constant_color3" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_color4_genosl" nodedef="ND_constant_color4" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_vector2_genosl" nodedef="ND_constant_vector2" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_vector3_genosl" nodedef="ND_constant_vector3" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_vector4_genosl" nodedef="ND_constant_vector4" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_boolean_genosl" nodedef="ND_constant_boolean" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_integer_genosl" nodedef="ND_constant_integer" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_matrix33_genosl" nodedef="ND_constant_matrix33" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_matrix44_genosl" nodedef="ND_constant_matrix44" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_string_genosl" nodedef="ND_constant_string" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_filename_genosl" nodedef="ND_constant_filename" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
 
   <!-- <ramplr> -->
-  <implementation name="IM_ramplr_float_genosl" nodedef="ND_ramplr_float" file="stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_color3_genosl" nodedef="ND_ramplr_color3" file="stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_color4_genosl" nodedef="ND_ramplr_color4" file="stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_vector2_genosl" nodedef="ND_ramplr_vector2" file="stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_vector3_genosl" nodedef="ND_ramplr_vector3" file="stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_vector4_genosl" nodedef="ND_ramplr_vector4" file="stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_float_genosl" nodedef="ND_ramplr_float" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_color3_genosl" nodedef="ND_ramplr_color3" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_color4_genosl" nodedef="ND_ramplr_color4" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_vector2_genosl" nodedef="ND_ramplr_vector2" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_vector3_genosl" nodedef="ND_ramplr_vector3" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_vector4_genosl" nodedef="ND_ramplr_vector4" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
 
   <!-- <ramptb> -->
-  <implementation name="IM_ramptb_float_genosl" nodedef="ND_ramptb_float" file="stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_color3_genosl" nodedef="ND_ramptb_color3" file="stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_color4_genosl" nodedef="ND_ramptb_color4" file="stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_vector2_genosl" nodedef="ND_ramptb_vector2" file="stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_vector3_genosl" nodedef="ND_ramptb_vector3" file="stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_vector4_genosl" nodedef="ND_ramptb_vector4" file="stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_float_genosl" nodedef="ND_ramptb_float" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_color3_genosl" nodedef="ND_ramptb_color3" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_color4_genosl" nodedef="ND_ramptb_color4" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_vector2_genosl" nodedef="ND_ramptb_vector2" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_vector3_genosl" nodedef="ND_ramptb_vector3" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_vector4_genosl" nodedef="ND_ramptb_vector4" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
 
   <!-- <splitlr> -->
-  <implementation name="IM_splitlr_float_genosl" nodedef="ND_splitlr_float" file="stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_color3_genosl" nodedef="ND_splitlr_color3" file="stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_color4_genosl" nodedef="ND_splitlr_color4" file="stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_vector2_genosl" nodedef="ND_splitlr_vector2" file="stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_vector3_genosl" nodedef="ND_splitlr_vector3" file="stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_vector4_genosl" nodedef="ND_splitlr_vector4" file="stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_float_genosl" nodedef="ND_splitlr_float" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_color3_genosl" nodedef="ND_splitlr_color3" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_color4_genosl" nodedef="ND_splitlr_color4" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_vector2_genosl" nodedef="ND_splitlr_vector2" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_vector3_genosl" nodedef="ND_splitlr_vector3" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_vector4_genosl" nodedef="ND_splitlr_vector4" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
 
   <!-- <splittb> -->
-  <implementation name="IM_splittb_float_genosl" nodedef="ND_splittb_float" file="stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_color3_genosl" nodedef="ND_splittb_color3" file="stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_color4_genosl" nodedef="ND_splittb_color4" file="stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_vector2_genosl" nodedef="ND_splittb_vector2" file="stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_vector3_genosl" nodedef="ND_splittb_vector3" file="stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_vector4_genosl" nodedef="ND_splittb_vector4" file="stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_float_genosl" nodedef="ND_splittb_float" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_color3_genosl" nodedef="ND_splittb_color3" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_color4_genosl" nodedef="ND_splittb_color4" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_vector2_genosl" nodedef="ND_splittb_vector2" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_vector3_genosl" nodedef="ND_splittb_vector3" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_vector4_genosl" nodedef="ND_splittb_vector4" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
 
   <!-- <noise2d> -->
-  <implementation name="IM_noise2d_float_genosl" nodedef="ND_noise2d_float" file="stdlib/genosl/mx_noise2d_float.osl" function="mx_noise2d_float" target="genosl" />
-  <implementation name="IM_noise2d_color3_genosl" nodedef="ND_noise2d_color3" file="stdlib/genosl/mx_noise2d_color3.osl" function="mx_noise2d_color3" target="genosl" />
-  <implementation name="IM_noise2d_color4_genosl" nodedef="ND_noise2d_color4" file="stdlib/genosl/mx_noise2d_color4.osl" function="mx_noise2d_color4" target="genosl" />
-  <implementation name="IM_noise2d_color3FA_genosl" nodedef="ND_noise2d_color3FA" file="stdlib/genosl/mx_noise2d_fa_color3.osl" function="mx_noise2d_fa_color3" target="genosl" />
-  <implementation name="IM_noise2d_color4FA_genosl" nodedef="ND_noise2d_color4FA" file="stdlib/genosl/mx_noise2d_fa_color4.osl" function="mx_noise2d_fa_color4" target="genosl" />
-  <implementation name="IM_noise2d_vector2_genosl" nodedef="ND_noise2d_vector2" file="stdlib/genosl/mx_noise2d_vector2.osl" function="mx_noise2d_vector2" target="genosl" />
-  <implementation name="IM_noise2d_vector3_genosl" nodedef="ND_noise2d_vector3" file="stdlib/genosl/mx_noise2d_vector3.osl" function="mx_noise2d_vector3" target="genosl" />
-  <implementation name="IM_noise2d_vector4_genosl" nodedef="ND_noise2d_vector4" file="stdlib/genosl/mx_noise2d_vector4.osl" function="mx_noise2d_vector4" target="genosl" />
-  <implementation name="IM_noise2d_vector2FA_genosl" nodedef="ND_noise2d_vector2FA" file="stdlib/genosl/mx_noise2d_fa_vector2.osl" function="mx_noise2d_fa_vector2" target="genosl" />
-  <implementation name="IM_noise2d_vector3FA_genosl" nodedef="ND_noise2d_vector3FA" file="stdlib/genosl/mx_noise2d_fa_vector3.osl" function="mx_noise2d_fa_vector3" target="genosl" />
-  <implementation name="IM_noise2d_vector4FA_genosl" nodedef="ND_noise2d_vector4FA" file="stdlib/genosl/mx_noise2d_fa_vector4.osl" function="mx_noise2d_fa_vector4" target="genosl" />
+  <implementation name="IM_noise2d_float_genosl" nodedef="ND_noise2d_float" file="libraries/stdlib/genosl/mx_noise2d_float.osl" function="mx_noise2d_float" target="genosl" />
+  <implementation name="IM_noise2d_color3_genosl" nodedef="ND_noise2d_color3" file="libraries/stdlib/genosl/mx_noise2d_color3.osl" function="mx_noise2d_color3" target="genosl" />
+  <implementation name="IM_noise2d_color4_genosl" nodedef="ND_noise2d_color4" file="libraries/stdlib/genosl/mx_noise2d_color4.osl" function="mx_noise2d_color4" target="genosl" />
+  <implementation name="IM_noise2d_color3FA_genosl" nodedef="ND_noise2d_color3FA" file="libraries/stdlib/genosl/mx_noise2d_fa_color3.osl" function="mx_noise2d_fa_color3" target="genosl" />
+  <implementation name="IM_noise2d_color4FA_genosl" nodedef="ND_noise2d_color4FA" file="libraries/stdlib/genosl/mx_noise2d_fa_color4.osl" function="mx_noise2d_fa_color4" target="genosl" />
+  <implementation name="IM_noise2d_vector2_genosl" nodedef="ND_noise2d_vector2" file="libraries/stdlib/genosl/mx_noise2d_vector2.osl" function="mx_noise2d_vector2" target="genosl" />
+  <implementation name="IM_noise2d_vector3_genosl" nodedef="ND_noise2d_vector3" file="libraries/stdlib/genosl/mx_noise2d_vector3.osl" function="mx_noise2d_vector3" target="genosl" />
+  <implementation name="IM_noise2d_vector4_genosl" nodedef="ND_noise2d_vector4" file="libraries/stdlib/genosl/mx_noise2d_vector4.osl" function="mx_noise2d_vector4" target="genosl" />
+  <implementation name="IM_noise2d_vector2FA_genosl" nodedef="ND_noise2d_vector2FA" file="libraries/stdlib/genosl/mx_noise2d_fa_vector2.osl" function="mx_noise2d_fa_vector2" target="genosl" />
+  <implementation name="IM_noise2d_vector3FA_genosl" nodedef="ND_noise2d_vector3FA" file="libraries/stdlib/genosl/mx_noise2d_fa_vector3.osl" function="mx_noise2d_fa_vector3" target="genosl" />
+  <implementation name="IM_noise2d_vector4FA_genosl" nodedef="ND_noise2d_vector4FA" file="libraries/stdlib/genosl/mx_noise2d_fa_vector4.osl" function="mx_noise2d_fa_vector4" target="genosl" />
 
   <!-- <noise3d> -->
-  <implementation name="IM_noise3d_float_genosl" nodedef="ND_noise3d_float" file="stdlib/genosl/mx_noise3d_float.osl" function="mx_noise3d_float" target="genosl" />
-  <implementation name="IM_noise3d_color3_genosl" nodedef="ND_noise3d_color3" file="stdlib/genosl/mx_noise3d_color3.osl" function="mx_noise3d_color3" target="genosl" />
-  <implementation name="IM_noise3d_color4_genosl" nodedef="ND_noise3d_color4" file="stdlib/genosl/mx_noise3d_color4.osl" function="mx_noise3d_color4" target="genosl" />
-  <implementation name="IM_noise3d_color3FA_genosl" nodedef="ND_noise3d_color3FA" file="stdlib/genosl/mx_noise3d_fa_color3.osl" function="mx_noise3d_fa_color3" target="genosl" />
-  <implementation name="IM_noise3d_color4FA_genosl" nodedef="ND_noise3d_color4FA" file="stdlib/genosl/mx_noise3d_fa_color4.osl" function="mx_noise3d_fa_color4" target="genosl" />
-  <implementation name="IM_noise3d_vector2_genosl" nodedef="ND_noise3d_vector2" file="stdlib/genosl/mx_noise3d_vector2.osl" function="mx_noise3d_vector2" target="genosl" />
-  <implementation name="IM_noise3d_vector3_genosl" nodedef="ND_noise3d_vector3" file="stdlib/genosl/mx_noise3d_vector3.osl" function="mx_noise3d_vector3" target="genosl" />
-  <implementation name="IM_noise3d_vector4_genosl" nodedef="ND_noise3d_vector4" file="stdlib/genosl/mx_noise3d_vector4.osl" function="mx_noise3d_vector4" target="genosl" />
-  <implementation name="IM_noise3d_vector2FA_genosl" nodedef="ND_noise3d_vector2FA" file="stdlib/genosl/mx_noise3d_fa_vector2.osl" function="mx_noise3d_fa_vector2" target="genosl" />
-  <implementation name="IM_noise3d_vector3FA_genosl" nodedef="ND_noise3d_vector3FA" file="stdlib/genosl/mx_noise3d_fa_vector3.osl" function="mx_noise3d_fa_vector3" target="genosl" />
-  <implementation name="IM_noise3d_vector4FA_genosl" nodedef="ND_noise3d_vector4FA" file="stdlib/genosl/mx_noise3d_fa_vector4.osl" function="mx_noise3d_fa_vector4" target="genosl" />
+  <implementation name="IM_noise3d_float_genosl" nodedef="ND_noise3d_float" file="libraries/stdlib/genosl/mx_noise3d_float.osl" function="mx_noise3d_float" target="genosl" />
+  <implementation name="IM_noise3d_color3_genosl" nodedef="ND_noise3d_color3" file="libraries/stdlib/genosl/mx_noise3d_color3.osl" function="mx_noise3d_color3" target="genosl" />
+  <implementation name="IM_noise3d_color4_genosl" nodedef="ND_noise3d_color4" file="libraries/stdlib/genosl/mx_noise3d_color4.osl" function="mx_noise3d_color4" target="genosl" />
+  <implementation name="IM_noise3d_color3FA_genosl" nodedef="ND_noise3d_color3FA" file="libraries/stdlib/genosl/mx_noise3d_fa_color3.osl" function="mx_noise3d_fa_color3" target="genosl" />
+  <implementation name="IM_noise3d_color4FA_genosl" nodedef="ND_noise3d_color4FA" file="libraries/stdlib/genosl/mx_noise3d_fa_color4.osl" function="mx_noise3d_fa_color4" target="genosl" />
+  <implementation name="IM_noise3d_vector2_genosl" nodedef="ND_noise3d_vector2" file="libraries/stdlib/genosl/mx_noise3d_vector2.osl" function="mx_noise3d_vector2" target="genosl" />
+  <implementation name="IM_noise3d_vector3_genosl" nodedef="ND_noise3d_vector3" file="libraries/stdlib/genosl/mx_noise3d_vector3.osl" function="mx_noise3d_vector3" target="genosl" />
+  <implementation name="IM_noise3d_vector4_genosl" nodedef="ND_noise3d_vector4" file="libraries/stdlib/genosl/mx_noise3d_vector4.osl" function="mx_noise3d_vector4" target="genosl" />
+  <implementation name="IM_noise3d_vector2FA_genosl" nodedef="ND_noise3d_vector2FA" file="libraries/stdlib/genosl/mx_noise3d_fa_vector2.osl" function="mx_noise3d_fa_vector2" target="genosl" />
+  <implementation name="IM_noise3d_vector3FA_genosl" nodedef="ND_noise3d_vector3FA" file="libraries/stdlib/genosl/mx_noise3d_fa_vector3.osl" function="mx_noise3d_fa_vector3" target="genosl" />
+  <implementation name="IM_noise3d_vector4FA_genosl" nodedef="ND_noise3d_vector4FA" file="libraries/stdlib/genosl/mx_noise3d_fa_vector4.osl" function="mx_noise3d_fa_vector4" target="genosl" />
 
   <!-- <fractal3d> -->
-  <implementation name="IM_fractal3d_float_genosl" nodedef="ND_fractal3d_float" file="stdlib/genosl/mx_fractal3d_float.osl" function="mx_fractal3d_float" target="genosl" />
-  <implementation name="IM_fractal3d_color3_genosl" nodedef="ND_fractal3d_color3" file="stdlib/genosl/mx_fractal3d_color3.osl" function="mx_fractal3d_color3" target="genosl" />
-  <implementation name="IM_fractal3d_color4_genosl" nodedef="ND_fractal3d_color4" file="stdlib/genosl/mx_fractal3d_color4.osl" function="mx_fractal3d_color4" target="genosl" />
-  <implementation name="IM_fractal3d_color3FA_genosl" nodedef="ND_fractal3d_color3FA" file="stdlib/genosl/mx_fractal3d_fa_color3.osl" function="mx_fractal3d_fa_color3" target="genosl" />
-  <implementation name="IM_fractal3d_color4FA_genosl" nodedef="ND_fractal3d_color4FA" file="stdlib/genosl/mx_fractal3d_fa_color4.osl" function="mx_fractal3d_fa_color4" target="genosl" />
-  <implementation name="IM_fractal3d_vector2_genosl" nodedef="ND_fractal3d_vector2" file="stdlib/genosl/mx_fractal3d_vector2.osl" function="mx_fractal3d_vector2" target="genosl" />
-  <implementation name="IM_fractal3d_vector3_genosl" nodedef="ND_fractal3d_vector3" file="stdlib/genosl/mx_fractal3d_vector3.osl" function="mx_fractal3d_vector3" target="genosl" />
-  <implementation name="IM_fractal3d_vector4_genosl" nodedef="ND_fractal3d_vector4" file="stdlib/genosl/mx_fractal3d_vector4.osl" function="mx_fractal3d_vector4" target="genosl" />
-  <implementation name="IM_fractal3d_vector2FA_genosl" nodedef="ND_fractal3d_vector2FA" file="stdlib/genosl/mx_fractal3d_fa_vector2.osl" function="mx_fractal3d_fa_vector2" target="genosl" />
-  <implementation name="IM_fractal3d_vector3FA_genosl" nodedef="ND_fractal3d_vector3FA" file="stdlib/genosl/mx_fractal3d_fa_vector3.osl" function="mx_fractal3d_fa_vector3" target="genosl" />
-  <implementation name="IM_fractal3d_vector4FA_genosl" nodedef="ND_fractal3d_vector4FA" file="stdlib/genosl/mx_fractal3d_fa_vector4.osl" function="mx_fractal3d_fa_vector4" target="genosl" />
+  <implementation name="IM_fractal3d_float_genosl" nodedef="ND_fractal3d_float" file="libraries/stdlib/genosl/mx_fractal3d_float.osl" function="mx_fractal3d_float" target="genosl" />
+  <implementation name="IM_fractal3d_color3_genosl" nodedef="ND_fractal3d_color3" file="libraries/stdlib/genosl/mx_fractal3d_color3.osl" function="mx_fractal3d_color3" target="genosl" />
+  <implementation name="IM_fractal3d_color4_genosl" nodedef="ND_fractal3d_color4" file="libraries/stdlib/genosl/mx_fractal3d_color4.osl" function="mx_fractal3d_color4" target="genosl" />
+  <implementation name="IM_fractal3d_color3FA_genosl" nodedef="ND_fractal3d_color3FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_color3.osl" function="mx_fractal3d_fa_color3" target="genosl" />
+  <implementation name="IM_fractal3d_color4FA_genosl" nodedef="ND_fractal3d_color4FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_color4.osl" function="mx_fractal3d_fa_color4" target="genosl" />
+  <implementation name="IM_fractal3d_vector2_genosl" nodedef="ND_fractal3d_vector2" file="libraries/stdlib/genosl/mx_fractal3d_vector2.osl" function="mx_fractal3d_vector2" target="genosl" />
+  <implementation name="IM_fractal3d_vector3_genosl" nodedef="ND_fractal3d_vector3" file="libraries/stdlib/genosl/mx_fractal3d_vector3.osl" function="mx_fractal3d_vector3" target="genosl" />
+  <implementation name="IM_fractal3d_vector4_genosl" nodedef="ND_fractal3d_vector4" file="libraries/stdlib/genosl/mx_fractal3d_vector4.osl" function="mx_fractal3d_vector4" target="genosl" />
+  <implementation name="IM_fractal3d_vector2FA_genosl" nodedef="ND_fractal3d_vector2FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_vector2.osl" function="mx_fractal3d_fa_vector2" target="genosl" />
+  <implementation name="IM_fractal3d_vector3FA_genosl" nodedef="ND_fractal3d_vector3FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_vector3.osl" function="mx_fractal3d_fa_vector3" target="genosl" />
+  <implementation name="IM_fractal3d_vector4FA_genosl" nodedef="ND_fractal3d_vector4FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_vector4.osl" function="mx_fractal3d_fa_vector4" target="genosl" />
 
   <!-- <cellnoise2d> -->
-  <implementation name="IM_cellnoise2d_float_genosl" nodedef="ND_cellnoise2d_float" file="stdlib/genosl/mx_cellnoise2d_float.osl" function="mx_cellnoise2d_float" target="genosl" />
+  <implementation name="IM_cellnoise2d_float_genosl" nodedef="ND_cellnoise2d_float" file="libraries/stdlib/genosl/mx_cellnoise2d_float.osl" function="mx_cellnoise2d_float" target="genosl" />
 
   <!-- <cellnoise3d> -->
-  <implementation name="IM_cellnoise3d_float_genosl" nodedef="ND_cellnoise3d_float" file="stdlib/genosl/mx_cellnoise3d_float.osl" function="mx_cellnoise3d_float" target="genosl" />
+  <implementation name="IM_cellnoise3d_float_genosl" nodedef="ND_cellnoise3d_float" file="libraries/stdlib/genosl/mx_cellnoise3d_float.osl" function="mx_cellnoise3d_float" target="genosl" />
 
   <!-- <worleynoise2d> -->
-  <implementation name="IM_worleynoise2d_float_genosl" nodedef="ND_worleynoise2d_float" file="stdlib/genosl/mx_worleynoise2d_float.osl" function="mx_worleynoise2d_float" target="genosl" />
-  <implementation name="IM_worleynoise2d_vector2_genosl" nodedef="ND_worleynoise2d_vector2" file="stdlib/genosl/mx_worleynoise2d_vector2.osl" function="mx_worleynoise2d_vector2" target="genosl" />
-  <implementation name="IM_worleynoise2d_vector3_genosl" nodedef="ND_worleynoise2d_vector3" file="stdlib/genosl/mx_worleynoise2d_vector3.osl" function="mx_worleynoise2d_vector3" target="genosl" />
+  <implementation name="IM_worleynoise2d_float_genosl" nodedef="ND_worleynoise2d_float" file="libraries/stdlib/genosl/mx_worleynoise2d_float.osl" function="mx_worleynoise2d_float" target="genosl" />
+  <implementation name="IM_worleynoise2d_vector2_genosl" nodedef="ND_worleynoise2d_vector2" file="libraries/stdlib/genosl/mx_worleynoise2d_vector2.osl" function="mx_worleynoise2d_vector2" target="genosl" />
+  <implementation name="IM_worleynoise2d_vector3_genosl" nodedef="ND_worleynoise2d_vector3" file="libraries/stdlib/genosl/mx_worleynoise2d_vector3.osl" function="mx_worleynoise2d_vector3" target="genosl" />
 
   <!-- <worleynoise3d> -->
-  <implementation name="IM_worleynoise3d_float_genosl" nodedef="ND_worleynoise3d_float" file="stdlib/genosl/mx_worleynoise3d_float.osl" function="mx_worleynoise3d_float" target="genosl" />
-  <implementation name="IM_worleynoise3d_vector2_genosl" nodedef="ND_worleynoise3d_vector2" file="stdlib/genosl/mx_worleynoise3d_vector2.osl" function="mx_worleynoise3d_vector2" target="genosl" />
-  <implementation name="IM_worleynoise3d_vector3_genosl" nodedef="ND_worleynoise3d_vector3" file="stdlib/genosl/mx_worleynoise3d_vector3.osl" function="mx_worleynoise3d_vector3" target="genosl" />
+  <implementation name="IM_worleynoise3d_float_genosl" nodedef="ND_worleynoise3d_float" file="libraries/stdlib/genosl/mx_worleynoise3d_float.osl" function="mx_worleynoise3d_float" target="genosl" />
+  <implementation name="IM_worleynoise3d_vector2_genosl" nodedef="ND_worleynoise3d_vector2" file="libraries/stdlib/genosl/mx_worleynoise3d_vector2.osl" function="mx_worleynoise3d_vector2" target="genosl" />
+  <implementation name="IM_worleynoise3d_vector3_genosl" nodedef="ND_worleynoise3d_vector3" file="libraries/stdlib/genosl/mx_worleynoise3d_vector3.osl" function="mx_worleynoise3d_vector3" target="genosl" />
 
 
   <!-- ======================================================================== -->
@@ -154,456 +154,456 @@
   <!-- ======================================================================== -->
 
   <!-- <ambientocclusion> -->
-  <implementation name="IM_ambientocclusion_float_genosl" nodedef="ND_ambientocclusion_float" file="stdlib/genosl/mx_ambientocclusion_float.osl" function="mx_ambientocclusion_float" target="genosl" />
+  <implementation name="IM_ambientocclusion_float_genosl" nodedef="ND_ambientocclusion_float" file="libraries/stdlib/genosl/mx_ambientocclusion_float.osl" function="mx_ambientocclusion_float" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Geometric nodes                                                          -->
   <!-- ======================================================================== -->
 
   <!-- <position> -->
-  <implementation name="IM_position_vector3_genosl" nodedef="ND_position_vector3" file="stdlib/genosl/mx_position_vector3.inline" target="genosl" />
+  <implementation name="IM_position_vector3_genosl" nodedef="ND_position_vector3" file="libraries/stdlib/genosl/mx_position_vector3.inline" target="genosl" />
 
   <!-- <normal> -->
-  <implementation name="IM_normal_vector3_genosl" nodedef="ND_normal_vector3" file="stdlib/genosl/mx_normal_vector3.inline" target="genosl" />
+  <implementation name="IM_normal_vector3_genosl" nodedef="ND_normal_vector3" file="libraries/stdlib/genosl/mx_normal_vector3.inline" target="genosl" />
 
   <!-- <tangent> -->
-  <implementation name="IM_tangent_vector3_genosl" nodedef="ND_tangent_vector3" file="stdlib/genosl/mx_tangent_vector3.inline" target="genosl" />
+  <implementation name="IM_tangent_vector3_genosl" nodedef="ND_tangent_vector3" file="libraries/stdlib/genosl/mx_tangent_vector3.inline" target="genosl" />
 
   <!-- <bitangent> -->
-  <implementation name="IM_bitangent_vector3_genosl" nodedef="ND_bitangent_vector3" file="stdlib/genosl/mx_bitangent_vector3.inline" target="genosl" />
+  <implementation name="IM_bitangent_vector3_genosl" nodedef="ND_bitangent_vector3" file="libraries/stdlib/genosl/mx_bitangent_vector3.inline" target="genosl" />
 
   <!-- <texcoord> -->
-  <implementation name="IM_texcoord_vector2_genosl" nodedef="ND_texcoord_vector2" file="stdlib/genosl/mx_texcoord_vector2.inline" target="genosl" />
-  <implementation name="IM_texcoord_vector3_genosl" nodedef="ND_texcoord_vector3" file="stdlib/genosl/mx_texcoord_vector3.inline" target="genosl" />
+  <implementation name="IM_texcoord_vector2_genosl" nodedef="ND_texcoord_vector2" file="libraries/stdlib/genosl/mx_texcoord_vector2.inline" target="genosl" />
+  <implementation name="IM_texcoord_vector3_genosl" nodedef="ND_texcoord_vector3" file="libraries/stdlib/genosl/mx_texcoord_vector3.inline" target="genosl" />
 
   <!-- <geomcolor> -->
-  <implementation name="IM_geomcolor_float_genosl" nodedef="ND_geomcolor_float" file="stdlib/genosl/mx_geomcolor_float.osl" function="mx_geomcolor_float" target="genosl" />
-  <implementation name="IM_geomcolor_color3_genosl" nodedef="ND_geomcolor_color3" file="stdlib/genosl/mx_geomcolor_color3.osl" function="mx_geomcolor_color3" target="genosl" />
-  <implementation name="IM_geomcolor_color4_genosl" nodedef="ND_geomcolor_color4" file="stdlib/genosl/mx_geomcolor_color4.osl" function="mx_geomcolor_color4" target="genosl" />
+  <implementation name="IM_geomcolor_float_genosl" nodedef="ND_geomcolor_float" file="libraries/stdlib/genosl/mx_geomcolor_float.osl" function="mx_geomcolor_float" target="genosl" />
+  <implementation name="IM_geomcolor_color3_genosl" nodedef="ND_geomcolor_color3" file="libraries/stdlib/genosl/mx_geomcolor_color3.osl" function="mx_geomcolor_color3" target="genosl" />
+  <implementation name="IM_geomcolor_color4_genosl" nodedef="ND_geomcolor_color4" file="libraries/stdlib/genosl/mx_geomcolor_color4.osl" function="mx_geomcolor_color4" target="genosl" />
 
   <!-- <geompropvalue> -->
-  <implementation name="IM_geompropvalue_integer_genosl" nodedef="ND_geompropvalue_integer" file="stdlib/genosl/mx_geompropvalue_integer.osl" function="mx_geompropvalue_integer" target="genosl" />
-  <implementation name="IM_geompropvalue_boolean_genosl" nodedef="ND_geompropvalue_boolean" file="stdlib/genosl/mx_geompropvalue_boolean.osl" function="mx_geompropvalue_boolean" target="genosl" />
-  <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalue_string" file="stdlib/genosl/mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
-  <implementation name="IM_geompropvalue_float_genosl" nodedef="ND_geompropvalue_float" file="stdlib/genosl/mx_geompropvalue_float.osl" function="mx_geompropvalue_float" target="genosl" />
-  <implementation name="IM_geompropvalue_color3_genosl" nodedef="ND_geompropvalue_color3" file="stdlib/genosl/mx_geompropvalue_color3.osl" function="mx_geompropvalue_color" target="genosl" />
-  <implementation name="IM_geompropvalue_color4_genosl" nodedef="ND_geompropvalue_color4" file="stdlib/genosl/mx_geompropvalue_color4.osl" function="mx_geompropvalue_color4" target="genosl" />
-  <implementation name="IM_geompropvalue_vector2_genosl" nodedef="ND_geompropvalue_vector2" file="stdlib/genosl/mx_geompropvalue_vector2.osl" function="mx_geompropvalue_vector2" target="genosl" />
-  <implementation name="IM_geompropvalue_vector3_genosl" nodedef="ND_geompropvalue_vector3" file="stdlib/genosl/mx_geompropvalue_vector3.osl" function="mx_geompropvalue_vector" target="genosl" />
-  <implementation name="IM_geompropvalue_vector4_genosl" nodedef="ND_geompropvalue_vector4" file="stdlib/genosl/mx_geompropvalue_vector4.osl" function="mx_geompropvalue_vector4" target="genosl" />
+  <implementation name="IM_geompropvalue_integer_genosl" nodedef="ND_geompropvalue_integer" file="libraries/stdlib/genosl/mx_geompropvalue_integer.osl" function="mx_geompropvalue_integer" target="genosl" />
+  <implementation name="IM_geompropvalue_boolean_genosl" nodedef="ND_geompropvalue_boolean" file="libraries/stdlib/genosl/mx_geompropvalue_boolean.osl" function="mx_geompropvalue_boolean" target="genosl" />
+  <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalue_string" file="libraries/stdlib/genosl/mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
+  <implementation name="IM_geompropvalue_float_genosl" nodedef="ND_geompropvalue_float" file="libraries/stdlib/genosl/mx_geompropvalue_float.osl" function="mx_geompropvalue_float" target="genosl" />
+  <implementation name="IM_geompropvalue_color3_genosl" nodedef="ND_geompropvalue_color3" file="libraries/stdlib/genosl/mx_geompropvalue_color3.osl" function="mx_geompropvalue_color" target="genosl" />
+  <implementation name="IM_geompropvalue_color4_genosl" nodedef="ND_geompropvalue_color4" file="libraries/stdlib/genosl/mx_geompropvalue_color4.osl" function="mx_geompropvalue_color4" target="genosl" />
+  <implementation name="IM_geompropvalue_vector2_genosl" nodedef="ND_geompropvalue_vector2" file="libraries/stdlib/genosl/mx_geompropvalue_vector2.osl" function="mx_geompropvalue_vector2" target="genosl" />
+  <implementation name="IM_geompropvalue_vector3_genosl" nodedef="ND_geompropvalue_vector3" file="libraries/stdlib/genosl/mx_geompropvalue_vector3.osl" function="mx_geompropvalue_vector" target="genosl" />
+  <implementation name="IM_geompropvalue_vector4_genosl" nodedef="ND_geompropvalue_vector4" file="libraries/stdlib/genosl/mx_geompropvalue_vector4.osl" function="mx_geompropvalue_vector4" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Application nodes                                                        -->
   <!-- ======================================================================== -->
 
   <!-- <frame> -->
-  <implementation name="IM_frame_float_genosl" nodedef="ND_frame_float" file="stdlib/genosl/mx_frame_float.osl" function="mx_frame_float" target="genosl" />
+  <implementation name="IM_frame_float_genosl" nodedef="ND_frame_float" file="libraries/stdlib/genosl/mx_frame_float.osl" function="mx_frame_float" target="genosl" />
 
   <!-- <time> -->
-  <implementation name="IM_time_float_genosl" nodedef="ND_time_float" file="stdlib/genosl/mx_time_float.osl" function="mx_time_float" target="genosl" />
+  <implementation name="IM_time_float_genosl" nodedef="ND_time_float" file="libraries/stdlib/genosl/mx_time_float.osl" function="mx_time_float" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Math nodes                                                               -->
   <!-- ======================================================================== -->
 
   <!-- <add> -->
-  <implementation name="IM_add_float_genosl" nodedef="ND_add_float" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color3_genosl" nodedef="ND_add_color3" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color3FA_genosl" nodedef="ND_add_color3FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color4_genosl" nodedef="ND_add_color4" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color4FA_genosl" nodedef="ND_add_color4FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector2_genosl" nodedef="ND_add_vector2" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector2FA_genosl" nodedef="ND_add_vector2FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector3_genosl" nodedef="ND_add_vector3" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector3FA_genosl" nodedef="ND_add_vector3FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector4_genosl" nodedef="ND_add_vector4" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector4FA_genosl" nodedef="ND_add_vector4FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix33_genosl" nodedef="ND_add_matrix33" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix33FA_genosl" nodedef="ND_add_matrix33FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix44_genosl" nodedef="ND_add_matrix44" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix44FA_genosl" nodedef="ND_add_matrix44FA" file="stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_surfaceshader_genosl" nodedef="ND_add_surfaceshader" file="stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_float_genosl" nodedef="ND_add_float" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color3_genosl" nodedef="ND_add_color3" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color3FA_genosl" nodedef="ND_add_color3FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color4_genosl" nodedef="ND_add_color4" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color4FA_genosl" nodedef="ND_add_color4FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector2_genosl" nodedef="ND_add_vector2" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector2FA_genosl" nodedef="ND_add_vector2FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector3_genosl" nodedef="ND_add_vector3" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector3FA_genosl" nodedef="ND_add_vector3FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector4_genosl" nodedef="ND_add_vector4" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector4FA_genosl" nodedef="ND_add_vector4FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix33_genosl" nodedef="ND_add_matrix33" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix33FA_genosl" nodedef="ND_add_matrix33FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix44_genosl" nodedef="ND_add_matrix44" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix44FA_genosl" nodedef="ND_add_matrix44FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_surfaceshader_genosl" nodedef="ND_add_surfaceshader" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
 
   <!-- <subtract> -->
-  <implementation name="IM_subtract_float_genosl" nodedef="ND_subtract_float" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color3_genosl" nodedef="ND_subtract_color3" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color3FA_genosl" nodedef="ND_subtract_color3FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color4_genosl" nodedef="ND_subtract_color4" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color4FA_genosl" nodedef="ND_subtract_color4FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector2_genosl" nodedef="ND_subtract_vector2" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector2FA_genosl" nodedef="ND_subtract_vector2FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector3_genosl" nodedef="ND_subtract_vector3" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector3FA_genosl" nodedef="ND_subtract_vector3FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector4_genosl" nodedef="ND_subtract_vector4" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector4FA_genosl" nodedef="ND_subtract_vector4FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix33_genosl" nodedef="ND_subtract_matrix33" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix33FA_genosl" nodedef="ND_subtract_matrix33FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix44_genosl" nodedef="ND_subtract_matrix44" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix44FA_genosl" nodedef="ND_subtract_matrix44FA" file="stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_float_genosl" nodedef="ND_subtract_float" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color3_genosl" nodedef="ND_subtract_color3" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color3FA_genosl" nodedef="ND_subtract_color3FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color4_genosl" nodedef="ND_subtract_color4" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color4FA_genosl" nodedef="ND_subtract_color4FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector2_genosl" nodedef="ND_subtract_vector2" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector2FA_genosl" nodedef="ND_subtract_vector2FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector3_genosl" nodedef="ND_subtract_vector3" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector3FA_genosl" nodedef="ND_subtract_vector3FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector4_genosl" nodedef="ND_subtract_vector4" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector4FA_genosl" nodedef="ND_subtract_vector4FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix33_genosl" nodedef="ND_subtract_matrix33" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix33FA_genosl" nodedef="ND_subtract_matrix33FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix44_genosl" nodedef="ND_subtract_matrix44" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix44FA_genosl" nodedef="ND_subtract_matrix44FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
 
   <!-- <multiply> -->
-  <implementation name="IM_multiply_float_genosl" nodedef="ND_multiply_float" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color3_genosl" nodedef="ND_multiply_color3" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color3FA_genosl" nodedef="ND_multiply_color3FA" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color4_genosl" nodedef="ND_multiply_color4" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color4FA_genosl" nodedef="ND_multiply_color4FA" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector2_genosl" nodedef="ND_multiply_vector2" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector2FA_genosl" nodedef="ND_multiply_vector2FA" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector3_genosl" nodedef="ND_multiply_vector3" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector3FA_genosl" nodedef="ND_multiply_vector3FA" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector4_genosl" nodedef="ND_multiply_vector4" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector4FA_genosl" nodedef="ND_multiply_vector4FA" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_matrix33_genosl" nodedef="ND_multiply_matrix33" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_matrix44_genosl" nodedef="ND_multiply_matrix44" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_surfaceshaderF_genosl" nodedef="ND_multiply_surfaceshaderF" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_surfaceshaderC_genosl" nodedef="ND_multiply_surfaceshaderC" file="stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_float_genosl" nodedef="ND_multiply_float" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color3_genosl" nodedef="ND_multiply_color3" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color3FA_genosl" nodedef="ND_multiply_color3FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color4_genosl" nodedef="ND_multiply_color4" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color4FA_genosl" nodedef="ND_multiply_color4FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector2_genosl" nodedef="ND_multiply_vector2" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector2FA_genosl" nodedef="ND_multiply_vector2FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector3_genosl" nodedef="ND_multiply_vector3" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector3FA_genosl" nodedef="ND_multiply_vector3FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector4_genosl" nodedef="ND_multiply_vector4" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector4FA_genosl" nodedef="ND_multiply_vector4FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_matrix33_genosl" nodedef="ND_multiply_matrix33" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_matrix44_genosl" nodedef="ND_multiply_matrix44" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_surfaceshaderF_genosl" nodedef="ND_multiply_surfaceshaderF" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_surfaceshaderC_genosl" nodedef="ND_multiply_surfaceshaderC" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
 
   <!-- <divide> -->
-  <implementation name="IM_divide_float_genosl" nodedef="ND_divide_float" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color3_genosl" nodedef="ND_divide_color3" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color3FA_genosl" nodedef="ND_divide_color3FA" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color4_genosl" nodedef="ND_divide_color4" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color4FA_genosl" nodedef="ND_divide_color4FA" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector2_genosl" nodedef="ND_divide_vector2" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector2FA_genosl" nodedef="ND_divide_vector2FA" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector3_genosl" nodedef="ND_divide_vector3" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector3FA_genosl" nodedef="ND_divide_vector3FA" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector4_genosl" nodedef="ND_divide_vector4" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector4FA_genosl" nodedef="ND_divide_vector4FA" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_matrix33_genosl" nodedef="ND_divide_matrix33" file="stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_matrix44_genosl" nodedef="ND_divide_matrix44" file="stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_float_genosl" nodedef="ND_divide_float" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color3_genosl" nodedef="ND_divide_color3" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color3FA_genosl" nodedef="ND_divide_color3FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color4_genosl" nodedef="ND_divide_color4" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color4FA_genosl" nodedef="ND_divide_color4FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector2_genosl" nodedef="ND_divide_vector2" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector2FA_genosl" nodedef="ND_divide_vector2FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector3_genosl" nodedef="ND_divide_vector3" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector3FA_genosl" nodedef="ND_divide_vector3FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector4_genosl" nodedef="ND_divide_vector4" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector4FA_genosl" nodedef="ND_divide_vector4FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_matrix33_genosl" nodedef="ND_divide_matrix33" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_matrix44_genosl" nodedef="ND_divide_matrix44" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
 
   <!-- <modulo> -->
-  <implementation name="IM_modulo_float_genosl" nodedef="ND_modulo_float" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_color3_genosl" nodedef="ND_modulo_color3" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_color3FA_genosl" nodedef="ND_modulo_color3FA" file="stdlib/genosl/mx_modulo_color3FA.inline" target="genosl" />
-  <implementation name="IM_modulo_color4_genosl" nodedef="ND_modulo_color4" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_color4FA_genosl" nodedef="ND_modulo_color4FA" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector2_genosl" nodedef="ND_modulo_vector2" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector2FA_genosl" nodedef="ND_modulo_vector2FA" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector3_genosl" nodedef="ND_modulo_vector3" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector3FA_genosl" nodedef="ND_modulo_vector3FA" file="stdlib/genosl/mx_modulo_vector3FA.inline" target="genosl" />
-  <implementation name="IM_modulo_vector4_genosl" nodedef="ND_modulo_vector4" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector4FA_genosl" nodedef="ND_modulo_vector4FA" file="stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_float_genosl" nodedef="ND_modulo_float" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_color3_genosl" nodedef="ND_modulo_color3" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_color3FA_genosl" nodedef="ND_modulo_color3FA" file="libraries/stdlib/genosl/mx_modulo_color3FA.inline" target="genosl" />
+  <implementation name="IM_modulo_color4_genosl" nodedef="ND_modulo_color4" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_color4FA_genosl" nodedef="ND_modulo_color4FA" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector2_genosl" nodedef="ND_modulo_vector2" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector2FA_genosl" nodedef="ND_modulo_vector2FA" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector3_genosl" nodedef="ND_modulo_vector3" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector3FA_genosl" nodedef="ND_modulo_vector3FA" file="libraries/stdlib/genosl/mx_modulo_vector3FA.inline" target="genosl" />
+  <implementation name="IM_modulo_vector4_genosl" nodedef="ND_modulo_vector4" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector4FA_genosl" nodedef="ND_modulo_vector4FA" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
 
   <!-- <invert> -->
-  <implementation name="IM_invert_float_genosl" nodedef="ND_invert_float" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color3_genosl" nodedef="ND_invert_color3" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color3FA_genosl" nodedef="ND_invert_color3FA" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color4_genosl" nodedef="ND_invert_color4" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color4FA_genosl" nodedef="ND_invert_color4FA" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector2_genosl" nodedef="ND_invert_vector2" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector2FA_genosl" nodedef="ND_invert_vector2FA" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector3_genosl" nodedef="ND_invert_vector3" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector3FA_genosl" nodedef="ND_invert_vector3FA" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector4_genosl" nodedef="ND_invert_vector4" file="stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector4FA_genosl" nodedef="ND_invert_vector4FA" file="stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_float_genosl" nodedef="ND_invert_float" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color3_genosl" nodedef="ND_invert_color3" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color3FA_genosl" nodedef="ND_invert_color3FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color4_genosl" nodedef="ND_invert_color4" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color4FA_genosl" nodedef="ND_invert_color4FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector2_genosl" nodedef="ND_invert_vector2" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector2FA_genosl" nodedef="ND_invert_vector2FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector3_genosl" nodedef="ND_invert_vector3" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector3FA_genosl" nodedef="ND_invert_vector3FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector4_genosl" nodedef="ND_invert_vector4" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector4FA_genosl" nodedef="ND_invert_vector4FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
 
   <!-- <absval> -->
-  <implementation name="IM_absval_float_genosl" nodedef="ND_absval_float" file="stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_color3_genosl" nodedef="ND_absval_color3" file="stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_color4_genosl" nodedef="ND_absval_color4" file="stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_vector2_genosl" nodedef="ND_absval_vector2" file="stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_vector3_genosl" nodedef="ND_absval_vector3" file="stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_vector4_genosl" nodedef="ND_absval_vector4" file="stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_float_genosl" nodedef="ND_absval_float" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_color3_genosl" nodedef="ND_absval_color3" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_color4_genosl" nodedef="ND_absval_color4" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_vector2_genosl" nodedef="ND_absval_vector2" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_vector3_genosl" nodedef="ND_absval_vector3" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_vector4_genosl" nodedef="ND_absval_vector4" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
 
   <!-- <floor> -->
-  <implementation name="IM_floor_float_genosl" nodedef="ND_floor_float" file="stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_color3_genosl" nodedef="ND_floor_color3" file="stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_color4_genosl" nodedef="ND_floor_color4" file="stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_vector2_genosl" nodedef="ND_floor_vector2" file="stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_vector3_genosl" nodedef="ND_floor_vector3" file="stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_vector4_genosl" nodedef="ND_floor_vector4" file="stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_float_genosl" nodedef="ND_floor_float" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_color3_genosl" nodedef="ND_floor_color3" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_color4_genosl" nodedef="ND_floor_color4" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_vector2_genosl" nodedef="ND_floor_vector2" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_vector3_genosl" nodedef="ND_floor_vector3" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_vector4_genosl" nodedef="ND_floor_vector4" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
 
   <!-- <ceil> -->
-  <implementation name="IM_ceil_float_genosl" nodedef="ND_ceil_float" file="stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_color3_genosl" nodedef="ND_ceil_color3" file="stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_color4_genosl" nodedef="ND_ceil_color4" file="stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_vector2_genosl" nodedef="ND_ceil_vector2" file="stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_vector3_genosl" nodedef="ND_ceil_vector3" file="stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_vector4_genosl" nodedef="ND_ceil_vector4" file="stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_float_genosl" nodedef="ND_ceil_float" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_color3_genosl" nodedef="ND_ceil_color3" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_color4_genosl" nodedef="ND_ceil_color4" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_vector2_genosl" nodedef="ND_ceil_vector2" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_vector3_genosl" nodedef="ND_ceil_vector3" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_vector4_genosl" nodedef="ND_ceil_vector4" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
 
   <!-- <power> -->
-  <implementation name="IM_power_float_genosl" nodedef="ND_power_float" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color3_genosl" nodedef="ND_power_color3" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color3FA_genosl" nodedef="ND_power_color3FA" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color4_genosl" nodedef="ND_power_color4" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color4FA_genosl" nodedef="ND_power_color4FA" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector2_genosl" nodedef="ND_power_vector2" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector2FA_genosl" nodedef="ND_power_vector2FA" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector3_genosl" nodedef="ND_power_vector3" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector3FA_genosl" nodedef="ND_power_vector3FA" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector4_genosl" nodedef="ND_power_vector4" file="stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector4FA_genosl" nodedef="ND_power_vector4FA" file="stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_float_genosl" nodedef="ND_power_float" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color3_genosl" nodedef="ND_power_color3" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color3FA_genosl" nodedef="ND_power_color3FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color4_genosl" nodedef="ND_power_color4" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color4FA_genosl" nodedef="ND_power_color4FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector2_genosl" nodedef="ND_power_vector2" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector2FA_genosl" nodedef="ND_power_vector2FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector3_genosl" nodedef="ND_power_vector3" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector3FA_genosl" nodedef="ND_power_vector3FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector4_genosl" nodedef="ND_power_vector4" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector4FA_genosl" nodedef="ND_power_vector4FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
 
   <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genosl" nodedef="ND_sin_float" file="stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_float_genosl" nodedef="ND_cos_float" file="stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_float_genosl" nodedef="ND_tan_float" file="stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" file="stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" file="stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" file="stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_float_genosl" nodedef="ND_sin_float" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_float_genosl" nodedef="ND_cos_float" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_float_genosl" nodedef="ND_tan_float" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
 
-  <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" file="stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" file="stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_vector2_genosl" nodedef="ND_tan_vector2" file="stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" file="stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" file="stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" file="stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_vector2_genosl" nodedef="ND_tan_vector2" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
 
-  <implementation name="IM_sin_vector3_genosl" nodedef="ND_sin_vector3" file="stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_vector3_genosl" nodedef="ND_cos_vector3" file="stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_vector3_genosl" nodedef="ND_tan_vector3" file="stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" file="stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" file="stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" file="stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_vector3_genosl" nodedef="ND_sin_vector3" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_vector3_genosl" nodedef="ND_cos_vector3" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_vector3_genosl" nodedef="ND_tan_vector3" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
 
-  <implementation name="IM_sin_vector4_genosl" nodedef="ND_sin_vector4" file="stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_vector4_genosl" nodedef="ND_cos_vector4" file="stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_vector4_genosl" nodedef="ND_tan_vector4" file="stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" file="stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" file="stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" file="stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_vector4_genosl" nodedef="ND_sin_vector4" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_vector4_genosl" nodedef="ND_cos_vector4" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_vector4_genosl" nodedef="ND_tan_vector4" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
 
   <!-- <sqrt> -->
-  <implementation name="IM_sqrt_float_genosl" nodedef="ND_sqrt_float" file="stdlib/genosl/mx_sqrt.inline" target="genosl" />
-  <implementation name="IM_sqrt_vector2_genosl" nodedef="ND_sqrt_vector2" file="stdlib/genosl/mx_sqrt.inline" target="genosl" />
-  <implementation name="IM_sqrt_vector3_genosl" nodedef="ND_sqrt_vector3" file="stdlib/genosl/mx_sqrt.inline" target="genosl" />
-  <implementation name="IM_sqrt_vector4_genosl" nodedef="ND_sqrt_vector4" file="stdlib/genosl/mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_float_genosl" nodedef="ND_sqrt_float" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_vector2_genosl" nodedef="ND_sqrt_vector2" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_vector3_genosl" nodedef="ND_sqrt_vector3" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_vector4_genosl" nodedef="ND_sqrt_vector4" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
 
   <!-- <ln> -->
-  <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" file="stdlib/genosl/mx_ln.inline" target="genosl" />
-  <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" file="stdlib/genosl/mx_ln.inline" target="genosl" />
-  <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" file="stdlib/genosl/mx_ln.inline" target="genosl" />
-  <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" file="stdlib/genosl/mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
 
   <!-- <exp> -->
-  <implementation name="IM_exp_float_genosl" nodedef="ND_exp_float" file="stdlib/genosl/mx_exp.inline" target="genosl" />
-  <implementation name="IM_exp_vector2_genosl" nodedef="ND_exp_vector2" file="stdlib/genosl/mx_exp.inline" target="genosl" />
-  <implementation name="IM_exp_vector3_genosl" nodedef="ND_exp_vector3" file="stdlib/genosl/mx_exp.inline" target="genosl" />
-  <implementation name="IM_exp_vector4_genosl" nodedef="ND_exp_vector4" file="stdlib/genosl/mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_float_genosl" nodedef="ND_exp_float" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_vector2_genosl" nodedef="ND_exp_vector2" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_vector3_genosl" nodedef="ND_exp_vector3" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_vector4_genosl" nodedef="ND_exp_vector4" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
 
   <!-- sign -->
-  <implementation name="IM_sign_float_genosl" nodedef="ND_sign_float" file="stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_color3_genosl" nodedef="ND_sign_color3" file="stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_color4_genosl" nodedef="ND_sign_color4" file="stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_vector2_genosl" nodedef="ND_sign_vector2" file="stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_vector3_genosl" nodedef="ND_sign_vector3" file="stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_vector4_genosl" nodedef="ND_sign_vector4" file="stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_float_genosl" nodedef="ND_sign_float" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_color3_genosl" nodedef="ND_sign_color3" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_color4_genosl" nodedef="ND_sign_color4" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_vector2_genosl" nodedef="ND_sign_vector2" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_vector3_genosl" nodedef="ND_sign_vector3" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_vector4_genosl" nodedef="ND_sign_vector4" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
 
   <!-- <clamp> -->
-  <implementation name="IM_clamp_float_genosl" nodedef="ND_clamp_float" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color3_genosl" nodedef="ND_clamp_color3" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color3FA_genosl" nodedef="ND_clamp_color3FA" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color4_genosl" nodedef="ND_clamp_color4" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color4FA_genosl" nodedef="ND_clamp_color4FA" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector2_genosl" nodedef="ND_clamp_vector2" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector2FA_genosl" nodedef="ND_clamp_vector2FA" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector3_genosl" nodedef="ND_clamp_vector3" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector3FA_genosl" nodedef="ND_clamp_vector3FA" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector4_genosl" nodedef="ND_clamp_vector4" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector4FA_genosl" nodedef="ND_clamp_vector4FA" file="stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_float_genosl" nodedef="ND_clamp_float" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color3_genosl" nodedef="ND_clamp_color3" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color3FA_genosl" nodedef="ND_clamp_color3FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color4_genosl" nodedef="ND_clamp_color4" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color4FA_genosl" nodedef="ND_clamp_color4FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector2_genosl" nodedef="ND_clamp_vector2" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector2FA_genosl" nodedef="ND_clamp_vector2FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector3_genosl" nodedef="ND_clamp_vector3" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector3FA_genosl" nodedef="ND_clamp_vector3FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector4_genosl" nodedef="ND_clamp_vector4" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector4FA_genosl" nodedef="ND_clamp_vector4FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
 
   <!-- <min> -->
-  <implementation name="IM_min_float_genosl" nodedef="ND_min_float" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color3_genosl" nodedef="ND_min_color3" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color3FA_genosl" nodedef="ND_min_color3FA" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color4_genosl" nodedef="ND_min_color4" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color4FA_genosl" nodedef="ND_min_color4FA" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector2_genosl" nodedef="ND_min_vector2" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector2FA_genosl" nodedef="ND_min_vector2FA" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector3_genosl" nodedef="ND_min_vector3" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector3FA_genosl" nodedef="ND_min_vector3FA" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector4_genosl" nodedef="ND_min_vector4" file="stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector4FA_genosl" nodedef="ND_min_vector4FA" file="stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_float_genosl" nodedef="ND_min_float" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color3_genosl" nodedef="ND_min_color3" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color3FA_genosl" nodedef="ND_min_color3FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color4_genosl" nodedef="ND_min_color4" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color4FA_genosl" nodedef="ND_min_color4FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector2_genosl" nodedef="ND_min_vector2" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector2FA_genosl" nodedef="ND_min_vector2FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector3_genosl" nodedef="ND_min_vector3" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector3FA_genosl" nodedef="ND_min_vector3FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector4_genosl" nodedef="ND_min_vector4" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector4FA_genosl" nodedef="ND_min_vector4FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
 
   <!-- <max> -->
-  <implementation name="IM_max_float_genosl" nodedef="ND_max_float" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color3_genosl" nodedef="ND_max_color3" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color3FA_genosl" nodedef="ND_max_color3FA" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color4_genosl" nodedef="ND_max_color4" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color4FA_genosl" nodedef="ND_max_color4FA" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector2_genosl" nodedef="ND_max_vector2" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector2FA_genosl" nodedef="ND_max_vector2FA" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector3_genosl" nodedef="ND_max_vector3" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector3FA_genosl" nodedef="ND_max_vector3FA" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector4_genosl" nodedef="ND_max_vector4" file="stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector4FA_genosl" nodedef="ND_max_vector4FA" file="stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_float_genosl" nodedef="ND_max_float" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color3_genosl" nodedef="ND_max_color3" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color3FA_genosl" nodedef="ND_max_color3FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color4_genosl" nodedef="ND_max_color4" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color4FA_genosl" nodedef="ND_max_color4FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector2_genosl" nodedef="ND_max_vector2" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector2FA_genosl" nodedef="ND_max_vector2FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector3_genosl" nodedef="ND_max_vector3" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector3FA_genosl" nodedef="ND_max_vector3FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector4_genosl" nodedef="ND_max_vector4" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector4FA_genosl" nodedef="ND_max_vector4FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
 
   <!-- <normalize> -->
-  <implementation name="IM_normalize_vector2_genosl" nodedef="ND_normalize_vector2" file="stdlib/genosl/mx_normalize.inline" target="genosl" />
-  <implementation name="IM_normalize_vector3_genosl" nodedef="ND_normalize_vector3" file="stdlib/genosl/mx_normalize.inline" target="genosl" />
-  <implementation name="IM_normalize_vector4_genosl" nodedef="ND_normalize_vector4" file="stdlib/genosl/mx_normalize.inline" target="genosl" />
+  <implementation name="IM_normalize_vector2_genosl" nodedef="ND_normalize_vector2" file="libraries/stdlib/genosl/mx_normalize.inline" target="genosl" />
+  <implementation name="IM_normalize_vector3_genosl" nodedef="ND_normalize_vector3" file="libraries/stdlib/genosl/mx_normalize.inline" target="genosl" />
+  <implementation name="IM_normalize_vector4_genosl" nodedef="ND_normalize_vector4" file="libraries/stdlib/genosl/mx_normalize.inline" target="genosl" />
 
   <!-- <magnitude> -->
-  <implementation name="IM_magnitude_vector2_genosl" nodedef="ND_magnitude_vector2" file="stdlib/genosl/mx_magnitude.inline" target="genosl" />
-  <implementation name="IM_magnitude_vector3_genosl" nodedef="ND_magnitude_vector3" file="stdlib/genosl/mx_magnitude.inline" target="genosl" />
-  <implementation name="IM_magnitude_vector4_genosl" nodedef="ND_magnitude_vector4" file="stdlib/genosl/mx_magnitude.inline" target="genosl" />
+  <implementation name="IM_magnitude_vector2_genosl" nodedef="ND_magnitude_vector2" file="libraries/stdlib/genosl/mx_magnitude.inline" target="genosl" />
+  <implementation name="IM_magnitude_vector3_genosl" nodedef="ND_magnitude_vector3" file="libraries/stdlib/genosl/mx_magnitude.inline" target="genosl" />
+  <implementation name="IM_magnitude_vector4_genosl" nodedef="ND_magnitude_vector4" file="libraries/stdlib/genosl/mx_magnitude.inline" target="genosl" />
 
   <!-- <dotproduct> -->
-  <implementation name="IM_dotproduct_vector2_genosl" nodedef="ND_dotproduct_vector2" file="stdlib/genosl/mx_dotproduct.inline" target="genosl" />
-  <implementation name="IM_dotproduct_vector3_genosl" nodedef="ND_dotproduct_vector3" file="stdlib/genosl/mx_dotproduct.inline" target="genosl" />
-  <implementation name="IM_dotproduct_vector4_genosl" nodedef="ND_dotproduct_vector4" file="stdlib/genosl/mx_dotproduct.inline" target="genosl" />
+  <implementation name="IM_dotproduct_vector2_genosl" nodedef="ND_dotproduct_vector2" file="libraries/stdlib/genosl/mx_dotproduct.inline" target="genosl" />
+  <implementation name="IM_dotproduct_vector3_genosl" nodedef="ND_dotproduct_vector3" file="libraries/stdlib/genosl/mx_dotproduct.inline" target="genosl" />
+  <implementation name="IM_dotproduct_vector4_genosl" nodedef="ND_dotproduct_vector4" file="libraries/stdlib/genosl/mx_dotproduct.inline" target="genosl" />
 
   <!-- <crossproduct> -->
-  <implementation name="IM_crossproduct_vector3_genosl" nodedef="ND_crossproduct_vector3" file="stdlib/genosl/mx_crossproduct.inline" target="genosl" />
+  <implementation name="IM_crossproduct_vector3_genosl" nodedef="ND_crossproduct_vector3" file="libraries/stdlib/genosl/mx_crossproduct.inline" target="genosl" />
 
   <!-- <transformpoint> -->
-  <implementation name="IM_transformpoint_vector3_genosl" nodedef="ND_transformpoint_vector3" file="stdlib/genosl/mx_transformpoint.inline" target="genosl" />
+  <implementation name="IM_transformpoint_vector3_genosl" nodedef="ND_transformpoint_vector3" file="libraries/stdlib/genosl/mx_transformpoint.inline" target="genosl" />
 
   <!-- <transformvector> -->
-  <implementation name="IM_transformvector_vector3_genosl" nodedef="ND_transformvector_vector3" file="stdlib/genosl/mx_transformvector.inline" target="genosl" />
+  <implementation name="IM_transformvector_vector3_genosl" nodedef="ND_transformvector_vector3" file="libraries/stdlib/genosl/mx_transformvector.inline" target="genosl" />
 
   <!-- <transformnormal> -->
-  <implementation name="IM_transformnormal_vector3_genosl" nodedef="ND_transformnormal_vector3" file="stdlib/genosl/mx_transformnormal.inline" target="genosl" />
+  <implementation name="IM_transformnormal_vector3_genosl" nodedef="ND_transformnormal_vector3" file="libraries/stdlib/genosl/mx_transformnormal.inline" target="genosl" />
 
   <!-- <transformmatrix> -->
-  <implementation name="IM_transformmatrix_vector2M3_genosl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="stdlib/genosl/mx_transformmatrix_vector2M3.osl" target="genosl" />
-  <implementation name="IM_transformmatrix_vector3_genosl" nodedef="ND_transformmatrix_vector3" file="stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
-  <implementation name="IM_transformmatrix_vector3M4_genosl" nodedef="ND_transformmatrix_vector3M4" file="stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
-  <implementation name="IM_transformmatrix_vector4_genosl" nodedef="ND_transformmatrix_vector4" file="stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
+  <implementation name="IM_transformmatrix_vector2M3_genosl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="libraries/stdlib/genosl/mx_transformmatrix_vector2M3.osl" target="genosl" />
+  <implementation name="IM_transformmatrix_vector3_genosl" nodedef="ND_transformmatrix_vector3" file="libraries/stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
+  <implementation name="IM_transformmatrix_vector3M4_genosl" nodedef="ND_transformmatrix_vector3M4" file="libraries/stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
+  <implementation name="IM_transformmatrix_vector4_genosl" nodedef="ND_transformmatrix_vector4" file="libraries/stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
 
   <!-- <transpose> -->
-  <implementation name="IM_transpose_matrix33_genosl" nodedef="ND_transpose_matrix33" file="stdlib/genosl/mx_transpose.inline" target="genosl" />
-  <implementation name="IM_transpose_matrix44_genosl" nodedef="ND_transpose_matrix44" file="stdlib/genosl/mx_transpose.inline" target="genosl" />
+  <implementation name="IM_transpose_matrix33_genosl" nodedef="ND_transpose_matrix33" file="libraries/stdlib/genosl/mx_transpose.inline" target="genosl" />
+  <implementation name="IM_transpose_matrix44_genosl" nodedef="ND_transpose_matrix44" file="libraries/stdlib/genosl/mx_transpose.inline" target="genosl" />
 
   <!-- <determinant> -->
-  <implementation name="IM_determinant_matrix33_genosl" nodedef="ND_determinant_matrix33" file="stdlib/genosl/mx_determinant.inline" target="genosl" />
-  <implementation name="IM_determinant_matrix44_genosl" nodedef="ND_determinant_matrix44" file="stdlib/genosl/mx_determinant.inline" target="genosl" />
+  <implementation name="IM_determinant_matrix33_genosl" nodedef="ND_determinant_matrix33" file="libraries/stdlib/genosl/mx_determinant.inline" target="genosl" />
+  <implementation name="IM_determinant_matrix44_genosl" nodedef="ND_determinant_matrix44" file="libraries/stdlib/genosl/mx_determinant.inline" target="genosl" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genosl" nodedef="ND_invertmatrix_matrix33" file="stdlib/genosl/mx_invertM.inline" target="genosl" />
-  <implementation name="IM_invertmatrix_matrix44_genosl" nodedef="ND_invertmatrix_matrix44" file="stdlib/genosl/mx_invertM.inline" target="genosl" />
+  <implementation name="IM_invertmatrix_matrix33_genosl" nodedef="ND_invertmatrix_matrix33" file="libraries/stdlib/genosl/mx_invertM.inline" target="genosl" />
+  <implementation name="IM_invertmatrix_matrix44_genosl" nodedef="ND_invertmatrix_matrix44" file="libraries/stdlib/genosl/mx_invertM.inline" target="genosl" />
 
   <!-- <rotate2d> -->
-  <implementation name="IM_rotate2d_vector2_genosl" nodedef="ND_rotate2d_vector2" file="stdlib/genosl/mx_rotate_vector2.osl" function="mx_rotate_vector2" target="genosl" />
+  <implementation name="IM_rotate2d_vector2_genosl" nodedef="ND_rotate2d_vector2" file="libraries/stdlib/genosl/mx_rotate_vector2.osl" function="mx_rotate_vector2" target="genosl" />
 
   <!-- <rotate3d> -->
-  <implementation name="IM_rotate3d_vector3_genosl" nodedef="ND_rotate3d_vector3" file="stdlib/genosl/mx_rotate_vector3.osl" function="mx_rotate_vector3" target="genosl" />
+  <implementation name="IM_rotate3d_vector3_genosl" nodedef="ND_rotate3d_vector3" file="libraries/stdlib/genosl/mx_rotate_vector3.osl" function="mx_rotate_vector3" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
   <!-- ======================================================================== -->
 
   <!-- <remap> -->
-  <implementation name="IM_remap_float_genosl" nodedef="ND_remap_float" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color3_genosl" nodedef="ND_remap_color3" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color3FA_genosl" nodedef="ND_remap_color3FA" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color4_genosl" nodedef="ND_remap_color4" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color4FA_genosl" nodedef="ND_remap_color4FA" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector2_genosl" nodedef="ND_remap_vector2" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector2FA_genosl" nodedef="ND_remap_vector2FA" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector3_genosl" nodedef="ND_remap_vector3" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector3FA_genosl" nodedef="ND_remap_vector3FA" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector4_genosl" nodedef="ND_remap_vector4" file="stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector4FA_genosl" nodedef="ND_remap_vector4FA" file="stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_float_genosl" nodedef="ND_remap_float" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color3_genosl" nodedef="ND_remap_color3" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color3FA_genosl" nodedef="ND_remap_color3FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color4_genosl" nodedef="ND_remap_color4" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color4FA_genosl" nodedef="ND_remap_color4FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector2_genosl" nodedef="ND_remap_vector2" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector2FA_genosl" nodedef="ND_remap_vector2FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector3_genosl" nodedef="ND_remap_vector3" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector3FA_genosl" nodedef="ND_remap_vector3FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector4_genosl" nodedef="ND_remap_vector4" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector4FA_genosl" nodedef="ND_remap_vector4FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
 
   <!-- <smoothstep> -->
-  <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color3_genosl" nodedef="ND_smoothstep_color3" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color3FA_genosl" nodedef="ND_smoothstep_color3FA" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color4_genosl" nodedef="ND_smoothstep_color4" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color4FA_genosl" nodedef="ND_smoothstep_color4FA" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector2FA_genosl" nodedef="ND_smoothstep_vector2FA" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector3FA_genosl" nodedef="ND_smoothstep_vector3FA" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector4FA_genosl" nodedef="ND_smoothstep_vector4FA" file="stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color3_genosl" nodedef="ND_smoothstep_color3" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color3FA_genosl" nodedef="ND_smoothstep_color3FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color4_genosl" nodedef="ND_smoothstep_color4" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color4FA_genosl" nodedef="ND_smoothstep_color4FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector2FA_genosl" nodedef="ND_smoothstep_vector2FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector3FA_genosl" nodedef="ND_smoothstep_vector3FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector4FA_genosl" nodedef="ND_smoothstep_vector4FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
 
   <!-- <luminance> -->
-  <implementation name="IM_luminance_color3_genosl" nodedef="ND_luminance_color3" file="stdlib/genosl/mx_luminance_color3.osl" function="mx_luminance_color3" target="genosl" />
-  <implementation name="IM_luminance_color4_genosl" nodedef="ND_luminance_color4" file="stdlib/genosl/mx_luminance_color4.osl" function="mx_luminance_color4" target="genosl" />
+  <implementation name="IM_luminance_color3_genosl" nodedef="ND_luminance_color3" file="libraries/stdlib/genosl/mx_luminance_color3.osl" function="mx_luminance_color3" target="genosl" />
+  <implementation name="IM_luminance_color4_genosl" nodedef="ND_luminance_color4" file="libraries/stdlib/genosl/mx_luminance_color4.osl" function="mx_luminance_color4" target="genosl" />
 
   <!-- <rgbtohsv> -->
-  <implementation name="IM_rgbtohsv_color3_genosl" nodedef="ND_rgbtohsv_color3" file="stdlib/genosl/mx_rgbtohsv_color3.osl" function="mx_rgbtohsv_color3" target="genosl" />
-  <implementation name="IM_rgbtohsv_color4_genosl" nodedef="ND_rgbtohsv_color4" file="stdlib/genosl/mx_rgbtohsv_color4.osl" function="mx_rgbtohsv_color4" target="genosl" />
+  <implementation name="IM_rgbtohsv_color3_genosl" nodedef="ND_rgbtohsv_color3" file="libraries/stdlib/genosl/mx_rgbtohsv_color3.osl" function="mx_rgbtohsv_color3" target="genosl" />
+  <implementation name="IM_rgbtohsv_color4_genosl" nodedef="ND_rgbtohsv_color4" file="libraries/stdlib/genosl/mx_rgbtohsv_color4.osl" function="mx_rgbtohsv_color4" target="genosl" />
 
   <!-- <hsvtorgb> -->
-  <implementation name="IM_hsvtorgb_color3_genosl" nodedef="ND_hsvtorgb_color3" file="stdlib/genosl/mx_hsvtorgb_color3.osl" function="mx_hsvtorgb_color3" target="genosl" />
-  <implementation name="IM_hsvtorgb_color4_genosl" nodedef="ND_hsvtorgb_color4" file="stdlib/genosl/mx_hsvtorgb_color4.osl" function="mx_hsvtorgb_color4" target="genosl" />
+  <implementation name="IM_hsvtorgb_color3_genosl" nodedef="ND_hsvtorgb_color3" file="libraries/stdlib/genosl/mx_hsvtorgb_color3.osl" function="mx_hsvtorgb_color3" target="genosl" />
+  <implementation name="IM_hsvtorgb_color4_genosl" nodedef="ND_hsvtorgb_color4" file="libraries/stdlib/genosl/mx_hsvtorgb_color4.osl" function="mx_hsvtorgb_color4" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->
   <!-- ======================================================================== -->
 
   <!-- <premult> -->
-  <implementation name="IM_premult_color4_genosl" nodedef="ND_premult_color4" file="stdlib/genosl/mx_premult_color4.osl" function="mx_premult_color4" target="genosl" />
+  <implementation name="IM_premult_color4_genosl" nodedef="ND_premult_color4" file="libraries/stdlib/genosl/mx_premult_color4.osl" function="mx_premult_color4" target="genosl" />
 
   <!-- <unpremult> -->
-  <implementation name="IM_unpremult_color4_genosl" nodedef="ND_unpremult_color4" file="stdlib/genosl/mx_unpremult_color4.osl" function="mx_unpremult_color4" target="genosl" />
+  <implementation name="IM_unpremult_color4_genosl" nodedef="ND_unpremult_color4" file="libraries/stdlib/genosl/mx_unpremult_color4.osl" function="mx_unpremult_color4" target="genosl" />
 
   <!-- <plus> -->
-  <implementation name="IM_plus_float_genosl" nodedef="ND_plus_float" file="stdlib/genosl/mx_plus.inline" target="genosl" />
-  <implementation name="IM_plus_color3_genosl" nodedef="ND_plus_color3" file="stdlib/genosl/mx_plus.inline" target="genosl" />
-  <implementation name="IM_plus_color4_genosl" nodedef="ND_plus_color4" file="stdlib/genosl/mx_plus.inline" target="genosl" />
+  <implementation name="IM_plus_float_genosl" nodedef="ND_plus_float" file="libraries/stdlib/genosl/mx_plus.inline" target="genosl" />
+  <implementation name="IM_plus_color3_genosl" nodedef="ND_plus_color3" file="libraries/stdlib/genosl/mx_plus.inline" target="genosl" />
+  <implementation name="IM_plus_color4_genosl" nodedef="ND_plus_color4" file="libraries/stdlib/genosl/mx_plus.inline" target="genosl" />
 
   <!-- <minus> -->
-  <implementation name="IM_minus_float_genosl" nodedef="ND_minus_float" file="stdlib/genosl/mx_minus.inline" target="genosl" />
-  <implementation name="IM_minus_color3_genosl" nodedef="ND_minus_color3" file="stdlib/genosl/mx_minus.inline" target="genosl" />
-  <implementation name="IM_minus_color4_genosl" nodedef="ND_minus_color4" file="stdlib/genosl/mx_minus.inline" target="genosl" />
+  <implementation name="IM_minus_float_genosl" nodedef="ND_minus_float" file="libraries/stdlib/genosl/mx_minus.inline" target="genosl" />
+  <implementation name="IM_minus_color3_genosl" nodedef="ND_minus_color3" file="libraries/stdlib/genosl/mx_minus.inline" target="genosl" />
+  <implementation name="IM_minus_color4_genosl" nodedef="ND_minus_color4" file="libraries/stdlib/genosl/mx_minus.inline" target="genosl" />
 
   <!-- <difference> -->
-  <implementation name="IM_difference_float_genosl" nodedef="ND_difference_float" file="stdlib/genosl/mx_difference.inline" target="genosl" />
-  <implementation name="IM_difference_color3_genosl" nodedef="ND_difference_color3" file="stdlib/genosl/mx_difference.inline" target="genosl" />
-  <implementation name="IM_difference_color4_genosl" nodedef="ND_difference_color4" file="stdlib/genosl/mx_difference.inline" target="genosl" />
+  <implementation name="IM_difference_float_genosl" nodedef="ND_difference_float" file="libraries/stdlib/genosl/mx_difference.inline" target="genosl" />
+  <implementation name="IM_difference_color3_genosl" nodedef="ND_difference_color3" file="libraries/stdlib/genosl/mx_difference.inline" target="genosl" />
+  <implementation name="IM_difference_color4_genosl" nodedef="ND_difference_color4" file="libraries/stdlib/genosl/mx_difference.inline" target="genosl" />
 
   <!-- <burn> -->
-  <implementation name="IM_burn_float_genosl" nodedef="ND_burn_float" file="stdlib/genosl/mx_burn_float.osl" function="mx_burn_float" target="genosl" />
-  <implementation name="IM_burn_color3_genosl" nodedef="ND_burn_color3" file="stdlib/genosl/mx_burn_color3.osl" function="mx_burn_color3" target="genosl" />
-  <implementation name="IM_burn_color4_genosl" nodedef="ND_burn_color4" file="stdlib/genosl/mx_burn_color4.osl" function="mx_burn_color4" target="genosl" />
+  <implementation name="IM_burn_float_genosl" nodedef="ND_burn_float" file="libraries/stdlib/genosl/mx_burn_float.osl" function="mx_burn_float" target="genosl" />
+  <implementation name="IM_burn_color3_genosl" nodedef="ND_burn_color3" file="libraries/stdlib/genosl/mx_burn_color3.osl" function="mx_burn_color3" target="genosl" />
+  <implementation name="IM_burn_color4_genosl" nodedef="ND_burn_color4" file="libraries/stdlib/genosl/mx_burn_color4.osl" function="mx_burn_color4" target="genosl" />
 
   <!-- <dodge> -->
-  <implementation name="IM_dodge_float_genosl" nodedef="ND_dodge_float" file="stdlib/genosl/mx_dodge_float.osl" function="mx_dodge_float" target="genosl" />
-  <implementation name="IM_dodge_color3_genosl" nodedef="ND_dodge_color3" file="stdlib/genosl/mx_dodge_color3.osl" function="mx_dodge_color3" target="genosl" />
-  <implementation name="IM_dodge_color4_genosl" nodedef="ND_dodge_color4" file="stdlib/genosl/mx_dodge_color4.osl" function="mx_dodge_color4" target="genosl" />
+  <implementation name="IM_dodge_float_genosl" nodedef="ND_dodge_float" file="libraries/stdlib/genosl/mx_dodge_float.osl" function="mx_dodge_float" target="genosl" />
+  <implementation name="IM_dodge_color3_genosl" nodedef="ND_dodge_color3" file="libraries/stdlib/genosl/mx_dodge_color3.osl" function="mx_dodge_color3" target="genosl" />
+  <implementation name="IM_dodge_color4_genosl" nodedef="ND_dodge_color4" file="libraries/stdlib/genosl/mx_dodge_color4.osl" function="mx_dodge_color4" target="genosl" />
 
   <!-- <screen> -->
-  <implementation name="IM_screen_float_genosl" nodedef="ND_screen_float" file="stdlib/genosl/mx_screen.inline" target="genosl" />
-  <implementation name="IM_screen_color3_genosl" nodedef="ND_screen_color3" file="stdlib/genosl/mx_screen.inline" target="genosl" />
-  <implementation name="IM_screen_color4_genosl" nodedef="ND_screen_color4" file="stdlib/genosl/mx_screen.inline" target="genosl" />
+  <implementation name="IM_screen_float_genosl" nodedef="ND_screen_float" file="libraries/stdlib/genosl/mx_screen.inline" target="genosl" />
+  <implementation name="IM_screen_color3_genosl" nodedef="ND_screen_color3" file="libraries/stdlib/genosl/mx_screen.inline" target="genosl" />
+  <implementation name="IM_screen_color4_genosl" nodedef="ND_screen_color4" file="libraries/stdlib/genosl/mx_screen.inline" target="genosl" />
 
   <!-- <overlay> -->
-  <implementation name="IM_overlay_float_genosl" nodedef="ND_overlay_float" file="stdlib/genosl/mx_overlay.inline" target="genosl" />
-  <implementation name="IM_overlay_color3_genosl" nodedef="ND_overlay_color3" file="stdlib/genosl/mx_overlay_color3.osl" function="mx_overlay_color3" target="genosl" />
-  <implementation name="IM_overlay_color4_genosl" nodedef="ND_overlay_color4" file="stdlib/genosl/mx_overlay_color4.osl" function="mx_overlay_color4" target="genosl" />
+  <implementation name="IM_overlay_float_genosl" nodedef="ND_overlay_float" file="libraries/stdlib/genosl/mx_overlay.inline" target="genosl" />
+  <implementation name="IM_overlay_color3_genosl" nodedef="ND_overlay_color3" file="libraries/stdlib/genosl/mx_overlay_color3.osl" function="mx_overlay_color3" target="genosl" />
+  <implementation name="IM_overlay_color4_genosl" nodedef="ND_overlay_color4" file="libraries/stdlib/genosl/mx_overlay_color4.osl" function="mx_overlay_color4" target="genosl" />
 
   <!-- <disjointover> -->
-  <implementation name="IM_disjointover_color4_genosl" nodedef="ND_disjointover_color4" file="stdlib/genosl/mx_disjointover_color4.osl" function="mx_disjointover_color4" target="genosl" />
+  <implementation name="IM_disjointover_color4_genosl" nodedef="ND_disjointover_color4" file="libraries/stdlib/genosl/mx_disjointover_color4.osl" function="mx_disjointover_color4" target="genosl" />
 
   <!-- <in> -->
-  <implementation name="IM_in_color4_genosl" nodedef="ND_in_color4" file="stdlib/genosl/mx_in.inline" target="genosl" />
+  <implementation name="IM_in_color4_genosl" nodedef="ND_in_color4" file="libraries/stdlib/genosl/mx_in.inline" target="genosl" />
 
   <!-- <mask> -->
-  <implementation name="IM_mask_color4_genosl" nodedef="ND_mask_color4" file="stdlib/genosl/mx_mask.inline" target="genosl" />
+  <implementation name="IM_mask_color4_genosl" nodedef="ND_mask_color4" file="libraries/stdlib/genosl/mx_mask.inline" target="genosl" />
 
   <!-- <matte> -->
-  <implementation name="IM_matte_color4_genosl" nodedef="ND_matte_color4" file="stdlib/genosl/mx_matte_color4.inline" target="genosl" />
+  <implementation name="IM_matte_color4_genosl" nodedef="ND_matte_color4" file="libraries/stdlib/genosl/mx_matte_color4.inline" target="genosl" />
 
   <!-- <out> -->
-  <implementation name="IM_out_color4_genosl" nodedef="ND_out_color4" file="stdlib/genosl/mx_out.inline" target="genosl" />
+  <implementation name="IM_out_color4_genosl" nodedef="ND_out_color4" file="libraries/stdlib/genosl/mx_out.inline" target="genosl" />
 
   <!-- <over> -->
-  <implementation name="IM_over_color4_genosl" nodedef="ND_over_color4" file="stdlib/genosl/mx_over.inline" target="genosl" />
+  <implementation name="IM_over_color4_genosl" nodedef="ND_over_color4" file="libraries/stdlib/genosl/mx_over.inline" target="genosl" />
 
   <!-- <inside> -->
-  <implementation name="IM_inside_float_genosl" nodedef="ND_inside_float" file="stdlib/genosl/mx_inside.inline" target="genosl" />
-  <implementation name="IM_inside_color3_genosl" nodedef="ND_inside_color3" file="stdlib/genosl/mx_inside.inline" target="genosl" />
-  <implementation name="IM_inside_color4_genosl" nodedef="ND_inside_color4" file="stdlib/genosl/mx_inside.inline" target="genosl" />
+  <implementation name="IM_inside_float_genosl" nodedef="ND_inside_float" file="libraries/stdlib/genosl/mx_inside.inline" target="genosl" />
+  <implementation name="IM_inside_color3_genosl" nodedef="ND_inside_color3" file="libraries/stdlib/genosl/mx_inside.inline" target="genosl" />
+  <implementation name="IM_inside_color4_genosl" nodedef="ND_inside_color4" file="libraries/stdlib/genosl/mx_inside.inline" target="genosl" />
 
   <!-- <outside> -->
-  <implementation name="IM_outside_float_genosl" nodedef="ND_outside_float" file="stdlib/genosl/mx_outside.inline" target="genosl" />
-  <implementation name="IM_outside_color3_genosl" nodedef="ND_outside_color3" file="stdlib/genosl/mx_outside.inline" target="genosl" />
-  <implementation name="IM_outside_color4_genosl" nodedef="ND_outside_color4" file="stdlib/genosl/mx_outside.inline" target="genosl" />
+  <implementation name="IM_outside_float_genosl" nodedef="ND_outside_float" file="libraries/stdlib/genosl/mx_outside.inline" target="genosl" />
+  <implementation name="IM_outside_color3_genosl" nodedef="ND_outside_color3" file="libraries/stdlib/genosl/mx_outside.inline" target="genosl" />
+  <implementation name="IM_outside_color4_genosl" nodedef="ND_outside_color4" file="libraries/stdlib/genosl/mx_outside.inline" target="genosl" />
 
   <!-- <mix> -->
-  <implementation name="IM_mix_float_genosl" nodedef="ND_mix_float" file="stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_color3_genosl" nodedef="ND_mix_color3" file="stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_color4_genosl" nodedef="ND_mix_color4" file="stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_vector2_genosl" nodedef="ND_mix_vector2" file="stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_vector3_genosl" nodedef="ND_mix_vector3" file="stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_vector4_genosl" nodedef="ND_mix_vector4" file="stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_surfaceshader_genosl" nodedef="ND_mix_surfaceshader" file="stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_float_genosl" nodedef="ND_mix_float" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_color3_genosl" nodedef="ND_mix_color3" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_color4_genosl" nodedef="ND_mix_color4" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_vector2_genosl" nodedef="ND_mix_vector2" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_vector3_genosl" nodedef="ND_mix_vector3" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_vector4_genosl" nodedef="ND_mix_vector4" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_surfaceshader_genosl" nodedef="ND_mix_surfaceshader" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
@@ -766,28 +766,28 @@
   <implementation name="IM_blur_vector4_genosl" nodedef="ND_blur_vector4" target="genosl" />
 
   <!-- <heighttonormal> -->
-  <implementation name="IM_heighttonormal_vector3_genosl" nodedef="ND_heighttonormal_vector3" file="stdlib/genosl/mx_heighttonormal_vector3.osl" function="mx_heighttonormal_vector3" target="genosl" />
+  <implementation name="IM_heighttonormal_vector3_genosl" nodedef="ND_heighttonormal_vector3" file="libraries/stdlib/genosl/mx_heighttonormal_vector3.osl" function="mx_heighttonormal_vector3" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 
   <!-- <dot> -->
-  <implementation name="IM_dot_float_genosl" nodedef="ND_dot_float" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_color3_genosl" nodedef="ND_dot_color3" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_color4_genosl" nodedef="ND_dot_color4" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_vector2_genosl" nodedef="ND_dot_vector2" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_vector3_genosl" nodedef="ND_dot_vector3" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_vector4_genosl" nodedef="ND_dot_vector4" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_boolean_genosl" nodedef="ND_dot_boolean" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_integer_genosl" nodedef="ND_dot_integer" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_matrix33_genosl" nodedef="ND_dot_matrix33" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_matrix44_genosl" nodedef="ND_dot_matrix44" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_string_genosl" nodedef="ND_dot_string" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_filename_genosl" nodedef="ND_dot_filename" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_surfaceshader_genosl" nodedef="ND_dot_surfaceshader" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_displacementshader_genosl" nodedef="ND_dot_displacementshader" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_volumeshader_genosl" nodedef="ND_dot_volumeshader" file="stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_lightshader_genosl" nodedef="ND_dot_lightshader" file="stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_float_genosl" nodedef="ND_dot_float" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_color3_genosl" nodedef="ND_dot_color3" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_color4_genosl" nodedef="ND_dot_color4" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_vector2_genosl" nodedef="ND_dot_vector2" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_vector3_genosl" nodedef="ND_dot_vector3" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_vector4_genosl" nodedef="ND_dot_vector4" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_boolean_genosl" nodedef="ND_dot_boolean" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_integer_genosl" nodedef="ND_dot_integer" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_matrix33_genosl" nodedef="ND_dot_matrix33" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_matrix44_genosl" nodedef="ND_dot_matrix44" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_string_genosl" nodedef="ND_dot_string" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_filename_genosl" nodedef="ND_dot_filename" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_surfaceshader_genosl" nodedef="ND_dot_surfaceshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_displacementshader_genosl" nodedef="ND_dot_displacementshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_volumeshader_genosl" nodedef="ND_dot_volumeshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_lightshader_genosl" nodedef="ND_dot_lightshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
 
 </materialx>

--- a/python/MaterialXTest/genshader.py
+++ b/python/MaterialXTest/genshader.py
@@ -13,10 +13,9 @@ class TestGenShader(unittest.TestCase):
     def test_ShaderInterface(self):
         doc = mx.createDocument()
 
-        libraryFolders = ["targets", "stdlib"]
         filePath = os.path.dirname(os.path.abspath(__file__))
-        searchPath = os.path.join(filePath, "..", "..", "libraries")
-        mx.loadLibraries(libraryFolders, searchPath, doc)
+        searchPath = os.path.join(filePath, "..", "..")
+        mx.loadLibraries(["libraries"], searchPath, doc)
 
         exampleName = u"shader_interface"
 

--- a/python/Scripts/baketextures.py
+++ b/python/Scripts/baketextures.py
@@ -33,7 +33,7 @@ def main():
     filePath = os.path.dirname(os.path.abspath(__file__))
     searchPath = mx.FileSearchPath(os.path.join(filePath, '..', '..'))
     searchPath.append(os.path.dirname(opts.inputFilename))
-    libraryFolders = [ "libraries" ]
+    libraryFolders = []
     if opts.paths:
         for pathList in opts.paths:
             for path in pathList:
@@ -42,6 +42,7 @@ def main():
         for libraryList in opts.libraries:
             for library in libraryList:
                 libraryFolders.append(library)
+    libraryFolders.append("libraries")
     mx.loadLibraries(libraryFolders, searchPath, stdlib)
     doc.importLibrary(stdlib)
 

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -50,7 +50,7 @@ def main():
     filePath = os.path.dirname(os.path.abspath(__file__))
     searchPath = mx.FileSearchPath(os.path.join(filePath, '..', '..', 'libraries'))
     searchPath.append(os.path.dirname(opts.inputFilename))
-    libraryFolders = [ 'libraries' ]
+    libraryFolders = []
     if opts.paths:
         for pathList in opts.paths:
             for path in pathList:
@@ -59,6 +59,7 @@ def main():
         for libraryList in opts.libraries:
             for library in libraryList:
                 libraryFolders.append(library)
+    libraryFolders.append("libraries")
     mx.loadLibraries(libraryFolders, searchPath, stdlib)
     doc.importLibrary(stdlib)
 

--- a/python/Scripts/translateshader.py
+++ b/python/Scripts/translateshader.py
@@ -35,7 +35,7 @@ def main():
     filePath = os.path.dirname(os.path.abspath(__file__))
     searchPath = mx.FileSearchPath(os.path.join(filePath, '..', '..'))
     searchPath.append(os.path.dirname(opts.inputFilename))
-    libraryFolders = [ "libraries" ]
+    libraryFolders = []
     if opts.paths:
         for pathList in opts.paths:
             for path in pathList:
@@ -44,6 +44,7 @@ def main():
         for libraryList in opts.libraries:
             for library in libraryList:
                 libraryFolders.append(library)
+    libraryFolders.append("libraries")
     mx.loadLibraries(libraryFolders, searchPath, stdlib)
     doc.importLibrary(stdlib)
 

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -344,15 +344,15 @@ void GlslShaderGenerator::emitSpecularEnvironment(GenContext& context, ShaderSta
     int specularMethod = context.getOptions().hwSpecularEnvironmentMethod;
     if (specularMethod == SPECULAR_ENVIRONMENT_FIS)
     {
-        emitInclude("pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_fis.glsl", context, stage);
+        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_fis.glsl", context, stage);
     }
     else if (specularMethod == SPECULAR_ENVIRONMENT_PREFILTER)
     {
-        emitInclude("pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_prefilter.glsl", context, stage);
+        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_prefilter.glsl", context, stage);
     }
     else if (specularMethod == SPECULAR_ENVIRONMENT_NONE)
     {
-        emitInclude("pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_none.glsl", context, stage);
+        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_none.glsl", context, stage);
     }
     else
     {
@@ -522,7 +522,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitOutputs(context, stage);
 
     // Add common math functions
-    emitInclude("stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_math.glsl", context, stage);
+    emitInclude("libraries/stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_math.glsl", context, stage);
     emitLineBreak(stage);
 
     // Determine whether lighting is required
@@ -556,13 +556,13 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
                      context.getOptions().hwWriteDepthMoments;
     if (shadowing)
     {
-        emitInclude("pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_shadow.glsl", context, stage);
+        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_shadow.glsl", context, stage);
     }
 
     // Emit directional albedo table code.
     if (context.getOptions().hwWriteAlbedoTable)
     {
-        emitInclude("pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_table.glsl", context, stage);
+        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_table.glsl", context, stage);
         emitLineBreak(stage);
     }
 
@@ -570,11 +570,11 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     // depending on the vertical flip flag.
     if (context.getOptions().fileTextureVerticalFlip)
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_transform_uv_vflip.glsl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_transform_uv_vflip.glsl";
     }
     else
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_transform_uv.glsl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_transform_uv.glsl";
     }
 
     // Emit uv transform code globally if needed.

--- a/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
@@ -20,7 +20,7 @@ ShaderNodeImplPtr BlurNodeGlsl::create()
 void BlurNodeGlsl::emitSamplingFunctionDefinition(const ShaderNode& /*node*/, GenContext& context, ShaderStage& stage) const
 {
     const ShaderGenerator& shadergen = context.getShaderGenerator();
-    shadergen.emitInclude("stdlib/genglsl/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
+    shadergen.emitInclude("libraries/stdlib/genglsl/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
     shadergen.emitLineBreak(stage);
 }
 

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -55,7 +55,7 @@ void HeightToNormalNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContex
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
         // Emit sampling functions
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-        shadergen.emitInclude("stdlib/genglsl/lib/mx_sampling.glsl", context, stage);
+        shadergen.emitInclude("libraries/stdlib/genglsl/lib/mx_sampling.glsl", context, stage);
         shadergen.emitLineBreak(stage);
     END_SHADER_STAGE(shader, Stage::PIXEL)
 }

--- a/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
@@ -20,7 +20,7 @@ ShaderNodeImplPtr BlurNodeOsl::create()
 void BlurNodeOsl::emitSamplingFunctionDefinition(const ShaderNode& /*node*/, GenContext& context, ShaderStage& stage) const
 {
     const ShaderGenerator& shadergen = context.getShaderGenerator();
-    shadergen.emitInclude("stdlib/genosl/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
+    shadergen.emitInclude("libraries/stdlib/genosl/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
     shadergen.emitLineBreak(stage);
 }
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -204,11 +204,11 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     // depending on the vertical flip flag.
     if (context.getOptions().fileTextureVerticalFlip)
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "stdlib/" + OslShaderGenerator::TARGET + "/lib/mx_transform_uv_vflip.osl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + OslShaderGenerator::TARGET + "/lib/mx_transform_uv_vflip.osl";
     }
     else
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "stdlib/" + OslShaderGenerator::TARGET + "/lib/mx_transform_uv.osl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + OslShaderGenerator::TARGET + "/lib/mx_transform_uv.osl";
     }
 
     // Emit function definitions for all nodes

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -475,10 +475,7 @@ DocumentPtr TextureBaker::bakeMaterialToDoc(DocumentPtr doc, const FileSearchPat
 
     DefaultColorManagementSystemPtr cms = DefaultColorManagementSystem::create(genContext.getShaderGenerator().getTarget());
     cms->loadLibrary(doc);
-    for (const FilePath& path : searchPath)
-    {
-        genContext.registerSourceCodeSearchPath(path / "libraries");
-    }
+    genContext.registerSourceCodeSearchPath(searchPath);
     genContext.getShaderGenerator().setColorManagementSystem(cms);
 
     // Compute the material tag set.

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -139,9 +139,8 @@ TEST_CASE("Node", "[node]")
 TEST_CASE("Inheritance", "[nodedef]")
 {
     mx::DocumentPtr doc = mx::createDocument();
-    const mx::FilePathVec libraryFolders;
-    mx::FileSearchPath libraryRoot(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    mx::loadLibraries(libraryFolders, libraryRoot, doc);
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
     REQUIRE(doc->validate());
     auto nodedef = doc->getNodeDef("ND_standard_surface_surfaceshader");
     REQUIRE(nodedef);

--- a/source/MaterialXTest/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXTest/MaterialXCore/Traversal.cpp
@@ -174,16 +174,14 @@ TEST_CASE("IntraGraph Traversal", "[traversal]")
     REQUIRE(doc->validate());
 }
 
-TEST_CASE("InterGraph Tranversal", "[traversal]")
+TEST_CASE("InterGraph Traversal", "[traversal]")
 {
-    mx::FileSearchPath searchPath;
-    const mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    searchPath.append(currentPath / mx::FilePath("libraries"));
-
     mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibraries({ "stdlib", "pbrlib", "bxdf" }, searchPath, doc);
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    mx::FileSearchPath searchPath(currentPath);
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
 
-    mx::FilePath testFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx");
+    mx::FilePath testFile = currentPath / mx::FilePath("resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx");
     mx::readFromXmlFile(doc, testFile, searchPath);
     REQUIRE(doc->validate());
 

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -91,8 +91,8 @@ TEST_CASE("GenShader: GLSL Unique Names", "[genglsl]")
 {
     mx::GenContext context(mx::GlslShaderGenerator::create());
 
-    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    context.registerSourceCodeSearchPath(searchPath);
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    context.registerSourceCodeSearchPath(currentPath);
 
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
@@ -102,8 +102,8 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
     mx::DocumentPtr doc = mx::createDocument();
 
     mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    loadLibraries({ "targets", "stdlib", "pbrlib", "lights" }, searchPath, doc);
+    searchPath.append(mx::FilePath::getCurrentPath());
+    loadLibraries({ "libraries" }, searchPath, doc);
 
     mx::NodeDefPtr pointLightShader = doc->getNodeDef("ND_point_light");
     mx::NodeDefPtr spotLightShader = doc->getNodeDef("ND_spot_light");
@@ -111,7 +111,7 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
     REQUIRE(spotLightShader != nullptr);
 
     mx::GenContext context(mx::GlslShaderGenerator::create());
-    context.registerSourceCodeSearchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    context.registerSourceCodeSearchPath(searchPath);
 
     mx::HwShaderGenerator::bindLightShader(*pointLightShader, 42, context);
     REQUIRE_THROWS(mx::HwShaderGenerator::bindLightShader(*spotLightShader, 42, context));
@@ -127,7 +127,7 @@ static void generateGlslCode(bool generateLayout = false)
     mx::FilePathVec testRootPaths;
     testRootPaths.push_back("resources/Materials/TestSuite");
     testRootPaths.push_back("resources/Materials/Examples");
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
+    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath();
     const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
     bool writeShadersToDisk = false;
 

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -95,20 +95,6 @@ TEST_CASE("GenShader: MDL Implementation Check", "[genmdl]")
     GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 55);
 }
 
-/*
-TEST_CASE("GenShader: MDL Unique Names", "[genmdl]")
-{
-    mx::GenContext context(mx::MdlShaderGenerator::create());
-
-    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    context.registerSourceCodeSearchPath(searchPath);
-    // TODO: Add path to find MDL module files
-    // context.registerSourceCodeSearchPath(searchPath / mx::FilePath("stdlib/mdl"));
-
-    GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
-}
-*/
-
 void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& sourceCodePaths)
 {
     if (sourceCodePaths.empty() || sourceCodePaths[0].isEmpty())
@@ -240,9 +226,9 @@ TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
     testRootPaths.push_back("resources/Materials/TestSuite");
     testRootPaths.push_back("resources/Materials/Examples");
 
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
+    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath();
     mx::FileSearchPath srcSearchPath(libSearchPath.asString());
-    srcSearchPath.append(libSearchPath / mx::FilePath("stdlib/genmdl"));
+    srcSearchPath.append(libSearchPath / mx::FilePath("libraries/stdlib/genmdl"));
 
     const mx::FilePath logPath("genmdl_mdl_generate_test.txt");
 

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -95,11 +95,9 @@ TEST_CASE("GenShader: OSL Implementation Check", "[genosl]")
 TEST_CASE("GenShader: OSL Unique Names", "[genosl]")
 {
     mx::GenContext context(mx::OslShaderGenerator::create());
-
-    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    context.registerSourceCodeSearchPath(searchPath);
-    // Add path to find OSL include files
-    context.registerSourceCodeSearchPath(searchPath / mx::FilePath("stdlib/genosl/include"));
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    context.registerSourceCodeSearchPath(currentPath);
+    context.registerSourceCodeSearchPath(currentPath / mx::FilePath("libraries/stdlib/genosl/include"));
 
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
@@ -107,10 +105,10 @@ TEST_CASE("GenShader: OSL Unique Names", "[genosl]")
 TEST_CASE("GenShader: OSL Metadata", "[genosl]")
 {
     mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    searchPath.append(mx::FilePath::getCurrentPath());
 
     mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibraries({ "targets", "stdlib", "pbrlib", "bxdf" }, searchPath, doc);
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
 
     //
     // Define custom attributes to be exported as shader metadata
@@ -193,9 +191,9 @@ static void generateOslCode()
     testRootPaths.push_back("resources/Materials/TestSuite");
     testRootPaths.push_back("resources/Materials/Examples");
 
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
+    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath();
     mx::FileSearchPath srcSearchPath(libSearchPath.asString());
-    srcSearchPath.append(libSearchPath / mx::FilePath("stdlib/genosl/include"));
+    srcSearchPath.append(libSearchPath / mx::FilePath("libraries/stdlib/genosl/include"));
     srcSearchPath.append(mx::FilePath::getCurrentPath());
     const mx::FilePath logPath("genosl_vanilla_generate_test.txt");
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -58,8 +58,8 @@ TEST_CASE("GenShader: Valid Libraries", "[genshader]")
     mx::DocumentPtr doc = mx::createDocument();
 
     mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    loadLibraries({ "targets", "stdlib", "pbrlib" }, searchPath, doc);
+    searchPath.append(mx::FilePath::getCurrentPath());
+    loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib" }, searchPath, doc);
 
     std::string validationErrors;
     bool valid = doc->validate(&validationErrors);
@@ -108,11 +108,11 @@ TEST_CASE("GenShader: Graph + Nodedf Translation Check", "[genshader]")
 {
     mx::FileSearchPath searchPath;
     const mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    searchPath.append(currentPath / mx::FilePath("libraries"));
+    searchPath.append(currentPath);
     searchPath.append(currentPath / mx::FilePath("resources/Materials/TestSuite"));
 
     mx::DocumentPtr doc = mx::createDocument();
-    loadLibraries({ "targets", "stdlib", "pbrlib", "bxdf",  }, searchPath, doc);
+    loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib", "libraries/bxdf" }, searchPath, doc);
     mx::FilePath testPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx");
     mx::readFromXmlFile(doc, testPath, searchPath);
 
@@ -167,8 +167,8 @@ TEST_CASE("GenShader: Graph + Nodedf Translation Check", "[genshader]")
 
 TEST_CASE("GenShader: Transparency Regression Check", "[genshader]")
 {
-    const mx::FilePath currentPath = mx::FilePath::getCurrentPath();
     mx::DocumentPtr libraries = mx::createDocument();
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
     mx::FileSearchPath searchPath(currentPath);
     mx::loadLibraries({ "libraries" }, searchPath, libraries);
 
@@ -263,9 +263,9 @@ void testDeterministicGeneration(mx::DocumentPtr libraries, mx::GenContext& cont
 
 TEST_CASE("GenShader: Deterministic Generation", "[genshader]")
 {
-    const mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
     mx::DocumentPtr libraries = mx::createDocument();
-    mx::loadLibraries({ "targets", "stdlib", "pbrlib", "bxdf" }, searchPath, libraries);
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    mx::loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib", "libraries/bxdf" }, searchPath, libraries);
 
 #ifdef MATERIALX_BUILD_GEN_GLSL
     {

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -73,10 +73,8 @@ void checkImplementations(mx::GenContext& context,
 
     const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
-    mx::FileSearchPath searchPath; 
-    mx::FilePath librariesRoot = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    searchPath.append(librariesRoot);
-    loadLibraries({ "targets", "adsk", "stdlib", "pbrlib" }, searchPath, doc);
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib" }, searchPath, doc);
 
     const std::string& target = shadergen.getTarget();
 
@@ -86,9 +84,7 @@ void checkImplementations(mx::GenContext& context,
     implDumpBuffer.open(fileName, std::ios::out);
     std::ostream implDumpStream(&implDumpBuffer);
 
-    mx::FileSearchPath sourceSearchPath = searchPath;
-    sourceSearchPath.append(librariesRoot / mx::FilePath("adsk"));
-    context.registerSourceCodeSearchPath(sourceSearchPath);
+    context.registerSourceCodeSearchPath(searchPath);
 
     // Node types to explicitly skip temporarily.
     mx::StringSet skipNodeTypes =
@@ -289,9 +285,8 @@ void testUniqueNames(mx::GenContext& context, const std::string& stage)
 {
     mx::DocumentPtr doc = mx::createDocument();
 
-    mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    loadLibraries({ "targets", "stdlib" }, searchPath, doc);
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    loadLibraries({ "libraries/targets", "libraries/stdlib" }, searchPath, doc);
 
     const std::string exampleName = "unique_names";
 
@@ -488,8 +483,7 @@ void ShaderGeneratorTester::setupDependentLibraries()
     _dependLib = mx::createDocument();
 
     // Load the standard libraries.
-    const mx::FilePathVec libraries = { "targets", "adsk", "stdlib", "pbrlib", "bxdf", "lights" };
-    loadLibraries(libraries, _libSearchPath, _dependLib, _skipLibraryFiles);
+    loadLibraries({ "libraries" }, _libSearchPath, _dependLib, _skipLibraryFiles);
 }
 
 void ShaderGeneratorTester::addSkipFiles()

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -60,8 +60,7 @@ void ShaderRenderTester::loadDependentLibraries(GenShaderUtil::TestSuiteOptions 
 {
     dependLib = mx::createDocument();
 
-    const mx::FilePathVec libraries = { "targets", "adsk", "stdlib", "pbrlib", "bxdf", "lights" };
-    mx::loadLibraries(libraries, searchPath, dependLib);
+    mx::loadLibraries({ "libraries" }, searchPath, dependLib);
     for (size_t i = 0; i < options.extraLibraryPaths.size(); i++)
     {
         const mx::FilePath& libraryPath = options.extraLibraryPaths[i];
@@ -145,8 +144,9 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     addSkipFiles();
 
     // Library search path
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
     mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    searchPath.append(currentPath);
 
     // Load in the library dependencies once
     // This will be imported in each test document below
@@ -176,8 +176,8 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     _shaderGenerator->getUnitSystem()->setUnitConverterRegistry(registry);
 
     mx::GenContext context(_shaderGenerator);
-    context.registerSourceCodeSearchPath(searchPath);
-    registerSourceCodeSearchPaths(context);
+    context.registerSourceCodeSearchPath(currentPath);
+    context.registerSourceCodeSearchPath(currentPath / mx::FilePath("libraries/stdlib/genosl/include"));
 
     // Set target unit space
     context.getOptions().targetDistanceUnit = "meter";

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -128,9 +128,6 @@ class ShaderRenderTester
     // Code generation methods
     //
 
-    // Register any additional source code paths used by the generator
-    virtual void registerSourceCodeSearchPaths(mx::GenContext& /*context*/) {};
-
     // Register any lights used by the generation context
     virtual void registerLights(mx::DocumentPtr /*dependLib*/,
                                 const GenShaderUtil::TestSuiteOptions &/*options*/,

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -23,9 +23,9 @@ namespace mx = MaterialX;
 TEST_CASE("GenReference: OSL Reference", "[genreference]")
 {
     mx::DocumentPtr stdlib = mx::createDocument();
-    mx::FilePath librariesPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    mx::FileSearchPath searchPath(librariesPath);
-    loadLibraries({ "targets", "stdlib" }, searchPath, stdlib);
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    mx::FileSearchPath searchPath(currentPath);
+    loadLibraries({ "libraries/targets", "libraries/stdlib" }, searchPath, stdlib);
 
     // Create renderer if requested.
     bool runCompileTest = !std::string(MATERIALX_OSL_BINARY_OSLC).empty();
@@ -38,7 +38,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
         oslIncludePaths.append(mx::FilePath(MATERIALX_OSL_INCLUDE_PATH));
         // Add in library include path for compile testing as the generated
         // shader's includes are not added with absolute paths.
-        oslIncludePaths.append(librariesPath / mx::FilePath("stdlib/genosl/include"));
+        oslIncludePaths.append(currentPath / mx::FilePath("libraries/stdlib/genosl/include"));
         oslRenderer->setOslIncludePath(oslIncludePaths);
     }
 
@@ -46,7 +46,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     mx::ShaderGeneratorPtr generator = mx::OslShaderGenerator::create();
     mx::GenContext context(generator);
     context.getOptions().addUpstreamDependencies = false;
-    context.registerSourceCodeSearchPath(librariesPath);
+    context.registerSourceCodeSearchPath(currentPath);
     context.getOptions().fileTextureVerticalFlip = true;
 
     // Create output directory.

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -78,16 +78,6 @@ class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
     }
 
   protected:
-    void registerSourceCodeSearchPaths(mx::GenContext& context) override
-    {
-        // Include extra OSL implementation files
-        mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-        context.registerSourceCodeSearchPath(searchPath / mx::FilePath("stdlib/genosl/include"));
-
-        // Include current path to find resources.
-        context.registerSourceCodeSearchPath(mx::FilePath::getCurrentPath());
-    }
-
     void createRenderer(std::ostream& log) override;
 
     bool runRenderer(const std::string& shaderName,

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* const argv[])
     std::string meshFilename = "resources/Geometry/shaderball.obj";
     std::string envRadianceFilename = "resources/Lights/san_giuseppe_bridge_split.hdr";
     mx::FileSearchPath searchPath = getDefaultSearchPath();
-    mx::FilePathVec libraryFolders = { "libraries" };
+    mx::FilePathVec libraryFolders;
 
     mx::Vector3 meshRotation;
     float meshScale = 1.0f;
@@ -247,6 +247,9 @@ int main(int argc, char* const argv[])
             i++;
         }
     }
+
+    // Append the standard library folder, giving it a lower precedence than user-supplied libraries.
+    libraryFolders.push_back("libraries");
 
     ng::init();
     {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -258,7 +258,6 @@ Viewer::Viewer(const std::string& materialFilename,
     _wedgePropertyMin(0.0f),
     _wedgePropertyMax(1.0f),
     _wedgeImageCount(8),
-    _bakeTextures(false),
     _bakeHdr(false),
     _bakeAverage(false),
     _bakeOptimize(true),
@@ -500,7 +499,8 @@ void Viewer::loadEnvironmentLight()
         _lightRigFilename = _envRadianceFilename;
         _lightRigFilename.removeExtension();
         _lightRigFilename.addExtension(mx::MTLX_EXTENSION);
-        if (_searchPath.find(_lightRigFilename).exists())
+        _lightRigFilename = _searchPath.find(_lightRigFilename);
+        if (_lightRigFilename.exists())
         {
             _lightRigDoc = mx::createDocument();
             mx::readFromXmlFile(_lightRigDoc, _lightRigFilename, _searchPath);
@@ -953,7 +953,7 @@ void Viewer::createAdvancedSettings(Widget* parent)
     textureLabel->set_font("sans-bold");
 
     ng::CheckBox* bakeHdrBox = new ng::CheckBox(advancedPopup, "Bake HDR Textures");
-    bakeHdrBox->set_checked(_bakeTextures);
+    bakeHdrBox->set_checked(_bakeHdr);
     bakeHdrBox->set_callback([this](bool enable)
     {
         _bakeHdr = enable;
@@ -1563,11 +1563,8 @@ mx::DocumentPtr Viewer::translateMaterial()
 
 void Viewer::initContext(mx::GenContext& context)
 {
-    // Initialize search paths.
-    for (const mx::FilePath& path : _searchPath)
-    {
-        context.registerSourceCodeSearchPath(path / "libraries");
-    }
+    // Initialize search path.
+    context.registerSourceCodeSearchPath(_searchPath);
 
     // Initialize color management.
     mx::DefaultColorManagementSystemPtr cms = mx::DefaultColorManagementSystem::create(context.getShaderGenerator().getTarget());

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -377,7 +377,6 @@ class Viewer : public ng::Screen
     unsigned int _wedgeImageCount;
 
     // Texture baking
-    bool _bakeTextures;
     bool _bakeHdr;
     bool _bakeAverage;
     bool _bakeOptimize;


### PR DESCRIPTION
This changelist removes a hardcoded inclusion of the "libraries" string in calls to GenContext::registerSourceCodeSearchPath, giving control back to include directives to specify which top-level folder is intended.

As a result, applications with custom code generators will need to remove this string from their own calls to GenContext::registerSourceCodeSearchPath when they upgrade to MaterialX 1.38.4.

Supporting changes include:
- Give precedence to user-supplied libraries over the standard libraries in MaterialXView, generateshader.py, and translateshader.py.
- Minor fixes to texture baking in MaterialXView.