### PR TITLE
Initial refraction approximation in GLSL

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -382,7 +382,8 @@ export class Material
             u_envRadiance: { value: radianceTexture },
             u_envRadianceMips: { value: Math.trunc(Math.log2(Math.max(radianceTexture.image.width, radianceTexture.image.height))) + 1 },
             u_envRadianceSamples: { value: 16 },
-            u_envIrradiance: { value: irradianceTexture }
+            u_envIrradiance: { value: irradianceTexture },
+            u_refractionEnv: { value: true }
         });
 
         // Create Three JS Material

--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -34,7 +34,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
 
         // Compute the half vector and incoming light direction.
         vec3 H = mx_ggx_importance_sample_NDF(Xi, alpha);
-        vec3 L = -reflect(V, H);
+        vec3 L = fd.refraction ? mx_refraction_solid_sphere(-V, H, fd.ior.x) : -reflect(V, H);
         
         // Compute dot products for this sample.
         float NdotH = clamp(H.z, M_FLOAT_EPS, 1.0);
@@ -54,13 +54,16 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
         // Compute the geometric term.
         float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
+        // Compute the combined FG term, which is inverted for refraction.
+        vec3 FG = fd.refraction ? vec3(1.0) - (F * G) : F * G;
+
         // Add the radiance contribution of this sample.
         // From https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
         //   incidentLight = sampleColor * NdotL
         //   microfacetSpecular = D * F * G / (4 * NdotL * NdotV)
         //   pdf = D * NdotH / (4 * VdotH)
         //   radiance = incidentLight * microfacetSpecular / pdf
-        radiance += sampleColor * F * G * VdotH / (NdotV * NdotH);
+        radiance += sampleColor * FG * VdotH / (NdotV * NdotH);
     }
 
     // Normalize and return the final radiance.

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -26,6 +26,9 @@ struct FresnelData
     // Thin film
     float tf_thickness;
     float tf_ior;
+
+    // Refraction
+    bool refraction;
 };
 
 // https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf
@@ -217,6 +220,13 @@ float mx_ior_to_f0(float ior)
     return mx_square((ior - 1.0) / (ior + 1.0));
 }
 
+// Convert normal-incidence reflectivity to real-valued index of refraction.
+float mx_f0_to_ior(float F0)
+{
+    float sqrtF0 = sqrt(F0);
+    return (1.0 + sqrtF0) / (1.0 - sqrtF0);
+}
+
 // https://seblagarde.wordpress.com/2013/04/29/memo-on-fresnel-equations/
 float mx_fresnel_dielectric(float cosTheta, float ior)
 {
@@ -387,7 +397,7 @@ vec3 mx_fresnel_airy(float cosTheta, vec3 ior, vec3 extinction, float tf_thickne
 
 FresnelData mx_init_fresnel_data(int model)
 {
-    return FresnelData(model, vec3(0.0), vec3(0.0), vec3(0.0), vec3(0.0), 0.0, 0.0, 0.0);
+    return FresnelData(model, vec3(0.0), vec3(0.0), vec3(0.0), vec3(0.0), 0.0, 0.0, 0.0, false);
 }
 
 FresnelData mx_init_fresnel_dielectric(float ior)
@@ -460,6 +470,14 @@ vec3 mx_compute_fresnel(float cosTheta, FresnelData fd)
     {
         return mx_fresnel_airy(cosTheta, fd.ior, fd.extinction, fd.tf_thickness, fd.tf_ior);
     }
+}
+
+// Compute the refraction of a ray through a solid sphere.
+vec3 mx_refraction_solid_sphere(vec3 R, vec3 N, float ior)
+{
+    R = refract(R, N, 1.0 / ior);
+    vec3 N1 = normalize(R * dot(R, N) - N * 0.5);
+    return refract(R, N1, ior);
 }
 
 vec2 mx_latlong_projection(vec3 dir)

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -27,7 +27,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     }
     else
     {
-         fd = mx_init_fresnel_dielectric(ior);
+        fd = mx_init_fresnel_dielectric(ior);
     }
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(Ht, safeAlpha);
@@ -44,14 +44,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
 
 void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
-    if (scatter_mode == 1)
-    {
-        bsdf.response = tint * weight;
-        bsdf.throughput = bsdf.response;
-        return;
-    }
-
-    if (weight < M_FLOAT_EPS)
+    if (weight < M_FLOAT_EPS || scatter_mode == 0)
     {
         return;
     }
@@ -61,20 +54,29 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
 
     FresnelData fd;
     if (bsdf.thickness > 0.0)
+    { 
         fd = mx_init_fresnel_dielectric_airy(ior, bsdf.thickness, bsdf.ior);
+    }
     else
+    {
         fd = mx_init_fresnel_dielectric(ior);
-
+    }
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgAlpha = mx_average_alpha(safeAlpha);
+
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
     vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
-    bsdf.response = (scatter_mode == 2) ? tint * weight * bsdf.throughput : vec3(0.0);
+    // For now, we approximate the appearance of dielectric transmission as
+    // glossy environment map refraction, ignoring any scene geometry that
+    // might be visible through the surface.
+    fd.refraction = true;
+    vec3 Li = $refractionEnv ? mx_environment_radiance(N, V, X, safeAlpha, distribution, fd) : $refractionColor;
+    bsdf.response = Li * tint * weight;
 }
 
 void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
@@ -90,14 +92,18 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
 
     FresnelData fd;
     if (bsdf.thickness > 0.0)
+    { 
         fd = mx_init_fresnel_dielectric_airy(ior, bsdf.thickness, bsdf.ior);
+    }
     else
+    {
         fd = mx_init_fresnel_dielectric(ior);
-
+    }
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgAlpha = mx_average_alpha(safeAlpha);
+
     float F0 = mx_ior_to_f0(ior);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
     vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -36,14 +36,7 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
 
 void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
-    if (scatter_mode == 1)
-    {
-        bsdf.response = color0 * weight;
-        bsdf.throughput = bsdf.response;
-        return;
-    }
-
-    if (weight < M_FLOAT_EPS)
+    if (weight < M_FLOAT_EPS || scatter_mode == 0)
     {
         return;
     }
@@ -56,12 +49,20 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgAlpha = mx_average_alpha(safeAlpha);
+
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
     vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
-    bsdf.response = (scatter_mode == 2) ? color0 * weight * bsdf.throughput : vec3(0.0);
+    // For now, we approximate the appearance of Schlick transmission as
+    // glossy environment map refraction, ignoring any scene geometry that
+    // might be visible through the surface.
+    float avgF0 = dot(color0, vec3(1.0 / 3.0));
+    fd.refraction = true;
+    fd.ior.x = mx_f0_to_ior(avgF0);
+    vec3 Li = $refractionEnv ? mx_environment_radiance(N, V, X, safeAlpha, distribution, fd) : $refractionColor;
+    bsdf.response = Li * color0 * weight;
 }
 
 void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)

--- a/resources/Materials/Examples/StandardSurface/standard_surface_glass_tinted.mtlx
+++ b/resources/Materials/Examples/StandardSurface/standard_surface_glass_tinted.mtlx
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <standard_surface name="SR_glass_tinted" type="surfaceshader">
+    <input name="base" type="float" value="0" />
+    <input name="specular" type="float" value="1" />
+    <input name="specular_color" type="color3" value="1, 1, 1" />
+    <input name="specular_roughness" type="float" value="0.15" />
+    <input name="specular_IOR" type="float" value="1.54" />
+    <input name="transmission" type="float" value="1" />
+    <input name="transmission_color" type="color3" value="0.2, 0.1, 1" />
+  </standard_surface>
+  <surfacematerial name="GlassTinted" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_glass_tinted" />
+  </surfacematerial>
+</materialx>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/dielectric.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/dielectric.mtlx
@@ -5,49 +5,44 @@
     <dielectric_bsdf name="bsdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="tint" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="ior" type="float" value="1.7" />
       <input name="scatter_mode" type="string" value="R" />
     </dielectric_bsdf>
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="bsdf1" />
     </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
+    <output name="dielectric_bsdf_R_out" type="surfaceshader" nodename="surface1" />
   </nodegraph>
   <nodegraph name="dielectric_bsdf_T">
     <dielectric_bsdf name="bsdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="tint" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="ior" type="float" value="1.7" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="bsdf1" />
     </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
+    <output name="dielectric_bsdf_T_out" type="surfaceshader" nodename="surface1" />
   </nodegraph>
   <nodegraph name="dielectric_bsdf_RT">
     <dielectric_bsdf name="bsdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="tint" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="ior" type="float" value="1.7" />
       <input name="scatter_mode" type="string" value="RT" />
     </dielectric_bsdf>
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="bsdf1" />
     </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
+    <output name="dielectric_bsdf_RT_out" type="surfaceshader" nodename="surface1" />
   </nodegraph>
   <nodegraph name="dielectric_bsdf_layeredRT">
     <dielectric_bsdf name="bsdf1" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="tint" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="ior" type="float" value="1.7" />
       <input name="scatter_mode" type="string" value="R" />
     </dielectric_bsdf>
     <dielectric_bsdf name="bsdf2" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="tint" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="ior" type="float" value="1.7" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
     <layer name="layer1" type="BSDF">
@@ -57,66 +52,6 @@
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="layer1" />
     </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
-  </nodegraph>
-
-  <!-- Test generalized_schlick_bsdf in various scatter modes -->
-  <nodegraph name="generalized_schlick_bsdf_R">
-    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="scatter_mode" type="string" value="R" />
-    </generalized_schlick_bsdf>
-    <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="bsdf1" />
-    </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
-  </nodegraph>
-  <nodegraph name="generalized_schlick_bsdf_T">
-    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="scatter_mode" type="string" value="T" />
-    </generalized_schlick_bsdf>
-    <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="bsdf1" />
-    </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
-  </nodegraph>
-  <nodegraph name="generalized_schlick_bsdf_RT">
-    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="scatter_mode" type="string" value="RT" />
-    </generalized_schlick_bsdf>
-    <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="bsdf1" />
-    </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
-  </nodegraph>
-  <nodegraph name="generalized_schlick_bsdf_layeredRT">
-    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="scatter_mode" type="string" value="R" />
-    </generalized_schlick_bsdf>
-    <generalized_schlick_bsdf name="bsdf2" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="scatter_mode" type="string" value="T" />
-    </generalized_schlick_bsdf>
-    <layer name="layer1" type="BSDF">
-      <input name="top" type="BSDF" nodename="bsdf1" />
-      <input name="base" type="BSDF" nodename="bsdf2" />
-    </layer>
-    <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="layer1" />
-    </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
+    <output name="dielectric_bsdf_layeredRT_out" type="surfaceshader" nodename="surface1" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/generalized_schlick.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/generalized_schlick.mtlx
@@ -1,20 +1,67 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="test_generalized_schlick">
-    <roughness_anisotropy name="roughness1" type="vector2">
-      <input name="roughness" type="float" value="0.2" />
-      <input name="anisotropy" type="float" value="0.0" />
-    </roughness_anisotropy>
-    <generalized_schlick_bsdf name="generalized_schlick_brdf1" type="BSDF">
-      <input name="color0" type="color3" value="0.3, 0.3, 1.0" />
-      <input name="color90" type="color3" value="1.0, 0.3, 0.3" />
+  <!-- Test generalized_schlick_bsdf in various scatter modes -->
+  <nodegraph name="generalized_schlick_bsdf_R">
+    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
       <input name="exponent" type="float" value="5.0" />
-      <input name="roughness" type="vector2" nodename="roughness1" />
+      <input name="scatter_mode" type="string" value="R" />
     </generalized_schlick_bsdf>
     <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" nodename="generalized_schlick_brdf1" />
-      <input name="opacity" type="float" value="1.0" />
+      <input name="bsdf" type="BSDF" nodename="bsdf1" />
     </surface>
-    <output name="out" type="surfaceshader" nodename="surface1" />
+    <output name="generalized_schlick_bsdf_R_out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+  <nodegraph name="generalized_schlick_bsdf_T">
+    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="scatter_mode" type="string" value="T" />
+    </generalized_schlick_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="bsdf1" />
+    </surface>
+    <output name="generalized_schlick_bsdf_T_out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+  <nodegraph name="generalized_schlick_bsdf_RT">
+    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="scatter_mode" type="string" value="RT" />
+    </generalized_schlick_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="bsdf1" />
+    </surface>
+    <output name="generalized_schlick_bsdf_RT_out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+  <nodegraph name="generalized_schlick_bsdf_layeredRT">
+    <generalized_schlick_bsdf name="bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="scatter_mode" type="string" value="R" />
+    </generalized_schlick_bsdf>
+    <generalized_schlick_bsdf name="bsdf2" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="scatter_mode" type="string" value="T" />
+    </generalized_schlick_bsdf>
+    <layer name="layer1" type="BSDF">
+      <input name="top" type="BSDF" nodename="bsdf1" />
+      <input name="base" type="BSDF" nodename="bsdf2" />
+    </layer>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="layer1" />
+    </surface>
+    <output name="generalized_schlick_bsdf_layeredRT_out" type="surfaceshader" nodename="surface1" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx
@@ -17,16 +17,6 @@
     <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
     </standard_surface>
-    <standard_surface name="ss_transmission" type="surfaceshader" version="1.0.1">
-      <input name="transmission" type="float" value="0.1" />
-      <input name="transmission_color" type="color3" value="0, 1, 0" />
-      <input name="transmission_depth" type="float" value="20" />
-      <input name="transmission_scatter" type="color3" value="1, 1, 1" />
-      <input name="transmission_dispersion" type="float" value="20" />
-    </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
-      <input name="transmission" type="float" nodename="image" />
-    </standard_surface>
     <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
       <input name="edf" type="EDF" value="" />
@@ -45,35 +35,27 @@
     </mix>
     <output name="ss_opacity_mapped_out" type="surfaceshader" nodename="ss_opacity_mapped" />
     <output name="surf_opacity_out" type="surfaceshader" nodename="surface_opacity_unmapped" />
-    <output name="ss_transmission_mapped_out" type="surfaceshader" nodename="ss_transmission_mapped" />
     <output name="surf_opacity_mapped" type="surfaceshader" nodename="surface_opacity_mapped" />
     <output name="ss_opacity_unmapped_out" type="surfaceshader" nodename="ss_opacity" />
-    <output name="ss_transm_unmapped_out" type="surfaceshader" nodename="ss_transmission" />
   </nodegraph>
   <nodedef name="ND_transpGraph_image0" node="transptype_0" version="1.0" isdefaultversion="true">
     <input name="opacity_file" type="filename" uniform="true" value="resources/Images/grid.png" />
     <output name="ss_opacity_mapped_out" type="surfaceshader" />
     <output name="surf_opacity_out" type="surfaceshader" />
-    <output name="ss_transmission_mapped_out" type="surfaceshader" />
     <output name="surf_opacity_mapped" type="surfaceshader" />
     <output name="ss_opacity_unmapped_out" type="surfaceshader" />
-    <output name="ss_transm_unmapped_out" type="surfaceshader" />
   </nodedef>
   <transptype_0 name="transptype_1" type="multioutput">
     <input name="opacity_file" type="filename" value="resources/Images/grid.png" />
     <output name="ss_opacity_mapped_out" type="surfaceshader" value="" />
     <output name="surf_opacity_out" type="surfaceshader" value="" />
-    <output name="ss_transmission_mapped_out" type="surfaceshader" value="" />
     <output name="surf_opacity_mapped" type="surfaceshader" value="" />
     <output name="ss_opacity_unmapped_out" type="surfaceshader" value="" />
-    <output name="ss_transm_unmapped_out" type="surfaceshader" value="" />
   </transptype_0>
   <output name="ss_opacity_mapped_out" nodename="transptype_1" output="ss_opacity_mapped_out" type="surfaceshader" />
   <output name="surf_opacity_out" nodename="transptype_1" output="surf_opacity_out" type="surfaceshader" />
-  <output name="ss_transmission_mapped_out" nodename="transptype_1" output="ss_transmission_mapped_out" type="surfaceshader" />
   <output name="surf_opacity_mapped" nodename="transptype_1" output="surf_opacity_mapped" type="surfaceshader" />
   <output name="ss_opacity_unmapped_out" nodename="transptype_1" output="ss_opacity_unmapped_out" type="surfaceshader" />
-  <output name="ss_transm_unmapped_out" nodename="transptype_1" output="ss_transm_unmapped_out" type="surfaceshader" />
   <nodegraph name="NG_transpGraph_proc0" nodedef="ND_transpGraph_proc0">
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
@@ -85,9 +67,6 @@
     </convert>
     <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
-    </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
-      <input name="transmission" type="float" nodename="ramp4" />
     </standard_surface>
     <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
@@ -115,24 +94,20 @@
       <input name="mix" type="float" value="0.5" />
     </mix>
     <output name="ss_opacity_ramp_out" type="surfaceshader" nodename="ss_opacity_mapped" />
-    <output name="ss_transmission_ramp_out" type="surfaceshader" nodename="ss_transmission_mapped" />
     <output name="surf_opacity_ramp" type="surfaceshader" nodename="surface_opacity_mapped" />
   </nodegraph>
   <nodedef name="ND_transpGraph_proc0" node="transptype_0" version="1.0" isdefaultversion="true">
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
     <output name="ss_opacity_ramp_out" type="surfaceshader" />
-    <output name="ss_transmission_ramp_out" type="surfaceshader" />
     <output name="surf_opacity_ramp" type="surfaceshader" />
   </nodedef>
   <transptype_0 name="transptype_2" type="multioutput">
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
     <output name="ss_opacity_ramp_out" type="surfaceshader" value="" />
-    <output name="ss_transmission_ramp_out" type="surfaceshader" value="" />
     <output name="surf_opacity_ramp" type="surfaceshader" value="" />
   </transptype_0>
   <output name="ss_opacity_ramp_out" nodename="transptype_2" output="ss_opacity_ramp_out" type="surfaceshader" />
-  <output name="ss_transmission_ramp_out" nodename="transptype_2" output="ss_transmission_ramp_out" type="surfaceshader" />
   <output name="surf_opacity_ramp" nodename="transptype_2" output="surf_opacity_ramp" type="surfaceshader" />
 </materialx>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx
@@ -17,16 +17,6 @@
     <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
     </standard_surface>
-    <standard_surface name="ss_transmission" type="surfaceshader" version="1.0.1">
-      <input name="transmission" type="float" value="0.1" />
-      <input name="transmission_color" type="color3" value="0, 1, 0" />
-      <input name="transmission_depth" type="float" value="20" />
-      <input name="transmission_scatter" type="color3" value="1, 1, 1" />
-      <input name="transmission_dispersion" type="float" value="20" />
-    </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
-      <input name="transmission" type="float" nodename="image" />
-    </standard_surface>
     <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
       <input name="edf" type="EDF" value="" />
@@ -45,10 +35,8 @@
     </mix>
     <output name="ss_opacity_mapped_out" type="surfaceshader" nodename="ss_opacity_mapped" />
     <output name="surf_opacity_out" type="surfaceshader" nodename="surface_opacity_unmapped" />
-    <output name="ss_transmission_mapped_out" type="surfaceshader" nodename="ss_transmission_mapped" />
     <output name="surf_opacity_mapped" type="surfaceshader" nodename="surface_opacity_mapped" />
     <output name="ss_opacity_unmapped_out" type="surfaceshader" nodename="ss_opacity" />
-    <output name="ss_transm_unmapped_out" type="surfaceshader" nodename="ss_transmission" />
   </nodegraph>
   <nodegraph name="transpGraph_proc">
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
@@ -61,9 +49,6 @@
     </convert>
     <standard_surface name="ss_opacity_mapped" type="surfaceshader" version="1.0.1">
       <input name="opacity" type="color3" nodename="convert" />
-    </standard_surface>
-    <standard_surface name="ss_transmission_mapped" type="surfaceshader" version="1.0.1">
-      <input name="transmission" type="float" nodename="ramp4" />
     </standard_surface>
     <surface name="surface_opacity_mapped" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="mix" />
@@ -91,7 +76,6 @@
       <input name="mix" type="float" value="0.5" />
     </mix>
     <output name="ss_opacity_ramp_out" type="surfaceshader" nodename="ss_opacity_mapped" />
-    <output name="ss_transmission_ramp_out" type="surfaceshader" nodename="ss_transmission_mapped" />
     <output name="surf_opacity_ramp" type="surfaceshader" nodename="surface_opacity_mapped" />
   </nodegraph>
 </materialx>

--- a/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
@@ -45,10 +45,6 @@ void UnlitSurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& 
             shadergen.emitLine(outColor + " *= " + surfaceOpacity, stage);
             shadergen.emitLine(outTransparency + " = mix(vec3(1.0), " + outTransparency + ", " + surfaceOpacity + ")", stage);
         }
-        else
-        {
-            shadergen.emitLine(outTransparency + " = vec3(0.0)", stage);
-        }
 
     END_SHADER_STAGE(stage, Stage::PIXEL)
 }

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -57,6 +57,8 @@ namespace HW
     const string T_ENV_RADIANCE_MIPS              = "$envRadianceMips";
     const string T_ENV_RADIANCE_SAMPLES           = "$envRadianceSamples";
     const string T_ENV_IRRADIANCE                 = "$envIrradiance";
+    const string T_REFRACTION_ENV                 = "$refractionEnv";
+    const string T_REFRACTION_COLOR               = "$refractionColor";
     const string T_ALBEDO_TABLE                   = "$albedoTable";
     const string T_ALBEDO_TABLE_SIZE              = "$albedoTableSize";
     const string T_AMB_OCC_MAP                    = "$ambOccMap";
@@ -109,6 +111,8 @@ namespace HW
     const string ENV_RADIANCE_MIPS                = "u_envRadianceMips";
     const string ENV_RADIANCE_SAMPLES             = "u_envRadianceSamples";
     const string ENV_IRRADIANCE                   = "u_envIrradiance";
+    const string REFRACTION_ENV                   = "u_refractionEnv";
+    const string REFRACTION_COLOR                 = "u_refractionColor";
     const string ALBEDO_TABLE                     = "u_albedoTable";
     const string ALBEDO_TABLE_SIZE                = "u_albedoTableSize";
     const string AMB_OCC_MAP                      = "u_ambOccMap";
@@ -204,6 +208,8 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
     _tokenSubstitutions[HW::T_ENV_RADIANCE_MIPS] = HW::ENV_RADIANCE_MIPS;
     _tokenSubstitutions[HW::T_ENV_RADIANCE_SAMPLES] = HW::ENV_RADIANCE_SAMPLES;
     _tokenSubstitutions[HW::T_ENV_IRRADIANCE] = HW::ENV_IRRADIANCE;
+    _tokenSubstitutions[HW::T_REFRACTION_ENV] = HW::REFRACTION_ENV;
+    _tokenSubstitutions[HW::T_REFRACTION_COLOR] = HW::REFRACTION_COLOR;
     _tokenSubstitutions[HW::T_ALBEDO_TABLE] = HW::ALBEDO_TABLE;
     _tokenSubstitutions[HW::T_ALBEDO_TABLE_SIZE] = HW::ALBEDO_TABLE_SIZE;
     _tokenSubstitutions[HW::T_SHADOW_MAP] = HW::SHADOW_MAP;
@@ -306,6 +312,8 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
         psPrivateUniforms->add(Type::INTEGER, HW::T_ENV_RADIANCE_MIPS, Value::createValue<int>(1));
         psPrivateUniforms->add(Type::INTEGER, HW::T_ENV_RADIANCE_SAMPLES, Value::createValue<int>(16));
         psPrivateUniforms->add(Type::FILENAME, HW::T_ENV_IRRADIANCE);
+        psPrivateUniforms->add(Type::BOOLEAN, HW::T_REFRACTION_ENV);
+        psPrivateUniforms->add(Type::COLOR3, HW::T_REFRACTION_COLOR);
     }
 
     // Add uniforms for the directional albedo table.

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -125,6 +125,8 @@ namespace HW
     extern MX_GENSHADER_API const string T_ENV_RADIANCE_MIPS;
     extern MX_GENSHADER_API const string T_ENV_RADIANCE_SAMPLES;
     extern MX_GENSHADER_API const string T_ENV_IRRADIANCE;
+    extern MX_GENSHADER_API const string T_REFRACTION_ENV;
+    extern MX_GENSHADER_API const string T_REFRACTION_COLOR;
     extern MX_GENSHADER_API const string T_ALBEDO_TABLE;
     extern MX_GENSHADER_API const string T_ALBEDO_TABLE_SIZE;
     extern MX_GENSHADER_API const string T_AMB_OCC_MAP;
@@ -179,6 +181,8 @@ namespace HW
     extern MX_GENSHADER_API const string ENV_RADIANCE_MIPS;
     extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLES;
     extern MX_GENSHADER_API const string ENV_IRRADIANCE;
+    extern MX_GENSHADER_API const string REFRACTION_ENV;
+    extern MX_GENSHADER_API const string REFRACTION_COLOR;
     extern MX_GENSHADER_API const string ALBEDO_TABLE;
     extern MX_GENSHADER_API const string ALBEDO_TABLE_SIZE;
     extern MX_GENSHADER_API const string AMB_OCC_MAP;

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -90,8 +90,7 @@ namespace
 
         // Inputs on a surface shader which are checked for transparency
         const OpaqueTestPairList inputPairList = { {"opacity", 1.0f},
-                                                   {"existence", 1.0f},
-                                                   {"transmission", 0.0f} };
+                                                   {"existence", 1.0f} };
 
 
         // Check against the interface if a node is passed in to check against

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -20,7 +20,7 @@ MATERIALX_NAMESPACE_BEGIN
 class ShaderGenerator;
 
 /// Returns true if the given element is a surface shader with the potential
-/// of beeing transparent. This can be used by HW shader generators to determine
+/// of being transparent. This can be used by HW shader generators to determine
 /// if a shader will require transparency handling.
 ///
 /// Note: This function will check some common cases for how a surface

--- a/source/MaterialXRender/LightHandler.h
+++ b/source/MaterialXRender/LightHandler.h
@@ -37,7 +37,8 @@ class MX_RENDER_API LightHandler
         _lightTransform(Matrix44::IDENTITY),
         _directLighting(true),
         _indirectLighting(true),
-        _envSampleCount(DEFAULT_ENV_SAMPLE_COUNT)
+        _envSampleCount(DEFAULT_ENV_SAMPLE_COUNT),
+        _refractionEnv(true)
     {
     }
     virtual ~LightHandler() { }
@@ -112,18 +113,6 @@ class MX_RENDER_API LightHandler
         return _envIrradianceMap;
     }
 
-    /// Set the directional albedo table
-    void setAlbedoTable(ImagePtr table)
-    {
-        _albedoTable = table;
-    }
-
-    /// Return the directional albedo table
-    ImagePtr getAlbedoTable() const
-    {
-        return _albedoTable;
-    }
-
     /// Set the environment lighting sample count.
     void setEnvSampleCount(int count)
     {
@@ -134,6 +123,46 @@ class MX_RENDER_API LightHandler
     int getEnvSampleCount() const
     {
         return _envSampleCount;
+    }
+
+    /// Set environment visibility in refractions.
+    void setRefractionEnv(bool enable)
+    {
+        _refractionEnv = enable;
+    }
+
+    /// Return environment visibility in refractions.
+    int getRefractionEnv() const
+    {
+        return _refractionEnv;
+    }
+
+    /// Set the uniform refraction color.
+    void setRefractionColor(const Color3& color)
+    {
+        _refractionColor = color;
+    }
+
+    /// Return the uniform refraction color.
+    Color3 getRefractionColor() const
+    {
+        return _refractionColor;
+    }
+
+    /// @}
+    /// @name Albedo Table
+    /// @{
+
+    /// Set the directional albedo table
+    void setAlbedoTable(ImagePtr table)
+    {
+        _albedoTable = table;
+    }
+
+    /// Return the directional albedo table
+    ImagePtr getAlbedoTable() const
+    {
+        return _albedoTable;
     }
 
     /// @}
@@ -202,8 +231,12 @@ class MX_RENDER_API LightHandler
 
     ImagePtr _envRadianceMap;
     ImagePtr _envIrradianceMap;
-    ImagePtr _albedoTable;
     int _envSampleCount;
+
+    bool _refractionEnv;
+    Color3 _refractionColor;
+
+    ImagePtr _albedoTable;
 
     vector<NodePtr> _lightSources;
     std::unordered_map<string, unsigned int> _lightIdMap;

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -600,6 +600,8 @@ void GlslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr ima
             }
         }
     }
+    bindUniform(HW::REFRACTION_ENV, Value::createValue(lightHandler->getRefractionEnv()), false);
+    bindUniform(HW::REFRACTION_COLOR, Value::createValue(lightHandler->getRefractionColor()), false);
 
     // Bind direct lighting properties.
     if (hasUniform(HW::NUM_ACTIVE_LIGHT_SOURCES))

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -324,9 +324,4 @@ void GlslRenderer::drawScreenSpaceQuad(const Vector2& uvMin, const Vector2& uvMa
     checkGlErrors("after draw screen-space quad");
 }
 
-void GlslRenderer::setScreenColor(const Color3& screenColor)
-{
-    _screenColor = screenColor;
-}
-
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -103,7 +103,16 @@ class MX_RENDERGLSL_API GlslRenderer : public ShaderRenderer
     void drawScreenSpaceQuad(const Vector2& uvMin = Vector2(0.0f), const Vector2& uvMax = Vector2(1.0f));
 
     /// Set the screen background color.
-    void setScreenColor(const Color3& screenColor);
+    void setScreenColor(const Color3& screenColor)
+    {
+        _screenColor = screenColor;
+    }
+
+    /// Return the screen background color.
+    Color3 getScreenColor() const
+    {
+        return _screenColor;
+    }
 
     /// @}
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -216,7 +216,7 @@ TEST_CASE("GenShader: Transparency Regression Check", "[genshader]")
         "Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx",
         "Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx",
     };
-    std::vector<bool> transparencyTest = { false, true, true, true, true };
+    std::vector<bool> transparencyTest = { false, false, true, true, true };
     for (size_t i=0; i<testFiles.size(); i++)
     {
         const mx::FilePath& testFile = resourcePath / testFiles[i];

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -97,9 +97,13 @@ void GlslShaderRenderTester::registerLights(mx::DocumentPtr document,
     mx::ImagePtr envIrradiance = _renderer->getImageHandler()->acquireImage(options.irradianceIBLPath);
     REQUIRE(envRadiance);
     REQUIRE(envIrradiance);
+
+    // Apply light settings for render tests.
     _lightHandler->setEnvRadianceMap(envRadiance);
     _lightHandler->setEnvIrradianceMap(envIrradiance);
     _lightHandler->setEnvSampleCount(1024);
+    _lightHandler->setRefractionEnv(false);
+    _lightHandler->setRefractionColor(_renderer->getScreenColor().srgbToLinear());
 }
 
 //


### PR DESCRIPTION
This changelist introduces a rough approximation of refraction in GLSL, allowing transmissive materials such as glass to respond visually to changes in specular_IOR, specular_roughness, and transmission_color.

Because this initial approximation is limited to a single render pass, only the environment radiance map is currently visible in refractions, and opaque objects behind transmissive surfaces are not yet visible.