### PR TITLE
Fix getDownstreamNodes to use Qualified names (fixes flattenSubGraphs)

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -197,7 +197,7 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
 vector<PortElementPtr> Node::getDownstreamPorts() const
 {
     vector<PortElementPtr> downstreamPorts;
-    for (PortElementPtr port : getDocument()->getMatchingPorts(getName()))
+    for (PortElementPtr port : getDocument()->getMatchingPorts(getQualifiedName(getName())))
     {
         if (port->getConnectedNode() == getSelf())
         {


### PR DESCRIPTION
This is to fix https://github.com/AcademySoftwareFoundation/MaterialX/issues/865