### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXGenShader/Shader.h
+++ b/source/MaterialXGenShader/Shader.h
@@ -95,7 +95,7 @@ class MX_GENSHADER_API Shader
     bool hasClassification(unsigned int c) const { return _graph->hasClassification(c); }
 
     /// Set the shader source code for a given shader stage.
-    const void setSourceCode(const string& code, const string& stage = Stage::PIXEL) { getStage(stage).setSourceCode(code); }
+    void setSourceCode(const string& code, const string& stage = Stage::PIXEL) { getStage(stage).setSourceCode(code); }
 
     /// Return the shader source code for a given shader stage.
     const string& getSourceCode(const string& stage = Stage::PIXEL) const { return getStage(stage).getSourceCode(); }

--- a/source/MaterialXRender/Harmonics.h
+++ b/source/MaterialXRender/Harmonics.h
@@ -26,9 +26,8 @@ template <class C, size_t B> class ShCoeffs
     static const size_t NUM_COEFFS = B * B;
 
   public:
-    ShCoeffs() { }
+    ShCoeffs() = default;
     explicit ShCoeffs(const std::array<C, NUM_COEFFS>& arr) : _arr(arr) { }
-    ~ShCoeffs() { }
 
     /// @name Comparison Operators
     /// @{

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -17,9 +17,9 @@ MATERIALX_NAMESPACE_BEGIN
 // GLFramebuffer methods
 //
 
-GLFrameBufferPtr GLFramebuffer::create(unsigned int width, unsigned int height, unsigned channelCount, Image::BaseType baseType)
+GLFramebufferPtr GLFramebuffer::create(unsigned int width, unsigned int height, unsigned channelCount, Image::BaseType baseType)
 {
-    return GLFrameBufferPtr(new GLFramebuffer(width, height, channelCount, baseType));
+    return GLFramebufferPtr(new GLFramebuffer(width, height, channelCount, baseType));
 }
 
 GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned int channelCount, Image::BaseType baseType) :
@@ -28,7 +28,7 @@ GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned i
     _channelCount(channelCount),
     _baseType(baseType),
     _encodeSrgb(false),
-    _frameBuffer(0),
+    _framebuffer(0),
     _colorTexture(0),
     _depthTexture(0)
 {
@@ -42,8 +42,8 @@ GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned i
     GLTextureHandler::mapTextureFormatToGL(baseType, channelCount, true, glType, glFormat, glInternalFormat);
 
     // Create and bind framebuffer.
-    glGenFramebuffers(1, &_frameBuffer);
-    glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
+    glGenFramebuffers(1, &_framebuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
 
     // Create the offscreen color target and attach to the framebuffer.
     glGenTextures(1, &_colorTexture);
@@ -69,8 +69,8 @@ GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned i
     if (status != GL_FRAMEBUFFER_COMPLETE)
     {
         glBindFramebuffer(GL_FRAMEBUFFER, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
-        glDeleteFramebuffers(1, &_frameBuffer);
-        _frameBuffer = GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
+        glDeleteFramebuffers(1, &_framebuffer);
+        _framebuffer = GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID;
 
         string errorMessage;
         switch (status)
@@ -113,12 +113,12 @@ GLFramebuffer::GLFramebuffer(unsigned int width, unsigned int height, unsigned i
 
 GLFramebuffer::~GLFramebuffer()
 {
-    if (_frameBuffer)
+    if (_framebuffer)
     {
         glBindFramebuffer(GL_FRAMEBUFFER, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
         glDeleteTextures(1, &_colorTexture);
         glDeleteTextures(1, &_depthTexture);
-        glDeleteFramebuffers(1, &_frameBuffer);
+        glDeleteFramebuffers(1, &_framebuffer);
     }
 }
 
@@ -151,12 +151,12 @@ void GLFramebuffer::resize(unsigned int width, unsigned int height)
 
 void GLFramebuffer::bind()
 {
-    if (!_frameBuffer)
+    if (!_framebuffer)
     {
         throw ExceptionRenderError("No framebuffer exists to bind");
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER, _frameBuffer);
+    glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
     GLenum colorList[1] = { GL_COLOR_ATTACHMENT0 };
     glDrawBuffers(1, colorList);
 
@@ -200,7 +200,7 @@ ImagePtr GLFramebuffer::getColorImage(ImagePtr image)
 
 void GLFramebuffer::blit()
 {
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, _frameBuffer);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, _framebuffer);
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
     glDrawBuffer(GL_BACK);
 

--- a/source/MaterialXRenderGlsl/GLFramebuffer.h
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.h
@@ -18,7 +18,7 @@ MATERIALX_NAMESPACE_BEGIN
 class GLFramebuffer;
 
 /// Shared pointer to a GLFramebuffer
-using GLFrameBufferPtr = std::shared_ptr<GLFramebuffer>;
+using GLFramebufferPtr = std::shared_ptr<GLFramebuffer>;
 
 /// @class GLFramebuffer
 /// Wrapper for an OpenGL framebuffer
@@ -26,7 +26,7 @@ class MX_RENDERGLSL_API GLFramebuffer
 {
   public:
     /// Create a new framebuffer
-    static GLFrameBufferPtr create(unsigned int width, unsigned int height, unsigned int channelCount, Image::BaseType baseType);
+    static GLFramebufferPtr create(unsigned int width, unsigned int height, unsigned int channelCount, Image::BaseType baseType);
 
     /// Destructor
     virtual ~GLFramebuffer();
@@ -83,7 +83,7 @@ class MX_RENDERGLSL_API GLFramebuffer
     Image::BaseType _baseType;
     bool _encodeSrgb;
 
-    unsigned int _frameBuffer;
+    unsigned int _framebuffer;
     unsigned int _colorTexture;
     unsigned int _depthTexture;
 };

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -211,12 +211,11 @@ int GLTextureHandler::mapAddressModeToGL(ImageSamplingProperties::AddressMode ad
 
 int GLTextureHandler::mapFilterTypeToGL(ImageSamplingProperties::FilterType filterTypeEnum, bool enableMipmaps)
 {
-    int filterType = enableMipmaps ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR;
     if (filterTypeEnum == ImageSamplingProperties::FilterType::CLOSEST)
     {
-        filterType = enableMipmaps ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
+        return enableMipmaps ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
     }
-    return filterType;
+    return enableMipmaps ? GL_LINEAR_MIPMAP_LINEAR : GL_LINEAR;
 }
 
 void GLTextureHandler::mapTextureFormatToGL(Image::BaseType baseType, unsigned int channelCount, bool srgb,

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -79,7 +79,7 @@ void GlslRenderer::initialize()
 #endif
             glClearStencil(0);
 
-            _frameBuffer = GLFramebuffer::create(_width, _height, 4, _baseType);
+            _framebuffer = GLFramebuffer::create(_width, _height, 4, _baseType);
             _initialized = true;
         }
     }
@@ -115,9 +115,9 @@ void GlslRenderer::renderTextureSpace()
     _program->bind();
     _program->bindTextures(_imageHandler);
 
-    _frameBuffer->bind();
+    _framebuffer->bind();
     drawScreenSpaceQuad();
-    _frameBuffer->unbind();
+    _framebuffer->unbind();
 
     _program->unbind();
 }
@@ -138,13 +138,13 @@ void GlslRenderer::setSize(unsigned int width, unsigned int height)
 {
     if (_context->makeCurrent())
     {
-        if (_frameBuffer)
+        if (_framebuffer)
         {
-            _frameBuffer->resize(width, height);
+            _framebuffer->resize(width, height);
         }
         else
         {
-            _frameBuffer = GLFramebuffer::create(width, height, 4, _baseType);
+            _framebuffer = GLFramebuffer::create(width, height, 4, _baseType);
         }
         _width = width;
         _height = height;
@@ -173,7 +173,7 @@ void GlslRenderer::render()
     }
 
     // Set up target
-    _frameBuffer->bind();
+    _framebuffer->bind();
 
     glClearColor(_clearColor[0], _clearColor[1], _clearColor[2], _clearColor[3]);
 
@@ -252,17 +252,17 @@ void GlslRenderer::render()
     }
     catch (ExceptionRenderError& e)
     {
-        _frameBuffer->unbind();
+        _framebuffer->unbind();
         throw e;
     }
 
     // Unset target
-    _frameBuffer->unbind();
+    _framebuffer->unbind();
 }
 
 ImagePtr GlslRenderer::captureImage(ImagePtr image)
 {
-    return _frameBuffer->getColorImage(image);
+    return _framebuffer->getColorImage(image);
 }
 
 void GlslRenderer::drawScreenSpaceQuad()

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -88,9 +88,9 @@ class MX_RENDERGLSL_API GlslRenderer : public ShaderRenderer
     ImagePtr captureImage(ImagePtr image = nullptr) override;
 
     /// Return the GL frame buffer.
-    GLFrameBufferPtr getFrameBuffer() const
+    GLFramebufferPtr getFramebuffer() const
     {
-        return _frameBuffer;
+        return _framebuffer;
     }
 
     /// Return the GLSL program.
@@ -116,7 +116,7 @@ class MX_RENDERGLSL_API GlslRenderer : public ShaderRenderer
   private:
     GlslProgramPtr _program;
 
-    GLFrameBufferPtr _frameBuffer;
+    GLFramebufferPtr _framebuffer;
 
     bool _initialized;
 

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -210,7 +210,7 @@ void TextureBaker::bakeGraphOutput(OutputPtr output, GenContext& context, const 
 
     bool encodeSrgb = _colorSpace == SRGB_TEXTURE &&
         (output->getType() == "color3" || output->getType() == "color4");
-    getFrameBuffer()->setEncodeSrgb(encodeSrgb);
+    getFramebuffer()->setEncodeSrgb(encodeSrgb);
 
     // Render and capture the requested image.
     renderTextureSpace();

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -2245,10 +2245,11 @@ void Viewer::initCamera()
     _userCameraEnabled = _cameraTarget == mx::Vector3(0.0) &&
                          _meshScale == 1.0f;
 
-    if (_geometryHandler->getMeshes().empty())
+    if (!_userCameraEnabled || _geometryHandler->getMeshes().empty())
     {
         return;
     }
+
     const mx::Vector3& boxMax = _geometryHandler->getMaximumBounds();
     const mx::Vector3& boxMin = _geometryHandler->getMinimumBounds();
     mx::Vector3 sphereCenter = (boxMax + boxMin) * 0.5;
@@ -2256,12 +2257,8 @@ void Viewer::initCamera()
     mx::Matrix44 meshRotation = mx::Matrix44::createRotationZ(_meshRotation[2] / 180.0f * PI) *
                                 mx::Matrix44::createRotationY(_meshRotation[1] / 180.0f * PI) *
                                 mx::Matrix44::createRotationX(_meshRotation[0] / 180.0f * PI);
-
-    if (_userCameraEnabled)
-    {
-        _meshTranslation = -meshRotation.transformPoint(sphereCenter);
-        _meshScale = IDEAL_MESH_SPHERE_RADIUS / (sphereCenter - boxMin).getMagnitude();
-    }
+    _meshTranslation = -meshRotation.transformPoint(sphereCenter);
+    _meshScale = IDEAL_MESH_SPHERE_RADIUS / (sphereCenter - boxMin).getMagnitude();
 }
 
 void Viewer::updateCameras()
@@ -2429,7 +2426,7 @@ mx::ImagePtr Viewer::getShadowMap()
         if (_shadowMaterial && _shadowBlurMaterial)
         {
             // Create framebuffer.
-            mx::GLFrameBufferPtr framebuffer = mx::GLFramebuffer::create(SHADOW_MAP_SIZE, SHADOW_MAP_SIZE, 2, mx::Image::BaseType::FLOAT);
+            mx::GLFramebufferPtr framebuffer = mx::GLFramebuffer::create(SHADOW_MAP_SIZE, SHADOW_MAP_SIZE, 2, mx::Image::BaseType::FLOAT);
             framebuffer->bind();
             glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
@@ -2499,7 +2496,7 @@ void Viewer::updateAlbedoTable()
     }
 
     // Create framebuffer.
-    mx::GLFrameBufferPtr framebuffer = mx::GLFramebuffer::create(ALBEDO_TABLE_SIZE, ALBEDO_TABLE_SIZE, 3, mx::Image::BaseType::FLOAT);
+    mx::GLFramebufferPtr framebuffer = mx::GLFramebuffer::create(ALBEDO_TABLE_SIZE, ALBEDO_TABLE_SIZE, 3, mx::Image::BaseType::FLOAT);
     framebuffer->bind();
     glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);


### PR DESCRIPTION
- Remove const keyword from Shader::setSourceCode.
- Assign explicitly-defaulted constructor to the ShCoeffs class.
- Use consistent letter case for GLFramebuffer and related classes.
- Clarify logic in GLTextureHandler::mapFilterTypeToGL and Viewer::initCamera.