### PR TITLE
Pass strings by const reference

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -455,7 +455,7 @@ string Element::asString() const
     return res;
 }
 
-void Element::validateRequire(bool expression, bool& res, string* message, string errorDesc) const
+void Element::validateRequire(bool expression, bool& res, string* message, const string& errorDesc) const
 {
     if (!expression)
     {

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -775,7 +775,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
   protected:
     // Enforce a requirement within a validate method, updating the validation
     // state and optional output text if the requirement is not met.
-    void validateRequire(bool expression, bool& res, string* message, string errorDesc) const;
+    void validateRequire(bool expression, bool& res, string* message, const string& errorDesc) const;
 
   public:
     static const string NAME_ATTRIBUTE;

--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -184,7 +184,7 @@ void ShaderTranslator::translateShader(NodePtr shader, const string& destCategor
     _translationNode = nullptr;
 }
 
-void ShaderTranslator::translateAllMaterials(DocumentPtr doc, string destCategory)
+void ShaderTranslator::translateAllMaterials(DocumentPtr doc, const string& destCategory)
 {
     vector<TypedElementPtr> materialNodes;
     std::unordered_set<ElementPtr> shaderOutputs;

--- a/source/MaterialXGenShader/ShaderTranslator.h
+++ b/source/MaterialXGenShader/ShaderTranslator.h
@@ -30,7 +30,7 @@ class MX_GENSHADER_API ShaderTranslator
 
     /// Translate each material in the input document to the destination
     /// shading model.
-    void translateAllMaterials(DocumentPtr doc, string destShader);
+    void translateAllMaterials(DocumentPtr doc, const string& destShader);
 
   protected:
     ShaderTranslator() { }

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -469,7 +469,7 @@ DocumentPtr TextureBaker::generateNewDocumentFromShader(NodePtr shader, const St
 }
 
 DocumentPtr TextureBaker::bakeMaterialToDoc(DocumentPtr doc, const FileSearchPath& searchPath, const string& materialPath, 
-                                            const StringVec udimSet, string& documentName)
+                                            const StringVec& udimSet, string& documentName)
 {
     if (_outputStream)
     {

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -228,7 +228,7 @@ class MX_RENDERGLSL_API TextureBaker : public GlslRenderer
 
     /// Bake material to document in memory and write baked textures to disk.
     DocumentPtr bakeMaterialToDoc(DocumentPtr doc, const FileSearchPath& searchPath, const string& materialPath, 
-                                  const StringVec udimSet, std::string& documentName);
+                                  const StringVec& udimSet, std::string& documentName);
 
     /// Bake materials in the given document and write them to disk.  If multiple documents are written,
     /// then the given output filename will be used as a template.


### PR DESCRIPTION
This changelist updates a handful of common methods to pass strings by const reference rather than by value.