### PR TITLE
Update generator search path in JavaScript

### DIFF
--- a/source/JsMaterialX/JsMaterialXGenShader/JsGenContext.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsGenContext.cpp
@@ -19,13 +19,12 @@ namespace ems = emscripten;
 namespace mx = MaterialX;
 
 /// Initialize the given generation context
-void initContext(mx::GenContext& context, mx::FileSearchPath searchPath, mx::DocumentPtr stdLib, mx::UnitConverterRegistryPtr unitRegistry) {
-    // Initialize search paths.
-    for (const mx::FilePath& path : searchPath)
-    {
-        context.registerSourceCodeSearchPath(path / "libraries");
-    }
+void initContext(mx::GenContext& context, mx::FileSearchPath searchPath, mx::DocumentPtr stdLib, mx::UnitConverterRegistryPtr unitRegistry)
+{
+    // Register the search path for shader source code.
+    context.registerSourceCodeSearchPath(searchPath);
 
+    // Set shader generation options.
     context.getOptions().targetColorSpaceOverride = "lin_rec709";
     context.getOptions().fileTextureVerticalFlip = false;
     context.getOptions().hwMaxActiveLightSources = 1;


### PR DESCRIPTION
This changelist updates the generator search path used in MaterialX JavaScript, aligning it with other generators in the MaterialX codebase.