### PR TITLE
Initial static analysis in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
           compiler: xcode
           compiler_version: "13.1"
           python: 3.9
+          static_analysis: ON
 
         - name: Windows_VS2019_Win32_Python27
           os: windows-2019
@@ -202,6 +203,13 @@ jobs:
         glslangValidator.exe -v
         python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
         python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --path . --target essl --validator glslangValidator.exe
+
+    - name: Static Analysis Tests
+      if: matrix.static_analysis == 'ON' && runner.os == 'macOS'
+      run: |
+        brew install cppcheck
+        cppcheck --max-configs=1 --error-exitcode=1 --suppress=*:*/Catch/* --suppress=*:*/External/* --suppress=*:*JsMaterialX/* --suppress=*:*/NanoGUI/* --suppress=*:*/PugiXML/* --suppress=*:*/PyBind11/* --suppress=toomanyconfigs -I. .
+      working-directory: source
 
     - name: Initialize Virtual Framebuffer
       if: matrix.test_render == 'ON' && runner.os == 'Linux'

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -47,11 +47,9 @@ const TypeDesc* TypeDesc::registerType(const string& name, unsigned char basetyp
         throw Exception("A type with name '" + name + "' is already registered");
     }
 
-    std::unique_ptr<TypeDesc> uniquePtr(new TypeDesc(name, basetype, semantic, size, editable, channelMapping));
-    TypeDesc* rawPtr = uniquePtr.get();
-    map[name] = std::move(uniquePtr);
-
-    return rawPtr;
+    TypeDesc* typeDesc = new TypeDesc(name, basetype, semantic, size, editable, channelMapping);
+    map[name] = std::unique_ptr<TypeDesc>(typeDesc);
+    return typeDesc;
 }
 
 int TypeDesc::getChannelIndex(char channel) const

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -162,7 +162,8 @@ class MX_RENDER_API Half
         v.si ^= sign;
         sign >>= shiftSign; // logical shift
         s.si = mulN;
-        s.si = (int32_t) (s.f * v.f); // correct subnormals
+        int32_t subN = (int32_t) (s.f * v.f); // correct subnormals
+        s.si = subN;
         v.si ^= (s.si ^ v.si) & -(minN > v.si);
         v.si ^= (infN ^ v.si) & -((infN > v.si) & (v.si > maxN));
         v.si ^= (nanN ^ v.si) & -((nanN > v.si) & (v.si > infN));


### PR DESCRIPTION
This changelist adds an initial static analysis test to GitHub Actions, running cppcheck on the C++ codebase for each commit to the repository.

Also, two related improvements:
- Clarify the handling of the unique_ptr in TypeDesc::registerType.
- Clarify the order of reads and writes to a union in Half::toFloat16.