### PR TITLE
Additional improvements to surface_unlit

### DIFF
--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -11,7 +11,7 @@
   <!-- Shader nodes                                                             -->
   <!-- ======================================================================== -->
 
-  <!-- <surface> -->
+  <!-- <surface_unlit> -->
   <implementation name="IM_surface_unlit_genglsl" nodedef="ND_surface_unlit" target="genglsl" />
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -11,7 +11,7 @@
   <!-- Shader nodes                                                             -->
   <!-- ======================================================================== -->
 
-  <!-- <surface> -->
+  <!-- <surface_unlit> -->
   <implementation name="IM_surface_unlit_genmdl" nodedef="ND_surface_unlit" sourcecode="mx::stdlib::mx_surface_unlit({{emission}}, {{emission_color}}, {{transmission}}, {{transmission_color}}, {{opacity}})" target="genmdl" />
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -11,7 +11,7 @@
   <!-- Shader nodes                                                             -->
   <!-- ======================================================================== -->
 
-  <!-- <surface> -->
+  <!-- <surface_unlit> -->
   <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="libraries/stdlib/genosl/mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl" />
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -101,12 +101,12 @@
   <!-- ======================================================================== -->
 
   <!--
-    Node: <surface>
+    Node: <surface_unlit>
     An unlit surface shader node. Represents a surface that can emit and transmit light, 
     but does not receive illumination from light sources or other surfaces.
   -->
-  <nodedef name="ND_surface_unlit" node="surface" nodegroup="shader" doc="Construct a surface shader from emission and transmission values.">
-    <input name="emission" type="float" value="0.0" doc="Surface emission amount." />
+  <nodedef name="ND_surface_unlit" node="surface_unlit" nodegroup="shader" doc="Construct a surface shader from emission and transmission values.">
+    <input name="emission" type="float" value="1.0" doc="Surface emission amount." />
     <input name="emission_color" type="color3" value="1,1,1" doc="Surface emission color." />
     <input name="transmission" type="float" value="0.0" doc="Surface transmission amount." />
     <input name="transmission_color" type="color3" value="1,1,1" doc="Surface transmission color." />

--- a/resources/Materials/TestSuite/stdlib/shader/surface.mtlx
+++ b/resources/Materials/TestSuite/stdlib/shader/surface.mtlx
@@ -55,28 +55,28 @@
     <input name="in2" type="float" value="0.7" />
   </multiply>
 
-  <surface name="unlit_surface1" type="surfaceshader">
+  <surface_unlit name="unlit_surface1" type="surfaceshader">
     <input name="emission" type="float" nodename="checker1" />
     <input name="opacity" type="float" value="1.0" />
-  </surface>
+  </surface_unlit>
   <surfacematerial name="unlit_mtrl1" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="unlit_surface1" />
   </surfacematerial>
 
-  <surface name="unlit_surface2" type="surfaceshader">
+  <surface_unlit name="unlit_surface2" type="surfaceshader">
     <input name="emission" type="float" nodename="checker1" />
     <input name="opacity" type="float" nodename="checker3" />
-  </surface>
+  </surface_unlit>
   <surfacematerial name="unlit_mtrl2" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="unlit_surface2" />
   </surfacematerial>
 
-  <surface name="unlit_surface3" type="surfaceshader">
+  <surface_unlit name="unlit_surface3" type="surfaceshader">
     <input name="emission" type="float" nodename="checker1" />
     <input name="transmission" type="float" nodename="checker4" />
     <input name="transmission_color" type="color3" value="0.0, 0.0, 1.0" />
     <input name="opacity" type="float" value="1.0" />
-  </surface>
+  </surface_unlit>
   <surfacematerial name="unlit_mtrl3" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="unlit_surface3" />
   </surfacematerial>


### PR DESCRIPTION
- Assign a unique name to the new node, in order to avoid name collisions in applications with dynamic node typing (i.e. where node types are inferred from connections).
- Set the default value of the emission scalar input to 1.