### PR TITLE
Add emissive strength to glTF PBR

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -20,7 +20,7 @@
     <input name="clearcoat_normal" type="vector3" defaultgeomprop="Nworld" uiname="Clearcoat Normal" uifolder="Clearcoat" />
     <input name="emissive" type="color3" value="0, 0, 0" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Emissive" uifolder="Emission" />
     <input name="emissive_strength" uniform="true" type="float" value="1" uimin="0" uiname="Emissive Strength" uifolder="Emission" />
-    <input name="thickness" uniform="false" type="float" uimin="0" uiname="Thickness" uifolder="Volume" />
+    <input name="thickness" uniform="false" type="float" value="0" uimin="0" uiname="Thickness" uifolder="Volume" />
     <input name="attenuation_distance" uniform="true" type="float" uimin="0" uiname="Attenuation Distance" uifolder="Volume" />
     <input name="attenuation_color" uniform="true" type="color3" value="1, 1, 1" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Attenuation Color" uifolder="Volume" />
     <output name="out" type="surfaceshader" />

--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -19,6 +19,7 @@
     <input name="clearcoat_roughness" type="float" value="0" uimin="0" uimax="1" uiname="Clearcoat Roughness" uifolder="Clearcoat" />
     <input name="clearcoat_normal" type="vector3" defaultgeomprop="Nworld" uiname="Clearcoat Normal" uifolder="Clearcoat" />
     <input name="emissive" type="color3" value="0, 0, 0" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Emissive" uifolder="Emission" />
+    <input name="emissive_strength" uniform="true" type="float" value="1" uimin="0" uiname="Emissive Strength" uifolder="Emission" />
     <input name="thickness" uniform="false" type="float" uimin="0" uiname="Thickness" uifolder="Volume" />
     <input name="attenuation_distance" uniform="true" type="float" uimin="0" uiname="Attenuation Distance" uifolder="Volume" />
     <input name="attenuation_color" uniform="true" type="color3" value="1, 1, 1" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Attenuation Color" uifolder="Volume" />
@@ -224,8 +225,13 @@
 
     <!-- Emission -->
 
+    <multiply name="emission_color" type="color3">
+      <input name="in1" type="color3" interfacename="emissive" />
+      <input name="in2" type="float" interfacename="emissive_strength" />
+    </multiply>
+
     <uniform_edf name="emission" type="EDF">
-      <input name="color" type="color3" interfacename="emissive" />
+      <input name="color" type="color3" nodename="emission_color" />
     </uniform_edf>
 
     <!-- Alpha -->

--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_boombox.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_boombox.mtlx
@@ -57,6 +57,7 @@
     <input name="clearcoat_roughness" type="float" value="0" />
     <input name="clearcoat_normal" type="vector3" value="0, 0, 1" />
     <input name="emissive" type="color3" nodegraph="NG_boombox" output="out_emission" />
+    <input name="emissive_strength" type="float" value="1" />
     <input name="alpha" type="float" value="1" />
     <input name="alpha_mode" type="integer" value="0" />
     <input name="alpha_cutoff" type="float" value="0.5" />

--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_default.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_default.mtlx
@@ -19,6 +19,7 @@
     <input name="clearcoat_roughness" type="float" value="0" />
     <input name="clearcoat_normal" type="vector3" value="0, 0, 1" />
     <input name="emissive" type="color3" value="0, 0, 0" />
+    <input name="emissive_strength" type="float" value="1" />
     <input name="thickness" type="float" value="0" />
     <input name="attenuation_distance" type="float" value="100000" />
     <input name="attenuation_color" type="color3" value="0, 0, 0" />


### PR DESCRIPTION
This PR adds support for the upcoming KHR_materials_emissive_strength (KhronosGroup/glTF#1994) extension to the glTF PBR node definition and implementation. The extension adds a parameter called "Emissive Strength". It is a scalar (uniform) multiplier to the emission color. The additional parameter is required in glTF because the glTF core spec limits emission color to 1 (KhronosGroup/glTF#1083).

The extension is currently in "Release Candidate" status, which means we do not expect huge changes anymore and implementations can adapt it.