### PR TITLE
Improvements to geometric constants

### DIFF
--- a/python/Scripts/translateshader.py
+++ b/python/Scripts/translateshader.py
@@ -54,7 +54,7 @@ def main():
         print(msg)
 
     # Check the document for a UDIM set.
-    udimSetValue = doc.getGeomPropValue('udimset')
+    udimSetValue = doc.getGeomPropValue(mx.UDIM_SET_PROPERTY)
     udimSet = udimSetValue.getData() if udimSetValue else []
 
     # Compute baking resolution from the source document.

--- a/source/JsMaterialX/JsMaterialXCore/JsGeom.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsGeom.cpp
@@ -21,8 +21,8 @@ EMSCRIPTEN_BINDINGS(geom)
     ems::constant("GEOM_PATH_SEPARATOR", mx::GEOM_PATH_SEPARATOR);
     ems::constant("UNIVERSAL_GEOM_NAME", mx::UNIVERSAL_GEOM_NAME);
     ems::constant("UDIM_TOKEN", mx::UDIM_TOKEN);
-    ems::constant("UDIMSET", mx::UDIMSET);
     ems::constant("UV_TILE_TOKEN", mx::UV_TILE_TOKEN);       
+    ems::constant("UDIM_SET_PROPERTY", mx::UDIM_SET_PROPERTY);
 
     ems::class_<mx::GeomElement, ems::base<mx::Element>>("GeomElement")
         .smart_ptr<std::shared_ptr<mx::GeomElement>>("GeomElement")

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -607,7 +607,7 @@ void Document::upgradeVersion()
             }
 
             GeomInfoPtr udimSetInfo = addGeomInfo();
-            udimSetInfo->setGeomPropValue("udimset", udimSetString, getTypeString<StringVec>());
+            udimSetInfo->setGeomPropValue(UDIM_SET_PROPERTY, udimSetString, getTypeString<StringVec>());
         }
 
         minorVersion = 34;

--- a/source/MaterialXCore/Geom.cpp
+++ b/source/MaterialXCore/Geom.cpp
@@ -11,9 +11,9 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string GEOM_PATH_SEPARATOR = "/";
 const string UNIVERSAL_GEOM_NAME = GEOM_PATH_SEPARATOR;
-const string UDIMSET = "udimset";
 const string UDIM_TOKEN = "<UDIM>";
 const string UV_TILE_TOKEN = "<UVTILE>";
+const string UDIM_SET_PROPERTY = "udimset";
 
 const string GeomElement::GEOM_ATTRIBUTE = "geom";
 const string GeomElement::COLLECTION_ATTRIBUTE = "collection";

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -18,8 +18,8 @@ MATERIALX_NAMESPACE_BEGIN
 extern MX_CORE_API const string GEOM_PATH_SEPARATOR;
 extern MX_CORE_API const string UNIVERSAL_GEOM_NAME;
 extern MX_CORE_API const string UDIM_TOKEN;
-extern MX_CORE_API const string UDIMSET;
 extern MX_CORE_API const string UV_TILE_TOKEN;
+extern MX_CORE_API const string UDIM_SET_PROPERTY;
 
 class GeomElement;
 class GeomInfo;

--- a/source/MaterialXGenShader/Nodes/HwImageNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.cpp
@@ -41,7 +41,7 @@ void HwImageNode::setValues(const Node& node, ShaderNode& shaderNode, GenContext
             const string& fileName = file->getValueString();
             if (fileName.find(UDIM_TOKEN) != string::npos)
             {
-                ValuePtr udimSetValue = node.getDocument()->getGeomPropValue(UDIMSET);
+                ValuePtr udimSetValue = node.getDocument()->getGeomPropValue(UDIM_SET_PROPERTY);
                 if (udimSetValue && udimSetValue->isA<StringVec>())
                 {
                     const StringVec& udimIdentifiers = udimSetValue->asA<StringVec>();

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -335,7 +335,7 @@ DocumentPtr TextureBaker::generateNewDocumentFromShader(NodePtr shader, const St
     GeomInfoPtr bakedGeom = !udimSet.empty() ? bakedTextureDoc->addGeomInfo(_bakedGeomInfoName) : nullptr;
     if (bakedGeom)
     {
-        bakedGeom->setGeomPropValue("udimset", udimSet, "stringarray");
+        bakedGeom->setGeomPropValue(UDIM_SET_PROPERTY, udimSet, "stringarray");
     }
 
     // Create a shader node.
@@ -550,7 +550,7 @@ void TextureBaker::bakeAllMaterials(DocumentPtr doc, const FileSearchPath& searc
     findRenderableElements(doc, renderableMaterials);
 
     // Compute the UDIM set.
-    ValuePtr udimSetValue = doc->getGeomPropValue("udimset");
+    ValuePtr udimSetValue = doc->getGeomPropValue(UDIM_SET_PROPERTY);
     StringVec udimSet;
     if (udimSetValue && udimSetValue->isA<StringVec>())
     {

--- a/source/MaterialXTest/MaterialXCore/Geom.cpp
+++ b/source/MaterialXTest/MaterialXCore/Geom.cpp
@@ -56,9 +56,9 @@ TEST_CASE("Geom elements", "[geom]")
     // Create a geominfo with an attribute.
     mx::GeomInfoPtr geominfo4 = doc->addGeomInfo("geominfo4", "/robot1");
     mx::StringVec udimSet = {"1001", "1002", "1003", "1004"};
-    geominfo4->setGeomPropValue("udimset", udimSet);
-    REQUIRE(doc->getGeomPropValue("udimset", "/robot1")->asA<mx::StringVec>() == udimSet);
-    REQUIRE(doc->getGeomPropValue("udimset", "/robot2") == nullptr);
+    geominfo4->setGeomPropValue(mx::UDIM_SET_PROPERTY, udimSet);
+    REQUIRE(doc->getGeomPropValue(mx::UDIM_SET_PROPERTY, "/robot1")->asA<mx::StringVec>() == udimSet);
+    REQUIRE(doc->getGeomPropValue(mx::UDIM_SET_PROPERTY, "/robot2") == nullptr);
 
     // Create a base collection.
     mx::CollectionPtr collection1 = doc->addCollection("collection1");

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1199,7 +1199,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
         }
 
         // Check for any udim set.
-        mx::ValuePtr udimSetValue = doc->getGeomPropValue("udimset");
+        mx::ValuePtr udimSetValue = doc->getGeomPropValue(mx::UDIM_SET_PROPERTY);
 
         // Create new materials.
         mx::TypedElementPtr udimElement;

--- a/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
@@ -89,4 +89,10 @@ void bindPyGeom(py::module& mod)
         .def_readonly_static("CATEGORY", &mx::Collection::CATEGORY);
 
     mod.def("geomStringsMatch", &mx::geomStringsMatch);
+
+    mod.attr("GEOM_PATH_SEPARATOR") = mx::GEOM_PATH_SEPARATOR;
+    mod.attr("UNIVERSAL_GEOM_NAME") = mx::UNIVERSAL_GEOM_NAME;
+    mod.attr("UDIM_TOKEN") = mx::UDIM_TOKEN;
+    mod.attr("UV_TILE_TOKEN") = mx::UV_TILE_TOKEN;
+    mod.attr("UDIM_SET_PROPERTY") = mx::UDIM_SET_PROPERTY;
 }


### PR DESCRIPTION
- Add Python bindings for all geometric constants (e.g. UDIM_TOKEN, UV_TILE_TOKEN).
- Clarify the name of the UDIM_SET_PROPERTY constant.