### PR TITLE
Upgrade light nodes

### DIFF
--- a/libraries/lights/genglsl/lights_genglsl_impl.mtlx
+++ b/libraries/lights/genglsl/lights_genglsl_impl.mtlx
@@ -1,13 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<materialx version="1.37">
+<?xml version="1.0"?>
+<materialx version="1.38">
 
   <!-- <point_light> -->
-  <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="libraries/lights/genglsl/mx_point_light.glsl" function="mx_point_light" target="genglsl"/>
+  <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="libraries/lights/genglsl/mx_point_light.glsl" function="mx_point_light" target="genglsl" />
 
   <!-- <directional_light> -->
-  <implementation name="IM_directional_light_genglsl" nodedef="ND_directional_light" file="libraries/lights/genglsl/mx_directional_light.glsl" function="mx_directional_light" target="genglsl"/>
+  <implementation name="IM_directional_light_genglsl" nodedef="ND_directional_light" file="libraries/lights/genglsl/mx_directional_light.glsl" function="mx_directional_light" target="genglsl" />
 
   <!-- <spot_light> -->
-  <implementation name="IM_spot_light_genglsl" nodedef="ND_spot_light" file="libraries/lights/genglsl/mx_spot_light.glsl" function="mx_spot_light" target="genglsl"/>
+  <implementation name="IM_spot_light_genglsl" nodedef="ND_spot_light" file="libraries/lights/genglsl/mx_spot_light.glsl" function="mx_spot_light" target="genglsl" />
 
 </materialx>

--- a/libraries/lights/lights_defs.mtlx
+++ b/libraries/lights/lights_defs.mtlx
@@ -1,16 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
-  TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-  All rights reserved.  See LICENSE.txt for license.
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <!--
+    TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+    All rights reserved.  See LICENSE.txt for license.
 
-  Declarations of example light shader nodes.
+    Declarations of common light nodes, used in code generation for hardware
+    shading languages that require explicit light loops.
 
-  DISCLAIMER: These nodes are only to serve as examples of light shader nodes.
-  They are not standardized members of MaterialX's standard libraries, and they
-  may change in future revisions.
--->
-
-<materialx version="1.37">
+    These nodes are a required implementation detail for hardware shader
+    generation, and are not themselves part of the MaterialX standard.
+  -->
 
   <!-- ======================================================================== -->
   <!-- Light shader nodes                                                       -->
@@ -19,39 +18,36 @@
   <!--
     Node: <point_light>
   -->
-  <nodedef name="ND_point_light" node="point_light" nodegroup="light"
-           doc="A light shader node of 'point' type.">
-    <input name="position" type="vector3" doc="Light source position."/>
-    <input name="color" type="color3" doc="Light color."/>
-    <input name="intensity" type="float" doc="Light intensity."/>
-    <input name="decay_rate" type="float" value="2.0" doc="Light decay exponent. Defaults to 2 for quadratic decay."/>
-    <output name="out" type="lightshader"/>
+  <nodedef name="ND_point_light" node="point_light" nodegroup="light" doc="A light shader node of 'point' type.">
+    <input name="position" type="vector3" doc="Light source position." />
+    <input name="color" type="color3" doc="Light color." />
+    <input name="intensity" type="float" doc="Light intensity." />
+    <input name="decay_rate" type="float" value="2.0" doc="Light decay exponent. Defaults to 2 for quadratic decay." />
+    <output name="out" type="lightshader" />
   </nodedef>
 
   <!--
     Node: <directional_light>
   -->
-  <nodedef name="ND_directional_light" node="directional_light" nodegroup="light"
-           doc="A light shader node of 'directional' type.">
-    <input name="direction" type="vector3" doc="Light source direction."/>
-    <input name="color" type="color3" doc="Light color."/>
-    <input name="intensity" type="float" doc="Light intensity."/>
-    <output name="out" type="lightshader"/>
+  <nodedef name="ND_directional_light" node="directional_light" nodegroup="light" doc="A light shader node of 'directional' type.">
+    <input name="direction" type="vector3" doc="Light source direction." />
+    <input name="color" type="color3" doc="Light color." />
+    <input name="intensity" type="float" doc="Light intensity." />
+    <output name="out" type="lightshader" />
   </nodedef>
 
   <!--
     Node: <spot_light>
   -->
-  <nodedef name="ND_spot_light" node="spot_light" nodegroup="light"
-           doc="A light shader node of 'spot' type.">
-    <input name="position" type="vector3" doc="Light source position."/>
-    <input name="direction" type="vector3" doc="Light source direction."/>
-    <input name="color" type="color3" doc="Light color."/>
-    <input name="intensity" type="float" doc="Light intensity."/>
-    <input name="decay_rate" type="float" value="2.0" doc="Light decay exponent. Defaults to 2 for quadratic decay."/>
-    <input name="inner_angle" type="float" doc="Inner cone angle."/>
-    <input name="outer_angle" type="float" doc="Outer cone angle."/>
-    <output name="out" type="lightshader"/>
+  <nodedef name="ND_spot_light" node="spot_light" nodegroup="light" doc="A light shader node of 'spot' type.">
+    <input name="position" type="vector3" doc="Light source position." />
+    <input name="direction" type="vector3" doc="Light source direction." />
+    <input name="color" type="color3" doc="Light color." />
+    <input name="intensity" type="float" doc="Light intensity." />
+    <input name="decay_rate" type="float" value="2.0" doc="Light decay exponent. Defaults to 2 for quadratic decay." />
+    <input name="inner_angle" type="float" doc="Inner cone angle." />
+    <input name="outer_angle" type="float" doc="Outer cone angle." />
+    <output name="out" type="lightshader" />
   </nodedef>
 
 </materialx>


### PR DESCRIPTION
This changelist upgrades all light nodes used in hardware shading to the 1.38 standard, refining their documentation for clarity.