### PR TITLE
Fix environment preview for viewer

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -480,8 +480,7 @@ void Viewer::loadEnvironmentLight()
         }
     }
 
-    // Clear out the previous environment material shader
-    // so it get's recompiled when needed for 3d preview.
+    // Invalidate the existing environment material, if any.
     _envMaterial = nullptr;
 }
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -479,6 +479,10 @@ void Viewer::loadEnvironmentLight()
             _lightRigDoc = nullptr;
         }
     }
+
+    // Clear out the previous environment material shader
+    // so it get's recompiled when needed for 3d preview.
+    _envMaterial = nullptr;
 }
 
 void Viewer::applyDirectLights(mx::DocumentPtr doc)


### PR DESCRIPTION
The environment material used for 3d preview was not being recompiled when changing the environment.
Hence the scene was rendering using the new environment but the preview was not.
