### PR TITLE
Move Quaternion class to MaterialXRender

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsTypes.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsTypes.cpp
@@ -78,15 +78,6 @@ EMSCRIPTEN_BINDINGS(types)
         .constructor<float, float, float, float>()
             BIND_VECTOR_SUBCLASS(mx::Vector4);                
 
-    ems::class_<mx::Quaternion, ems::base<mx::VectorBase>>("Quaternion")
-        .constructor<>()
-        .constructor<float, float, float, float>()
-            BIND_VECTOR_SUBCLASS(mx::Vector4)
-        .function("multiplyQuaternion", ems::optional_override([](const mx::Quaternion &self, const mx::Quaternion &q) { return self * q; }))
-        .function("getNormalized", ems::optional_override([](mx::Quaternion &self) { return self.getNormalized(); }))
-        .class_function("createFromAxisAngle", &mx::Quaternion::createFromAxisAngle)
-        .class_property("IDENTITY", &mx::Quaternion::IDENTITY);
-
     ems::class_<mx::Color3, ems::base<mx::VectorBase>>("Color3")
         .constructor<>()
         .constructor<float, float, float>()
@@ -123,7 +114,6 @@ EMSCRIPTEN_BINDINGS(types)
         .class_function("createRotationX", &mx::Matrix44::createRotationX)
         .class_function("createRotationY", &mx::Matrix44::createRotationY)
         .class_function("createRotationZ", &mx::Matrix44::createRotationZ)
-        .class_function("createRotation", &mx::Matrix44::createRotation)
         .class_property("IDENTITY", &mx::Matrix44::IDENTITY);
 
     ems::constant("DEFAULT_TYPE_STRING", mx::DEFAULT_TYPE_STRING);

--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -36,8 +36,6 @@ const Matrix44 Matrix44::IDENTITY(1, 0, 0, 0,
                                   0, 0, 1, 0,
                                   0, 0, 0, 1);
 
-const Quaternion Quaternion::IDENTITY(0, 0, 0, 1);
-
 //
 // Matrix33 methods
 //
@@ -267,24 +265,6 @@ Matrix44 Matrix44::createRotationZ(float angle)
     return Matrix44( cos,  sin, 0.0f, 0.0f,
                     -sin,  cos, 0.0f, 0.0f,
                     0.0f, 0.0f, 1.0f, 0.0f,
-                    0.0f, 0.0f, 0.0f, 1.0f);
-}
-
-Matrix44 Matrix44::createRotation(const Quaternion& q)
-{
-    Vector3 xaxis(1 - 2 * (q[1] * q[1] + q[2] * q[2]),
-                  2 * (q[0] * q[1] + q[2] * q[3]),
-                  2 * (q[2] * q[0] - q[1] * q[3]));
-    Vector3 yaxis(2 * (q[0] * q[1] - q[2] * q[3]),
-                  1 - 2 * (q[2] * q[2] + q[0] * q[0]),
-                  2 * (q[1] * q[2] + q[0] * q[3]));
-    Vector3 zaxis(2 * (q[2] * q[0] + q[1] * q[3]),
-                  2 * (q[1] * q[2] - q[0] * q[3]),
-                  1 - 2 * (q[1] * q[1] + q[0] * q[0]));
-
-    return Matrix44(xaxis[0], xaxis[1], xaxis[2], 0.0f,
-                    yaxis[0], yaxis[1], yaxis[2], 0.0f,
-                    zaxis[0], zaxis[1], zaxis[2], 0.0f,
                     0.0f, 0.0f, 0.0f, 1.0f);
 }
 

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -333,45 +333,6 @@ class MX_CORE_API Vector4 : public VectorN<Vector4, float, 4>
     }
 };
 
-/// @class Quaternion
-/// A quaternion vector
-class MX_CORE_API Quaternion : public VectorN<Vector4, float, 4>
-{
-  public:
-    using VectorN<Vector4, float, 4>::VectorN;
-    Quaternion() = default;
-    Quaternion(float x, float y, float z, float w) :
-        VectorN(Uninit{})
-    {
-        _arr = { x, y, z, w };
-    }
-
-    Quaternion operator*(const Quaternion& q) const
-    {
-        return {
-            _arr[0] * q._arr[3] + _arr[3] * q._arr[0] + _arr[1] * q._arr[2] - _arr[2] * q._arr[1],
-            _arr[1] * q._arr[3] + _arr[3] * q._arr[1] + _arr[2] * q._arr[0] - _arr[0] * q._arr[2],
-            _arr[2] * q._arr[3] + _arr[3] * q._arr[2] + _arr[0] * q._arr[1] - _arr[1] * q._arr[0],
-            _arr[3] * q._arr[3] - _arr[0] * q._arr[0] - _arr[1] * q._arr[1] - _arr[2] * q._arr[2]
-        };
-    }
-
-    Quaternion getNormalized() const
-    {
-        float l = 1.f / getMagnitude() * (_arr[3] < 0 ? -1.f : 1.f); // after normalization, real part will be non-negative
-        return { _arr[0] * l, _arr[1] * l, _arr[2] * l, _arr[3] * l };
-    }
-
-    static Quaternion createFromAxisAngle(const Vector3& v, float a)
-    {
-        float s = std::sin(a * 0.5f);
-        return Quaternion(v[0] * s, v[1] * s, v[2] * s, std::cos(a * 0.5f));
-    }
-
-  public:
-    static const Quaternion IDENTITY;
-};
-
 /// @class Color3
 /// A three-component color value
 class MX_CORE_API Color3 : public VectorN<Color3, float, 3>
@@ -725,11 +686,6 @@ class MX_CORE_API Matrix44 : public MatrixN<Matrix44, float, 4>
     /// Create a rotation matrix about the Z-axis.
     /// @param angle Angle in radians
     static Matrix44 createRotationZ(float angle);
-
-    /// Create a rotation matrix using a quaternion whose imaginary component is in the
-    /// the supplied vectors xyz, and whose real component is in the fourth component, w.
-    /// @param quaternion
-    static Matrix44 createRotation(const Quaternion& quaternion);
 
     /// @}
 

--- a/source/MaterialXRender/Camera.h
+++ b/source/MaterialXRender/Camera.h
@@ -6,9 +6,7 @@
 #ifndef MATERIALX_CAMERA_H
 #define MATERIALX_CAMERA_H
 
-#include <MaterialXRender/Export.h>
-
-#include <MaterialXCore/Types.h>
+#include <MaterialXRender/Types.h>
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -144,7 +142,7 @@ class MX_RENDER_API Camera
     /// Return the arcball matrix.
     Matrix44 arcballMatrix() const
     {
-        return Matrix44::createRotation(_arcballDelta * _arcballQuat);
+        return (_arcballDelta * _arcballQuat).toMatrix();
     }
 
     /// @}

--- a/source/MaterialXRender/Types.cpp
+++ b/source/MaterialXRender/Types.cpp
@@ -1,0 +1,34 @@
+//
+// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXRender/Types.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+const Quaternion Quaternion::IDENTITY(0, 0, 0, 1);
+
+//
+// Quaternion methods
+//
+
+Matrix44 Quaternion::toMatrix() const
+{
+    Vector3 x(1.0f - 2.0f * (_arr[1] * _arr[1] + _arr[2] * _arr[2]),
+              2.0f * (_arr[0] * _arr[1] + _arr[2] * _arr[3]),
+              2.0f * (_arr[2] * _arr[0] - _arr[1] * _arr[3]));
+    Vector3 y(2.0f * (_arr[0] * _arr[1] - _arr[2] * _arr[3]),
+              1.0f - 2.0f * (_arr[2] * _arr[2] + _arr[0] * _arr[0]),
+              2.0f * (_arr[1] * _arr[2] + _arr[0] * _arr[3]));
+    Vector3 z(2.0f * (_arr[2] * _arr[0] + _arr[1] * _arr[3]),
+              2.0f * (_arr[1] * _arr[2] - _arr[0] * _arr[3]),
+              1.0f - 2.0f * (_arr[1] * _arr[1] + _arr[0] * _arr[0]));
+
+    return Matrix44(x[0], x[1], x[2], 0.0f,
+                    y[0], y[1], y[2], 0.0f,
+                    z[0], z[1], z[2], 0.0f,
+                    0.0f, 0.0f, 0.0f, 1.0f);
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -9,10 +9,52 @@
 /// @file
 /// Data types for rendering functionality
 
-#include <MaterialXCore/Types.h>
 #include <MaterialXRender/Export.h>
 
+#include <MaterialXCore/Types.h>
+
 MATERIALX_NAMESPACE_BEGIN
+
+/// @class Quaternion
+/// A quaternion vector
+class MX_RENDER_API Quaternion : public VectorN<Vector4, float, 4>
+{
+  public:
+    using VectorN<Vector4, float, 4>::VectorN;
+    Quaternion() = default;
+    Quaternion(float x, float y, float z, float w) :
+        VectorN(Uninit{})
+    {
+        _arr = { x, y, z, w };
+    }
+
+    Quaternion operator*(const Quaternion& q) const
+    {
+        return {
+            _arr[0] * q._arr[3] + _arr[3] * q._arr[0] + _arr[1] * q._arr[2] - _arr[2] * q._arr[1],
+            _arr[1] * q._arr[3] + _arr[3] * q._arr[1] + _arr[2] * q._arr[0] - _arr[0] * q._arr[2],
+            _arr[2] * q._arr[3] + _arr[3] * q._arr[2] + _arr[0] * q._arr[1] - _arr[1] * q._arr[0],
+            _arr[3] * q._arr[3] - _arr[0] * q._arr[0] - _arr[1] * q._arr[1] - _arr[2] * q._arr[2]
+        };
+    }
+
+    Quaternion getNormalized() const
+    {
+        float l = 1.f / getMagnitude() * (_arr[3] < 0 ? -1.f : 1.f); // after normalization, real part will be non-negative
+        return { _arr[0] * l, _arr[1] * l, _arr[2] * l, _arr[3] * l };
+    }
+
+    static Quaternion createFromAxisAngle(const Vector3& v, float a)
+    {
+        float s = std::sin(a * 0.5f);
+        return Quaternion(v[0] * s, v[1] * s, v[2] * s, std::cos(a * 0.5f));
+    }
+
+    Matrix44 toMatrix() const;
+
+  public:
+    static const Quaternion IDENTITY;
+};
 
 /// @class Vector3d
 /// A vector of three floating-point values (double-precision)


### PR DESCRIPTION
This changelist moves the Quaternion class from MaterialXCore to MaterialXRender, clarifying its role as a camera/render helper class rather than a core MaterialX data type.