### PR TITLE
Simplify MaterialXCore includes

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXCore/Document.h>
 
-#include <MaterialXCore/Util.h>
-
 #include <mutex>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXCore/Element.h>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Node.h>
 #include <MaterialXCore/Util.h>
 
 #include <iterator>

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -7,8 +7,6 @@
 
 #include <MaterialXCore/Definition.h>
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Material.h>
-#include <MaterialXCore/Node.h>
 
 #include <stdexcept>
 

--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -19,6 +19,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <MaterialXCore/Generated.h>
+
 /// Platform-specific macros for declaring imported and exported symbols.
 #if defined(MATERIALX_BUILD_SHARED_LIBS)
     #if defined(_WIN32)
@@ -44,9 +46,8 @@
     #define MATERIALX_IMPORT_EXTERN_TEMPLATE(...)
 #endif
 
-#include <MaterialXCore/Generated.h>
-
 MATERIALX_NAMESPACE_BEGIN
+
 using std::string;
 using std::vector;
 using std::shared_ptr;

--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <MaterialXCore/Look.h>
+
 #include <MaterialXCore/Document.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXCore/Property.cpp
+++ b/source/MaterialXCore/Property.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXCore/Property.h>
 
-#include <MaterialXCore/Document.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 const string PropertyAssign::PROPERTY_ATTRIBUTE = "property";

--- a/source/MaterialXCore/Unit.cpp
+++ b/source/MaterialXCore/Unit.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXCore/Unit.h>
 
-#include <MaterialXCore/Util.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 namespace

--- a/source/MaterialXCore/Unit.h
+++ b/source/MaterialXCore/Unit.h
@@ -11,7 +11,6 @@
 
 #include <MaterialXCore/Export.h>
 
-#include <MaterialXCore/Definition.h>
 #include <MaterialXCore/Document.h>
 
 MATERIALX_NAMESPACE_BEGIN


### PR DESCRIPTION
- Remove duplicate header includes in MaterialXCore.
- Include Generated.h before defining platform macros in Library.h.