### PR TITLE
Relative shader includes

### DIFF
--- a/libraries/lights/genglsl/lights_genglsl_impl.mtlx
+++ b/libraries/lights/genglsl/lights_genglsl_impl.mtlx
@@ -2,12 +2,12 @@
 <materialx version="1.38">
 
   <!-- <point_light> -->
-  <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="libraries/lights/genglsl/mx_point_light.glsl" function="mx_point_light" target="genglsl" />
+  <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="mx_point_light.glsl" function="mx_point_light" target="genglsl" />
 
   <!-- <directional_light> -->
-  <implementation name="IM_directional_light_genglsl" nodedef="ND_directional_light" file="libraries/lights/genglsl/mx_directional_light.glsl" function="mx_directional_light" target="genglsl" />
+  <implementation name="IM_directional_light_genglsl" nodedef="ND_directional_light" file="mx_directional_light.glsl" function="mx_directional_light" target="genglsl" />
 
   <!-- <spot_light> -->
-  <implementation name="IM_spot_light_genglsl" nodedef="ND_spot_light" file="libraries/lights/genglsl/mx_spot_light.glsl" function="mx_spot_light" target="genglsl" />
+  <implementation name="IM_spot_light_genglsl" nodedef="ND_spot_light" file="mx_spot_light.glsl" function="mx_spot_light" target="genglsl" />
 
 </materialx>

--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "mx_microfacet_specular.glsl"
 
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
 // Section 20.4 Equation 13

--- a/libraries/pbrlib/genglsl/lib/mx_environment_none.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_none.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "mx_microfacet_specular.glsl"
 
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 roughness, int distribution, FresnelData fd)
 {

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "mx_microfacet_specular.glsl"
 
 float mx_latlong_compute_lod(float alpha)
 {

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet.glsl"
+#include "mx_microfacet.glsl"
 
 // Based on the OSL implementation of Oren-Nayar diffuse, which is in turn
 // based on https://mimosa-pudica.net/improved-oren-nayar.html.

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet.glsl"
+#include "mx_microfacet.glsl"
 
 // http://www.aconty.com/pdf/s2017_pbs_imageworks_sheen.pdf
 // Equation 2

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet.glsl"
+#include "mx_microfacet.glsl"
 
 // Fresnel model options.
 const int FRESNEL_MODEL_DIELECTRIC = 0;

--- a/libraries/pbrlib/genglsl/lib/mx_table.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_table.glsl
@@ -1,5 +1,5 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "mx_microfacet_sheen.glsl"
+#include "mx_microfacet_specular.glsl"
 
 vec3 mx_generate_dir_albedo_table()
 {

--- a/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+#include "lib/mx_microfacet_diffuse.glsl"
 
 void mx_burley_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "lib/mx_microfacet_specular.glsl"
 
 void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 ior_n, vec3 ior_k, vec2 roughness, vec3 N, vec3 X, int distribution, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "lib/mx_microfacet_specular.glsl"
 
 void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl"
+#include "lib/mx_microfacet_specular.glsl"
 
 void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+#include "lib/mx_microfacet_diffuse.glsl"
 
 void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl"
+#include "lib/mx_microfacet_sheen.glsl"
 
 void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl
@@ -1,4 +1,4 @@
-﻿#include "libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl"
+﻿#include "lib/mx_microfacet_diffuse.glsl"
 
 void mx_subsurface_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, inout BSDF bsdf)
 {

--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -2,31 +2,31 @@
 <materialx version="1.38">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genglsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genglsl" />
+  <implementation name="IM_oren_nayar_diffuse_bsdf_genglsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genglsl" />
 
   <!-- <burley_diffuse_bsdf> -->
-  <implementation name="IM_burley_diffuse_bsdf_genglsl" nodedef="ND_burley_diffuse_bsdf" file="libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl" function="mx_burley_diffuse_bsdf" target="genglsl" />
+  <implementation name="IM_burley_diffuse_bsdf_genglsl" nodedef="ND_burley_diffuse_bsdf" file="mx_burley_diffuse_bsdf.glsl" function="mx_burley_diffuse_bsdf" target="genglsl" />
 
   <!-- <translucent_bsdf> -->
-  <implementation name="IM_translucent_bsdf_genglsl" nodedef="ND_translucent_bsdf" file="libraries/pbrlib/genglsl/mx_translucent_bsdf.glsl" function="mx_translucent_bsdf" target="genglsl" />
+  <implementation name="IM_translucent_bsdf_genglsl" nodedef="ND_translucent_bsdf" file="mx_translucent_bsdf.glsl" function="mx_translucent_bsdf" target="genglsl" />
 
   <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genglsl" nodedef="ND_dielectric_bsdf" file="libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl" function="mx_dielectric_bsdf" target="genglsl" />
+  <implementation name="IM_dielectric_bsdf_genglsl" nodedef="ND_dielectric_bsdf" file="mx_dielectric_bsdf.glsl" function="mx_dielectric_bsdf" target="genglsl" />
 
   <!-- <conductor_bsdf> -->
-  <implementation name="IM_conductor_bsdf_genglsl" nodedef="ND_conductor_bsdf" file="libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl" function="mx_conductor_bsdf" target="genglsl" />
+  <implementation name="IM_conductor_bsdf_genglsl" nodedef="ND_conductor_bsdf" file="mx_conductor_bsdf.glsl" function="mx_conductor_bsdf" target="genglsl" />
 
   <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genglsl" nodedef="ND_generalized_schlick_bsdf" file="libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl" function="mx_generalized_schlick_bsdf" target="genglsl" />
+  <implementation name="IM_generalized_schlick_bsdf_genglsl" nodedef="ND_generalized_schlick_bsdf" file="mx_generalized_schlick_bsdf.glsl" function="mx_generalized_schlick_bsdf" target="genglsl" />
 
   <!-- <subsurface_bsdf> -->
-  <implementation name="IM_subsurface_bsdf_genglsl" nodedef="ND_subsurface_bsdf" file="libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl" function="mx_subsurface_bsdf" target="genglsl" />
+  <implementation name="IM_subsurface_bsdf_genglsl" nodedef="ND_subsurface_bsdf" file="mx_subsurface_bsdf.glsl" function="mx_subsurface_bsdf" target="genglsl" />
 
   <!-- <sheen_bsdf> -->
-  <implementation name="IM_sheen_bsdf_genglsl" nodedef="ND_sheen_bsdf" file="libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl" function="mx_sheen_bsdf" target="genglsl" />
+  <implementation name="IM_sheen_bsdf_genglsl" nodedef="ND_sheen_bsdf" file="mx_sheen_bsdf.glsl" function="mx_sheen_bsdf" target="genglsl" />
 
   <!-- <anisotropic_vdf> -->
-  <implementation name="IM_anisotropic_vdf_genglsl" nodedef="ND_anisotropic_vdf" file="libraries/pbrlib/genglsl/mx_anisotropic_vdf.glsl" function="mx_anisotropic_vdf" target="genglsl" />
+  <implementation name="IM_anisotropic_vdf_genglsl" nodedef="ND_anisotropic_vdf" file="mx_anisotropic_vdf.glsl" function="mx_anisotropic_vdf" target="genglsl" />
 
   <!-- <thin_film_bsdf> -->
   <implementation name="IM_thin_film_bsdf_genglsl" nodedef="ND_thin_film_bsdf" target="genglsl" />
@@ -50,7 +50,7 @@
   <implementation name="IM_multiply_edfF_genglsl" nodedef="ND_multiply_edfF" target="genglsl" />
 
   <!-- <uniform_edf> -->
-  <implementation name="IM_uniform_edf_genglsl" nodedef="ND_uniform_edf" file="libraries/pbrlib/genglsl/mx_uniform_edf.glsl" function="mx_uniform_edf" target="genglsl" />
+  <implementation name="IM_uniform_edf_genglsl" nodedef="ND_uniform_edf" file="mx_uniform_edf.glsl" function="mx_uniform_edf" target="genglsl" />
 
   <!-- <surface> -->
   <implementation name="IM_surface_genglsl" nodedef="ND_surface" target="genglsl" />
@@ -59,12 +59,12 @@
   <implementation name="IM_light_genglsl" nodedef="ND_light" target="genglsl" />
 
   <!-- <roughness_anisotropy> -->
-  <implementation name="IM_roughness_anisotropy_genglsl" nodedef="ND_roughness_anisotropy" file="libraries/pbrlib/genglsl/mx_roughness_anisotropy.glsl" function="mx_roughness_anisotropy" target="genglsl" />
+  <implementation name="IM_roughness_anisotropy_genglsl" nodedef="ND_roughness_anisotropy" file="mx_roughness_anisotropy.glsl" function="mx_roughness_anisotropy" target="genglsl" />
 
   <!-- <roughness_dual> -->
-  <implementation name="IM_roughness_dual_genglsl" nodedef="ND_roughness_dual" file="libraries/pbrlib/genglsl/mx_roughness_dual.glsl" function="mx_roughness_dual" target="genglsl" />
+  <implementation name="IM_roughness_dual_genglsl" nodedef="ND_roughness_dual" file="mx_roughness_dual.glsl" function="mx_roughness_dual" target="genglsl" />
 
   <!-- <artistic_ior> -->
-  <implementation name="IM_artistic_ior_genglsl" nodedef="ND_artistic_ior" file="libraries/pbrlib/genglsl/mx_artistic_ior.glsl" function="mx_artistic_ior" target="genglsl" />
+  <implementation name="IM_artistic_ior_genglsl" nodedef="ND_artistic_ior" file="mx_artistic_ior.glsl" function="mx_artistic_ior" target="genglsl" />
 
 </materialx>

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genosl/lib/mx_microfacet.osl"
+#include "mx_microfacet.osl"
 
 // Rational curve fit approximation for the directional albedo of Imageworks sheen.
 float mx_imageworks_sheen_dir_albedo_analytic(float NdotV, float roughness)

--- a/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
+++ b/libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genosl/lib/mx_microfacet.osl"
+#include "mx_microfacet.osl"
 
 // Compute the average of an anisotropic alpha pair.
 float mx_average_alpha(vector2 alpha)

--- a/libraries/pbrlib/genosl/mx_conductor_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_conductor_bsdf.osl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl"
+#include "lib/mx_microfacet_specular.osl"
 
 void mx_conductor_bsdf(float weight, color ior_n, color ior_k, vector2 roughness, normal N, vector U, string distribution, output BSDF bsdf)
 {

--- a/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl"
+#include "lib/mx_microfacet_specular.osl"
 
 void mx_dielectric_bsdf(float weight, color tint, float ior, vector2 roughness, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {

--- a/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genosl/lib/mx_microfacet_specular.osl"
+#include "lib/mx_microfacet_specular.osl"
 
 void mx_generalized_schlick_bsdf(float weight, color color0, color color90, float exponent, vector2 roughness, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {

--- a/libraries/pbrlib/genosl/mx_sheen_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_sheen_bsdf.osl
@@ -1,4 +1,4 @@
-#include "libraries/pbrlib/genosl/lib/mx_microfacet_sheen.osl"
+#include "lib/mx_microfacet_sheen.osl"
 
 // TODO: Vanilla OSL doesn't have a proper sheen closure,
 // so use 'diffuse' scaled by sheen directional albedo for now.

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -2,37 +2,37 @@
 <materialx version="1.38">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" file="libraries/pbrlib/genosl/mx_oren_nayar_diffuse_bsdf.osl" function="mx_oren_nayar_diffuse_bsdf" target="genosl" />
+  <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" file="mx_oren_nayar_diffuse_bsdf.osl" function="mx_oren_nayar_diffuse_bsdf" target="genosl" />
 
   <!-- <burley_diffuse_bsdf> -->
-  <implementation name="IM_burley_diffuse_bsdf_genosl" nodedef="ND_burley_diffuse_bsdf" file="libraries/pbrlib/genosl/mx_burley_diffuse_bsdf.osl" function="mx_burley_diffuse_bsdf" target="genosl" />
+  <implementation name="IM_burley_diffuse_bsdf_genosl" nodedef="ND_burley_diffuse_bsdf" file="mx_burley_diffuse_bsdf.osl" function="mx_burley_diffuse_bsdf" target="genosl" />
 
   <!-- <translucent_bsdf> -->
-  <implementation name="IM_translucent_bsdf_genosl" nodedef="ND_translucent_bsdf" file="libraries/pbrlib/genosl/mx_translucent_bsdf.osl" function="mx_translucent_bsdf" target="genosl" />
+  <implementation name="IM_translucent_bsdf_genosl" nodedef="ND_translucent_bsdf" file="mx_translucent_bsdf.osl" function="mx_translucent_bsdf" target="genosl" />
 
   <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genosl" nodedef="ND_dielectric_bsdf" file="libraries/pbrlib/genosl/mx_dielectric_bsdf.osl" function="mx_dielectric_bsdf" target="genosl" />
+  <implementation name="IM_dielectric_bsdf_genosl" nodedef="ND_dielectric_bsdf" file="mx_dielectric_bsdf.osl" function="mx_dielectric_bsdf" target="genosl" />
 
   <!-- <conductor_bsdf> -->
-  <implementation name="IM_conductor_bsdf_genosl" nodedef="ND_conductor_bsdf" file="libraries/pbrlib/genosl/mx_conductor_bsdf.osl" function="mx_conductor_bsdf" target="genosl" />
+  <implementation name="IM_conductor_bsdf_genosl" nodedef="ND_conductor_bsdf" file="mx_conductor_bsdf.osl" function="mx_conductor_bsdf" target="genosl" />
 
   <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genosl" nodedef="ND_generalized_schlick_bsdf" file="libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl" function="mx_generalized_schlick_bsdf" target="genosl" />
+  <implementation name="IM_generalized_schlick_bsdf_genosl" nodedef="ND_generalized_schlick_bsdf" file="mx_generalized_schlick_bsdf.osl" function="mx_generalized_schlick_bsdf" target="genosl" />
 
   <!-- <subsurface_bsdf> -->
-  <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="libraries/pbrlib/genosl/mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
+  <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
 
   <!-- <sheen_bsdf> -->
-  <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" file="libraries/pbrlib/genosl/mx_sheen_bsdf.osl" function="mx_sheen_bsdf" target="genosl" />
+  <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" file="mx_sheen_bsdf.osl" function="mx_sheen_bsdf" target="genosl" />
 
   <!-- <anisotropic_vdf> -->
-  <implementation name="IM_anisotropic_vdf_genosl" nodedef="ND_anisotropic_vdf" file="libraries/pbrlib/genosl/mx_anisotropic_vdf.osl" function="mx_anisotropic_vdf" target="genosl" />
+  <implementation name="IM_anisotropic_vdf_genosl" nodedef="ND_anisotropic_vdf" file="mx_anisotropic_vdf.osl" function="mx_anisotropic_vdf" target="genosl" />
 
   <!-- <thin_film_bsdf> -->
   <implementation name="IM_thin_film_bsdf_genosl" nodedef="ND_thin_film_bsdf" target="genosl" />
 
   <!-- <uniform_edf> -->
-  <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" file="libraries/pbrlib/genosl/mx_uniform_edf.inline" target="genosl" />
+  <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" file="mx_uniform_edf.inline" target="genosl" />
 
   <!-- <layer> -->
   <implementation name="IM_layer_bsdf_genosl" nodedef="ND_layer_bsdf" target="genosl" />
@@ -53,19 +53,19 @@
   <implementation name="IM_multiply_edfF_genosl" nodedef="ND_multiply_edfF" target="genosl" />
 
   <!-- <surface> -->
-  <implementation name="IM_surface_genosl" nodedef="ND_surface" file="libraries/pbrlib/genosl/mx_surface.osl" function="mx_surface" target="genosl" />
+  <implementation name="IM_surface_genosl" nodedef="ND_surface" file="mx_surface.osl" function="mx_surface" target="genosl" />
 
   <!-- <displacement> -->
-  <implementation name="IM_displacement_float_genosl" nodedef="ND_displacement_float" file="libraries/pbrlib/genosl/mx_displacement_float.osl" function="mx_displacement_float" target="genosl" />
-  <implementation name="IM_displacement_vector3_genosl" nodedef="ND_displacement_vector3" file="libraries/pbrlib/genosl/mx_displacement_vector3.osl" function="mx_displacement_vector3" target="genosl" />
+  <implementation name="IM_displacement_float_genosl" nodedef="ND_displacement_float" file="mx_displacement_float.osl" function="mx_displacement_float" target="genosl" />
+  <implementation name="IM_displacement_vector3_genosl" nodedef="ND_displacement_vector3" file="mx_displacement_vector3.osl" function="mx_displacement_vector3" target="genosl" />
 
   <!-- <roughness_anisotropy> -->
-  <implementation name="IM_roughness_anisotropy_genosl" nodedef="ND_roughness_anisotropy" file="libraries/pbrlib/genosl/mx_roughness_anisotropy.osl" function="mx_roughness_anisotropy" target="genosl" />
+  <implementation name="IM_roughness_anisotropy_genosl" nodedef="ND_roughness_anisotropy" file="mx_roughness_anisotropy.osl" function="mx_roughness_anisotropy" target="genosl" />
 
   <!-- <roughness_dual> -->
-  <implementation name="IM_roughness_dual_genosl" nodedef="ND_roughness_dual" file="libraries/pbrlib/genosl/mx_roughness_dual.osl" function="mx_roughness_dual" target="genosl" />
+  <implementation name="IM_roughness_dual_genosl" nodedef="ND_roughness_dual" file="mx_roughness_dual.osl" function="mx_roughness_dual" target="genosl" />
 
   <!-- <artistic_ior> -->
-  <implementation name="IM_artistic_ior_genosl" nodedef="ND_artistic_ior" file="libraries/pbrlib/genosl/mx_artistic_ior.osl" function="mx_artistic_ior" target="genosl" />
+  <implementation name="IM_artistic_ior_genosl" nodedef="ND_artistic_ior" file="mx_artistic_ior.osl" function="mx_artistic_ior" target="genosl" />
 
 </materialx>

--- a/libraries/stdlib/genglsl/mx_ap1_to_rec709_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_ap1_to_rec709_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "lib/mx_transform_color.glsl"
 
 void mx_ap1_to_rec709_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_ap1_to_rec709_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_ap1_to_rec709_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "lib/mx_transform_color.glsl"
 
 void mx_ap1_to_rec709_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_burn_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_burn_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_burn_float.glsl"
+#include "mx_burn_float.glsl"
 
 void mx_burn_color3(vec3 fg, vec3 bg, float mixval, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_burn_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_burn_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_burn_float.glsl"
+#include "mx_burn_float.glsl"
 
 void mx_burn_color4(vec4 fg, vec4 bg, float mixval, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_cellnoise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_cellnoise2d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_cellnoise2d_float(vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_cellnoise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_cellnoise3d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_cellnoise3d_float(vec3 position, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_dodge_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_dodge_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_dodge_float.glsl"
+#include "mx_dodge_float.glsl"
 
 void mx_dodge_color3(vec3 fg, vec3 bg, float mixval, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_dodge_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_dodge_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_dodge_float.glsl"
+#include "mx_dodge_float.glsl"
 
 void mx_dodge_color4(vec4 fg , vec4 bg , float mixval, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_fa_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_fa_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_fa_vector2(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_fa_vector3(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_fa_vector4(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_float(float amplitude, int octaves, float lacunarity, float diminish, vec3 position, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_vector2(vec2 amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_vector3(vec3 amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_fractal3d_vector4(vec4 amplitude, int octaves, float lacunarity, float diminish, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "lib/mx_transform_color.glsl"
 
 void mx_g22_ap1_to_lin_rec709_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "lib/mx_transform_color.glsl"
 
 void mx_g22_ap1_to_lin_rec709_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_hsvtorgb_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_hsvtorgb_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
+#include "lib/mx_hsv.glsl"
 
 void mx_hsvtorgb_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
+#include "lib/mx_hsv.glsl"
 
 void mx_hsvtorgb_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_image_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color3.glsl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_image_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color4.glsl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_color4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_image_float.glsl
+++ b/libraries/stdlib/genglsl/mx_image_float.glsl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_float(sampler2D tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_image_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector2.glsl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_vector2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_image_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector3.glsl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_vector3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_image_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector4.glsl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_vector4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_fa_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_fa_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_fa_vector2(float amplitude, float pivot, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_fa_vector3(float amplitude, float pivot, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_fa_vector4(float amplitude, float pivot, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_float(float amplitude, float pivot, vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_vector2(vec2 amplitude, float pivot, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_vector3(vec3 amplitude, float pivot, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise2d_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise2d_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise2d_vector4(vec4 amplitude, float pivot, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_fa_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_fa_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_fa_vector2(float amplitude, float pivot, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_fa_vector3(float amplitude, float pivot, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_fa_vector4(float amplitude, float pivot, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_float(float amplitude, float pivot, vec3 position, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_vector2(vec2 amplitude, float pivot, vec3 position, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_vector3(vec3 amplitude, float pivot, vec3 position, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_noise3d_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_noise3d_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_noise3d_vector4(vec4 amplitude, float pivot, vec3 position, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_overlay_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_overlay_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_overlay.glsl"
+#include "mx_overlay.glsl"
 
 void mx_overlay_color3(vec3 fg, vec3 bg, float mix, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_overlay_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_overlay_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_overlay.glsl"
+#include "mx_overlay.glsl"
 
 void mx_overlay_color4(vec4 fg, vec4 bg, float mix, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_rgbtohsv_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_rgbtohsv_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
+#include "lib/mx_hsv.glsl"
 
 void mx_rgbtohsv_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_hsv.glsl"
+#include "lib/mx_hsv.glsl"
 
 void mx_rgbtohsv_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec2.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec2(vec2 val, vec2 low, vec2 high, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec2FA.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec2FA.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec2FA(vec2 val, float low, float high, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec3(vec3 val, vec3 low, vec3 high, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec3FA(vec3 val, float low, float high, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec4(vec4 val, vec4 low, vec4 high, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl
+++ b/libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_smoothstep_float.glsl"
+#include "mx_smoothstep_float.glsl"
 
 void mx_smoothstep_vec4FA(vec4 val, float low, float high, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_float.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splitlr_float(float valuel, float valuer, float center, vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splitlr_vector2(vec2 valuel, vec2 valuer, float center, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splitlr_vector3(vec3 valuel, vec3 valuer, float center, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_splitlr_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_splitlr_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splitlr_vector4(vec4 valuel, vec4 valuer, float center, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_float.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splittb_float(float valuet, float valueb, float center, vec2 texcoord, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splittb_vector2(vec2 valuet, vec2 valueb, float center, vec2 texcoord, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splittb_vector3(vec3 valuet, vec3 valueb, float center, vec2 texcoord, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_splittb_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/mx_aastep.glsl"
+#include "mx_aastep.glsl"
 
 void mx_splittb_vector4(vec4 valuet, vec4 valueb, float center, vec2 texcoord, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "lib/mx_transform_color.glsl"
 
 void mx_srgb_texture_to_lin_rec709_color3(vec3 _in, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_transform_color.glsl"
+#include "lib/mx_transform_color.glsl"
 
 void mx_srgb_texture_to_lin_rec709_color4(vec4 _in, out vec4 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_worleynoise2d_float(vec2 texcoord, float jitter, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_worleynoise2d_vector2(vec2 texcoord, float jitter, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_worleynoise2d_vector3(vec2 texcoord, float jitter, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_worleynoise3d_float(vec3 position, float jitter, out float result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_worleynoise3d_vector2(vec3 position, float jitter, out vec2 result)
 {

--- a/libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genglsl/lib/mx_noise.glsl"
+#include "lib/mx_noise.glsl"
 
 void mx_worleynoise3d_vector3(vec3 position, float jitter, out vec3 result)
 {

--- a/libraries/stdlib/genglsl/stdlib_genglsl_cm_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_cm_impl.mtlx
@@ -5,20 +5,20 @@
   <!-- Color Management System Implementations -->
   <!-- ======================================================================== -->
 
-  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_gamma18_to_linear_color3.glsl" function="mx_gamma18_to_linear_color3" target="genglsl" />
-  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_gamma18_to_linear_color4.glsl" function="mx_gamma18_to_linear_color4" target="genglsl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_gamma22_to_linear_color3.glsl" function="mx_gamma22_to_linear_color3" target="genglsl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_gamma22_to_linear_color4.glsl" function="mx_gamma22_to_linear_color4" target="genglsl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_gamma24_to_linear_color3.glsl" function="mx_gamma24_to_linear_color3" target="genglsl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_gamma24_to_linear_color4.glsl" function="mx_gamma24_to_linear_color4" target="genglsl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genglsl" file="mx_gamma18_to_linear_color3.glsl" function="mx_gamma18_to_linear_color3" target="genglsl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genglsl" file="mx_gamma18_to_linear_color4.glsl" function="mx_gamma18_to_linear_color4" target="genglsl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genglsl" file="mx_gamma22_to_linear_color3.glsl" function="mx_gamma22_to_linear_color3" target="genglsl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genglsl" file="mx_gamma22_to_linear_color4.glsl" function="mx_gamma22_to_linear_color4" target="genglsl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genglsl" file="mx_gamma24_to_linear_color3.glsl" function="mx_gamma24_to_linear_color3" target="genglsl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genglsl" file="mx_gamma24_to_linear_color4.glsl" function="mx_gamma24_to_linear_color4" target="genglsl" />
 
-  <implementation name="IM_acescg_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_ap1_to_rec709_color3.glsl" function="mx_ap1_to_rec709_color3" target="genglsl" />
-  <implementation name="IM_acescg_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_ap1_to_rec709_color4.glsl" function="mx_ap1_to_rec709_color4" target="genglsl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genglsl" file="mx_ap1_to_rec709_color3.glsl" function="mx_ap1_to_rec709_color3" target="genglsl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genglsl" file="mx_ap1_to_rec709_color4.glsl" function="mx_ap1_to_rec709_color4" target="genglsl" />
 
-  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color3.glsl" function="mx_g22_ap1_to_lin_rec709_color3" target="genglsl" />
-  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_g22_ap1_to_lin_rec709_color4.glsl" function="mx_g22_ap1_to_lin_rec709_color4" target="genglsl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genglsl" file="mx_g22_ap1_to_lin_rec709_color3.glsl" function="mx_g22_ap1_to_lin_rec709_color3" target="genglsl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genglsl" file="mx_g22_ap1_to_lin_rec709_color4.glsl" function="mx_g22_ap1_to_lin_rec709_color4" target="genglsl" />
 
-  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genglsl" file="libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color3.glsl" function="mx_srgb_texture_to_lin_rec709_color3" target="genglsl" />
-  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genglsl" file="libraries/stdlib/genglsl/mx_srgb_texture_to_lin_rec709_color4.glsl" function="mx_srgb_texture_to_lin_rec709_color4" target="genglsl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genglsl" file="mx_srgb_texture_to_lin_rec709_color3.glsl" function="mx_srgb_texture_to_lin_rec709_color3" target="genglsl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genglsl" file="mx_srgb_texture_to_lin_rec709_color4.glsl" function="mx_srgb_texture_to_lin_rec709_color4" target="genglsl" />
 
 </materialx>

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -19,132 +19,132 @@
   <!-- ======================================================================== -->
 
   <!-- <image> -->
-  <implementation name="IM_image_float_genglsl" nodedef="ND_image_float" file="libraries/stdlib/genglsl/mx_image_float.glsl" function="mx_image_float" target="genglsl">
+  <implementation name="IM_image_float_genglsl" nodedef="ND_image_float" file="mx_image_float.glsl" function="mx_image_float" target="genglsl">
     <input name="default" type="float" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color3_genglsl" nodedef="ND_image_color3" file="libraries/stdlib/genglsl/mx_image_color3.glsl" function="mx_image_color3" target="genglsl">
+  <implementation name="IM_image_color3_genglsl" nodedef="ND_image_color3" file="mx_image_color3.glsl" function="mx_image_color3" target="genglsl">
     <input name="default" type="color3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color4_genglsl" nodedef="ND_image_color4" file="libraries/stdlib/genglsl/mx_image_color4.glsl" function="mx_image_color4" target="genglsl">
+  <implementation name="IM_image_color4_genglsl" nodedef="ND_image_color4" file="mx_image_color4.glsl" function="mx_image_color4" target="genglsl">
     <input name="default" type="color4" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector2_genglsl" nodedef="ND_image_vector2" file="libraries/stdlib/genglsl/mx_image_vector2.glsl" function="mx_image_vector2" target="genglsl">
+  <implementation name="IM_image_vector2_genglsl" nodedef="ND_image_vector2" file="mx_image_vector2.glsl" function="mx_image_vector2" target="genglsl">
     <input name="default" type="vector2" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector3_genglsl" nodedef="ND_image_vector3" file="libraries/stdlib/genglsl/mx_image_vector3.glsl" function="mx_image_vector3" target="genglsl">
+  <implementation name="IM_image_vector3_genglsl" nodedef="ND_image_vector3" file="mx_image_vector3.glsl" function="mx_image_vector3" target="genglsl">
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector4_genglsl" nodedef="ND_image_vector4" file="libraries/stdlib/genglsl/mx_image_vector4.glsl" function="mx_image_vector4" target="genglsl">
+  <implementation name="IM_image_vector4_genglsl" nodedef="ND_image_vector4" file="mx_image_vector4.glsl" function="mx_image_vector4" target="genglsl">
     <input name="default" type="vector4" implname="default_value" />
   </implementation>
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_genglsl" nodedef="ND_normalmap" file="libraries/stdlib/genglsl/mx_normalmap.glsl" function="mx_normalmap" target="genglsl" />
+  <implementation name="IM_normalmap_genglsl" nodedef="ND_normalmap" file="mx_normalmap.glsl" function="mx_normalmap" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->
   <!-- ======================================================================== -->
 
   <!-- <constant> -->
-  <implementation name="IM_constant_float_genglsl" nodedef="ND_constant_float" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_color3_genglsl" nodedef="ND_constant_color3" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_color4_genglsl" nodedef="ND_constant_color4" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_vector2_genglsl" nodedef="ND_constant_vector2" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_vector3_genglsl" nodedef="ND_constant_vector3" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_vector4_genglsl" nodedef="ND_constant_vector4" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_boolean_genglsl" nodedef="ND_constant_boolean" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_integer_genglsl" nodedef="ND_constant_integer" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_matrix33_genglsl" nodedef="ND_constant_matrix33" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_matrix44_genglsl" nodedef="ND_constant_matrix44" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_string_genglsl" nodedef="ND_constant_string" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
-  <implementation name="IM_constant_filename_genglsl" nodedef="ND_constant_filename" file="libraries/stdlib/genglsl/mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_float_genglsl" nodedef="ND_constant_float" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_color3_genglsl" nodedef="ND_constant_color3" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_color4_genglsl" nodedef="ND_constant_color4" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_vector2_genglsl" nodedef="ND_constant_vector2" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_vector3_genglsl" nodedef="ND_constant_vector3" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_vector4_genglsl" nodedef="ND_constant_vector4" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_boolean_genglsl" nodedef="ND_constant_boolean" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_integer_genglsl" nodedef="ND_constant_integer" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_matrix33_genglsl" nodedef="ND_constant_matrix33" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_matrix44_genglsl" nodedef="ND_constant_matrix44" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_string_genglsl" nodedef="ND_constant_string" file="mx_constant.inline" target="genglsl" />
+  <implementation name="IM_constant_filename_genglsl" nodedef="ND_constant_filename" file="mx_constant.inline" target="genglsl" />
 
   <!-- <ramplr> -->
-  <implementation name="IM_ramplr_float_genglsl" nodedef="ND_ramplr_float" file="libraries/stdlib/genglsl/mx_ramplr_float.glsl" function="mx_ramplr_float" target="genglsl" />
-  <implementation name="IM_ramplr_color3_genglsl" nodedef="ND_ramplr_color3" file="libraries/stdlib/genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
-  <implementation name="IM_ramplr_color4_genglsl" nodedef="ND_ramplr_color4" file="libraries/stdlib/genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
-  <implementation name="IM_ramplr_vector2_genglsl" nodedef="ND_ramplr_vector2" file="libraries/stdlib/genglsl/mx_ramplr_vector2.glsl" function="mx_ramplr_vector2" target="genglsl" />
-  <implementation name="IM_ramplr_vector3_genglsl" nodedef="ND_ramplr_vector3" file="libraries/stdlib/genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
-  <implementation name="IM_ramplr_vector4_genglsl" nodedef="ND_ramplr_vector4" file="libraries/stdlib/genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
+  <implementation name="IM_ramplr_float_genglsl" nodedef="ND_ramplr_float" file="mx_ramplr_float.glsl" function="mx_ramplr_float" target="genglsl" />
+  <implementation name="IM_ramplr_color3_genglsl" nodedef="ND_ramplr_color3" file="mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
+  <implementation name="IM_ramplr_color4_genglsl" nodedef="ND_ramplr_color4" file="mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
+  <implementation name="IM_ramplr_vector2_genglsl" nodedef="ND_ramplr_vector2" file="mx_ramplr_vector2.glsl" function="mx_ramplr_vector2" target="genglsl" />
+  <implementation name="IM_ramplr_vector3_genglsl" nodedef="ND_ramplr_vector3" file="mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genglsl" />
+  <implementation name="IM_ramplr_vector4_genglsl" nodedef="ND_ramplr_vector4" file="mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genglsl" />
 
   <!-- <ramptb> -->
-  <implementation name="IM_ramptb_float_genglsl" nodedef="ND_ramptb_float" file="libraries/stdlib/genglsl/mx_ramptb_float.glsl" function="mx_ramptb_float" target="genglsl" />
-  <implementation name="IM_ramptb_color3_genglsl" nodedef="ND_ramptb_color3" file="libraries/stdlib/genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
-  <implementation name="IM_ramptb_color4_genglsl" nodedef="ND_ramptb_color4" file="libraries/stdlib/genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
-  <implementation name="IM_ramptb_vector2_genglsl" nodedef="ND_ramptb_vector2" file="libraries/stdlib/genglsl/mx_ramptb_vector2.glsl" function="mx_ramptb_vector2" target="genglsl" />
-  <implementation name="IM_ramptb_vector3_genglsl" nodedef="ND_ramptb_vector3" file="libraries/stdlib/genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
-  <implementation name="IM_ramptb_vector4_genglsl" nodedef="ND_ramptb_vector4" file="libraries/stdlib/genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
+  <implementation name="IM_ramptb_float_genglsl" nodedef="ND_ramptb_float" file="mx_ramptb_float.glsl" function="mx_ramptb_float" target="genglsl" />
+  <implementation name="IM_ramptb_color3_genglsl" nodedef="ND_ramptb_color3" file="mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
+  <implementation name="IM_ramptb_color4_genglsl" nodedef="ND_ramptb_color4" file="mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
+  <implementation name="IM_ramptb_vector2_genglsl" nodedef="ND_ramptb_vector2" file="mx_ramptb_vector2.glsl" function="mx_ramptb_vector2" target="genglsl" />
+  <implementation name="IM_ramptb_vector3_genglsl" nodedef="ND_ramptb_vector3" file="mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genglsl" />
+  <implementation name="IM_ramptb_vector4_genglsl" nodedef="ND_ramptb_vector4" file="mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genglsl" />
 
   <!-- <splitlr> -->
-  <implementation name="IM_splitlr_float_genglsl" nodedef="ND_splitlr_float" file="libraries/stdlib/genglsl/mx_splitlr_float.glsl" function="mx_splitlr_float" target="genglsl" />
-  <implementation name="IM_splitlr_color3_genglsl" nodedef="ND_splitlr_color3" file="libraries/stdlib/genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
-  <implementation name="IM_splitlr_color4_genglsl" nodedef="ND_splitlr_color4" file="libraries/stdlib/genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
-  <implementation name="IM_splitlr_vector2_genglsl" nodedef="ND_splitlr_vector2" file="libraries/stdlib/genglsl/mx_splitlr_vector2.glsl" function="mx_splitlr_vector2" target="genglsl" />
-  <implementation name="IM_splitlr_vector3_genglsl" nodedef="ND_splitlr_vector3" file="libraries/stdlib/genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
-  <implementation name="IM_splitlr_vector4_genglsl" nodedef="ND_splitlr_vector4" file="libraries/stdlib/genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
+  <implementation name="IM_splitlr_float_genglsl" nodedef="ND_splitlr_float" file="mx_splitlr_float.glsl" function="mx_splitlr_float" target="genglsl" />
+  <implementation name="IM_splitlr_color3_genglsl" nodedef="ND_splitlr_color3" file="mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
+  <implementation name="IM_splitlr_color4_genglsl" nodedef="ND_splitlr_color4" file="mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
+  <implementation name="IM_splitlr_vector2_genglsl" nodedef="ND_splitlr_vector2" file="mx_splitlr_vector2.glsl" function="mx_splitlr_vector2" target="genglsl" />
+  <implementation name="IM_splitlr_vector3_genglsl" nodedef="ND_splitlr_vector3" file="mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genglsl" />
+  <implementation name="IM_splitlr_vector4_genglsl" nodedef="ND_splitlr_vector4" file="mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genglsl" />
 
   <!-- <splittb> -->
-  <implementation name="IM_splittb_float_genglsl" nodedef="ND_splittb_float" file="libraries/stdlib/genglsl/mx_splittb_float.glsl" function="mx_splittb_float" target="genglsl" />
-  <implementation name="IM_splittb_color3_genglsl" nodedef="ND_splittb_color3" file="libraries/stdlib/genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
-  <implementation name="IM_splittb_color4_genglsl" nodedef="ND_splittb_color4" file="libraries/stdlib/genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
-  <implementation name="IM_splittb_vector2_genglsl" nodedef="ND_splittb_vector2" file="libraries/stdlib/genglsl/mx_splittb_vector2.glsl" function="mx_splittb_vector2" target="genglsl" />
-  <implementation name="IM_splittb_vector3_genglsl" nodedef="ND_splittb_vector3" file="libraries/stdlib/genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
-  <implementation name="IM_splittb_vector4_genglsl" nodedef="ND_splittb_vector4" file="libraries/stdlib/genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
+  <implementation name="IM_splittb_float_genglsl" nodedef="ND_splittb_float" file="mx_splittb_float.glsl" function="mx_splittb_float" target="genglsl" />
+  <implementation name="IM_splittb_color3_genglsl" nodedef="ND_splittb_color3" file="mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
+  <implementation name="IM_splittb_color4_genglsl" nodedef="ND_splittb_color4" file="mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
+  <implementation name="IM_splittb_vector2_genglsl" nodedef="ND_splittb_vector2" file="mx_splittb_vector2.glsl" function="mx_splittb_vector2" target="genglsl" />
+  <implementation name="IM_splittb_vector3_genglsl" nodedef="ND_splittb_vector3" file="mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genglsl" />
+  <implementation name="IM_splittb_vector4_genglsl" nodedef="ND_splittb_vector4" file="mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genglsl" />
 
   <!-- <noise2d> -->
-  <implementation name="IM_noise2d_float_genglsl" nodedef="ND_noise2d_float" file="libraries/stdlib/genglsl/mx_noise2d_float.glsl" function="mx_noise2d_float" target="genglsl" />
-  <implementation name="IM_noise2d_color3_genglsl" nodedef="ND_noise2d_color3" file="libraries/stdlib/genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_color4_genglsl" nodedef="ND_noise2d_color4" file="libraries/stdlib/genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
-  <implementation name="IM_noise2d_color3FA_genglsl" nodedef="ND_noise2d_color3FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_color4FA_genglsl" nodedef="ND_noise2d_color4FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
-  <implementation name="IM_noise2d_vector2_genglsl" nodedef="ND_noise2d_vector2" file="libraries/stdlib/genglsl/mx_noise2d_vector2.glsl" function="mx_noise2d_vector2" target="genglsl" />
-  <implementation name="IM_noise2d_vector3_genglsl" nodedef="ND_noise2d_vector3" file="libraries/stdlib/genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_vector4_genglsl" nodedef="ND_noise2d_vector4" file="libraries/stdlib/genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
-  <implementation name="IM_noise2d_vector2FA_genglsl" nodedef="ND_noise2d_vector2FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector2.glsl" function="mx_noise2d_fa_vector2" target="genglsl" />
-  <implementation name="IM_noise2d_vector3FA_genglsl" nodedef="ND_noise2d_vector3FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise2d_vector4FA_genglsl" nodedef="ND_noise2d_vector4FA" file="libraries/stdlib/genglsl/mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_float_genglsl" nodedef="ND_noise2d_float" file="mx_noise2d_float.glsl" function="mx_noise2d_float" target="genglsl" />
+  <implementation name="IM_noise2d_color3_genglsl" nodedef="ND_noise2d_color3" file="mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_color4_genglsl" nodedef="ND_noise2d_color4" file="mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_color3FA_genglsl" nodedef="ND_noise2d_color3FA" file="mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_color4FA_genglsl" nodedef="ND_noise2d_color4FA" file="mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_vector2_genglsl" nodedef="ND_noise2d_vector2" file="mx_noise2d_vector2.glsl" function="mx_noise2d_vector2" target="genglsl" />
+  <implementation name="IM_noise2d_vector3_genglsl" nodedef="ND_noise2d_vector3" file="mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_vector4_genglsl" nodedef="ND_noise2d_vector4" file="mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genglsl" />
+  <implementation name="IM_noise2d_vector2FA_genglsl" nodedef="ND_noise2d_vector2FA" file="mx_noise2d_fa_vector2.glsl" function="mx_noise2d_fa_vector2" target="genglsl" />
+  <implementation name="IM_noise2d_vector3FA_genglsl" nodedef="ND_noise2d_vector3FA" file="mx_noise2d_fa_vector3.glsl" function="mx_noise2d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise2d_vector4FA_genglsl" nodedef="ND_noise2d_vector4FA" file="mx_noise2d_fa_vector4.glsl" function="mx_noise2d_fa_vector4" target="genglsl" />
 
   <!-- <noise3d> -->
-  <implementation name="IM_noise3d_float_genglsl" nodedef="ND_noise3d_float" file="libraries/stdlib/genglsl/mx_noise3d_float.glsl" function="mx_noise3d_float" target="genglsl" />
-  <implementation name="IM_noise3d_color3_genglsl" nodedef="ND_noise3d_color3" file="libraries/stdlib/genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_color4_genglsl" nodedef="ND_noise3d_color4" file="libraries/stdlib/genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
-  <implementation name="IM_noise3d_color3FA_genglsl" nodedef="ND_noise3d_color3FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_color4FA_genglsl" nodedef="ND_noise3d_color4FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
-  <implementation name="IM_noise3d_vector2_genglsl" nodedef="ND_noise3d_vector2" file="libraries/stdlib/genglsl/mx_noise3d_vector2.glsl" function="mx_noise3d_vector2" target="genglsl" />
-  <implementation name="IM_noise3d_vector3_genglsl" nodedef="ND_noise3d_vector3" file="libraries/stdlib/genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_vector4_genglsl" nodedef="ND_noise3d_vector4" file="libraries/stdlib/genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
-  <implementation name="IM_noise3d_vector2FA_genglsl" nodedef="ND_noise3d_vector2FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector2.glsl" function="mx_noise3d_fa_vector2" target="genglsl" />
-  <implementation name="IM_noise3d_vector3FA_genglsl" nodedef="ND_noise3d_vector3FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_noise3d_vector4FA_genglsl" nodedef="ND_noise3d_vector4FA" file="libraries/stdlib/genglsl/mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_float_genglsl" nodedef="ND_noise3d_float" file="mx_noise3d_float.glsl" function="mx_noise3d_float" target="genglsl" />
+  <implementation name="IM_noise3d_color3_genglsl" nodedef="ND_noise3d_color3" file="mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_color4_genglsl" nodedef="ND_noise3d_color4" file="mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_color3FA_genglsl" nodedef="ND_noise3d_color3FA" file="mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_color4FA_genglsl" nodedef="ND_noise3d_color4FA" file="mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_vector2_genglsl" nodedef="ND_noise3d_vector2" file="mx_noise3d_vector2.glsl" function="mx_noise3d_vector2" target="genglsl" />
+  <implementation name="IM_noise3d_vector3_genglsl" nodedef="ND_noise3d_vector3" file="mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_vector4_genglsl" nodedef="ND_noise3d_vector4" file="mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genglsl" />
+  <implementation name="IM_noise3d_vector2FA_genglsl" nodedef="ND_noise3d_vector2FA" file="mx_noise3d_fa_vector2.glsl" function="mx_noise3d_fa_vector2" target="genglsl" />
+  <implementation name="IM_noise3d_vector3FA_genglsl" nodedef="ND_noise3d_vector3FA" file="mx_noise3d_fa_vector3.glsl" function="mx_noise3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_noise3d_vector4FA_genglsl" nodedef="ND_noise3d_vector4FA" file="mx_noise3d_fa_vector4.glsl" function="mx_noise3d_fa_vector4" target="genglsl" />
 
   <!-- <fractal3d> -->
-  <implementation name="IM_fractal3d_float_genglsl" nodedef="ND_fractal3d_float" file="libraries/stdlib/genglsl/mx_fractal3d_float.glsl" function="mx_fractal3d_float" target="genglsl" />
-  <implementation name="IM_fractal3d_color3_genglsl" nodedef="ND_fractal3d_color3" file="libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_color4_genglsl" nodedef="ND_fractal3d_color4" file="libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
-  <implementation name="IM_fractal3d_color3FA_genglsl" nodedef="ND_fractal3d_color3FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_color4FA_genglsl" nodedef="ND_fractal3d_color4FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
-  <implementation name="IM_fractal3d_vector2_genglsl" nodedef="ND_fractal3d_vector2" file="libraries/stdlib/genglsl/mx_fractal3d_vector2.glsl" function="mx_fractal3d_vector2" target="genglsl" />
-  <implementation name="IM_fractal3d_vector3_genglsl" nodedef="ND_fractal3d_vector3" file="libraries/stdlib/genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_vector4_genglsl" nodedef="ND_fractal3d_vector4" file="libraries/stdlib/genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
-  <implementation name="IM_fractal3d_vector2FA_genglsl" nodedef="ND_fractal3d_vector2FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector2.glsl" function="mx_fractal3d_fa_vector2" target="genglsl" />
-  <implementation name="IM_fractal3d_vector3FA_genglsl" nodedef="ND_fractal3d_vector3FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
-  <implementation name="IM_fractal3d_vector4FA_genglsl" nodedef="ND_fractal3d_vector4FA" file="libraries/stdlib/genglsl/mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_float_genglsl" nodedef="ND_fractal3d_float" file="mx_fractal3d_float.glsl" function="mx_fractal3d_float" target="genglsl" />
+  <implementation name="IM_fractal3d_color3_genglsl" nodedef="ND_fractal3d_color3" file="mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_color4_genglsl" nodedef="ND_fractal3d_color4" file="mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_color3FA_genglsl" nodedef="ND_fractal3d_color3FA" file="mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_color4FA_genglsl" nodedef="ND_fractal3d_color4FA" file="mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_vector2_genglsl" nodedef="ND_fractal3d_vector2" file="mx_fractal3d_vector2.glsl" function="mx_fractal3d_vector2" target="genglsl" />
+  <implementation name="IM_fractal3d_vector3_genglsl" nodedef="ND_fractal3d_vector3" file="mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_vector4_genglsl" nodedef="ND_fractal3d_vector4" file="mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genglsl" />
+  <implementation name="IM_fractal3d_vector2FA_genglsl" nodedef="ND_fractal3d_vector2FA" file="mx_fractal3d_fa_vector2.glsl" function="mx_fractal3d_fa_vector2" target="genglsl" />
+  <implementation name="IM_fractal3d_vector3FA_genglsl" nodedef="ND_fractal3d_vector3FA" file="mx_fractal3d_fa_vector3.glsl" function="mx_fractal3d_fa_vector3" target="genglsl" />
+  <implementation name="IM_fractal3d_vector4FA_genglsl" nodedef="ND_fractal3d_vector4FA" file="mx_fractal3d_fa_vector4.glsl" function="mx_fractal3d_fa_vector4" target="genglsl" />
 
   <!-- <cellnoise2d> -->
-  <implementation name="IM_cellnoise2d_float_genglsl" nodedef="ND_cellnoise2d_float" file="libraries/stdlib/genglsl/mx_cellnoise2d_float.glsl" function="mx_cellnoise2d_float" target="genglsl" />
+  <implementation name="IM_cellnoise2d_float_genglsl" nodedef="ND_cellnoise2d_float" file="mx_cellnoise2d_float.glsl" function="mx_cellnoise2d_float" target="genglsl" />
 
   <!-- <cellnoise3d> -->
-  <implementation name="IM_cellnoise3d_float_genglsl" nodedef="ND_cellnoise3d_float" file="libraries/stdlib/genglsl/mx_cellnoise3d_float.glsl" function="mx_cellnoise3d_float" target="genglsl" />
+  <implementation name="IM_cellnoise3d_float_genglsl" nodedef="ND_cellnoise3d_float" file="mx_cellnoise3d_float.glsl" function="mx_cellnoise3d_float" target="genglsl" />
 
   <!-- <worleynoise2d> -->
-  <implementation name="IM_worleynoise2d_float_genglsl" nodedef="ND_worleynoise2d_float" file="libraries/stdlib/genglsl/mx_worleynoise2d_float.glsl" function="mx_worleynoise2d_float" target="genglsl" />
-  <implementation name="IM_worleynoise2d_vector2_genglsl" nodedef="ND_worleynoise2d_vector2" file="libraries/stdlib/genglsl/mx_worleynoise2d_vector2.glsl" function="mx_worleynoise2d_vector2" target="genglsl" />
-  <implementation name="IM_worleynoise2d_vector3_genglsl" nodedef="ND_worleynoise2d_vector3" file="libraries/stdlib/genglsl/mx_worleynoise2d_vector3.glsl" function="mx_worleynoise2d_vector3" target="genglsl" />
+  <implementation name="IM_worleynoise2d_float_genglsl" nodedef="ND_worleynoise2d_float" file="mx_worleynoise2d_float.glsl" function="mx_worleynoise2d_float" target="genglsl" />
+  <implementation name="IM_worleynoise2d_vector2_genglsl" nodedef="ND_worleynoise2d_vector2" file="mx_worleynoise2d_vector2.glsl" function="mx_worleynoise2d_vector2" target="genglsl" />
+  <implementation name="IM_worleynoise2d_vector3_genglsl" nodedef="ND_worleynoise2d_vector3" file="mx_worleynoise2d_vector3.glsl" function="mx_worleynoise2d_vector3" target="genglsl" />
 
   <!-- <worleynoise3d> -->
-  <implementation name="IM_worleynoise3d_float_genglsl" nodedef="ND_worleynoise3d_float" file="libraries/stdlib/genglsl/mx_worleynoise3d_float.glsl" function="mx_worleynoise3d_float" target="genglsl" />
-  <implementation name="IM_worleynoise3d_vector2_genglsl" nodedef="ND_worleynoise3d_vector2" file="libraries/stdlib/genglsl/mx_worleynoise3d_vector2.glsl" function="mx_worleynoise3d_vector2" target="genglsl" />
-  <implementation name="IM_worleynoise3d_vector3_genglsl" nodedef="ND_worleynoise3d_vector3" file="libraries/stdlib/genglsl/mx_worleynoise3d_vector3.glsl" function="mx_worleynoise3d_vector3" target="genglsl" />
+  <implementation name="IM_worleynoise3d_float_genglsl" nodedef="ND_worleynoise3d_float" file="mx_worleynoise3d_float.glsl" function="mx_worleynoise3d_float" target="genglsl" />
+  <implementation name="IM_worleynoise3d_vector2_genglsl" nodedef="ND_worleynoise3d_vector2" file="mx_worleynoise3d_vector2.glsl" function="mx_worleynoise3d_vector2" target="genglsl" />
+  <implementation name="IM_worleynoise3d_vector3_genglsl" nodedef="ND_worleynoise3d_vector3" file="mx_worleynoise3d_vector3.glsl" function="mx_worleynoise3d_vector3" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
@@ -204,242 +204,242 @@
   <!-- ======================================================================== -->
 
   <!-- <add> -->
-  <implementation name="IM_add_float_genglsl" nodedef="ND_add_float" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color3_genglsl" nodedef="ND_add_color3" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color3FA_genglsl" nodedef="ND_add_color3FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color4_genglsl" nodedef="ND_add_color4" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_color4FA_genglsl" nodedef="ND_add_color4FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector2_genglsl" nodedef="ND_add_vector2" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector2FA_genglsl" nodedef="ND_add_vector2FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector3_genglsl" nodedef="ND_add_vector3" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector3FA_genglsl" nodedef="ND_add_vector3FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector4_genglsl" nodedef="ND_add_vector4" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_vector4FA_genglsl" nodedef="ND_add_vector4FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix33_genglsl" nodedef="ND_add_matrix33" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix33FA_genglsl" nodedef="ND_add_matrix33FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix44_genglsl" nodedef="ND_add_matrix44" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_matrix44FA_genglsl" nodedef="ND_add_matrix44FA" file="libraries/stdlib/genglsl/mx_add.inline" target="genglsl" />
-  <implementation name="IM_add_surfaceshader_genglsl" nodedef="ND_add_surfaceshader" function="mx_add_surfaceshader" file="libraries/stdlib/genglsl/mx_add_surfaceshader.glsl" target="genglsl" />
+  <implementation name="IM_add_float_genglsl" nodedef="ND_add_float" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color3_genglsl" nodedef="ND_add_color3" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color3FA_genglsl" nodedef="ND_add_color3FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color4_genglsl" nodedef="ND_add_color4" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_color4FA_genglsl" nodedef="ND_add_color4FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector2_genglsl" nodedef="ND_add_vector2" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector2FA_genglsl" nodedef="ND_add_vector2FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector3_genglsl" nodedef="ND_add_vector3" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector3FA_genglsl" nodedef="ND_add_vector3FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector4_genglsl" nodedef="ND_add_vector4" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_vector4FA_genglsl" nodedef="ND_add_vector4FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix33_genglsl" nodedef="ND_add_matrix33" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix33FA_genglsl" nodedef="ND_add_matrix33FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix44_genglsl" nodedef="ND_add_matrix44" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_matrix44FA_genglsl" nodedef="ND_add_matrix44FA" file="mx_add.inline" target="genglsl" />
+  <implementation name="IM_add_surfaceshader_genglsl" nodedef="ND_add_surfaceshader" function="mx_add_surfaceshader" file="mx_add_surfaceshader.glsl" target="genglsl" />
 
   <!-- <subtract> -->
-  <implementation name="IM_subtract_float_genglsl" nodedef="ND_subtract_float" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color3_genglsl" nodedef="ND_subtract_color3" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color3FA_genglsl" nodedef="ND_subtract_color3FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color4_genglsl" nodedef="ND_subtract_color4" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_color4FA_genglsl" nodedef="ND_subtract_color4FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector2_genglsl" nodedef="ND_subtract_vector2" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector2FA_genglsl" nodedef="ND_subtract_vector2FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector3_genglsl" nodedef="ND_subtract_vector3" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector3FA_genglsl" nodedef="ND_subtract_vector3FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector4_genglsl" nodedef="ND_subtract_vector4" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_vector4FA_genglsl" nodedef="ND_subtract_vector4FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix33_genglsl" nodedef="ND_subtract_matrix33" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix33FA_genglsl" nodedef="ND_subtract_matrix33FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix44_genglsl" nodedef="ND_subtract_matrix44" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
-  <implementation name="IM_subtract_matrix44FA_genglsl" nodedef="ND_subtract_matrix44FA" file="libraries/stdlib/genglsl/mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_float_genglsl" nodedef="ND_subtract_float" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color3_genglsl" nodedef="ND_subtract_color3" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color3FA_genglsl" nodedef="ND_subtract_color3FA" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color4_genglsl" nodedef="ND_subtract_color4" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_color4FA_genglsl" nodedef="ND_subtract_color4FA" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector2_genglsl" nodedef="ND_subtract_vector2" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector2FA_genglsl" nodedef="ND_subtract_vector2FA" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector3_genglsl" nodedef="ND_subtract_vector3" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector3FA_genglsl" nodedef="ND_subtract_vector3FA" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector4_genglsl" nodedef="ND_subtract_vector4" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_vector4FA_genglsl" nodedef="ND_subtract_vector4FA" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix33_genglsl" nodedef="ND_subtract_matrix33" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix33FA_genglsl" nodedef="ND_subtract_matrix33FA" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix44_genglsl" nodedef="ND_subtract_matrix44" file="mx_subtract.inline" target="genglsl" />
+  <implementation name="IM_subtract_matrix44FA_genglsl" nodedef="ND_subtract_matrix44FA" file="mx_subtract.inline" target="genglsl" />
 
   <!-- <multiply> -->
-  <implementation name="IM_multiply_float_genglsl" nodedef="ND_multiply_float" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color3_genglsl" nodedef="ND_multiply_color3" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color3FA_genglsl" nodedef="ND_multiply_color3FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color4_genglsl" nodedef="ND_multiply_color4" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_color4FA_genglsl" nodedef="ND_multiply_color4FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector2_genglsl" nodedef="ND_multiply_vector2" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector2FA_genglsl" nodedef="ND_multiply_vector2FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector3_genglsl" nodedef="ND_multiply_vector3" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector3FA_genglsl" nodedef="ND_multiply_vector3FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector4_genglsl" nodedef="ND_multiply_vector4" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_vector4FA_genglsl" nodedef="ND_multiply_vector4FA" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_matrix33_genglsl" nodedef="ND_multiply_matrix33" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_matrix44_genglsl" nodedef="ND_multiply_matrix44" file="libraries/stdlib/genglsl/mx_multiply.inline" target="genglsl" />
-  <implementation name="IM_multiply_surfaceshaderF_genglsl" nodedef="ND_multiply_surfaceshaderF" function="mx_multiply_surfaceshader_float" file="libraries/stdlib/genglsl/mx_multiply_surfaceshader_float.glsl" target="genglsl" />
-  <implementation name="IM_multiply_surfaceshaderC_genglsl" nodedef="ND_multiply_surfaceshaderC" function="mx_multiply_surfaceshader_color3" file="libraries/stdlib/genglsl/mx_multiply_surfaceshader_color3.glsl" target="genglsl" />
+  <implementation name="IM_multiply_float_genglsl" nodedef="ND_multiply_float" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color3_genglsl" nodedef="ND_multiply_color3" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color3FA_genglsl" nodedef="ND_multiply_color3FA" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color4_genglsl" nodedef="ND_multiply_color4" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_color4FA_genglsl" nodedef="ND_multiply_color4FA" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector2_genglsl" nodedef="ND_multiply_vector2" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector2FA_genglsl" nodedef="ND_multiply_vector2FA" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector3_genglsl" nodedef="ND_multiply_vector3" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector3FA_genglsl" nodedef="ND_multiply_vector3FA" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector4_genglsl" nodedef="ND_multiply_vector4" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_vector4FA_genglsl" nodedef="ND_multiply_vector4FA" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_matrix33_genglsl" nodedef="ND_multiply_matrix33" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_matrix44_genglsl" nodedef="ND_multiply_matrix44" file="mx_multiply.inline" target="genglsl" />
+  <implementation name="IM_multiply_surfaceshaderF_genglsl" nodedef="ND_multiply_surfaceshaderF" function="mx_multiply_surfaceshader_float" file="mx_multiply_surfaceshader_float.glsl" target="genglsl" />
+  <implementation name="IM_multiply_surfaceshaderC_genglsl" nodedef="ND_multiply_surfaceshaderC" function="mx_multiply_surfaceshader_color3" file="mx_multiply_surfaceshader_color3.glsl" target="genglsl" />
 
   <!-- <divide> -->
-  <implementation name="IM_divide_float_genglsl" nodedef="ND_divide_float" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color3_genglsl" nodedef="ND_divide_color3" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color3FA_genglsl" nodedef="ND_divide_color3FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color4_genglsl" nodedef="ND_divide_color4" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_color4FA_genglsl" nodedef="ND_divide_color4FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector2_genglsl" nodedef="ND_divide_vector2" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector2FA_genglsl" nodedef="ND_divide_vector2FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector3_genglsl" nodedef="ND_divide_vector3" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector3FA_genglsl" nodedef="ND_divide_vector3FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector4_genglsl" nodedef="ND_divide_vector4" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_vector4FA_genglsl" nodedef="ND_divide_vector4FA" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_matrix33_genglsl" nodedef="ND_divide_matrix33" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
-  <implementation name="IM_divide_matrix44_genglsl" nodedef="ND_divide_matrix44" file="libraries/stdlib/genglsl/mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_float_genglsl" nodedef="ND_divide_float" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color3_genglsl" nodedef="ND_divide_color3" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color3FA_genglsl" nodedef="ND_divide_color3FA" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color4_genglsl" nodedef="ND_divide_color4" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_color4FA_genglsl" nodedef="ND_divide_color4FA" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector2_genglsl" nodedef="ND_divide_vector2" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector2FA_genglsl" nodedef="ND_divide_vector2FA" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector3_genglsl" nodedef="ND_divide_vector3" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector3FA_genglsl" nodedef="ND_divide_vector3FA" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector4_genglsl" nodedef="ND_divide_vector4" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_vector4FA_genglsl" nodedef="ND_divide_vector4FA" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_matrix33_genglsl" nodedef="ND_divide_matrix33" file="mx_divide.inline" target="genglsl" />
+  <implementation name="IM_divide_matrix44_genglsl" nodedef="ND_divide_matrix44" file="mx_divide.inline" target="genglsl" />
 
   <!-- <modulo> -->
-  <implementation name="IM_modulo_float_genglsl" nodedef="ND_modulo_float" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color3_genglsl" nodedef="ND_modulo_color3" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color3FA_genglsl" nodedef="ND_modulo_color3FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color4_genglsl" nodedef="ND_modulo_color4" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_color4FA_genglsl" nodedef="ND_modulo_color4FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector2_genglsl" nodedef="ND_modulo_vector2" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector2FA_genglsl" nodedef="ND_modulo_vector2FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector3_genglsl" nodedef="ND_modulo_vector3" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector3FA_genglsl" nodedef="ND_modulo_vector3FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector4_genglsl" nodedef="ND_modulo_vector4" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
-  <implementation name="IM_modulo_vector4FA_genglsl" nodedef="ND_modulo_vector4FA" file="libraries/stdlib/genglsl/mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_float_genglsl" nodedef="ND_modulo_float" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color3_genglsl" nodedef="ND_modulo_color3" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color3FA_genglsl" nodedef="ND_modulo_color3FA" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color4_genglsl" nodedef="ND_modulo_color4" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_color4FA_genglsl" nodedef="ND_modulo_color4FA" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector2_genglsl" nodedef="ND_modulo_vector2" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector2FA_genglsl" nodedef="ND_modulo_vector2FA" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector3_genglsl" nodedef="ND_modulo_vector3" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector3FA_genglsl" nodedef="ND_modulo_vector3FA" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector4_genglsl" nodedef="ND_modulo_vector4" file="mx_modulo.inline" target="genglsl" />
+  <implementation name="IM_modulo_vector4FA_genglsl" nodedef="ND_modulo_vector4FA" file="mx_modulo.inline" target="genglsl" />
 
   <!-- <invert> -->
-  <implementation name="IM_invert_float_genglsl" nodedef="ND_invert_float" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color3_genglsl" nodedef="ND_invert_color3" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color3FA_genglsl" nodedef="ND_invert_color3FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color4_genglsl" nodedef="ND_invert_color4" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_color4FA_genglsl" nodedef="ND_invert_color4FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector2_genglsl" nodedef="ND_invert_vector2" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector2FA_genglsl" nodedef="ND_invert_vector2FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector3_genglsl" nodedef="ND_invert_vector3" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector3FA_genglsl" nodedef="ND_invert_vector3FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector4_genglsl" nodedef="ND_invert_vector4" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
-  <implementation name="IM_invert_vector4FA_genglsl" nodedef="ND_invert_vector4FA" file="libraries/stdlib/genglsl/mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_float_genglsl" nodedef="ND_invert_float" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color3_genglsl" nodedef="ND_invert_color3" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color3FA_genglsl" nodedef="ND_invert_color3FA" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color4_genglsl" nodedef="ND_invert_color4" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_color4FA_genglsl" nodedef="ND_invert_color4FA" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector2_genglsl" nodedef="ND_invert_vector2" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector2FA_genglsl" nodedef="ND_invert_vector2FA" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector3_genglsl" nodedef="ND_invert_vector3" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector3FA_genglsl" nodedef="ND_invert_vector3FA" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector4_genglsl" nodedef="ND_invert_vector4" file="mx_invert.inline" target="genglsl" />
+  <implementation name="IM_invert_vector4FA_genglsl" nodedef="ND_invert_vector4FA" file="mx_invert.inline" target="genglsl" />
 
   <!-- <absval> -->
-  <implementation name="IM_absval_float_genglsl" nodedef="ND_absval_float" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_color3_genglsl" nodedef="ND_absval_color3" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_color4_genglsl" nodedef="ND_absval_color4" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_vector2_genglsl" nodedef="ND_absval_vector2" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_vector3_genglsl" nodedef="ND_absval_vector3" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
-  <implementation name="IM_absval_vector4_genglsl" nodedef="ND_absval_vector4" file="libraries/stdlib/genglsl/mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_float_genglsl" nodedef="ND_absval_float" file="mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_color3_genglsl" nodedef="ND_absval_color3" file="mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_color4_genglsl" nodedef="ND_absval_color4" file="mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_vector2_genglsl" nodedef="ND_absval_vector2" file="mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_vector3_genglsl" nodedef="ND_absval_vector3" file="mx_absval.inline" target="genglsl" />
+  <implementation name="IM_absval_vector4_genglsl" nodedef="ND_absval_vector4" file="mx_absval.inline" target="genglsl" />
 
   <!-- <floor> -->
-  <implementation name="IM_floor_float_genglsl" nodedef="ND_floor_float" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_color3_genglsl" nodedef="ND_floor_color3" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_color4_genglsl" nodedef="ND_floor_color4" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_vector2_genglsl" nodedef="ND_floor_vector2" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_vector3_genglsl" nodedef="ND_floor_vector3" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
-  <implementation name="IM_floor_vector4_genglsl" nodedef="ND_floor_vector4" file="libraries/stdlib/genglsl/mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_float_genglsl" nodedef="ND_floor_float" file="mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_color3_genglsl" nodedef="ND_floor_color3" file="mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_color4_genglsl" nodedef="ND_floor_color4" file="mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_vector2_genglsl" nodedef="ND_floor_vector2" file="mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_vector3_genglsl" nodedef="ND_floor_vector3" file="mx_floor.inline" target="genglsl" />
+  <implementation name="IM_floor_vector4_genglsl" nodedef="ND_floor_vector4" file="mx_floor.inline" target="genglsl" />
   <!-- <ceil> -->
-  <implementation name="IM_ceil_float_genglsl" nodedef="ND_ceil_float" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_color3_genglsl" nodedef="ND_ceil_color3" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_color4_genglsl" nodedef="ND_ceil_color4" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_vector2_genglsl" nodedef="ND_ceil_vector2" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_vector3_genglsl" nodedef="ND_ceil_vector3" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
-  <implementation name="IM_ceil_vector4_genglsl" nodedef="ND_ceil_vector4" file="libraries/stdlib/genglsl/mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_float_genglsl" nodedef="ND_ceil_float" file="mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_color3_genglsl" nodedef="ND_ceil_color3" file="mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_color4_genglsl" nodedef="ND_ceil_color4" file="mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_vector2_genglsl" nodedef="ND_ceil_vector2" file="mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_vector3_genglsl" nodedef="ND_ceil_vector3" file="mx_ceil.inline" target="genglsl" />
+  <implementation name="IM_ceil_vector4_genglsl" nodedef="ND_ceil_vector4" file="mx_ceil.inline" target="genglsl" />
 
   <!-- <power> -->
-  <implementation name="IM_power_float_genglsl" nodedef="ND_power_float" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_color3_genglsl" nodedef="ND_power_color3" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_color3FA_genglsl" nodedef="ND_power_color3FA" file="libraries/stdlib/genglsl/mx_power_color3_float.inline" target="genglsl" />
-  <implementation name="IM_power_color4_genglsl" nodedef="ND_power_color4" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_color4FA_genglsl" nodedef="ND_power_color4FA" file="libraries/stdlib/genglsl/mx_power_color4_float.inline" target="genglsl" />
-  <implementation name="IM_power_vector2_genglsl" nodedef="ND_power_vector2" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_vector2FA_genglsl" nodedef="ND_power_vector2FA" file="libraries/stdlib/genglsl/mx_power_vector2_float.inline" target="genglsl" />
-  <implementation name="IM_power_vector3_genglsl" nodedef="ND_power_vector3" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_vector3FA_genglsl" nodedef="ND_power_vector3FA" file="libraries/stdlib/genglsl/mx_power_vector3_float.inline" target="genglsl" />
-  <implementation name="IM_power_vector4_genglsl" nodedef="ND_power_vector4" file="libraries/stdlib/genglsl/mx_power.inline" target="genglsl" />
-  <implementation name="IM_power_vector4FA_genglsl" nodedef="ND_power_vector4FA" file="libraries/stdlib/genglsl/mx_power_vector4_float.inline" target="genglsl" />
+  <implementation name="IM_power_float_genglsl" nodedef="ND_power_float" file="mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_color3_genglsl" nodedef="ND_power_color3" file="mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_color3FA_genglsl" nodedef="ND_power_color3FA" file="mx_power_color3_float.inline" target="genglsl" />
+  <implementation name="IM_power_color4_genglsl" nodedef="ND_power_color4" file="mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_color4FA_genglsl" nodedef="ND_power_color4FA" file="mx_power_color4_float.inline" target="genglsl" />
+  <implementation name="IM_power_vector2_genglsl" nodedef="ND_power_vector2" file="mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_vector2FA_genglsl" nodedef="ND_power_vector2FA" file="mx_power_vector2_float.inline" target="genglsl" />
+  <implementation name="IM_power_vector3_genglsl" nodedef="ND_power_vector3" file="mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_vector3FA_genglsl" nodedef="ND_power_vector3FA" file="mx_power_vector3_float.inline" target="genglsl" />
+  <implementation name="IM_power_vector4_genglsl" nodedef="ND_power_vector4" file="mx_power.inline" target="genglsl" />
+  <implementation name="IM_power_vector4FA_genglsl" nodedef="ND_power_vector4FA" file="mx_power_vector4_float.inline" target="genglsl" />
 
   <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genglsl" nodedef="ND_sin_float" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_float_genglsl" nodedef="ND_cos_float" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
-  <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
-  <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
-  <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" file="libraries/stdlib/genglsl/mx_sin.inline" target="genglsl" />
-  <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" file="libraries/stdlib/genglsl/mx_cos.inline" target="genglsl" />
-  <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" file="libraries/stdlib/genglsl/mx_tan.inline" target="genglsl" />
-  <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" file="libraries/stdlib/genglsl/mx_asin.inline" target="genglsl" />
-  <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" file="libraries/stdlib/genglsl/mx_acos.inline" target="genglsl" />
-  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" file="libraries/stdlib/genglsl/mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_float_genglsl" nodedef="ND_sin_float" file="mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_float_genglsl" nodedef="ND_cos_float" file="mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" file="mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" file="mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" file="mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" file="mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" file="mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" file="mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" file="mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" file="mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" file="mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" file="mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" file="mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" file="mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" file="mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" file="mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" file="mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" file="mx_atan2.inline" target="genglsl" />
+  <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" file="mx_sin.inline" target="genglsl" />
+  <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" file="mx_cos.inline" target="genglsl" />
+  <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" file="mx_tan.inline" target="genglsl" />
+  <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" file="mx_asin.inline" target="genglsl" />
+  <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" file="mx_acos.inline" target="genglsl" />
+  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" file="mx_atan2.inline" target="genglsl" />
 
   <!-- <sqrt> -->
-  <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
-  <implementation name="IM_sqrt_vector2_genglsl" nodedef="ND_sqrt_vector2" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
-  <implementation name="IM_sqrt_vector3_genglsl" nodedef="ND_sqrt_vector3" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
-  <implementation name="IM_sqrt_vector4_genglsl" nodedef="ND_sqrt_vector4" file="libraries/stdlib/genglsl/mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" file="mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_vector2_genglsl" nodedef="ND_sqrt_vector2" file="mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_vector3_genglsl" nodedef="ND_sqrt_vector3" file="mx_sqrt.inline" target="genglsl" />
+  <implementation name="IM_sqrt_vector4_genglsl" nodedef="ND_sqrt_vector4" file="mx_sqrt.inline" target="genglsl" />
 
   <!-- <ln> -->
-  <implementation name="IM_ln_float_genglsl" nodedef="ND_ln_float" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
-  <implementation name="IM_ln_vector2_genglsl" nodedef="ND_ln_vector2" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
-  <implementation name="IM_ln_vector3_genglsl" nodedef="ND_ln_vector3" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
-  <implementation name="IM_ln_vector4_genglsl" nodedef="ND_ln_vector4" file="libraries/stdlib/genglsl/mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_float_genglsl" nodedef="ND_ln_float" file="mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_vector2_genglsl" nodedef="ND_ln_vector2" file="mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_vector3_genglsl" nodedef="ND_ln_vector3" file="mx_ln.inline" target="genglsl" />
+  <implementation name="IM_ln_vector4_genglsl" nodedef="ND_ln_vector4" file="mx_ln.inline" target="genglsl" />
 
   <!-- <exp> -->
-  <implementation name="IM_exp_float_genglsl" nodedef="ND_exp_float" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
-  <implementation name="IM_exp_vector2_genglsl" nodedef="ND_exp_vector2" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
-  <implementation name="IM_exp_vector3_genglsl" nodedef="ND_exp_vector3" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
-  <implementation name="IM_exp_vector4_genglsl" nodedef="ND_exp_vector4" file="libraries/stdlib/genglsl/mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_float_genglsl" nodedef="ND_exp_float" file="mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_vector2_genglsl" nodedef="ND_exp_vector2" file="mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_vector3_genglsl" nodedef="ND_exp_vector3" file="mx_exp.inline" target="genglsl" />
+  <implementation name="IM_exp_vector4_genglsl" nodedef="ND_exp_vector4" file="mx_exp.inline" target="genglsl" />
 
   <!-- sign -->
-  <implementation name="IM_sign_float_genglsl" nodedef="ND_sign_float" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_color3_genglsl" nodedef="ND_sign_color3" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_color4_genglsl" nodedef="ND_sign_color4" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_vector2_genglsl" nodedef="ND_sign_vector2" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_vector3_genglsl" nodedef="ND_sign_vector3" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
-  <implementation name="IM_sign_vector4_genglsl" nodedef="ND_sign_vector4" file="libraries/stdlib/genglsl/mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_float_genglsl" nodedef="ND_sign_float" file="mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_color3_genglsl" nodedef="ND_sign_color3" file="mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_color4_genglsl" nodedef="ND_sign_color4" file="mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_vector2_genglsl" nodedef="ND_sign_vector2" file="mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_vector3_genglsl" nodedef="ND_sign_vector3" file="mx_sign.inline" target="genglsl" />
+  <implementation name="IM_sign_vector4_genglsl" nodedef="ND_sign_vector4" file="mx_sign.inline" target="genglsl" />
 
   <!-- <clamp> -->
-  <implementation name="IM_clamp_float_genglsl" nodedef="ND_clamp_float" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color3_genglsl" nodedef="ND_clamp_color3" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color3FA_genglsl" nodedef="ND_clamp_color3FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color4_genglsl" nodedef="ND_clamp_color4" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_color4FA_genglsl" nodedef="ND_clamp_color4FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector2_genglsl" nodedef="ND_clamp_vector2" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector2FA_genglsl" nodedef="ND_clamp_vector2FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector3_genglsl" nodedef="ND_clamp_vector3" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector3FA_genglsl" nodedef="ND_clamp_vector3FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector4_genglsl" nodedef="ND_clamp_vector4" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
-  <implementation name="IM_clamp_vector4FA_genglsl" nodedef="ND_clamp_vector4FA" file="libraries/stdlib/genglsl/mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_float_genglsl" nodedef="ND_clamp_float" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color3_genglsl" nodedef="ND_clamp_color3" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color3FA_genglsl" nodedef="ND_clamp_color3FA" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color4_genglsl" nodedef="ND_clamp_color4" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_color4FA_genglsl" nodedef="ND_clamp_color4FA" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector2_genglsl" nodedef="ND_clamp_vector2" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector2FA_genglsl" nodedef="ND_clamp_vector2FA" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector3_genglsl" nodedef="ND_clamp_vector3" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector3FA_genglsl" nodedef="ND_clamp_vector3FA" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector4_genglsl" nodedef="ND_clamp_vector4" file="mx_clamp.inline" target="genglsl" />
+  <implementation name="IM_clamp_vector4FA_genglsl" nodedef="ND_clamp_vector4FA" file="mx_clamp.inline" target="genglsl" />
 
   <!-- <min> -->
-  <implementation name="IM_min_float_genglsl" nodedef="ND_min_float" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color3_genglsl" nodedef="ND_min_color3" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color3FA_genglsl" nodedef="ND_min_color3FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color4_genglsl" nodedef="ND_min_color4" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_color4FA_genglsl" nodedef="ND_min_color4FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector2_genglsl" nodedef="ND_min_vector2" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector2FA_genglsl" nodedef="ND_min_vector2FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector3_genglsl" nodedef="ND_min_vector3" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector3FA_genglsl" nodedef="ND_min_vector3FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector4_genglsl" nodedef="ND_min_vector4" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
-  <implementation name="IM_min_vector4FA_genglsl" nodedef="ND_min_vector4FA" file="libraries/stdlib/genglsl/mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_float_genglsl" nodedef="ND_min_float" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color3_genglsl" nodedef="ND_min_color3" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color3FA_genglsl" nodedef="ND_min_color3FA" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color4_genglsl" nodedef="ND_min_color4" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_color4FA_genglsl" nodedef="ND_min_color4FA" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector2_genglsl" nodedef="ND_min_vector2" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector2FA_genglsl" nodedef="ND_min_vector2FA" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector3_genglsl" nodedef="ND_min_vector3" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector3FA_genglsl" nodedef="ND_min_vector3FA" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector4_genglsl" nodedef="ND_min_vector4" file="mx_min.inline" target="genglsl" />
+  <implementation name="IM_min_vector4FA_genglsl" nodedef="ND_min_vector4FA" file="mx_min.inline" target="genglsl" />
 
   <!-- <max> -->
-  <implementation name="IM_max_float_genglsl" nodedef="ND_max_float" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color3_genglsl" nodedef="ND_max_color3" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color3FA_genglsl" nodedef="ND_max_color3FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color4_genglsl" nodedef="ND_max_color4" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_color4FA_genglsl" nodedef="ND_max_color4FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector2_genglsl" nodedef="ND_max_vector2" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector2FA_genglsl" nodedef="ND_max_vector2FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector3_genglsl" nodedef="ND_max_vector3" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector3FA_genglsl" nodedef="ND_max_vector3FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector4_genglsl" nodedef="ND_max_vector4" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
-  <implementation name="IM_max_vector4FA_genglsl" nodedef="ND_max_vector4FA" file="libraries/stdlib/genglsl/mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_float_genglsl" nodedef="ND_max_float" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color3_genglsl" nodedef="ND_max_color3" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color3FA_genglsl" nodedef="ND_max_color3FA" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color4_genglsl" nodedef="ND_max_color4" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_color4FA_genglsl" nodedef="ND_max_color4FA" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector2_genglsl" nodedef="ND_max_vector2" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector2FA_genglsl" nodedef="ND_max_vector2FA" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector3_genglsl" nodedef="ND_max_vector3" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector3FA_genglsl" nodedef="ND_max_vector3FA" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector4_genglsl" nodedef="ND_max_vector4" file="mx_max.inline" target="genglsl" />
+  <implementation name="IM_max_vector4FA_genglsl" nodedef="ND_max_vector4FA" file="mx_max.inline" target="genglsl" />
 
   <!-- <normalize> -->
-  <implementation name="IM_normalize_vector2_genglsl" nodedef="ND_normalize_vector2" file="libraries/stdlib/genglsl/mx_normalize.inline" target="genglsl" />
-  <implementation name="IM_normalize_vector3_genglsl" nodedef="ND_normalize_vector3" file="libraries/stdlib/genglsl/mx_normalize.inline" target="genglsl" />
-  <implementation name="IM_normalize_vector4_genglsl" nodedef="ND_normalize_vector4" file="libraries/stdlib/genglsl/mx_normalize.inline" target="genglsl" />
+  <implementation name="IM_normalize_vector2_genglsl" nodedef="ND_normalize_vector2" file="mx_normalize.inline" target="genglsl" />
+  <implementation name="IM_normalize_vector3_genglsl" nodedef="ND_normalize_vector3" file="mx_normalize.inline" target="genglsl" />
+  <implementation name="IM_normalize_vector4_genglsl" nodedef="ND_normalize_vector4" file="mx_normalize.inline" target="genglsl" />
 
   <!-- <magnitude> -->
-  <implementation name="IM_magnitude_vector2_genglsl" nodedef="ND_magnitude_vector2" file="libraries/stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
-  <implementation name="IM_magnitude_vector3_genglsl" nodedef="ND_magnitude_vector3" file="libraries/stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
-  <implementation name="IM_magnitude_vector4_genglsl" nodedef="ND_magnitude_vector4" file="libraries/stdlib/genglsl/mx_magnitude.inline" target="genglsl" />
+  <implementation name="IM_magnitude_vector2_genglsl" nodedef="ND_magnitude_vector2" file="mx_magnitude.inline" target="genglsl" />
+  <implementation name="IM_magnitude_vector3_genglsl" nodedef="ND_magnitude_vector3" file="mx_magnitude.inline" target="genglsl" />
+  <implementation name="IM_magnitude_vector4_genglsl" nodedef="ND_magnitude_vector4" file="mx_magnitude.inline" target="genglsl" />
 
   <!-- <dotproduct> -->
-  <implementation name="IM_dotproduct_vector2_genglsl" nodedef="ND_dotproduct_vector2" file="libraries/stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
-  <implementation name="IM_dotproduct_vector3_genglsl" nodedef="ND_dotproduct_vector3" file="libraries/stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
-  <implementation name="IM_dotproduct_vector4_genglsl" nodedef="ND_dotproduct_vector4" file="libraries/stdlib/genglsl/mx_dotproduct.inline" target="genglsl" />
+  <implementation name="IM_dotproduct_vector2_genglsl" nodedef="ND_dotproduct_vector2" file="mx_dotproduct.inline" target="genglsl" />
+  <implementation name="IM_dotproduct_vector3_genglsl" nodedef="ND_dotproduct_vector3" file="mx_dotproduct.inline" target="genglsl" />
+  <implementation name="IM_dotproduct_vector4_genglsl" nodedef="ND_dotproduct_vector4" file="mx_dotproduct.inline" target="genglsl" />
 
   <!-- <crossproduct> -->
-  <implementation name="IM_crossproduct_vector3_genglsl" nodedef="ND_crossproduct_vector3" file="libraries/stdlib/genglsl/mx_crossproduct.inline" target="genglsl" />
+  <implementation name="IM_crossproduct_vector3_genglsl" nodedef="ND_crossproduct_vector3" file="mx_crossproduct.inline" target="genglsl" />
 
   <!-- <transformpoint> -->
   <implementation name="IM_transformpoint_vector3_genglsl" nodedef="ND_transformpoint_vector3" target="genglsl" />
@@ -451,28 +451,28 @@
   <implementation name="IM_transformnormal_vector3_genglsl" nodedef="ND_transformnormal_vector3" target="genglsl" />
 
   <!-- <transformmatrix> -->
-  <implementation name="IM_transformmatrix_vector2M3_genglsl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="libraries/stdlib/genglsl/mx_transformmatrix_vector2M3.glsl" target="genglsl" />
-  <implementation name="IM_transformmatrix_vector3_genglsl" nodedef="ND_transformmatrix_vector3" file="libraries/stdlib/genglsl/mx_transformmatrix.inline" target="genglsl" />
-  <implementation name="IM_transformmatrix_vector3M4_genglsl" nodedef="ND_transformmatrix_vector3M4" function="mx_transformmatrix_vector3M4" file="libraries/stdlib/genglsl/mx_transformmatrix_vector3M4.glsl" target="genglsl" />
-  <implementation name="IM_transformmatrix_vector4_genglsl" nodedef="ND_transformmatrix_vector4" file="libraries/stdlib/genglsl/mx_transformmatrix.inline" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector2M3_genglsl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="mx_transformmatrix_vector2M3.glsl" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector3_genglsl" nodedef="ND_transformmatrix_vector3" file="mx_transformmatrix.inline" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector3M4_genglsl" nodedef="ND_transformmatrix_vector3M4" function="mx_transformmatrix_vector3M4" file="mx_transformmatrix_vector3M4.glsl" target="genglsl" />
+  <implementation name="IM_transformmatrix_vector4_genglsl" nodedef="ND_transformmatrix_vector4" file="mx_transformmatrix.inline" target="genglsl" />
 
   <!-- <transpose> -->
-  <implementation name="IM_transpose_matrix33_genglsl" nodedef="ND_transpose_matrix33" file="libraries/stdlib/genglsl/mx_transpose.inline" target="genglsl" />
-  <implementation name="IM_transpose_matrix44_genglsl" nodedef="ND_transpose_matrix44" file="libraries/stdlib/genglsl/mx_transpose.inline" target="genglsl" />
+  <implementation name="IM_transpose_matrix33_genglsl" nodedef="ND_transpose_matrix33" file="mx_transpose.inline" target="genglsl" />
+  <implementation name="IM_transpose_matrix44_genglsl" nodedef="ND_transpose_matrix44" file="mx_transpose.inline" target="genglsl" />
 
   <!-- <determinant> -->
-  <implementation name="IM_determinant_matrix33_genglsl" nodedef="ND_determinant_matrix33" file="libraries/stdlib/genglsl/mx_determinant.inline" target="genglsl" />
-  <implementation name="IM_determinant_matrix44_genglsl" nodedef="ND_determinant_matrix44" file="libraries/stdlib/genglsl/mx_determinant.inline" target="genglsl" />
+  <implementation name="IM_determinant_matrix33_genglsl" nodedef="ND_determinant_matrix33" file="mx_determinant.inline" target="genglsl" />
+  <implementation name="IM_determinant_matrix44_genglsl" nodedef="ND_determinant_matrix44" file="mx_determinant.inline" target="genglsl" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genglsl" nodedef="ND_invertmatrix_matrix33" file="libraries/stdlib/genglsl/mx_invertM.inline" target="genglsl" />
-  <implementation name="IM_invertmatrix_matrix44_genglsl" nodedef="ND_invertmatrix_matrix44" file="libraries/stdlib/genglsl/mx_invertM.inline" target="genglsl" />
+  <implementation name="IM_invertmatrix_matrix33_genglsl" nodedef="ND_invertmatrix_matrix33" file="mx_invertM.inline" target="genglsl" />
+  <implementation name="IM_invertmatrix_matrix44_genglsl" nodedef="ND_invertmatrix_matrix44" file="mx_invertM.inline" target="genglsl" />
 
   <!-- <rotate2d> -->
-  <implementation name="IM_rotate2d_vector2_genglsl" nodedef="ND_rotate2d_vector2" file="libraries/stdlib/genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genglsl" />
+  <implementation name="IM_rotate2d_vector2_genglsl" nodedef="ND_rotate2d_vector2" file="mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genglsl" />
 
   <!-- <rotate3d> -->
-  <implementation name="IM_rotate3d_vector3_genglsl" nodedef="ND_rotate3d_vector3" file="libraries/stdlib/genglsl/mx_rotate_vector3.glsl" function="mx_rotate_vector3" target="genglsl" />
+  <implementation name="IM_rotate3d_vector3_genglsl" nodedef="ND_rotate3d_vector3" file="mx_rotate_vector3.glsl" function="mx_rotate_vector3" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
@@ -481,124 +481,124 @@
   <!-- <contrast> -->
 
   <!-- <remap> -->
-  <implementation name="IM_remap_float_genglsl" nodedef="ND_remap_float" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color3_genglsl" nodedef="ND_remap_color3" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color3FA_genglsl" nodedef="ND_remap_color3FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color4_genglsl" nodedef="ND_remap_color4" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_color4FA_genglsl" nodedef="ND_remap_color4FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector2_genglsl" nodedef="ND_remap_vector2" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector2FA_genglsl" nodedef="ND_remap_vector2FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector3_genglsl" nodedef="ND_remap_vector3" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector3FA_genglsl" nodedef="ND_remap_vector3FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector4_genglsl" nodedef="ND_remap_vector4" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
-  <implementation name="IM_remap_vector4FA_genglsl" nodedef="ND_remap_vector4FA" file="libraries/stdlib/genglsl/mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_float_genglsl" nodedef="ND_remap_float" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color3_genglsl" nodedef="ND_remap_color3" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color3FA_genglsl" nodedef="ND_remap_color3FA" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color4_genglsl" nodedef="ND_remap_color4" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_color4FA_genglsl" nodedef="ND_remap_color4FA" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector2_genglsl" nodedef="ND_remap_vector2" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector2FA_genglsl" nodedef="ND_remap_vector2FA" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector3_genglsl" nodedef="ND_remap_vector3" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector3FA_genglsl" nodedef="ND_remap_vector3FA" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector4_genglsl" nodedef="ND_remap_vector4" file="mx_remap.inline" target="genglsl" />
+  <implementation name="IM_remap_vector4FA_genglsl" nodedef="ND_remap_vector4FA" file="mx_remap.inline" target="genglsl" />
 
   <!-- <smoothstep> -->
-  <implementation name="IM_smoothstep_float_genglsl" nodedef="ND_smoothstep_float" file="libraries/stdlib/genglsl/mx_smoothstep_float.glsl" function="mx_smoothstep_float" target="genglsl" />
-  <implementation name="IM_smoothstep_color3_genglsl" nodedef="ND_smoothstep_color3" file="libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
-  <implementation name="IM_smoothstep_color3FA_genglsl" nodedef="ND_smoothstep_color3FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
-  <implementation name="IM_smoothstep_color4_genglsl" nodedef="ND_smoothstep_color4" file="libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
-  <implementation name="IM_smoothstep_color4FA_genglsl" nodedef="ND_smoothstep_color4FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
-  <implementation name="IM_smoothstep_vector2_genglsl" nodedef="ND_smoothstep_vector2" file="libraries/stdlib/genglsl/mx_smoothstep_vec2.glsl" function="mx_smoothstep_vec2" target="genglsl" />
-  <implementation name="IM_smoothstep_vector2FA_genglsl" nodedef="ND_smoothstep_vector2FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec2FA.glsl" function="mx_smoothstep_vec2FA" target="genglsl" />
-  <implementation name="IM_smoothstep_vector3_genglsl" nodedef="ND_smoothstep_vector3" file="libraries/stdlib/genglsl/mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
-  <implementation name="IM_smoothstep_vector3FA_genglsl" nodedef="ND_smoothstep_vector3FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
-  <implementation name="IM_smoothstep_vector4_genglsl" nodedef="ND_smoothstep_vector4" file="libraries/stdlib/genglsl/mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
-  <implementation name="IM_smoothstep_vector4FA_genglsl" nodedef="ND_smoothstep_vector4FA" file="libraries/stdlib/genglsl/mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
+  <implementation name="IM_smoothstep_float_genglsl" nodedef="ND_smoothstep_float" file="mx_smoothstep_float.glsl" function="mx_smoothstep_float" target="genglsl" />
+  <implementation name="IM_smoothstep_color3_genglsl" nodedef="ND_smoothstep_color3" file="mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
+  <implementation name="IM_smoothstep_color3FA_genglsl" nodedef="ND_smoothstep_color3FA" file="mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
+  <implementation name="IM_smoothstep_color4_genglsl" nodedef="ND_smoothstep_color4" file="mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
+  <implementation name="IM_smoothstep_color4FA_genglsl" nodedef="ND_smoothstep_color4FA" file="mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
+  <implementation name="IM_smoothstep_vector2_genglsl" nodedef="ND_smoothstep_vector2" file="mx_smoothstep_vec2.glsl" function="mx_smoothstep_vec2" target="genglsl" />
+  <implementation name="IM_smoothstep_vector2FA_genglsl" nodedef="ND_smoothstep_vector2FA" file="mx_smoothstep_vec2FA.glsl" function="mx_smoothstep_vec2FA" target="genglsl" />
+  <implementation name="IM_smoothstep_vector3_genglsl" nodedef="ND_smoothstep_vector3" file="mx_smoothstep_vec3.glsl" function="mx_smoothstep_vec3" target="genglsl" />
+  <implementation name="IM_smoothstep_vector3FA_genglsl" nodedef="ND_smoothstep_vector3FA" file="mx_smoothstep_vec3FA.glsl" function="mx_smoothstep_vec3FA" target="genglsl" />
+  <implementation name="IM_smoothstep_vector4_genglsl" nodedef="ND_smoothstep_vector4" file="mx_smoothstep_vec4.glsl" function="mx_smoothstep_vec4" target="genglsl" />
+  <implementation name="IM_smoothstep_vector4FA_genglsl" nodedef="ND_smoothstep_vector4FA" file="mx_smoothstep_vec4FA.glsl" function="mx_smoothstep_vec4FA" target="genglsl" />
 
   <!-- <luminance> -->
-  <implementation name="IM_luminance_color3_genglsl" nodedef="ND_luminance_color3" file="libraries/stdlib/genglsl/mx_luminance_color3.glsl" function="mx_luminance_color3" target="genglsl" />
-  <implementation name="IM_luminance_color4_genglsl" nodedef="ND_luminance_color4" file="libraries/stdlib/genglsl/mx_luminance_color4.glsl" function="mx_luminance_color4" target="genglsl" />
+  <implementation name="IM_luminance_color3_genglsl" nodedef="ND_luminance_color3" file="mx_luminance_color3.glsl" function="mx_luminance_color3" target="genglsl" />
+  <implementation name="IM_luminance_color4_genglsl" nodedef="ND_luminance_color4" file="mx_luminance_color4.glsl" function="mx_luminance_color4" target="genglsl" />
 
   <!-- <rgbtohsv> -->
-  <implementation name="IM_rgbtohsv_color3_genglsl" nodedef="ND_rgbtohsv_color3" file="libraries/stdlib/genglsl/mx_rgbtohsv_color3.glsl" function="mx_rgbtohsv_color3" target="genglsl" />
-  <implementation name="IM_rgbtohsv_color4_genglsl" nodedef="ND_rgbtohsv_color4" file="libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl" function="mx_rgbtohsv_color4" target="genglsl" />
+  <implementation name="IM_rgbtohsv_color3_genglsl" nodedef="ND_rgbtohsv_color3" file="mx_rgbtohsv_color3.glsl" function="mx_rgbtohsv_color3" target="genglsl" />
+  <implementation name="IM_rgbtohsv_color4_genglsl" nodedef="ND_rgbtohsv_color4" file="mx_rgbtohsv_color4.glsl" function="mx_rgbtohsv_color4" target="genglsl" />
 
   <!-- <hsvtorgb> -->
-  <implementation name="IM_hsvtorgb_color3_genglsl" nodedef="ND_hsvtorgb_color3" file="libraries/stdlib/genglsl/mx_hsvtorgb_color3.glsl" function="mx_hsvtorgb_color3" target="genglsl" />
-  <implementation name="IM_hsvtorgb_color4_genglsl" nodedef="ND_hsvtorgb_color4" file="libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl" function="mx_hsvtorgb_color4" target="genglsl" />
+  <implementation name="IM_hsvtorgb_color3_genglsl" nodedef="ND_hsvtorgb_color3" file="mx_hsvtorgb_color3.glsl" function="mx_hsvtorgb_color3" target="genglsl" />
+  <implementation name="IM_hsvtorgb_color4_genglsl" nodedef="ND_hsvtorgb_color4" file="mx_hsvtorgb_color4.glsl" function="mx_hsvtorgb_color4" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->
   <!-- ======================================================================== -->
 
   <!-- <premult> -->
-  <implementation name="IM_premult_color4_genglsl" nodedef="ND_premult_color4" file="libraries/stdlib/genglsl/mx_premult_color4.glsl" function="mx_premult_color4" target="genglsl" />
+  <implementation name="IM_premult_color4_genglsl" nodedef="ND_premult_color4" file="mx_premult_color4.glsl" function="mx_premult_color4" target="genglsl" />
 
   <!-- <unpremult> -->
-  <implementation name="IM_unpremult_color4_genglsl" nodedef="ND_unpremult_color4" file="libraries/stdlib/genglsl/mx_unpremult_color4.glsl" function="mx_unpremult_color4" target="genglsl" />
+  <implementation name="IM_unpremult_color4_genglsl" nodedef="ND_unpremult_color4" file="mx_unpremult_color4.glsl" function="mx_unpremult_color4" target="genglsl" />
 
   <!-- <plus> -->
-  <implementation name="IM_plus_float_genglsl" nodedef="ND_plus_float" file="libraries/stdlib/genglsl/mx_plus.inline" target="genglsl" />
-  <implementation name="IM_plus_color3_genglsl" nodedef="ND_plus_color3" file="libraries/stdlib/genglsl/mx_plus.inline" target="genglsl" />
-  <implementation name="IM_plus_color4_genglsl" nodedef="ND_plus_color4" file="libraries/stdlib/genglsl/mx_plus.inline" target="genglsl" />
+  <implementation name="IM_plus_float_genglsl" nodedef="ND_plus_float" file="mx_plus.inline" target="genglsl" />
+  <implementation name="IM_plus_color3_genglsl" nodedef="ND_plus_color3" file="mx_plus.inline" target="genglsl" />
+  <implementation name="IM_plus_color4_genglsl" nodedef="ND_plus_color4" file="mx_plus.inline" target="genglsl" />
 
   <!-- <minus> -->
-  <implementation name="IM_minus_float_genglsl" nodedef="ND_minus_float" file="libraries/stdlib/genglsl/mx_minus.inline" target="genglsl" />
-  <implementation name="IM_minus_color3_genglsl" nodedef="ND_minus_color3" file="libraries/stdlib/genglsl/mx_minus.inline" target="genglsl" />
-  <implementation name="IM_minus_color4_genglsl" nodedef="ND_minus_color4" file="libraries/stdlib/genglsl/mx_minus.inline" target="genglsl" />
+  <implementation name="IM_minus_float_genglsl" nodedef="ND_minus_float" file="mx_minus.inline" target="genglsl" />
+  <implementation name="IM_minus_color3_genglsl" nodedef="ND_minus_color3" file="mx_minus.inline" target="genglsl" />
+  <implementation name="IM_minus_color4_genglsl" nodedef="ND_minus_color4" file="mx_minus.inline" target="genglsl" />
 
   <!-- <difference> -->
-  <implementation name="IM_difference_float_genglsl" nodedef="ND_difference_float" file="libraries/stdlib/genglsl/mx_difference.inline" target="genglsl" />
-  <implementation name="IM_difference_color3_genglsl" nodedef="ND_difference_color3" file="libraries/stdlib/genglsl/mx_difference.inline" target="genglsl" />
-  <implementation name="IM_difference_color4_genglsl" nodedef="ND_difference_color4" file="libraries/stdlib/genglsl/mx_difference.inline" target="genglsl" />
+  <implementation name="IM_difference_float_genglsl" nodedef="ND_difference_float" file="mx_difference.inline" target="genglsl" />
+  <implementation name="IM_difference_color3_genglsl" nodedef="ND_difference_color3" file="mx_difference.inline" target="genglsl" />
+  <implementation name="IM_difference_color4_genglsl" nodedef="ND_difference_color4" file="mx_difference.inline" target="genglsl" />
 
   <!-- <burn> -->
-  <implementation name="IM_burn_float_genglsl" nodedef="ND_burn_float" file="libraries/stdlib/genglsl/mx_burn_float.glsl" function="mx_burn_float" target="genglsl" />
-  <implementation name="IM_burn_color3_genglsl" nodedef="ND_burn_color3" file="libraries/stdlib/genglsl/mx_burn_color3.glsl" function="mx_burn_color3" target="genglsl" />
-  <implementation name="IM_burn_color4_genglsl" nodedef="ND_burn_color4" file="libraries/stdlib/genglsl/mx_burn_color4.glsl" function="mx_burn_color4" target="genglsl" />
+  <implementation name="IM_burn_float_genglsl" nodedef="ND_burn_float" file="mx_burn_float.glsl" function="mx_burn_float" target="genglsl" />
+  <implementation name="IM_burn_color3_genglsl" nodedef="ND_burn_color3" file="mx_burn_color3.glsl" function="mx_burn_color3" target="genglsl" />
+  <implementation name="IM_burn_color4_genglsl" nodedef="ND_burn_color4" file="mx_burn_color4.glsl" function="mx_burn_color4" target="genglsl" />
 
   <!-- <dodge> -->
-  <implementation name="IM_dodge_float_genglsl" nodedef="ND_dodge_float" file="libraries/stdlib/genglsl/mx_dodge_float.glsl" function="mx_dodge_float" target="genglsl" />
-  <implementation name="IM_dodge_color3_genglsl" nodedef="ND_dodge_color3" file="libraries/stdlib/genglsl/mx_dodge_color3.glsl" function="mx_dodge_color3" target="genglsl" />
-  <implementation name="IM_dodge_color4_genglsl" nodedef="ND_dodge_color4" file="libraries/stdlib/genglsl/mx_dodge_color4.glsl" function="mx_dodge_color4" target="genglsl" />
+  <implementation name="IM_dodge_float_genglsl" nodedef="ND_dodge_float" file="mx_dodge_float.glsl" function="mx_dodge_float" target="genglsl" />
+  <implementation name="IM_dodge_color3_genglsl" nodedef="ND_dodge_color3" file="mx_dodge_color3.glsl" function="mx_dodge_color3" target="genglsl" />
+  <implementation name="IM_dodge_color4_genglsl" nodedef="ND_dodge_color4" file="mx_dodge_color4.glsl" function="mx_dodge_color4" target="genglsl" />
 
   <!-- <screen> -->
-  <implementation name="IM_screen_float_genglsl" nodedef="ND_screen_float" file="libraries/stdlib/genglsl/mx_screen.inline" target="genglsl" />
-  <implementation name="IM_screen_color3_genglsl" nodedef="ND_screen_color3" file="libraries/stdlib/genglsl/mx_screen.inline" target="genglsl" />
-  <implementation name="IM_screen_color4_genglsl" nodedef="ND_screen_color4" file="libraries/stdlib/genglsl/mx_screen.inline" target="genglsl" />
+  <implementation name="IM_screen_float_genglsl" nodedef="ND_screen_float" file="mx_screen.inline" target="genglsl" />
+  <implementation name="IM_screen_color3_genglsl" nodedef="ND_screen_color3" file="mx_screen.inline" target="genglsl" />
+  <implementation name="IM_screen_color4_genglsl" nodedef="ND_screen_color4" file="mx_screen.inline" target="genglsl" />
 
   <!-- <overlay> -->
-  <implementation name="IM_overlay_float_genglsl" nodedef="ND_overlay_float" file="libraries/stdlib/genglsl/mx_overlay_float.inline" target="genglsl" />
-  <implementation name="IM_overlay_color3_genglsl" nodedef="ND_overlay_color3" file="libraries/stdlib/genglsl/mx_overlay_color3.glsl" function="mx_overlay_color3" target="genglsl" />
-  <implementation name="IM_overlay_color4_genglsl" nodedef="ND_overlay_color4" file="libraries/stdlib/genglsl/mx_overlay_color4.glsl" function="mx_overlay_color4" target="genglsl" />
+  <implementation name="IM_overlay_float_genglsl" nodedef="ND_overlay_float" file="mx_overlay_float.inline" target="genglsl" />
+  <implementation name="IM_overlay_color3_genglsl" nodedef="ND_overlay_color3" file="mx_overlay_color3.glsl" function="mx_overlay_color3" target="genglsl" />
+  <implementation name="IM_overlay_color4_genglsl" nodedef="ND_overlay_color4" file="mx_overlay_color4.glsl" function="mx_overlay_color4" target="genglsl" />
 
   <!-- <disjointover> -->
-  <implementation name="IM_disjointover_color4_genglsl" nodedef="ND_disjointover_color4" file="libraries/stdlib/genglsl/mx_disjointover_color4.glsl" function="mx_disjointover_color4" target="genglsl" />
+  <implementation name="IM_disjointover_color4_genglsl" nodedef="ND_disjointover_color4" file="mx_disjointover_color4.glsl" function="mx_disjointover_color4" target="genglsl" />
 
   <!-- <in> -->
-  <implementation name="IM_in_color4_genglsl" nodedef="ND_in_color4" file="libraries/stdlib/genglsl/mx_in_color4.inline" target="genglsl" />
+  <implementation name="IM_in_color4_genglsl" nodedef="ND_in_color4" file="mx_in_color4.inline" target="genglsl" />
 
   <!-- <mask> -->
-  <implementation name="IM_mask_color4_genglsl" nodedef="ND_mask_color4" file="libraries/stdlib/genglsl/mx_mask_color4.inline" target="genglsl" />
+  <implementation name="IM_mask_color4_genglsl" nodedef="ND_mask_color4" file="mx_mask_color4.inline" target="genglsl" />
 
   <!-- <matte> -->
-  <implementation name="IM_matte_color4_genglsl" nodedef="ND_matte_color4" file="libraries/stdlib/genglsl/mx_matte_color4.inline" target="genglsl" />
+  <implementation name="IM_matte_color4_genglsl" nodedef="ND_matte_color4" file="mx_matte_color4.inline" target="genglsl" />
 
   <!-- <out> -->
-  <implementation name="IM_out_color4_genglsl" nodedef="ND_out_color4" file="libraries/stdlib/genglsl/mx_out_color4.inline" target="genglsl" />
+  <implementation name="IM_out_color4_genglsl" nodedef="ND_out_color4" file="mx_out_color4.inline" target="genglsl" />
 
   <!-- <over> -->
-  <implementation name="IM_over_color4_genglsl" nodedef="ND_over_color4" file="libraries/stdlib/genglsl/mx_over_color4.inline" target="genglsl" />
+  <implementation name="IM_over_color4_genglsl" nodedef="ND_over_color4" file="mx_over_color4.inline" target="genglsl" />
 
   <!-- <inside> -->
-  <implementation name="IM_inside_float_genglsl" nodedef="ND_inside_float" file="libraries/stdlib/genglsl/mx_inside.inline" target="genglsl" />
-  <implementation name="IM_inside_color3_genglsl" nodedef="ND_inside_color3" file="libraries/stdlib/genglsl/mx_inside.inline" target="genglsl" />
-  <implementation name="IM_inside_color4_genglsl" nodedef="ND_inside_color4" file="libraries/stdlib/genglsl/mx_inside.inline" target="genglsl" />
+  <implementation name="IM_inside_float_genglsl" nodedef="ND_inside_float" file="mx_inside.inline" target="genglsl" />
+  <implementation name="IM_inside_color3_genglsl" nodedef="ND_inside_color3" file="mx_inside.inline" target="genglsl" />
+  <implementation name="IM_inside_color4_genglsl" nodedef="ND_inside_color4" file="mx_inside.inline" target="genglsl" />
 
   <!-- <outside> -->
-  <implementation name="IM_outside_float_genglsl" nodedef="ND_outside_float" file="libraries/stdlib/genglsl/mx_outside.inline" target="genglsl" />
-  <implementation name="IM_outside_color3_genglsl" nodedef="ND_outside_color3" file="libraries/stdlib/genglsl/mx_outside.inline" target="genglsl" />
-  <implementation name="IM_outside_color4_genglsl" nodedef="ND_outside_color4" file="libraries/stdlib/genglsl/mx_outside.inline" target="genglsl" />
+  <implementation name="IM_outside_float_genglsl" nodedef="ND_outside_float" file="mx_outside.inline" target="genglsl" />
+  <implementation name="IM_outside_color3_genglsl" nodedef="ND_outside_color3" file="mx_outside.inline" target="genglsl" />
+  <implementation name="IM_outside_color4_genglsl" nodedef="ND_outside_color4" file="mx_outside.inline" target="genglsl" />
 
   <!-- <mix> -->
-  <implementation name="IM_mix_float_genglsl" nodedef="ND_mix_float" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_color3_genglsl" nodedef="ND_mix_color3" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_color4_genglsl" nodedef="ND_mix_color4" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_vector2_genglsl" nodedef="ND_mix_vector2" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_vector3_genglsl" nodedef="ND_mix_vector3" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_vector4_genglsl" nodedef="ND_mix_vector4" file="libraries/stdlib/genglsl/mx_mix.inline" target="genglsl" />
-  <implementation name="IM_mix_surfaceshader_genglsl" nodedef="ND_mix_surfaceshader" function="mx_mix_surfaceshader" file="libraries/stdlib/genglsl/mx_mix_surfaceshader.glsl" target="genglsl" />
+  <implementation name="IM_mix_float_genglsl" nodedef="ND_mix_float" file="mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_color3_genglsl" nodedef="ND_mix_color3" file="mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_color4_genglsl" nodedef="ND_mix_color4" file="mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_vector2_genglsl" nodedef="ND_mix_vector2" file="mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_vector3_genglsl" nodedef="ND_mix_vector3" file="mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_vector4_genglsl" nodedef="ND_mix_vector4" file="mx_mix.inline" target="genglsl" />
+  <implementation name="IM_mix_surfaceshader_genglsl" nodedef="ND_mix_surfaceshader" function="mx_mix_surfaceshader" file="mx_mix_surfaceshader.glsl" target="genglsl" />
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
@@ -766,21 +766,21 @@
   <!-- ======================================================================== -->
 
   <!-- <dot> -->
-  <implementation name="IM_dot_float_genglsl" nodedef="ND_dot_float" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_color3_genglsl" nodedef="ND_dot_color3" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_color4_genglsl" nodedef="ND_dot_color4" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_vector2_genglsl" nodedef="ND_dot_vector2" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_vector3_genglsl" nodedef="ND_dot_vector3" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_vector4_genglsl" nodedef="ND_dot_vector4" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_integer_genglsl" nodedef="ND_dot_integer" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_boolean_genglsl" nodedef="ND_dot_boolean" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_matrix33_genglsl" nodedef="ND_dot_matrix33" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_matrix44_genglsl" nodedef="ND_dot_matrix44" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_string_genglsl" nodedef="ND_dot_string" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_filename_genglsl" nodedef="ND_dot_filename" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_surfaceshader_genglsl" nodedef="ND_dot_surfaceshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_displacementshader_genglsl" nodedef="ND_dot_displacementshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_volumeshader_genglsl" nodedef="ND_dot_volumeshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
-  <implementation name="IM_dot_lightshader_genglsl" nodedef="ND_dot_lightshader" file="libraries/stdlib/genglsl/mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_float_genglsl" nodedef="ND_dot_float" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_color3_genglsl" nodedef="ND_dot_color3" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_color4_genglsl" nodedef="ND_dot_color4" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_vector2_genglsl" nodedef="ND_dot_vector2" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_vector3_genglsl" nodedef="ND_dot_vector3" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_vector4_genglsl" nodedef="ND_dot_vector4" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_integer_genglsl" nodedef="ND_dot_integer" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_boolean_genglsl" nodedef="ND_dot_boolean" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_matrix33_genglsl" nodedef="ND_dot_matrix33" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_matrix44_genglsl" nodedef="ND_dot_matrix44" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_string_genglsl" nodedef="ND_dot_string" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_filename_genglsl" nodedef="ND_dot_filename" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_surfaceshader_genglsl" nodedef="ND_dot_surfaceshader" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_displacementshader_genglsl" nodedef="ND_dot_displacementshader" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_volumeshader_genglsl" nodedef="ND_dot_volumeshader" file="mx_dot.inline" target="genglsl" />
+  <implementation name="IM_dot_lightshader_genglsl" nodedef="ND_dot_lightshader" file="mx_dot.inline" target="genglsl" />
 
 </materialx>

--- a/libraries/stdlib/genosl/mx_burn_color3.osl
+++ b/libraries/stdlib/genosl/mx_burn_color3.osl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genosl/mx_burn_float.osl"
+#include "mx_burn_float.osl"
 
 void mx_burn_color3(color fg, color bg, float mix, output color result)
 {

--- a/libraries/stdlib/genosl/mx_burn_color4.osl
+++ b/libraries/stdlib/genosl/mx_burn_color4.osl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genosl/mx_burn_float.osl"
+#include "mx_burn_float.osl"
 
 void mx_burn_color4(color4 fg, color4 bg, float mix, output color4 result)
 {

--- a/libraries/stdlib/genosl/mx_dodge_color3.osl
+++ b/libraries/stdlib/genosl/mx_dodge_color3.osl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genosl/mx_dodge_float.osl"
+#include "mx_dodge_float.osl"
 
 void mx_dodge_color3(color fg, color bg, float mix, output color result)
 {

--- a/libraries/stdlib/genosl/mx_dodge_color4.osl
+++ b/libraries/stdlib/genosl/mx_dodge_color4.osl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genosl/mx_dodge_float.osl"
+#include "mx_dodge_float.osl"
 
 void mx_dodge_color4(color4 fg , color4 bg , float mix , output color4 result)
 {

--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_color3(textureresource file, string layer, color default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output color out)
 {

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_color4(textureresource file, string layer, color4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output color4 out)
 {

--- a/libraries/stdlib/genosl/mx_image_float.osl
+++ b/libraries/stdlib/genosl/mx_image_float.osl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_float(textureresource file, string layer, float default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output float out)
 {

--- a/libraries/stdlib/genosl/mx_image_vector2.osl
+++ b/libraries/stdlib/genosl/mx_image_vector2.osl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_vector2(textureresource file, string layer, vector2 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector2 out)
 {

--- a/libraries/stdlib/genosl/mx_image_vector3.osl
+++ b/libraries/stdlib/genosl/mx_image_vector3.osl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_vector3(textureresource file, string layer, vector default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector out)
 {

--- a/libraries/stdlib/genosl/mx_image_vector4.osl
+++ b/libraries/stdlib/genosl/mx_image_vector4.osl
@@ -1,4 +1,4 @@
-#include "$fileTransformUv"
+#include "lib/$fileTransformUv"
 
 void mx_image_vector4(textureresource file, string layer, vector4 default_value, vector2 texcoord, string uaddressmode, string vaddressmode, string filtertype, string framerange, int frameoffset, string frameendaction, output vector4 out)
 {

--- a/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl
+++ b/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genosl/lib/mx_transform_color.osl"
+#include "lib/mx_transform_color.osl"
 
 void mx_srgb_texture_to_lin_rec709_color3(color _in, output color result)
 {

--- a/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl
+++ b/libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl
@@ -1,4 +1,4 @@
-#include "libraries/stdlib/genosl/lib/mx_transform_color.osl"
+#include "lib/mx_transform_color.osl"
 
 void mx_srgb_texture_to_lin_rec709_color4(color4 _in, output color4 result)
 {

--- a/libraries/stdlib/genosl/stdlib_genosl_cm_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_cm_impl.mtlx
@@ -5,20 +5,20 @@
   <!-- Color Management System Implementations -->
   <!-- ======================================================================== -->
 
-  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_gamma18_to_linear_color3.osl" function="mx_gamma18_to_linear_color3" target="genosl" />
-  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_gamma18_to_linear_color4.osl" function="mx_gamma18_to_linear_color4" target="genosl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_gamma22_to_linear_color3.osl" function="mx_gamma22_to_linear_color3" target="genosl" />
-  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_gamma22_to_linear_color4.osl" function="mx_gamma22_to_linear_color4" target="genosl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_gamma24_to_linear_color3.osl" function="mx_gamma24_to_linear_color3" target="genosl" />
-  <implementation name="IM_rec709_display_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_gamma24_to_linear_color4.osl" function="mx_gamma24_to_linear_color4" target="genosl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color3_genosl" file="mx_gamma18_to_linear_color3.osl" function="mx_gamma18_to_linear_color3" target="genosl" />
+  <implementation name="IM_g18_rec709_to_lin_rec709_color4_genosl" file="mx_gamma18_to_linear_color4.osl" function="mx_gamma18_to_linear_color4" target="genosl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color3_genosl" file="mx_gamma22_to_linear_color3.osl" function="mx_gamma22_to_linear_color3" target="genosl" />
+  <implementation name="IM_g22_rec709_to_lin_rec709_color4_genosl" file="mx_gamma22_to_linear_color4.osl" function="mx_gamma22_to_linear_color4" target="genosl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color3_genosl" file="mx_gamma24_to_linear_color3.osl" function="mx_gamma24_to_linear_color3" target="genosl" />
+  <implementation name="IM_rec709_display_to_lin_rec709_color4_genosl" file="mx_gamma24_to_linear_color4.osl" function="mx_gamma24_to_linear_color4" target="genosl" />
 
-  <implementation name="IM_acescg_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_ap1_to_rec709_color3.osl" function="mx_ap1_to_rec709_color3" target="genosl" />
-  <implementation name="IM_acescg_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_ap1_to_rec709_color4.osl" function="mx_ap1_to_rec709_color4" target="genosl" />
+  <implementation name="IM_acescg_to_lin_rec709_color3_genosl" file="mx_ap1_to_rec709_color3.osl" function="mx_ap1_to_rec709_color3" target="genosl" />
+  <implementation name="IM_acescg_to_lin_rec709_color4_genosl" file="mx_ap1_to_rec709_color4.osl" function="mx_ap1_to_rec709_color4" target="genosl" />
 
-  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color3.osl" function="mx_g22_ap1_to_lin_rec709_color3" target="genosl" />
-  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color4.osl" function="mx_g22_ap1_to_lin_rec709_color4" target="genosl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color3_genosl" file="mx_g22_ap1_to_lin_rec709_color3.osl" function="mx_g22_ap1_to_lin_rec709_color3" target="genosl" />
+  <implementation name="IM_g22_ap1_to_lin_rec709_color4_genosl" file="mx_g22_ap1_to_lin_rec709_color4.osl" function="mx_g22_ap1_to_lin_rec709_color4" target="genosl" />
 
-  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genosl" file="libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color3.osl" function="mx_srgb_texture_to_lin_rec709_color3" target="genosl" />
-  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genosl" file="libraries/stdlib/genosl/mx_srgb_texture_to_lin_rec709_color4.osl" function="mx_srgb_texture_to_lin_rec709_color4" target="genosl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color3_genosl" file="mx_srgb_texture_to_lin_rec709_color3.osl" function="mx_srgb_texture_to_lin_rec709_color3" target="genosl" />
+  <implementation name="IM_srgb_texture_to_lin_rec709_color4_genosl" file="mx_srgb_texture_to_lin_rec709_color4.osl" function="mx_srgb_texture_to_lin_rec709_color4" target="genosl" />
 
 </materialx>

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -12,141 +12,141 @@
   <!-- ======================================================================== -->
 
   <!-- <surface_unlit> -->
-  <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="libraries/stdlib/genosl/mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl" />
+  <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Texture nodes                                                            -->
   <!-- ======================================================================== -->
 
   <!-- <image> -->
-  <implementation name="IM_image_float_genosl" nodedef="ND_image_float" file="libraries/stdlib/genosl/mx_image_float.osl" function="mx_image_float" target="genosl">
+  <implementation name="IM_image_float_genosl" nodedef="ND_image_float" file="mx_image_float.osl" function="mx_image_float" target="genosl">
     <input name="default" type="float" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color3_genosl" nodedef="ND_image_color3" file="libraries/stdlib/genosl/mx_image_color3.osl" function="mx_image_color3" target="genosl">
+  <implementation name="IM_image_color3_genosl" nodedef="ND_image_color3" file="mx_image_color3.osl" function="mx_image_color3" target="genosl">
     <input name="default" type="color3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color4_genosl" nodedef="ND_image_color4" file="libraries/stdlib/genosl/mx_image_color4.osl" function="mx_image_color4" target="genosl">
+  <implementation name="IM_image_color4_genosl" nodedef="ND_image_color4" file="mx_image_color4.osl" function="mx_image_color4" target="genosl">
     <input name="default" type="color4" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector2_genosl" nodedef="ND_image_vector2" file="libraries/stdlib/genosl/mx_image_vector2.osl" function="mx_image_vector2" target="genosl">
+  <implementation name="IM_image_vector2_genosl" nodedef="ND_image_vector2" file="mx_image_vector2.osl" function="mx_image_vector2" target="genosl">
     <input name="default" type="vector2" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector3_genosl" nodedef="ND_image_vector3" file="libraries/stdlib/genosl/mx_image_vector3.osl" function="mx_image_vector3" target="genosl">
+  <implementation name="IM_image_vector3_genosl" nodedef="ND_image_vector3" file="mx_image_vector3.osl" function="mx_image_vector3" target="genosl">
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector4_genosl" nodedef="ND_image_vector4" file="libraries/stdlib/genosl/mx_image_vector4.osl" function="mx_image_vector4" target="genosl">
+  <implementation name="IM_image_vector4_genosl" nodedef="ND_image_vector4" file="mx_image_vector4.osl" function="mx_image_vector4" target="genosl">
     <input name="default" type="vector4" implname="default_value" />
   </implementation>
 
   <!-- <triplanarprojection> -->
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_genosl" nodedef="ND_normalmap" file="libraries/stdlib/genosl/mx_normalmap.osl" function="mx_normalmap" target="genosl" />
+  <implementation name="IM_normalmap_genosl" nodedef="ND_normalmap" file="mx_normalmap.osl" function="mx_normalmap" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->
   <!-- ======================================================================== -->
 
   <!-- <constant> -->
-  <implementation name="IM_constant_float_genosl" nodedef="ND_constant_float" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_color3_genosl" nodedef="ND_constant_color3" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_color4_genosl" nodedef="ND_constant_color4" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_vector2_genosl" nodedef="ND_constant_vector2" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_vector3_genosl" nodedef="ND_constant_vector3" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_vector4_genosl" nodedef="ND_constant_vector4" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_boolean_genosl" nodedef="ND_constant_boolean" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_integer_genosl" nodedef="ND_constant_integer" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_matrix33_genosl" nodedef="ND_constant_matrix33" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_matrix44_genosl" nodedef="ND_constant_matrix44" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_string_genosl" nodedef="ND_constant_string" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
-  <implementation name="IM_constant_filename_genosl" nodedef="ND_constant_filename" file="libraries/stdlib/genosl/mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_float_genosl" nodedef="ND_constant_float" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_color3_genosl" nodedef="ND_constant_color3" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_color4_genosl" nodedef="ND_constant_color4" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_vector2_genosl" nodedef="ND_constant_vector2" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_vector3_genosl" nodedef="ND_constant_vector3" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_vector4_genosl" nodedef="ND_constant_vector4" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_boolean_genosl" nodedef="ND_constant_boolean" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_integer_genosl" nodedef="ND_constant_integer" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_matrix33_genosl" nodedef="ND_constant_matrix33" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_matrix44_genosl" nodedef="ND_constant_matrix44" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_string_genosl" nodedef="ND_constant_string" file="mx_constant.inline" target="genosl" />
+  <implementation name="IM_constant_filename_genosl" nodedef="ND_constant_filename" file="mx_constant.inline" target="genosl" />
 
   <!-- <ramplr> -->
-  <implementation name="IM_ramplr_float_genosl" nodedef="ND_ramplr_float" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_color3_genosl" nodedef="ND_ramplr_color3" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_color4_genosl" nodedef="ND_ramplr_color4" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_vector2_genosl" nodedef="ND_ramplr_vector2" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_vector3_genosl" nodedef="ND_ramplr_vector3" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
-  <implementation name="IM_ramplr_vector4_genosl" nodedef="ND_ramplr_vector4" file="libraries/stdlib/genosl/mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_float_genosl" nodedef="ND_ramplr_float" file="mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_color3_genosl" nodedef="ND_ramplr_color3" file="mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_color4_genosl" nodedef="ND_ramplr_color4" file="mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_vector2_genosl" nodedef="ND_ramplr_vector2" file="mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_vector3_genosl" nodedef="ND_ramplr_vector3" file="mx_ramplr.inline" target="genosl" />
+  <implementation name="IM_ramplr_vector4_genosl" nodedef="ND_ramplr_vector4" file="mx_ramplr.inline" target="genosl" />
 
   <!-- <ramptb> -->
-  <implementation name="IM_ramptb_float_genosl" nodedef="ND_ramptb_float" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_color3_genosl" nodedef="ND_ramptb_color3" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_color4_genosl" nodedef="ND_ramptb_color4" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_vector2_genosl" nodedef="ND_ramptb_vector2" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_vector3_genosl" nodedef="ND_ramptb_vector3" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
-  <implementation name="IM_ramptb_vector4_genosl" nodedef="ND_ramptb_vector4" file="libraries/stdlib/genosl/mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_float_genosl" nodedef="ND_ramptb_float" file="mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_color3_genosl" nodedef="ND_ramptb_color3" file="mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_color4_genosl" nodedef="ND_ramptb_color4" file="mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_vector2_genosl" nodedef="ND_ramptb_vector2" file="mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_vector3_genosl" nodedef="ND_ramptb_vector3" file="mx_ramptb.inline" target="genosl" />
+  <implementation name="IM_ramptb_vector4_genosl" nodedef="ND_ramptb_vector4" file="mx_ramptb.inline" target="genosl" />
 
   <!-- <splitlr> -->
-  <implementation name="IM_splitlr_float_genosl" nodedef="ND_splitlr_float" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_color3_genosl" nodedef="ND_splitlr_color3" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_color4_genosl" nodedef="ND_splitlr_color4" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_vector2_genosl" nodedef="ND_splitlr_vector2" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_vector3_genosl" nodedef="ND_splitlr_vector3" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
-  <implementation name="IM_splitlr_vector4_genosl" nodedef="ND_splitlr_vector4" file="libraries/stdlib/genosl/mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_float_genosl" nodedef="ND_splitlr_float" file="mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_color3_genosl" nodedef="ND_splitlr_color3" file="mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_color4_genosl" nodedef="ND_splitlr_color4" file="mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_vector2_genosl" nodedef="ND_splitlr_vector2" file="mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_vector3_genosl" nodedef="ND_splitlr_vector3" file="mx_splitlr.inline" target="genosl" />
+  <implementation name="IM_splitlr_vector4_genosl" nodedef="ND_splitlr_vector4" file="mx_splitlr.inline" target="genosl" />
 
   <!-- <splittb> -->
-  <implementation name="IM_splittb_float_genosl" nodedef="ND_splittb_float" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_color3_genosl" nodedef="ND_splittb_color3" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_color4_genosl" nodedef="ND_splittb_color4" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_vector2_genosl" nodedef="ND_splittb_vector2" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_vector3_genosl" nodedef="ND_splittb_vector3" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
-  <implementation name="IM_splittb_vector4_genosl" nodedef="ND_splittb_vector4" file="libraries/stdlib/genosl/mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_float_genosl" nodedef="ND_splittb_float" file="mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_color3_genosl" nodedef="ND_splittb_color3" file="mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_color4_genosl" nodedef="ND_splittb_color4" file="mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_vector2_genosl" nodedef="ND_splittb_vector2" file="mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_vector3_genosl" nodedef="ND_splittb_vector3" file="mx_splittb.inline" target="genosl" />
+  <implementation name="IM_splittb_vector4_genosl" nodedef="ND_splittb_vector4" file="mx_splittb.inline" target="genosl" />
 
   <!-- <noise2d> -->
-  <implementation name="IM_noise2d_float_genosl" nodedef="ND_noise2d_float" file="libraries/stdlib/genosl/mx_noise2d_float.osl" function="mx_noise2d_float" target="genosl" />
-  <implementation name="IM_noise2d_color3_genosl" nodedef="ND_noise2d_color3" file="libraries/stdlib/genosl/mx_noise2d_color3.osl" function="mx_noise2d_color3" target="genosl" />
-  <implementation name="IM_noise2d_color4_genosl" nodedef="ND_noise2d_color4" file="libraries/stdlib/genosl/mx_noise2d_color4.osl" function="mx_noise2d_color4" target="genosl" />
-  <implementation name="IM_noise2d_color3FA_genosl" nodedef="ND_noise2d_color3FA" file="libraries/stdlib/genosl/mx_noise2d_fa_color3.osl" function="mx_noise2d_fa_color3" target="genosl" />
-  <implementation name="IM_noise2d_color4FA_genosl" nodedef="ND_noise2d_color4FA" file="libraries/stdlib/genosl/mx_noise2d_fa_color4.osl" function="mx_noise2d_fa_color4" target="genosl" />
-  <implementation name="IM_noise2d_vector2_genosl" nodedef="ND_noise2d_vector2" file="libraries/stdlib/genosl/mx_noise2d_vector2.osl" function="mx_noise2d_vector2" target="genosl" />
-  <implementation name="IM_noise2d_vector3_genosl" nodedef="ND_noise2d_vector3" file="libraries/stdlib/genosl/mx_noise2d_vector3.osl" function="mx_noise2d_vector3" target="genosl" />
-  <implementation name="IM_noise2d_vector4_genosl" nodedef="ND_noise2d_vector4" file="libraries/stdlib/genosl/mx_noise2d_vector4.osl" function="mx_noise2d_vector4" target="genosl" />
-  <implementation name="IM_noise2d_vector2FA_genosl" nodedef="ND_noise2d_vector2FA" file="libraries/stdlib/genosl/mx_noise2d_fa_vector2.osl" function="mx_noise2d_fa_vector2" target="genosl" />
-  <implementation name="IM_noise2d_vector3FA_genosl" nodedef="ND_noise2d_vector3FA" file="libraries/stdlib/genosl/mx_noise2d_fa_vector3.osl" function="mx_noise2d_fa_vector3" target="genosl" />
-  <implementation name="IM_noise2d_vector4FA_genosl" nodedef="ND_noise2d_vector4FA" file="libraries/stdlib/genosl/mx_noise2d_fa_vector4.osl" function="mx_noise2d_fa_vector4" target="genosl" />
+  <implementation name="IM_noise2d_float_genosl" nodedef="ND_noise2d_float" file="mx_noise2d_float.osl" function="mx_noise2d_float" target="genosl" />
+  <implementation name="IM_noise2d_color3_genosl" nodedef="ND_noise2d_color3" file="mx_noise2d_color3.osl" function="mx_noise2d_color3" target="genosl" />
+  <implementation name="IM_noise2d_color4_genosl" nodedef="ND_noise2d_color4" file="mx_noise2d_color4.osl" function="mx_noise2d_color4" target="genosl" />
+  <implementation name="IM_noise2d_color3FA_genosl" nodedef="ND_noise2d_color3FA" file="mx_noise2d_fa_color3.osl" function="mx_noise2d_fa_color3" target="genosl" />
+  <implementation name="IM_noise2d_color4FA_genosl" nodedef="ND_noise2d_color4FA" file="mx_noise2d_fa_color4.osl" function="mx_noise2d_fa_color4" target="genosl" />
+  <implementation name="IM_noise2d_vector2_genosl" nodedef="ND_noise2d_vector2" file="mx_noise2d_vector2.osl" function="mx_noise2d_vector2" target="genosl" />
+  <implementation name="IM_noise2d_vector3_genosl" nodedef="ND_noise2d_vector3" file="mx_noise2d_vector3.osl" function="mx_noise2d_vector3" target="genosl" />
+  <implementation name="IM_noise2d_vector4_genosl" nodedef="ND_noise2d_vector4" file="mx_noise2d_vector4.osl" function="mx_noise2d_vector4" target="genosl" />
+  <implementation name="IM_noise2d_vector2FA_genosl" nodedef="ND_noise2d_vector2FA" file="mx_noise2d_fa_vector2.osl" function="mx_noise2d_fa_vector2" target="genosl" />
+  <implementation name="IM_noise2d_vector3FA_genosl" nodedef="ND_noise2d_vector3FA" file="mx_noise2d_fa_vector3.osl" function="mx_noise2d_fa_vector3" target="genosl" />
+  <implementation name="IM_noise2d_vector4FA_genosl" nodedef="ND_noise2d_vector4FA" file="mx_noise2d_fa_vector4.osl" function="mx_noise2d_fa_vector4" target="genosl" />
 
   <!-- <noise3d> -->
-  <implementation name="IM_noise3d_float_genosl" nodedef="ND_noise3d_float" file="libraries/stdlib/genosl/mx_noise3d_float.osl" function="mx_noise3d_float" target="genosl" />
-  <implementation name="IM_noise3d_color3_genosl" nodedef="ND_noise3d_color3" file="libraries/stdlib/genosl/mx_noise3d_color3.osl" function="mx_noise3d_color3" target="genosl" />
-  <implementation name="IM_noise3d_color4_genosl" nodedef="ND_noise3d_color4" file="libraries/stdlib/genosl/mx_noise3d_color4.osl" function="mx_noise3d_color4" target="genosl" />
-  <implementation name="IM_noise3d_color3FA_genosl" nodedef="ND_noise3d_color3FA" file="libraries/stdlib/genosl/mx_noise3d_fa_color3.osl" function="mx_noise3d_fa_color3" target="genosl" />
-  <implementation name="IM_noise3d_color4FA_genosl" nodedef="ND_noise3d_color4FA" file="libraries/stdlib/genosl/mx_noise3d_fa_color4.osl" function="mx_noise3d_fa_color4" target="genosl" />
-  <implementation name="IM_noise3d_vector2_genosl" nodedef="ND_noise3d_vector2" file="libraries/stdlib/genosl/mx_noise3d_vector2.osl" function="mx_noise3d_vector2" target="genosl" />
-  <implementation name="IM_noise3d_vector3_genosl" nodedef="ND_noise3d_vector3" file="libraries/stdlib/genosl/mx_noise3d_vector3.osl" function="mx_noise3d_vector3" target="genosl" />
-  <implementation name="IM_noise3d_vector4_genosl" nodedef="ND_noise3d_vector4" file="libraries/stdlib/genosl/mx_noise3d_vector4.osl" function="mx_noise3d_vector4" target="genosl" />
-  <implementation name="IM_noise3d_vector2FA_genosl" nodedef="ND_noise3d_vector2FA" file="libraries/stdlib/genosl/mx_noise3d_fa_vector2.osl" function="mx_noise3d_fa_vector2" target="genosl" />
-  <implementation name="IM_noise3d_vector3FA_genosl" nodedef="ND_noise3d_vector3FA" file="libraries/stdlib/genosl/mx_noise3d_fa_vector3.osl" function="mx_noise3d_fa_vector3" target="genosl" />
-  <implementation name="IM_noise3d_vector4FA_genosl" nodedef="ND_noise3d_vector4FA" file="libraries/stdlib/genosl/mx_noise3d_fa_vector4.osl" function="mx_noise3d_fa_vector4" target="genosl" />
+  <implementation name="IM_noise3d_float_genosl" nodedef="ND_noise3d_float" file="mx_noise3d_float.osl" function="mx_noise3d_float" target="genosl" />
+  <implementation name="IM_noise3d_color3_genosl" nodedef="ND_noise3d_color3" file="mx_noise3d_color3.osl" function="mx_noise3d_color3" target="genosl" />
+  <implementation name="IM_noise3d_color4_genosl" nodedef="ND_noise3d_color4" file="mx_noise3d_color4.osl" function="mx_noise3d_color4" target="genosl" />
+  <implementation name="IM_noise3d_color3FA_genosl" nodedef="ND_noise3d_color3FA" file="mx_noise3d_fa_color3.osl" function="mx_noise3d_fa_color3" target="genosl" />
+  <implementation name="IM_noise3d_color4FA_genosl" nodedef="ND_noise3d_color4FA" file="mx_noise3d_fa_color4.osl" function="mx_noise3d_fa_color4" target="genosl" />
+  <implementation name="IM_noise3d_vector2_genosl" nodedef="ND_noise3d_vector2" file="mx_noise3d_vector2.osl" function="mx_noise3d_vector2" target="genosl" />
+  <implementation name="IM_noise3d_vector3_genosl" nodedef="ND_noise3d_vector3" file="mx_noise3d_vector3.osl" function="mx_noise3d_vector3" target="genosl" />
+  <implementation name="IM_noise3d_vector4_genosl" nodedef="ND_noise3d_vector4" file="mx_noise3d_vector4.osl" function="mx_noise3d_vector4" target="genosl" />
+  <implementation name="IM_noise3d_vector2FA_genosl" nodedef="ND_noise3d_vector2FA" file="mx_noise3d_fa_vector2.osl" function="mx_noise3d_fa_vector2" target="genosl" />
+  <implementation name="IM_noise3d_vector3FA_genosl" nodedef="ND_noise3d_vector3FA" file="mx_noise3d_fa_vector3.osl" function="mx_noise3d_fa_vector3" target="genosl" />
+  <implementation name="IM_noise3d_vector4FA_genosl" nodedef="ND_noise3d_vector4FA" file="mx_noise3d_fa_vector4.osl" function="mx_noise3d_fa_vector4" target="genosl" />
 
   <!-- <fractal3d> -->
-  <implementation name="IM_fractal3d_float_genosl" nodedef="ND_fractal3d_float" file="libraries/stdlib/genosl/mx_fractal3d_float.osl" function="mx_fractal3d_float" target="genosl" />
-  <implementation name="IM_fractal3d_color3_genosl" nodedef="ND_fractal3d_color3" file="libraries/stdlib/genosl/mx_fractal3d_color3.osl" function="mx_fractal3d_color3" target="genosl" />
-  <implementation name="IM_fractal3d_color4_genosl" nodedef="ND_fractal3d_color4" file="libraries/stdlib/genosl/mx_fractal3d_color4.osl" function="mx_fractal3d_color4" target="genosl" />
-  <implementation name="IM_fractal3d_color3FA_genosl" nodedef="ND_fractal3d_color3FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_color3.osl" function="mx_fractal3d_fa_color3" target="genosl" />
-  <implementation name="IM_fractal3d_color4FA_genosl" nodedef="ND_fractal3d_color4FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_color4.osl" function="mx_fractal3d_fa_color4" target="genosl" />
-  <implementation name="IM_fractal3d_vector2_genosl" nodedef="ND_fractal3d_vector2" file="libraries/stdlib/genosl/mx_fractal3d_vector2.osl" function="mx_fractal3d_vector2" target="genosl" />
-  <implementation name="IM_fractal3d_vector3_genosl" nodedef="ND_fractal3d_vector3" file="libraries/stdlib/genosl/mx_fractal3d_vector3.osl" function="mx_fractal3d_vector3" target="genosl" />
-  <implementation name="IM_fractal3d_vector4_genosl" nodedef="ND_fractal3d_vector4" file="libraries/stdlib/genosl/mx_fractal3d_vector4.osl" function="mx_fractal3d_vector4" target="genosl" />
-  <implementation name="IM_fractal3d_vector2FA_genosl" nodedef="ND_fractal3d_vector2FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_vector2.osl" function="mx_fractal3d_fa_vector2" target="genosl" />
-  <implementation name="IM_fractal3d_vector3FA_genosl" nodedef="ND_fractal3d_vector3FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_vector3.osl" function="mx_fractal3d_fa_vector3" target="genosl" />
-  <implementation name="IM_fractal3d_vector4FA_genosl" nodedef="ND_fractal3d_vector4FA" file="libraries/stdlib/genosl/mx_fractal3d_fa_vector4.osl" function="mx_fractal3d_fa_vector4" target="genosl" />
+  <implementation name="IM_fractal3d_float_genosl" nodedef="ND_fractal3d_float" file="mx_fractal3d_float.osl" function="mx_fractal3d_float" target="genosl" />
+  <implementation name="IM_fractal3d_color3_genosl" nodedef="ND_fractal3d_color3" file="mx_fractal3d_color3.osl" function="mx_fractal3d_color3" target="genosl" />
+  <implementation name="IM_fractal3d_color4_genosl" nodedef="ND_fractal3d_color4" file="mx_fractal3d_color4.osl" function="mx_fractal3d_color4" target="genosl" />
+  <implementation name="IM_fractal3d_color3FA_genosl" nodedef="ND_fractal3d_color3FA" file="mx_fractal3d_fa_color3.osl" function="mx_fractal3d_fa_color3" target="genosl" />
+  <implementation name="IM_fractal3d_color4FA_genosl" nodedef="ND_fractal3d_color4FA" file="mx_fractal3d_fa_color4.osl" function="mx_fractal3d_fa_color4" target="genosl" />
+  <implementation name="IM_fractal3d_vector2_genosl" nodedef="ND_fractal3d_vector2" file="mx_fractal3d_vector2.osl" function="mx_fractal3d_vector2" target="genosl" />
+  <implementation name="IM_fractal3d_vector3_genosl" nodedef="ND_fractal3d_vector3" file="mx_fractal3d_vector3.osl" function="mx_fractal3d_vector3" target="genosl" />
+  <implementation name="IM_fractal3d_vector4_genosl" nodedef="ND_fractal3d_vector4" file="mx_fractal3d_vector4.osl" function="mx_fractal3d_vector4" target="genosl" />
+  <implementation name="IM_fractal3d_vector2FA_genosl" nodedef="ND_fractal3d_vector2FA" file="mx_fractal3d_fa_vector2.osl" function="mx_fractal3d_fa_vector2" target="genosl" />
+  <implementation name="IM_fractal3d_vector3FA_genosl" nodedef="ND_fractal3d_vector3FA" file="mx_fractal3d_fa_vector3.osl" function="mx_fractal3d_fa_vector3" target="genosl" />
+  <implementation name="IM_fractal3d_vector4FA_genosl" nodedef="ND_fractal3d_vector4FA" file="mx_fractal3d_fa_vector4.osl" function="mx_fractal3d_fa_vector4" target="genosl" />
 
   <!-- <cellnoise2d> -->
-  <implementation name="IM_cellnoise2d_float_genosl" nodedef="ND_cellnoise2d_float" file="libraries/stdlib/genosl/mx_cellnoise2d_float.osl" function="mx_cellnoise2d_float" target="genosl" />
+  <implementation name="IM_cellnoise2d_float_genosl" nodedef="ND_cellnoise2d_float" file="mx_cellnoise2d_float.osl" function="mx_cellnoise2d_float" target="genosl" />
 
   <!-- <cellnoise3d> -->
-  <implementation name="IM_cellnoise3d_float_genosl" nodedef="ND_cellnoise3d_float" file="libraries/stdlib/genosl/mx_cellnoise3d_float.osl" function="mx_cellnoise3d_float" target="genosl" />
+  <implementation name="IM_cellnoise3d_float_genosl" nodedef="ND_cellnoise3d_float" file="mx_cellnoise3d_float.osl" function="mx_cellnoise3d_float" target="genosl" />
 
   <!-- <worleynoise2d> -->
-  <implementation name="IM_worleynoise2d_float_genosl" nodedef="ND_worleynoise2d_float" file="libraries/stdlib/genosl/mx_worleynoise2d_float.osl" function="mx_worleynoise2d_float" target="genosl" />
-  <implementation name="IM_worleynoise2d_vector2_genosl" nodedef="ND_worleynoise2d_vector2" file="libraries/stdlib/genosl/mx_worleynoise2d_vector2.osl" function="mx_worleynoise2d_vector2" target="genosl" />
-  <implementation name="IM_worleynoise2d_vector3_genosl" nodedef="ND_worleynoise2d_vector3" file="libraries/stdlib/genosl/mx_worleynoise2d_vector3.osl" function="mx_worleynoise2d_vector3" target="genosl" />
+  <implementation name="IM_worleynoise2d_float_genosl" nodedef="ND_worleynoise2d_float" file="mx_worleynoise2d_float.osl" function="mx_worleynoise2d_float" target="genosl" />
+  <implementation name="IM_worleynoise2d_vector2_genosl" nodedef="ND_worleynoise2d_vector2" file="mx_worleynoise2d_vector2.osl" function="mx_worleynoise2d_vector2" target="genosl" />
+  <implementation name="IM_worleynoise2d_vector3_genosl" nodedef="ND_worleynoise2d_vector3" file="mx_worleynoise2d_vector3.osl" function="mx_worleynoise2d_vector3" target="genosl" />
 
   <!-- <worleynoise3d> -->
-  <implementation name="IM_worleynoise3d_float_genosl" nodedef="ND_worleynoise3d_float" file="libraries/stdlib/genosl/mx_worleynoise3d_float.osl" function="mx_worleynoise3d_float" target="genosl" />
-  <implementation name="IM_worleynoise3d_vector2_genosl" nodedef="ND_worleynoise3d_vector2" file="libraries/stdlib/genosl/mx_worleynoise3d_vector2.osl" function="mx_worleynoise3d_vector2" target="genosl" />
-  <implementation name="IM_worleynoise3d_vector3_genosl" nodedef="ND_worleynoise3d_vector3" file="libraries/stdlib/genosl/mx_worleynoise3d_vector3.osl" function="mx_worleynoise3d_vector3" target="genosl" />
+  <implementation name="IM_worleynoise3d_float_genosl" nodedef="ND_worleynoise3d_float" file="mx_worleynoise3d_float.osl" function="mx_worleynoise3d_float" target="genosl" />
+  <implementation name="IM_worleynoise3d_vector2_genosl" nodedef="ND_worleynoise3d_vector2" file="mx_worleynoise3d_vector2.osl" function="mx_worleynoise3d_vector2" target="genosl" />
+  <implementation name="IM_worleynoise3d_vector3_genosl" nodedef="ND_worleynoise3d_vector3" file="mx_worleynoise3d_vector3.osl" function="mx_worleynoise3d_vector3" target="genosl" />
 
 
   <!-- ======================================================================== -->
@@ -154,456 +154,456 @@
   <!-- ======================================================================== -->
 
   <!-- <ambientocclusion> -->
-  <implementation name="IM_ambientocclusion_float_genosl" nodedef="ND_ambientocclusion_float" file="libraries/stdlib/genosl/mx_ambientocclusion_float.osl" function="mx_ambientocclusion_float" target="genosl" />
+  <implementation name="IM_ambientocclusion_float_genosl" nodedef="ND_ambientocclusion_float" file="mx_ambientocclusion_float.osl" function="mx_ambientocclusion_float" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Geometric nodes                                                          -->
   <!-- ======================================================================== -->
 
   <!-- <position> -->
-  <implementation name="IM_position_vector3_genosl" nodedef="ND_position_vector3" file="libraries/stdlib/genosl/mx_position_vector3.inline" target="genosl" />
+  <implementation name="IM_position_vector3_genosl" nodedef="ND_position_vector3" file="mx_position_vector3.inline" target="genosl" />
 
   <!-- <normal> -->
-  <implementation name="IM_normal_vector3_genosl" nodedef="ND_normal_vector3" file="libraries/stdlib/genosl/mx_normal_vector3.inline" target="genosl" />
+  <implementation name="IM_normal_vector3_genosl" nodedef="ND_normal_vector3" file="mx_normal_vector3.inline" target="genosl" />
 
   <!-- <tangent> -->
-  <implementation name="IM_tangent_vector3_genosl" nodedef="ND_tangent_vector3" file="libraries/stdlib/genosl/mx_tangent_vector3.inline" target="genosl" />
+  <implementation name="IM_tangent_vector3_genosl" nodedef="ND_tangent_vector3" file="mx_tangent_vector3.inline" target="genosl" />
 
   <!-- <bitangent> -->
-  <implementation name="IM_bitangent_vector3_genosl" nodedef="ND_bitangent_vector3" file="libraries/stdlib/genosl/mx_bitangent_vector3.inline" target="genosl" />
+  <implementation name="IM_bitangent_vector3_genosl" nodedef="ND_bitangent_vector3" file="mx_bitangent_vector3.inline" target="genosl" />
 
   <!-- <texcoord> -->
-  <implementation name="IM_texcoord_vector2_genosl" nodedef="ND_texcoord_vector2" file="libraries/stdlib/genosl/mx_texcoord_vector2.inline" target="genosl" />
-  <implementation name="IM_texcoord_vector3_genosl" nodedef="ND_texcoord_vector3" file="libraries/stdlib/genosl/mx_texcoord_vector3.inline" target="genosl" />
+  <implementation name="IM_texcoord_vector2_genosl" nodedef="ND_texcoord_vector2" file="mx_texcoord_vector2.inline" target="genosl" />
+  <implementation name="IM_texcoord_vector3_genosl" nodedef="ND_texcoord_vector3" file="mx_texcoord_vector3.inline" target="genosl" />
 
   <!-- <geomcolor> -->
-  <implementation name="IM_geomcolor_float_genosl" nodedef="ND_geomcolor_float" file="libraries/stdlib/genosl/mx_geomcolor_float.osl" function="mx_geomcolor_float" target="genosl" />
-  <implementation name="IM_geomcolor_color3_genosl" nodedef="ND_geomcolor_color3" file="libraries/stdlib/genosl/mx_geomcolor_color3.osl" function="mx_geomcolor_color3" target="genosl" />
-  <implementation name="IM_geomcolor_color4_genosl" nodedef="ND_geomcolor_color4" file="libraries/stdlib/genosl/mx_geomcolor_color4.osl" function="mx_geomcolor_color4" target="genosl" />
+  <implementation name="IM_geomcolor_float_genosl" nodedef="ND_geomcolor_float" file="mx_geomcolor_float.osl" function="mx_geomcolor_float" target="genosl" />
+  <implementation name="IM_geomcolor_color3_genosl" nodedef="ND_geomcolor_color3" file="mx_geomcolor_color3.osl" function="mx_geomcolor_color3" target="genosl" />
+  <implementation name="IM_geomcolor_color4_genosl" nodedef="ND_geomcolor_color4" file="mx_geomcolor_color4.osl" function="mx_geomcolor_color4" target="genosl" />
 
   <!-- <geompropvalue> -->
-  <implementation name="IM_geompropvalue_integer_genosl" nodedef="ND_geompropvalue_integer" file="libraries/stdlib/genosl/mx_geompropvalue_integer.osl" function="mx_geompropvalue_integer" target="genosl" />
-  <implementation name="IM_geompropvalue_boolean_genosl" nodedef="ND_geompropvalue_boolean" file="libraries/stdlib/genosl/mx_geompropvalue_boolean.osl" function="mx_geompropvalue_boolean" target="genosl" />
-  <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalue_string" file="libraries/stdlib/genosl/mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
-  <implementation name="IM_geompropvalue_float_genosl" nodedef="ND_geompropvalue_float" file="libraries/stdlib/genosl/mx_geompropvalue_float.osl" function="mx_geompropvalue_float" target="genosl" />
-  <implementation name="IM_geompropvalue_color3_genosl" nodedef="ND_geompropvalue_color3" file="libraries/stdlib/genosl/mx_geompropvalue_color3.osl" function="mx_geompropvalue_color" target="genosl" />
-  <implementation name="IM_geompropvalue_color4_genosl" nodedef="ND_geompropvalue_color4" file="libraries/stdlib/genosl/mx_geompropvalue_color4.osl" function="mx_geompropvalue_color4" target="genosl" />
-  <implementation name="IM_geompropvalue_vector2_genosl" nodedef="ND_geompropvalue_vector2" file="libraries/stdlib/genosl/mx_geompropvalue_vector2.osl" function="mx_geompropvalue_vector2" target="genosl" />
-  <implementation name="IM_geompropvalue_vector3_genosl" nodedef="ND_geompropvalue_vector3" file="libraries/stdlib/genosl/mx_geompropvalue_vector3.osl" function="mx_geompropvalue_vector" target="genosl" />
-  <implementation name="IM_geompropvalue_vector4_genosl" nodedef="ND_geompropvalue_vector4" file="libraries/stdlib/genosl/mx_geompropvalue_vector4.osl" function="mx_geompropvalue_vector4" target="genosl" />
+  <implementation name="IM_geompropvalue_integer_genosl" nodedef="ND_geompropvalue_integer" file="mx_geompropvalue_integer.osl" function="mx_geompropvalue_integer" target="genosl" />
+  <implementation name="IM_geompropvalue_boolean_genosl" nodedef="ND_geompropvalue_boolean" file="mx_geompropvalue_boolean.osl" function="mx_geompropvalue_boolean" target="genosl" />
+  <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalue_string" file="mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
+  <implementation name="IM_geompropvalue_float_genosl" nodedef="ND_geompropvalue_float" file="mx_geompropvalue_float.osl" function="mx_geompropvalue_float" target="genosl" />
+  <implementation name="IM_geompropvalue_color3_genosl" nodedef="ND_geompropvalue_color3" file="mx_geompropvalue_color3.osl" function="mx_geompropvalue_color" target="genosl" />
+  <implementation name="IM_geompropvalue_color4_genosl" nodedef="ND_geompropvalue_color4" file="mx_geompropvalue_color4.osl" function="mx_geompropvalue_color4" target="genosl" />
+  <implementation name="IM_geompropvalue_vector2_genosl" nodedef="ND_geompropvalue_vector2" file="mx_geompropvalue_vector2.osl" function="mx_geompropvalue_vector2" target="genosl" />
+  <implementation name="IM_geompropvalue_vector3_genosl" nodedef="ND_geompropvalue_vector3" file="mx_geompropvalue_vector3.osl" function="mx_geompropvalue_vector" target="genosl" />
+  <implementation name="IM_geompropvalue_vector4_genosl" nodedef="ND_geompropvalue_vector4" file="mx_geompropvalue_vector4.osl" function="mx_geompropvalue_vector4" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Application nodes                                                        -->
   <!-- ======================================================================== -->
 
   <!-- <frame> -->
-  <implementation name="IM_frame_float_genosl" nodedef="ND_frame_float" file="libraries/stdlib/genosl/mx_frame_float.osl" function="mx_frame_float" target="genosl" />
+  <implementation name="IM_frame_float_genosl" nodedef="ND_frame_float" file="mx_frame_float.osl" function="mx_frame_float" target="genosl" />
 
   <!-- <time> -->
-  <implementation name="IM_time_float_genosl" nodedef="ND_time_float" file="libraries/stdlib/genosl/mx_time_float.osl" function="mx_time_float" target="genosl" />
+  <implementation name="IM_time_float_genosl" nodedef="ND_time_float" file="mx_time_float.osl" function="mx_time_float" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Math nodes                                                               -->
   <!-- ======================================================================== -->
 
   <!-- <add> -->
-  <implementation name="IM_add_float_genosl" nodedef="ND_add_float" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color3_genosl" nodedef="ND_add_color3" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color3FA_genosl" nodedef="ND_add_color3FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color4_genosl" nodedef="ND_add_color4" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_color4FA_genosl" nodedef="ND_add_color4FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector2_genosl" nodedef="ND_add_vector2" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector2FA_genosl" nodedef="ND_add_vector2FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector3_genosl" nodedef="ND_add_vector3" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector3FA_genosl" nodedef="ND_add_vector3FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector4_genosl" nodedef="ND_add_vector4" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_vector4FA_genosl" nodedef="ND_add_vector4FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix33_genosl" nodedef="ND_add_matrix33" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix33FA_genosl" nodedef="ND_add_matrix33FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix44_genosl" nodedef="ND_add_matrix44" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_matrix44FA_genosl" nodedef="ND_add_matrix44FA" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
-  <implementation name="IM_add_surfaceshader_genosl" nodedef="ND_add_surfaceshader" file="libraries/stdlib/genosl/mx_add.inline" target="genosl" />
+  <implementation name="IM_add_float_genosl" nodedef="ND_add_float" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color3_genosl" nodedef="ND_add_color3" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color3FA_genosl" nodedef="ND_add_color3FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color4_genosl" nodedef="ND_add_color4" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_color4FA_genosl" nodedef="ND_add_color4FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector2_genosl" nodedef="ND_add_vector2" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector2FA_genosl" nodedef="ND_add_vector2FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector3_genosl" nodedef="ND_add_vector3" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector3FA_genosl" nodedef="ND_add_vector3FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector4_genosl" nodedef="ND_add_vector4" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_vector4FA_genosl" nodedef="ND_add_vector4FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix33_genosl" nodedef="ND_add_matrix33" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix33FA_genosl" nodedef="ND_add_matrix33FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix44_genosl" nodedef="ND_add_matrix44" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_matrix44FA_genosl" nodedef="ND_add_matrix44FA" file="mx_add.inline" target="genosl" />
+  <implementation name="IM_add_surfaceshader_genosl" nodedef="ND_add_surfaceshader" file="mx_add.inline" target="genosl" />
 
   <!-- <subtract> -->
-  <implementation name="IM_subtract_float_genosl" nodedef="ND_subtract_float" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color3_genosl" nodedef="ND_subtract_color3" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color3FA_genosl" nodedef="ND_subtract_color3FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color4_genosl" nodedef="ND_subtract_color4" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_color4FA_genosl" nodedef="ND_subtract_color4FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector2_genosl" nodedef="ND_subtract_vector2" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector2FA_genosl" nodedef="ND_subtract_vector2FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector3_genosl" nodedef="ND_subtract_vector3" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector3FA_genosl" nodedef="ND_subtract_vector3FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector4_genosl" nodedef="ND_subtract_vector4" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_vector4FA_genosl" nodedef="ND_subtract_vector4FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix33_genosl" nodedef="ND_subtract_matrix33" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix33FA_genosl" nodedef="ND_subtract_matrix33FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix44_genosl" nodedef="ND_subtract_matrix44" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
-  <implementation name="IM_subtract_matrix44FA_genosl" nodedef="ND_subtract_matrix44FA" file="libraries/stdlib/genosl/mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_float_genosl" nodedef="ND_subtract_float" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color3_genosl" nodedef="ND_subtract_color3" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color3FA_genosl" nodedef="ND_subtract_color3FA" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color4_genosl" nodedef="ND_subtract_color4" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_color4FA_genosl" nodedef="ND_subtract_color4FA" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector2_genosl" nodedef="ND_subtract_vector2" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector2FA_genosl" nodedef="ND_subtract_vector2FA" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector3_genosl" nodedef="ND_subtract_vector3" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector3FA_genosl" nodedef="ND_subtract_vector3FA" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector4_genosl" nodedef="ND_subtract_vector4" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_vector4FA_genosl" nodedef="ND_subtract_vector4FA" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix33_genosl" nodedef="ND_subtract_matrix33" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix33FA_genosl" nodedef="ND_subtract_matrix33FA" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix44_genosl" nodedef="ND_subtract_matrix44" file="mx_subtract.inline" target="genosl" />
+  <implementation name="IM_subtract_matrix44FA_genosl" nodedef="ND_subtract_matrix44FA" file="mx_subtract.inline" target="genosl" />
 
   <!-- <multiply> -->
-  <implementation name="IM_multiply_float_genosl" nodedef="ND_multiply_float" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color3_genosl" nodedef="ND_multiply_color3" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color3FA_genosl" nodedef="ND_multiply_color3FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color4_genosl" nodedef="ND_multiply_color4" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_color4FA_genosl" nodedef="ND_multiply_color4FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector2_genosl" nodedef="ND_multiply_vector2" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector2FA_genosl" nodedef="ND_multiply_vector2FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector3_genosl" nodedef="ND_multiply_vector3" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector3FA_genosl" nodedef="ND_multiply_vector3FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector4_genosl" nodedef="ND_multiply_vector4" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_vector4FA_genosl" nodedef="ND_multiply_vector4FA" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_matrix33_genosl" nodedef="ND_multiply_matrix33" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_matrix44_genosl" nodedef="ND_multiply_matrix44" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_surfaceshaderF_genosl" nodedef="ND_multiply_surfaceshaderF" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
-  <implementation name="IM_multiply_surfaceshaderC_genosl" nodedef="ND_multiply_surfaceshaderC" file="libraries/stdlib/genosl/mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_float_genosl" nodedef="ND_multiply_float" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color3_genosl" nodedef="ND_multiply_color3" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color3FA_genosl" nodedef="ND_multiply_color3FA" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color4_genosl" nodedef="ND_multiply_color4" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_color4FA_genosl" nodedef="ND_multiply_color4FA" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector2_genosl" nodedef="ND_multiply_vector2" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector2FA_genosl" nodedef="ND_multiply_vector2FA" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector3_genosl" nodedef="ND_multiply_vector3" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector3FA_genosl" nodedef="ND_multiply_vector3FA" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector4_genosl" nodedef="ND_multiply_vector4" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_vector4FA_genosl" nodedef="ND_multiply_vector4FA" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_matrix33_genosl" nodedef="ND_multiply_matrix33" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_matrix44_genosl" nodedef="ND_multiply_matrix44" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_surfaceshaderF_genosl" nodedef="ND_multiply_surfaceshaderF" file="mx_multiply.inline" target="genosl" />
+  <implementation name="IM_multiply_surfaceshaderC_genosl" nodedef="ND_multiply_surfaceshaderC" file="mx_multiply.inline" target="genosl" />
 
   <!-- <divide> -->
-  <implementation name="IM_divide_float_genosl" nodedef="ND_divide_float" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color3_genosl" nodedef="ND_divide_color3" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color3FA_genosl" nodedef="ND_divide_color3FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color4_genosl" nodedef="ND_divide_color4" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_color4FA_genosl" nodedef="ND_divide_color4FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector2_genosl" nodedef="ND_divide_vector2" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector2FA_genosl" nodedef="ND_divide_vector2FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector3_genosl" nodedef="ND_divide_vector3" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector3FA_genosl" nodedef="ND_divide_vector3FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector4_genosl" nodedef="ND_divide_vector4" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_vector4FA_genosl" nodedef="ND_divide_vector4FA" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_matrix33_genosl" nodedef="ND_divide_matrix33" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
-  <implementation name="IM_divide_matrix44_genosl" nodedef="ND_divide_matrix44" file="libraries/stdlib/genosl/mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_float_genosl" nodedef="ND_divide_float" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color3_genosl" nodedef="ND_divide_color3" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color3FA_genosl" nodedef="ND_divide_color3FA" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color4_genosl" nodedef="ND_divide_color4" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_color4FA_genosl" nodedef="ND_divide_color4FA" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector2_genosl" nodedef="ND_divide_vector2" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector2FA_genosl" nodedef="ND_divide_vector2FA" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector3_genosl" nodedef="ND_divide_vector3" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector3FA_genosl" nodedef="ND_divide_vector3FA" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector4_genosl" nodedef="ND_divide_vector4" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_vector4FA_genosl" nodedef="ND_divide_vector4FA" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_matrix33_genosl" nodedef="ND_divide_matrix33" file="mx_divide.inline" target="genosl" />
+  <implementation name="IM_divide_matrix44_genosl" nodedef="ND_divide_matrix44" file="mx_divide.inline" target="genosl" />
 
   <!-- <modulo> -->
-  <implementation name="IM_modulo_float_genosl" nodedef="ND_modulo_float" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_color3_genosl" nodedef="ND_modulo_color3" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_color3FA_genosl" nodedef="ND_modulo_color3FA" file="libraries/stdlib/genosl/mx_modulo_color3FA.inline" target="genosl" />
-  <implementation name="IM_modulo_color4_genosl" nodedef="ND_modulo_color4" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_color4FA_genosl" nodedef="ND_modulo_color4FA" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector2_genosl" nodedef="ND_modulo_vector2" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector2FA_genosl" nodedef="ND_modulo_vector2FA" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector3_genosl" nodedef="ND_modulo_vector3" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector3FA_genosl" nodedef="ND_modulo_vector3FA" file="libraries/stdlib/genosl/mx_modulo_vector3FA.inline" target="genosl" />
-  <implementation name="IM_modulo_vector4_genosl" nodedef="ND_modulo_vector4" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
-  <implementation name="IM_modulo_vector4FA_genosl" nodedef="ND_modulo_vector4FA" file="libraries/stdlib/genosl/mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_float_genosl" nodedef="ND_modulo_float" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_color3_genosl" nodedef="ND_modulo_color3" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_color3FA_genosl" nodedef="ND_modulo_color3FA" file="mx_modulo_color3FA.inline" target="genosl" />
+  <implementation name="IM_modulo_color4_genosl" nodedef="ND_modulo_color4" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_color4FA_genosl" nodedef="ND_modulo_color4FA" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector2_genosl" nodedef="ND_modulo_vector2" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector2FA_genosl" nodedef="ND_modulo_vector2FA" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector3_genosl" nodedef="ND_modulo_vector3" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector3FA_genosl" nodedef="ND_modulo_vector3FA" file="mx_modulo_vector3FA.inline" target="genosl" />
+  <implementation name="IM_modulo_vector4_genosl" nodedef="ND_modulo_vector4" file="mx_modulo.inline" target="genosl" />
+  <implementation name="IM_modulo_vector4FA_genosl" nodedef="ND_modulo_vector4FA" file="mx_modulo.inline" target="genosl" />
 
   <!-- <invert> -->
-  <implementation name="IM_invert_float_genosl" nodedef="ND_invert_float" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color3_genosl" nodedef="ND_invert_color3" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color3FA_genosl" nodedef="ND_invert_color3FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color4_genosl" nodedef="ND_invert_color4" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_color4FA_genosl" nodedef="ND_invert_color4FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector2_genosl" nodedef="ND_invert_vector2" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector2FA_genosl" nodedef="ND_invert_vector2FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector3_genosl" nodedef="ND_invert_vector3" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector3FA_genosl" nodedef="ND_invert_vector3FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector4_genosl" nodedef="ND_invert_vector4" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
-  <implementation name="IM_invert_vector4FA_genosl" nodedef="ND_invert_vector4FA" file="libraries/stdlib/genosl/mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_float_genosl" nodedef="ND_invert_float" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color3_genosl" nodedef="ND_invert_color3" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color3FA_genosl" nodedef="ND_invert_color3FA" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color4_genosl" nodedef="ND_invert_color4" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_color4FA_genosl" nodedef="ND_invert_color4FA" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector2_genosl" nodedef="ND_invert_vector2" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector2FA_genosl" nodedef="ND_invert_vector2FA" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector3_genosl" nodedef="ND_invert_vector3" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector3FA_genosl" nodedef="ND_invert_vector3FA" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector4_genosl" nodedef="ND_invert_vector4" file="mx_invert.inline" target="genosl" />
+  <implementation name="IM_invert_vector4FA_genosl" nodedef="ND_invert_vector4FA" file="mx_invert.inline" target="genosl" />
 
   <!-- <absval> -->
-  <implementation name="IM_absval_float_genosl" nodedef="ND_absval_float" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_color3_genosl" nodedef="ND_absval_color3" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_color4_genosl" nodedef="ND_absval_color4" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_vector2_genosl" nodedef="ND_absval_vector2" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_vector3_genosl" nodedef="ND_absval_vector3" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
-  <implementation name="IM_absval_vector4_genosl" nodedef="ND_absval_vector4" file="libraries/stdlib/genosl/mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_float_genosl" nodedef="ND_absval_float" file="mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_color3_genosl" nodedef="ND_absval_color3" file="mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_color4_genosl" nodedef="ND_absval_color4" file="mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_vector2_genosl" nodedef="ND_absval_vector2" file="mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_vector3_genosl" nodedef="ND_absval_vector3" file="mx_absval.inline" target="genosl" />
+  <implementation name="IM_absval_vector4_genosl" nodedef="ND_absval_vector4" file="mx_absval.inline" target="genosl" />
 
   <!-- <floor> -->
-  <implementation name="IM_floor_float_genosl" nodedef="ND_floor_float" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_color3_genosl" nodedef="ND_floor_color3" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_color4_genosl" nodedef="ND_floor_color4" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_vector2_genosl" nodedef="ND_floor_vector2" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_vector3_genosl" nodedef="ND_floor_vector3" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
-  <implementation name="IM_floor_vector4_genosl" nodedef="ND_floor_vector4" file="libraries/stdlib/genosl/mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_float_genosl" nodedef="ND_floor_float" file="mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_color3_genosl" nodedef="ND_floor_color3" file="mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_color4_genosl" nodedef="ND_floor_color4" file="mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_vector2_genosl" nodedef="ND_floor_vector2" file="mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_vector3_genosl" nodedef="ND_floor_vector3" file="mx_floor.inline" target="genosl" />
+  <implementation name="IM_floor_vector4_genosl" nodedef="ND_floor_vector4" file="mx_floor.inline" target="genosl" />
 
   <!-- <ceil> -->
-  <implementation name="IM_ceil_float_genosl" nodedef="ND_ceil_float" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_color3_genosl" nodedef="ND_ceil_color3" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_color4_genosl" nodedef="ND_ceil_color4" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_vector2_genosl" nodedef="ND_ceil_vector2" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_vector3_genosl" nodedef="ND_ceil_vector3" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
-  <implementation name="IM_ceil_vector4_genosl" nodedef="ND_ceil_vector4" file="libraries/stdlib/genosl/mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_float_genosl" nodedef="ND_ceil_float" file="mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_color3_genosl" nodedef="ND_ceil_color3" file="mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_color4_genosl" nodedef="ND_ceil_color4" file="mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_vector2_genosl" nodedef="ND_ceil_vector2" file="mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_vector3_genosl" nodedef="ND_ceil_vector3" file="mx_ceil.inline" target="genosl" />
+  <implementation name="IM_ceil_vector4_genosl" nodedef="ND_ceil_vector4" file="mx_ceil.inline" target="genosl" />
 
   <!-- <power> -->
-  <implementation name="IM_power_float_genosl" nodedef="ND_power_float" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color3_genosl" nodedef="ND_power_color3" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color3FA_genosl" nodedef="ND_power_color3FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color4_genosl" nodedef="ND_power_color4" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_color4FA_genosl" nodedef="ND_power_color4FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector2_genosl" nodedef="ND_power_vector2" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector2FA_genosl" nodedef="ND_power_vector2FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector3_genosl" nodedef="ND_power_vector3" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector3FA_genosl" nodedef="ND_power_vector3FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector4_genosl" nodedef="ND_power_vector4" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
-  <implementation name="IM_power_vector4FA_genosl" nodedef="ND_power_vector4FA" file="libraries/stdlib/genosl/mx_power.inline" target="genosl" />
+  <implementation name="IM_power_float_genosl" nodedef="ND_power_float" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color3_genosl" nodedef="ND_power_color3" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color3FA_genosl" nodedef="ND_power_color3FA" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color4_genosl" nodedef="ND_power_color4" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_color4FA_genosl" nodedef="ND_power_color4FA" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector2_genosl" nodedef="ND_power_vector2" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector2FA_genosl" nodedef="ND_power_vector2FA" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector3_genosl" nodedef="ND_power_vector3" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector3FA_genosl" nodedef="ND_power_vector3FA" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector4_genosl" nodedef="ND_power_vector4" file="mx_power.inline" target="genosl" />
+  <implementation name="IM_power_vector4FA_genosl" nodedef="ND_power_vector4FA" file="mx_power.inline" target="genosl" />
 
   <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genosl" nodedef="ND_sin_float" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_float_genosl" nodedef="ND_cos_float" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_float_genosl" nodedef="ND_tan_float" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_float_genosl" nodedef="ND_sin_float" file="mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_float_genosl" nodedef="ND_cos_float" file="mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_float_genosl" nodedef="ND_tan_float" file="mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" file="mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" file="mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" file="mx_atan2.inline" target="genosl" />
 
-  <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_vector2_genosl" nodedef="ND_tan_vector2" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" file="mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" file="mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_vector2_genosl" nodedef="ND_tan_vector2" file="mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" file="mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" file="mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" file="mx_atan2.inline" target="genosl" />
 
-  <implementation name="IM_sin_vector3_genosl" nodedef="ND_sin_vector3" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_vector3_genosl" nodedef="ND_cos_vector3" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_vector3_genosl" nodedef="ND_tan_vector3" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_vector3_genosl" nodedef="ND_sin_vector3" file="mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_vector3_genosl" nodedef="ND_cos_vector3" file="mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_vector3_genosl" nodedef="ND_tan_vector3" file="mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" file="mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" file="mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" file="mx_atan2.inline" target="genosl" />
 
-  <implementation name="IM_sin_vector4_genosl" nodedef="ND_sin_vector4" file="libraries/stdlib/genosl/mx_sin.inline" target="genosl" />
-  <implementation name="IM_cos_vector4_genosl" nodedef="ND_cos_vector4" file="libraries/stdlib/genosl/mx_cos.inline" target="genosl" />
-  <implementation name="IM_tan_vector4_genosl" nodedef="ND_tan_vector4" file="libraries/stdlib/genosl/mx_tan.inline" target="genosl" />
-  <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" file="libraries/stdlib/genosl/mx_asin.inline" target="genosl" />
-  <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" file="libraries/stdlib/genosl/mx_acos.inline" target="genosl" />
-  <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" file="libraries/stdlib/genosl/mx_atan2.inline" target="genosl" />
+  <implementation name="IM_sin_vector4_genosl" nodedef="ND_sin_vector4" file="mx_sin.inline" target="genosl" />
+  <implementation name="IM_cos_vector4_genosl" nodedef="ND_cos_vector4" file="mx_cos.inline" target="genosl" />
+  <implementation name="IM_tan_vector4_genosl" nodedef="ND_tan_vector4" file="mx_tan.inline" target="genosl" />
+  <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" file="mx_asin.inline" target="genosl" />
+  <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" file="mx_acos.inline" target="genosl" />
+  <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" file="mx_atan2.inline" target="genosl" />
 
   <!-- <sqrt> -->
-  <implementation name="IM_sqrt_float_genosl" nodedef="ND_sqrt_float" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
-  <implementation name="IM_sqrt_vector2_genosl" nodedef="ND_sqrt_vector2" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
-  <implementation name="IM_sqrt_vector3_genosl" nodedef="ND_sqrt_vector3" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
-  <implementation name="IM_sqrt_vector4_genosl" nodedef="ND_sqrt_vector4" file="libraries/stdlib/genosl/mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_float_genosl" nodedef="ND_sqrt_float" file="mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_vector2_genosl" nodedef="ND_sqrt_vector2" file="mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_vector3_genosl" nodedef="ND_sqrt_vector3" file="mx_sqrt.inline" target="genosl" />
+  <implementation name="IM_sqrt_vector4_genosl" nodedef="ND_sqrt_vector4" file="mx_sqrt.inline" target="genosl" />
 
   <!-- <ln> -->
-  <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
-  <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
-  <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
-  <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" file="libraries/stdlib/genosl/mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" file="mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" file="mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" file="mx_ln.inline" target="genosl" />
+  <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" file="mx_ln.inline" target="genosl" />
 
   <!-- <exp> -->
-  <implementation name="IM_exp_float_genosl" nodedef="ND_exp_float" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
-  <implementation name="IM_exp_vector2_genosl" nodedef="ND_exp_vector2" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
-  <implementation name="IM_exp_vector3_genosl" nodedef="ND_exp_vector3" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
-  <implementation name="IM_exp_vector4_genosl" nodedef="ND_exp_vector4" file="libraries/stdlib/genosl/mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_float_genosl" nodedef="ND_exp_float" file="mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_vector2_genosl" nodedef="ND_exp_vector2" file="mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_vector3_genosl" nodedef="ND_exp_vector3" file="mx_exp.inline" target="genosl" />
+  <implementation name="IM_exp_vector4_genosl" nodedef="ND_exp_vector4" file="mx_exp.inline" target="genosl" />
 
   <!-- sign -->
-  <implementation name="IM_sign_float_genosl" nodedef="ND_sign_float" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_color3_genosl" nodedef="ND_sign_color3" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_color4_genosl" nodedef="ND_sign_color4" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_vector2_genosl" nodedef="ND_sign_vector2" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_vector3_genosl" nodedef="ND_sign_vector3" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
-  <implementation name="IM_sign_vector4_genosl" nodedef="ND_sign_vector4" file="libraries/stdlib/genosl/mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_float_genosl" nodedef="ND_sign_float" file="mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_color3_genosl" nodedef="ND_sign_color3" file="mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_color4_genosl" nodedef="ND_sign_color4" file="mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_vector2_genosl" nodedef="ND_sign_vector2" file="mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_vector3_genosl" nodedef="ND_sign_vector3" file="mx_sign.inline" target="genosl" />
+  <implementation name="IM_sign_vector4_genosl" nodedef="ND_sign_vector4" file="mx_sign.inline" target="genosl" />
 
   <!-- <clamp> -->
-  <implementation name="IM_clamp_float_genosl" nodedef="ND_clamp_float" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color3_genosl" nodedef="ND_clamp_color3" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color3FA_genosl" nodedef="ND_clamp_color3FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color4_genosl" nodedef="ND_clamp_color4" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_color4FA_genosl" nodedef="ND_clamp_color4FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector2_genosl" nodedef="ND_clamp_vector2" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector2FA_genosl" nodedef="ND_clamp_vector2FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector3_genosl" nodedef="ND_clamp_vector3" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector3FA_genosl" nodedef="ND_clamp_vector3FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector4_genosl" nodedef="ND_clamp_vector4" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
-  <implementation name="IM_clamp_vector4FA_genosl" nodedef="ND_clamp_vector4FA" file="libraries/stdlib/genosl/mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_float_genosl" nodedef="ND_clamp_float" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color3_genosl" nodedef="ND_clamp_color3" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color3FA_genosl" nodedef="ND_clamp_color3FA" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color4_genosl" nodedef="ND_clamp_color4" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_color4FA_genosl" nodedef="ND_clamp_color4FA" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector2_genosl" nodedef="ND_clamp_vector2" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector2FA_genosl" nodedef="ND_clamp_vector2FA" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector3_genosl" nodedef="ND_clamp_vector3" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector3FA_genosl" nodedef="ND_clamp_vector3FA" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector4_genosl" nodedef="ND_clamp_vector4" file="mx_clamp.inline" target="genosl" />
+  <implementation name="IM_clamp_vector4FA_genosl" nodedef="ND_clamp_vector4FA" file="mx_clamp.inline" target="genosl" />
 
   <!-- <min> -->
-  <implementation name="IM_min_float_genosl" nodedef="ND_min_float" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color3_genosl" nodedef="ND_min_color3" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color3FA_genosl" nodedef="ND_min_color3FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color4_genosl" nodedef="ND_min_color4" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_color4FA_genosl" nodedef="ND_min_color4FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector2_genosl" nodedef="ND_min_vector2" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector2FA_genosl" nodedef="ND_min_vector2FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector3_genosl" nodedef="ND_min_vector3" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector3FA_genosl" nodedef="ND_min_vector3FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector4_genosl" nodedef="ND_min_vector4" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
-  <implementation name="IM_min_vector4FA_genosl" nodedef="ND_min_vector4FA" file="libraries/stdlib/genosl/mx_min.inline" target="genosl" />
+  <implementation name="IM_min_float_genosl" nodedef="ND_min_float" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color3_genosl" nodedef="ND_min_color3" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color3FA_genosl" nodedef="ND_min_color3FA" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color4_genosl" nodedef="ND_min_color4" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_color4FA_genosl" nodedef="ND_min_color4FA" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector2_genosl" nodedef="ND_min_vector2" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector2FA_genosl" nodedef="ND_min_vector2FA" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector3_genosl" nodedef="ND_min_vector3" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector3FA_genosl" nodedef="ND_min_vector3FA" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector4_genosl" nodedef="ND_min_vector4" file="mx_min.inline" target="genosl" />
+  <implementation name="IM_min_vector4FA_genosl" nodedef="ND_min_vector4FA" file="mx_min.inline" target="genosl" />
 
   <!-- <max> -->
-  <implementation name="IM_max_float_genosl" nodedef="ND_max_float" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color3_genosl" nodedef="ND_max_color3" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color3FA_genosl" nodedef="ND_max_color3FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color4_genosl" nodedef="ND_max_color4" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_color4FA_genosl" nodedef="ND_max_color4FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector2_genosl" nodedef="ND_max_vector2" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector2FA_genosl" nodedef="ND_max_vector2FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector3_genosl" nodedef="ND_max_vector3" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector3FA_genosl" nodedef="ND_max_vector3FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector4_genosl" nodedef="ND_max_vector4" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
-  <implementation name="IM_max_vector4FA_genosl" nodedef="ND_max_vector4FA" file="libraries/stdlib/genosl/mx_max.inline" target="genosl" />
+  <implementation name="IM_max_float_genosl" nodedef="ND_max_float" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color3_genosl" nodedef="ND_max_color3" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color3FA_genosl" nodedef="ND_max_color3FA" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color4_genosl" nodedef="ND_max_color4" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_color4FA_genosl" nodedef="ND_max_color4FA" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector2_genosl" nodedef="ND_max_vector2" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector2FA_genosl" nodedef="ND_max_vector2FA" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector3_genosl" nodedef="ND_max_vector3" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector3FA_genosl" nodedef="ND_max_vector3FA" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector4_genosl" nodedef="ND_max_vector4" file="mx_max.inline" target="genosl" />
+  <implementation name="IM_max_vector4FA_genosl" nodedef="ND_max_vector4FA" file="mx_max.inline" target="genosl" />
 
   <!-- <normalize> -->
-  <implementation name="IM_normalize_vector2_genosl" nodedef="ND_normalize_vector2" file="libraries/stdlib/genosl/mx_normalize.inline" target="genosl" />
-  <implementation name="IM_normalize_vector3_genosl" nodedef="ND_normalize_vector3" file="libraries/stdlib/genosl/mx_normalize.inline" target="genosl" />
-  <implementation name="IM_normalize_vector4_genosl" nodedef="ND_normalize_vector4" file="libraries/stdlib/genosl/mx_normalize.inline" target="genosl" />
+  <implementation name="IM_normalize_vector2_genosl" nodedef="ND_normalize_vector2" file="mx_normalize.inline" target="genosl" />
+  <implementation name="IM_normalize_vector3_genosl" nodedef="ND_normalize_vector3" file="mx_normalize.inline" target="genosl" />
+  <implementation name="IM_normalize_vector4_genosl" nodedef="ND_normalize_vector4" file="mx_normalize.inline" target="genosl" />
 
   <!-- <magnitude> -->
-  <implementation name="IM_magnitude_vector2_genosl" nodedef="ND_magnitude_vector2" file="libraries/stdlib/genosl/mx_magnitude.inline" target="genosl" />
-  <implementation name="IM_magnitude_vector3_genosl" nodedef="ND_magnitude_vector3" file="libraries/stdlib/genosl/mx_magnitude.inline" target="genosl" />
-  <implementation name="IM_magnitude_vector4_genosl" nodedef="ND_magnitude_vector4" file="libraries/stdlib/genosl/mx_magnitude.inline" target="genosl" />
+  <implementation name="IM_magnitude_vector2_genosl" nodedef="ND_magnitude_vector2" file="mx_magnitude.inline" target="genosl" />
+  <implementation name="IM_magnitude_vector3_genosl" nodedef="ND_magnitude_vector3" file="mx_magnitude.inline" target="genosl" />
+  <implementation name="IM_magnitude_vector4_genosl" nodedef="ND_magnitude_vector4" file="mx_magnitude.inline" target="genosl" />
 
   <!-- <dotproduct> -->
-  <implementation name="IM_dotproduct_vector2_genosl" nodedef="ND_dotproduct_vector2" file="libraries/stdlib/genosl/mx_dotproduct.inline" target="genosl" />
-  <implementation name="IM_dotproduct_vector3_genosl" nodedef="ND_dotproduct_vector3" file="libraries/stdlib/genosl/mx_dotproduct.inline" target="genosl" />
-  <implementation name="IM_dotproduct_vector4_genosl" nodedef="ND_dotproduct_vector4" file="libraries/stdlib/genosl/mx_dotproduct.inline" target="genosl" />
+  <implementation name="IM_dotproduct_vector2_genosl" nodedef="ND_dotproduct_vector2" file="mx_dotproduct.inline" target="genosl" />
+  <implementation name="IM_dotproduct_vector3_genosl" nodedef="ND_dotproduct_vector3" file="mx_dotproduct.inline" target="genosl" />
+  <implementation name="IM_dotproduct_vector4_genosl" nodedef="ND_dotproduct_vector4" file="mx_dotproduct.inline" target="genosl" />
 
   <!-- <crossproduct> -->
-  <implementation name="IM_crossproduct_vector3_genosl" nodedef="ND_crossproduct_vector3" file="libraries/stdlib/genosl/mx_crossproduct.inline" target="genosl" />
+  <implementation name="IM_crossproduct_vector3_genosl" nodedef="ND_crossproduct_vector3" file="mx_crossproduct.inline" target="genosl" />
 
   <!-- <transformpoint> -->
-  <implementation name="IM_transformpoint_vector3_genosl" nodedef="ND_transformpoint_vector3" file="libraries/stdlib/genosl/mx_transformpoint.inline" target="genosl" />
+  <implementation name="IM_transformpoint_vector3_genosl" nodedef="ND_transformpoint_vector3" file="mx_transformpoint.inline" target="genosl" />
 
   <!-- <transformvector> -->
-  <implementation name="IM_transformvector_vector3_genosl" nodedef="ND_transformvector_vector3" file="libraries/stdlib/genosl/mx_transformvector.inline" target="genosl" />
+  <implementation name="IM_transformvector_vector3_genosl" nodedef="ND_transformvector_vector3" file="mx_transformvector.inline" target="genosl" />
 
   <!-- <transformnormal> -->
-  <implementation name="IM_transformnormal_vector3_genosl" nodedef="ND_transformnormal_vector3" file="libraries/stdlib/genosl/mx_transformnormal.inline" target="genosl" />
+  <implementation name="IM_transformnormal_vector3_genosl" nodedef="ND_transformnormal_vector3" file="mx_transformnormal.inline" target="genosl" />
 
   <!-- <transformmatrix> -->
-  <implementation name="IM_transformmatrix_vector2M3_genosl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="libraries/stdlib/genosl/mx_transformmatrix_vector2M3.osl" target="genosl" />
-  <implementation name="IM_transformmatrix_vector3_genosl" nodedef="ND_transformmatrix_vector3" file="libraries/stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
-  <implementation name="IM_transformmatrix_vector3M4_genosl" nodedef="ND_transformmatrix_vector3M4" file="libraries/stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
-  <implementation name="IM_transformmatrix_vector4_genosl" nodedef="ND_transformmatrix_vector4" file="libraries/stdlib/genosl/mx_transformmatrix.inline" target="genosl" />
+  <implementation name="IM_transformmatrix_vector2M3_genosl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="mx_transformmatrix_vector2M3.osl" target="genosl" />
+  <implementation name="IM_transformmatrix_vector3_genosl" nodedef="ND_transformmatrix_vector3" file="mx_transformmatrix.inline" target="genosl" />
+  <implementation name="IM_transformmatrix_vector3M4_genosl" nodedef="ND_transformmatrix_vector3M4" file="mx_transformmatrix.inline" target="genosl" />
+  <implementation name="IM_transformmatrix_vector4_genosl" nodedef="ND_transformmatrix_vector4" file="mx_transformmatrix.inline" target="genosl" />
 
   <!-- <transpose> -->
-  <implementation name="IM_transpose_matrix33_genosl" nodedef="ND_transpose_matrix33" file="libraries/stdlib/genosl/mx_transpose.inline" target="genosl" />
-  <implementation name="IM_transpose_matrix44_genosl" nodedef="ND_transpose_matrix44" file="libraries/stdlib/genosl/mx_transpose.inline" target="genosl" />
+  <implementation name="IM_transpose_matrix33_genosl" nodedef="ND_transpose_matrix33" file="mx_transpose.inline" target="genosl" />
+  <implementation name="IM_transpose_matrix44_genosl" nodedef="ND_transpose_matrix44" file="mx_transpose.inline" target="genosl" />
 
   <!-- <determinant> -->
-  <implementation name="IM_determinant_matrix33_genosl" nodedef="ND_determinant_matrix33" file="libraries/stdlib/genosl/mx_determinant.inline" target="genosl" />
-  <implementation name="IM_determinant_matrix44_genosl" nodedef="ND_determinant_matrix44" file="libraries/stdlib/genosl/mx_determinant.inline" target="genosl" />
+  <implementation name="IM_determinant_matrix33_genosl" nodedef="ND_determinant_matrix33" file="mx_determinant.inline" target="genosl" />
+  <implementation name="IM_determinant_matrix44_genosl" nodedef="ND_determinant_matrix44" file="mx_determinant.inline" target="genosl" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genosl" nodedef="ND_invertmatrix_matrix33" file="libraries/stdlib/genosl/mx_invertM.inline" target="genosl" />
-  <implementation name="IM_invertmatrix_matrix44_genosl" nodedef="ND_invertmatrix_matrix44" file="libraries/stdlib/genosl/mx_invertM.inline" target="genosl" />
+  <implementation name="IM_invertmatrix_matrix33_genosl" nodedef="ND_invertmatrix_matrix33" file="mx_invertM.inline" target="genosl" />
+  <implementation name="IM_invertmatrix_matrix44_genosl" nodedef="ND_invertmatrix_matrix44" file="mx_invertM.inline" target="genosl" />
 
   <!-- <rotate2d> -->
-  <implementation name="IM_rotate2d_vector2_genosl" nodedef="ND_rotate2d_vector2" file="libraries/stdlib/genosl/mx_rotate_vector2.osl" function="mx_rotate_vector2" target="genosl" />
+  <implementation name="IM_rotate2d_vector2_genosl" nodedef="ND_rotate2d_vector2" file="mx_rotate_vector2.osl" function="mx_rotate_vector2" target="genosl" />
 
   <!-- <rotate3d> -->
-  <implementation name="IM_rotate3d_vector3_genosl" nodedef="ND_rotate3d_vector3" file="libraries/stdlib/genosl/mx_rotate_vector3.osl" function="mx_rotate_vector3" target="genosl" />
+  <implementation name="IM_rotate3d_vector3_genosl" nodedef="ND_rotate3d_vector3" file="mx_rotate_vector3.osl" function="mx_rotate_vector3" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
   <!-- ======================================================================== -->
 
   <!-- <remap> -->
-  <implementation name="IM_remap_float_genosl" nodedef="ND_remap_float" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color3_genosl" nodedef="ND_remap_color3" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color3FA_genosl" nodedef="ND_remap_color3FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color4_genosl" nodedef="ND_remap_color4" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_color4FA_genosl" nodedef="ND_remap_color4FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector2_genosl" nodedef="ND_remap_vector2" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector2FA_genosl" nodedef="ND_remap_vector2FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector3_genosl" nodedef="ND_remap_vector3" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector3FA_genosl" nodedef="ND_remap_vector3FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector4_genosl" nodedef="ND_remap_vector4" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
-  <implementation name="IM_remap_vector4FA_genosl" nodedef="ND_remap_vector4FA" file="libraries/stdlib/genosl/mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_float_genosl" nodedef="ND_remap_float" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color3_genosl" nodedef="ND_remap_color3" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color3FA_genosl" nodedef="ND_remap_color3FA" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color4_genosl" nodedef="ND_remap_color4" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_color4FA_genosl" nodedef="ND_remap_color4FA" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector2_genosl" nodedef="ND_remap_vector2" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector2FA_genosl" nodedef="ND_remap_vector2FA" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector3_genosl" nodedef="ND_remap_vector3" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector3FA_genosl" nodedef="ND_remap_vector3FA" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector4_genosl" nodedef="ND_remap_vector4" file="mx_remap.inline" target="genosl" />
+  <implementation name="IM_remap_vector4FA_genosl" nodedef="ND_remap_vector4FA" file="mx_remap.inline" target="genosl" />
 
   <!-- <smoothstep> -->
-  <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color3_genosl" nodedef="ND_smoothstep_color3" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color3FA_genosl" nodedef="ND_smoothstep_color3FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color4_genosl" nodedef="ND_smoothstep_color4" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_color4FA_genosl" nodedef="ND_smoothstep_color4FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector2FA_genosl" nodedef="ND_smoothstep_vector2FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector3FA_genosl" nodedef="ND_smoothstep_vector3FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
-  <implementation name="IM_smoothstep_vector4FA_genosl" nodedef="ND_smoothstep_vector4FA" file="libraries/stdlib/genosl/mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color3_genosl" nodedef="ND_smoothstep_color3" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color3FA_genosl" nodedef="ND_smoothstep_color3FA" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color4_genosl" nodedef="ND_smoothstep_color4" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_color4FA_genosl" nodedef="ND_smoothstep_color4FA" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector2FA_genosl" nodedef="ND_smoothstep_vector2FA" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector3FA_genosl" nodedef="ND_smoothstep_vector3FA" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" file="mx_smoothstep.inline" target="genosl" />
+  <implementation name="IM_smoothstep_vector4FA_genosl" nodedef="ND_smoothstep_vector4FA" file="mx_smoothstep.inline" target="genosl" />
 
   <!-- <luminance> -->
-  <implementation name="IM_luminance_color3_genosl" nodedef="ND_luminance_color3" file="libraries/stdlib/genosl/mx_luminance_color3.osl" function="mx_luminance_color3" target="genosl" />
-  <implementation name="IM_luminance_color4_genosl" nodedef="ND_luminance_color4" file="libraries/stdlib/genosl/mx_luminance_color4.osl" function="mx_luminance_color4" target="genosl" />
+  <implementation name="IM_luminance_color3_genosl" nodedef="ND_luminance_color3" file="mx_luminance_color3.osl" function="mx_luminance_color3" target="genosl" />
+  <implementation name="IM_luminance_color4_genosl" nodedef="ND_luminance_color4" file="mx_luminance_color4.osl" function="mx_luminance_color4" target="genosl" />
 
   <!-- <rgbtohsv> -->
-  <implementation name="IM_rgbtohsv_color3_genosl" nodedef="ND_rgbtohsv_color3" file="libraries/stdlib/genosl/mx_rgbtohsv_color3.osl" function="mx_rgbtohsv_color3" target="genosl" />
-  <implementation name="IM_rgbtohsv_color4_genosl" nodedef="ND_rgbtohsv_color4" file="libraries/stdlib/genosl/mx_rgbtohsv_color4.osl" function="mx_rgbtohsv_color4" target="genosl" />
+  <implementation name="IM_rgbtohsv_color3_genosl" nodedef="ND_rgbtohsv_color3" file="mx_rgbtohsv_color3.osl" function="mx_rgbtohsv_color3" target="genosl" />
+  <implementation name="IM_rgbtohsv_color4_genosl" nodedef="ND_rgbtohsv_color4" file="mx_rgbtohsv_color4.osl" function="mx_rgbtohsv_color4" target="genosl" />
 
   <!-- <hsvtorgb> -->
-  <implementation name="IM_hsvtorgb_color3_genosl" nodedef="ND_hsvtorgb_color3" file="libraries/stdlib/genosl/mx_hsvtorgb_color3.osl" function="mx_hsvtorgb_color3" target="genosl" />
-  <implementation name="IM_hsvtorgb_color4_genosl" nodedef="ND_hsvtorgb_color4" file="libraries/stdlib/genosl/mx_hsvtorgb_color4.osl" function="mx_hsvtorgb_color4" target="genosl" />
+  <implementation name="IM_hsvtorgb_color3_genosl" nodedef="ND_hsvtorgb_color3" file="mx_hsvtorgb_color3.osl" function="mx_hsvtorgb_color3" target="genosl" />
+  <implementation name="IM_hsvtorgb_color4_genosl" nodedef="ND_hsvtorgb_color4" file="mx_hsvtorgb_color4.osl" function="mx_hsvtorgb_color4" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->
   <!-- ======================================================================== -->
 
   <!-- <premult> -->
-  <implementation name="IM_premult_color4_genosl" nodedef="ND_premult_color4" file="libraries/stdlib/genosl/mx_premult_color4.osl" function="mx_premult_color4" target="genosl" />
+  <implementation name="IM_premult_color4_genosl" nodedef="ND_premult_color4" file="mx_premult_color4.osl" function="mx_premult_color4" target="genosl" />
 
   <!-- <unpremult> -->
-  <implementation name="IM_unpremult_color4_genosl" nodedef="ND_unpremult_color4" file="libraries/stdlib/genosl/mx_unpremult_color4.osl" function="mx_unpremult_color4" target="genosl" />
+  <implementation name="IM_unpremult_color4_genosl" nodedef="ND_unpremult_color4" file="mx_unpremult_color4.osl" function="mx_unpremult_color4" target="genosl" />
 
   <!-- <plus> -->
-  <implementation name="IM_plus_float_genosl" nodedef="ND_plus_float" file="libraries/stdlib/genosl/mx_plus.inline" target="genosl" />
-  <implementation name="IM_plus_color3_genosl" nodedef="ND_plus_color3" file="libraries/stdlib/genosl/mx_plus.inline" target="genosl" />
-  <implementation name="IM_plus_color4_genosl" nodedef="ND_plus_color4" file="libraries/stdlib/genosl/mx_plus.inline" target="genosl" />
+  <implementation name="IM_plus_float_genosl" nodedef="ND_plus_float" file="mx_plus.inline" target="genosl" />
+  <implementation name="IM_plus_color3_genosl" nodedef="ND_plus_color3" file="mx_plus.inline" target="genosl" />
+  <implementation name="IM_plus_color4_genosl" nodedef="ND_plus_color4" file="mx_plus.inline" target="genosl" />
 
   <!-- <minus> -->
-  <implementation name="IM_minus_float_genosl" nodedef="ND_minus_float" file="libraries/stdlib/genosl/mx_minus.inline" target="genosl" />
-  <implementation name="IM_minus_color3_genosl" nodedef="ND_minus_color3" file="libraries/stdlib/genosl/mx_minus.inline" target="genosl" />
-  <implementation name="IM_minus_color4_genosl" nodedef="ND_minus_color4" file="libraries/stdlib/genosl/mx_minus.inline" target="genosl" />
+  <implementation name="IM_minus_float_genosl" nodedef="ND_minus_float" file="mx_minus.inline" target="genosl" />
+  <implementation name="IM_minus_color3_genosl" nodedef="ND_minus_color3" file="mx_minus.inline" target="genosl" />
+  <implementation name="IM_minus_color4_genosl" nodedef="ND_minus_color4" file="mx_minus.inline" target="genosl" />
 
   <!-- <difference> -->
-  <implementation name="IM_difference_float_genosl" nodedef="ND_difference_float" file="libraries/stdlib/genosl/mx_difference.inline" target="genosl" />
-  <implementation name="IM_difference_color3_genosl" nodedef="ND_difference_color3" file="libraries/stdlib/genosl/mx_difference.inline" target="genosl" />
-  <implementation name="IM_difference_color4_genosl" nodedef="ND_difference_color4" file="libraries/stdlib/genosl/mx_difference.inline" target="genosl" />
+  <implementation name="IM_difference_float_genosl" nodedef="ND_difference_float" file="mx_difference.inline" target="genosl" />
+  <implementation name="IM_difference_color3_genosl" nodedef="ND_difference_color3" file="mx_difference.inline" target="genosl" />
+  <implementation name="IM_difference_color4_genosl" nodedef="ND_difference_color4" file="mx_difference.inline" target="genosl" />
 
   <!-- <burn> -->
-  <implementation name="IM_burn_float_genosl" nodedef="ND_burn_float" file="libraries/stdlib/genosl/mx_burn_float.osl" function="mx_burn_float" target="genosl" />
-  <implementation name="IM_burn_color3_genosl" nodedef="ND_burn_color3" file="libraries/stdlib/genosl/mx_burn_color3.osl" function="mx_burn_color3" target="genosl" />
-  <implementation name="IM_burn_color4_genosl" nodedef="ND_burn_color4" file="libraries/stdlib/genosl/mx_burn_color4.osl" function="mx_burn_color4" target="genosl" />
+  <implementation name="IM_burn_float_genosl" nodedef="ND_burn_float" file="mx_burn_float.osl" function="mx_burn_float" target="genosl" />
+  <implementation name="IM_burn_color3_genosl" nodedef="ND_burn_color3" file="mx_burn_color3.osl" function="mx_burn_color3" target="genosl" />
+  <implementation name="IM_burn_color4_genosl" nodedef="ND_burn_color4" file="mx_burn_color4.osl" function="mx_burn_color4" target="genosl" />
 
   <!-- <dodge> -->
-  <implementation name="IM_dodge_float_genosl" nodedef="ND_dodge_float" file="libraries/stdlib/genosl/mx_dodge_float.osl" function="mx_dodge_float" target="genosl" />
-  <implementation name="IM_dodge_color3_genosl" nodedef="ND_dodge_color3" file="libraries/stdlib/genosl/mx_dodge_color3.osl" function="mx_dodge_color3" target="genosl" />
-  <implementation name="IM_dodge_color4_genosl" nodedef="ND_dodge_color4" file="libraries/stdlib/genosl/mx_dodge_color4.osl" function="mx_dodge_color4" target="genosl" />
+  <implementation name="IM_dodge_float_genosl" nodedef="ND_dodge_float" file="mx_dodge_float.osl" function="mx_dodge_float" target="genosl" />
+  <implementation name="IM_dodge_color3_genosl" nodedef="ND_dodge_color3" file="mx_dodge_color3.osl" function="mx_dodge_color3" target="genosl" />
+  <implementation name="IM_dodge_color4_genosl" nodedef="ND_dodge_color4" file="mx_dodge_color4.osl" function="mx_dodge_color4" target="genosl" />
 
   <!-- <screen> -->
-  <implementation name="IM_screen_float_genosl" nodedef="ND_screen_float" file="libraries/stdlib/genosl/mx_screen.inline" target="genosl" />
-  <implementation name="IM_screen_color3_genosl" nodedef="ND_screen_color3" file="libraries/stdlib/genosl/mx_screen.inline" target="genosl" />
-  <implementation name="IM_screen_color4_genosl" nodedef="ND_screen_color4" file="libraries/stdlib/genosl/mx_screen.inline" target="genosl" />
+  <implementation name="IM_screen_float_genosl" nodedef="ND_screen_float" file="mx_screen.inline" target="genosl" />
+  <implementation name="IM_screen_color3_genosl" nodedef="ND_screen_color3" file="mx_screen.inline" target="genosl" />
+  <implementation name="IM_screen_color4_genosl" nodedef="ND_screen_color4" file="mx_screen.inline" target="genosl" />
 
   <!-- <overlay> -->
-  <implementation name="IM_overlay_float_genosl" nodedef="ND_overlay_float" file="libraries/stdlib/genosl/mx_overlay.inline" target="genosl" />
-  <implementation name="IM_overlay_color3_genosl" nodedef="ND_overlay_color3" file="libraries/stdlib/genosl/mx_overlay_color3.osl" function="mx_overlay_color3" target="genosl" />
-  <implementation name="IM_overlay_color4_genosl" nodedef="ND_overlay_color4" file="libraries/stdlib/genosl/mx_overlay_color4.osl" function="mx_overlay_color4" target="genosl" />
+  <implementation name="IM_overlay_float_genosl" nodedef="ND_overlay_float" file="mx_overlay.inline" target="genosl" />
+  <implementation name="IM_overlay_color3_genosl" nodedef="ND_overlay_color3" file="mx_overlay_color3.osl" function="mx_overlay_color3" target="genosl" />
+  <implementation name="IM_overlay_color4_genosl" nodedef="ND_overlay_color4" file="mx_overlay_color4.osl" function="mx_overlay_color4" target="genosl" />
 
   <!-- <disjointover> -->
-  <implementation name="IM_disjointover_color4_genosl" nodedef="ND_disjointover_color4" file="libraries/stdlib/genosl/mx_disjointover_color4.osl" function="mx_disjointover_color4" target="genosl" />
+  <implementation name="IM_disjointover_color4_genosl" nodedef="ND_disjointover_color4" file="mx_disjointover_color4.osl" function="mx_disjointover_color4" target="genosl" />
 
   <!-- <in> -->
-  <implementation name="IM_in_color4_genosl" nodedef="ND_in_color4" file="libraries/stdlib/genosl/mx_in.inline" target="genosl" />
+  <implementation name="IM_in_color4_genosl" nodedef="ND_in_color4" file="mx_in.inline" target="genosl" />
 
   <!-- <mask> -->
-  <implementation name="IM_mask_color4_genosl" nodedef="ND_mask_color4" file="libraries/stdlib/genosl/mx_mask.inline" target="genosl" />
+  <implementation name="IM_mask_color4_genosl" nodedef="ND_mask_color4" file="mx_mask.inline" target="genosl" />
 
   <!-- <matte> -->
-  <implementation name="IM_matte_color4_genosl" nodedef="ND_matte_color4" file="libraries/stdlib/genosl/mx_matte_color4.inline" target="genosl" />
+  <implementation name="IM_matte_color4_genosl" nodedef="ND_matte_color4" file="mx_matte_color4.inline" target="genosl" />
 
   <!-- <out> -->
-  <implementation name="IM_out_color4_genosl" nodedef="ND_out_color4" file="libraries/stdlib/genosl/mx_out.inline" target="genosl" />
+  <implementation name="IM_out_color4_genosl" nodedef="ND_out_color4" file="mx_out.inline" target="genosl" />
 
   <!-- <over> -->
-  <implementation name="IM_over_color4_genosl" nodedef="ND_over_color4" file="libraries/stdlib/genosl/mx_over.inline" target="genosl" />
+  <implementation name="IM_over_color4_genosl" nodedef="ND_over_color4" file="mx_over.inline" target="genosl" />
 
   <!-- <inside> -->
-  <implementation name="IM_inside_float_genosl" nodedef="ND_inside_float" file="libraries/stdlib/genosl/mx_inside.inline" target="genosl" />
-  <implementation name="IM_inside_color3_genosl" nodedef="ND_inside_color3" file="libraries/stdlib/genosl/mx_inside.inline" target="genosl" />
-  <implementation name="IM_inside_color4_genosl" nodedef="ND_inside_color4" file="libraries/stdlib/genosl/mx_inside.inline" target="genosl" />
+  <implementation name="IM_inside_float_genosl" nodedef="ND_inside_float" file="mx_inside.inline" target="genosl" />
+  <implementation name="IM_inside_color3_genosl" nodedef="ND_inside_color3" file="mx_inside.inline" target="genosl" />
+  <implementation name="IM_inside_color4_genosl" nodedef="ND_inside_color4" file="mx_inside.inline" target="genosl" />
 
   <!-- <outside> -->
-  <implementation name="IM_outside_float_genosl" nodedef="ND_outside_float" file="libraries/stdlib/genosl/mx_outside.inline" target="genosl" />
-  <implementation name="IM_outside_color3_genosl" nodedef="ND_outside_color3" file="libraries/stdlib/genosl/mx_outside.inline" target="genosl" />
-  <implementation name="IM_outside_color4_genosl" nodedef="ND_outside_color4" file="libraries/stdlib/genosl/mx_outside.inline" target="genosl" />
+  <implementation name="IM_outside_float_genosl" nodedef="ND_outside_float" file="mx_outside.inline" target="genosl" />
+  <implementation name="IM_outside_color3_genosl" nodedef="ND_outside_color3" file="mx_outside.inline" target="genosl" />
+  <implementation name="IM_outside_color4_genosl" nodedef="ND_outside_color4" file="mx_outside.inline" target="genosl" />
 
   <!-- <mix> -->
-  <implementation name="IM_mix_float_genosl" nodedef="ND_mix_float" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_color3_genosl" nodedef="ND_mix_color3" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_color4_genosl" nodedef="ND_mix_color4" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_vector2_genosl" nodedef="ND_mix_vector2" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_vector3_genosl" nodedef="ND_mix_vector3" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_vector4_genosl" nodedef="ND_mix_vector4" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
-  <implementation name="IM_mix_surfaceshader_genosl" nodedef="ND_mix_surfaceshader" file="libraries/stdlib/genosl/mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_float_genosl" nodedef="ND_mix_float" file="mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_color3_genosl" nodedef="ND_mix_color3" file="mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_color4_genosl" nodedef="ND_mix_color4" file="mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_vector2_genosl" nodedef="ND_mix_vector2" file="mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_vector3_genosl" nodedef="ND_mix_vector3" file="mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_vector4_genosl" nodedef="ND_mix_vector4" file="mx_mix.inline" target="genosl" />
+  <implementation name="IM_mix_surfaceshader_genosl" nodedef="ND_mix_surfaceshader" file="mx_mix.inline" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
@@ -766,28 +766,28 @@
   <implementation name="IM_blur_vector4_genosl" nodedef="ND_blur_vector4" target="genosl" />
 
   <!-- <heighttonormal> -->
-  <implementation name="IM_heighttonormal_vector3_genosl" nodedef="ND_heighttonormal_vector3" file="libraries/stdlib/genosl/mx_heighttonormal_vector3.osl" function="mx_heighttonormal_vector3" target="genosl" />
+  <implementation name="IM_heighttonormal_vector3_genosl" nodedef="ND_heighttonormal_vector3" file="mx_heighttonormal_vector3.osl" function="mx_heighttonormal_vector3" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 
   <!-- <dot> -->
-  <implementation name="IM_dot_float_genosl" nodedef="ND_dot_float" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_color3_genosl" nodedef="ND_dot_color3" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_color4_genosl" nodedef="ND_dot_color4" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_vector2_genosl" nodedef="ND_dot_vector2" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_vector3_genosl" nodedef="ND_dot_vector3" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_vector4_genosl" nodedef="ND_dot_vector4" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_boolean_genosl" nodedef="ND_dot_boolean" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_integer_genosl" nodedef="ND_dot_integer" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_matrix33_genosl" nodedef="ND_dot_matrix33" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_matrix44_genosl" nodedef="ND_dot_matrix44" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_string_genosl" nodedef="ND_dot_string" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_filename_genosl" nodedef="ND_dot_filename" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_surfaceshader_genosl" nodedef="ND_dot_surfaceshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_displacementshader_genosl" nodedef="ND_dot_displacementshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_volumeshader_genosl" nodedef="ND_dot_volumeshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
-  <implementation name="IM_dot_lightshader_genosl" nodedef="ND_dot_lightshader" file="libraries/stdlib/genosl/mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_float_genosl" nodedef="ND_dot_float" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_color3_genosl" nodedef="ND_dot_color3" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_color4_genosl" nodedef="ND_dot_color4" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_vector2_genosl" nodedef="ND_dot_vector2" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_vector3_genosl" nodedef="ND_dot_vector3" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_vector4_genosl" nodedef="ND_dot_vector4" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_boolean_genosl" nodedef="ND_dot_boolean" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_integer_genosl" nodedef="ND_dot_integer" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_matrix33_genosl" nodedef="ND_dot_matrix33" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_matrix44_genosl" nodedef="ND_dot_matrix44" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_string_genosl" nodedef="ND_dot_string" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_filename_genosl" nodedef="ND_dot_filename" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_surfaceshader_genosl" nodedef="ND_dot_surfaceshader" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_displacementshader_genosl" nodedef="ND_dot_displacementshader" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_volumeshader_genosl" nodedef="ND_dot_volumeshader" file="mx_dot.inline" target="genosl" />
+  <implementation name="IM_dot_lightshader_genosl" nodedef="ND_dot_lightshader" file="mx_dot.inline" target="genosl" />
 
 </materialx>

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -344,15 +344,15 @@ void GlslShaderGenerator::emitSpecularEnvironment(GenContext& context, ShaderSta
     int specularMethod = context.getOptions().hwSpecularEnvironmentMethod;
     if (specularMethod == SPECULAR_ENVIRONMENT_FIS)
     {
-        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_fis.glsl", context, stage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_environment_fis.glsl", context, stage);
     }
     else if (specularMethod == SPECULAR_ENVIRONMENT_PREFILTER)
     {
-        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_prefilter.glsl", context, stage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_environment_prefilter.glsl", context, stage);
     }
     else if (specularMethod == SPECULAR_ENVIRONMENT_NONE)
     {
-        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_environment_none.glsl", context, stage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_environment_none.glsl", context, stage);
     }
     else
     {
@@ -522,7 +522,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitOutputs(context, stage);
 
     // Add common math functions
-    emitInclude("libraries/stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_math.glsl", context, stage);
+    emitLibraryInclude("stdlib/genglsl/lib/mx_math.glsl", context, stage);
     emitLineBreak(stage);
 
     // Determine whether lighting is required
@@ -547,7 +547,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
 
         if (context.getOptions().hwMaxActiveLightSources > 0)
         {
-          emitLightData(context, stage);
+            emitLightData(context, stage);
         }
     }
 
@@ -556,13 +556,13 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
                      context.getOptions().hwWriteDepthMoments;
     if (shadowing)
     {
-        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_shadow.glsl", context, stage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_shadow.glsl", context, stage);
     }
 
     // Emit directional albedo table code.
     if (context.getOptions().hwWriteAlbedoTable)
     {
-        emitInclude("libraries/pbrlib/" + GlslShaderGenerator::TARGET + "/lib/mx_table.glsl", context, stage);
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_table.glsl", context, stage);
         emitLineBreak(stage);
     }
 
@@ -570,17 +570,17 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     // depending on the vertical flip flag.
     if (context.getOptions().fileTextureVerticalFlip)
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_transform_uv_vflip.glsl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv_vflip.glsl";
     }
     else
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + GlslShaderGenerator::TARGET + "/lib/mx_transform_uv.glsl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv.glsl";
     }
 
     // Emit uv transform code globally if needed.
     if (context.getOptions().hwAmbientOcclusion)
     {
-        emitInclude(ShaderGenerator::T_FILE_TRANSFORM_UV, context, stage);
+        emitLibraryInclude("stdlib/genglsl/lib/" + _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV], context, stage);
     }
 
     emitLightFunctionDefinitions(graph, context, stage);

--- a/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
@@ -20,7 +20,7 @@ ShaderNodeImplPtr BlurNodeGlsl::create()
 void BlurNodeGlsl::emitSamplingFunctionDefinition(const ShaderNode& /*node*/, GenContext& context, ShaderStage& stage) const
 {
     const ShaderGenerator& shadergen = context.getShaderGenerator();
-    shadergen.emitInclude("libraries/stdlib/genglsl/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
+    shadergen.emitLibraryInclude("stdlib/genglsl/lib/mx_sampling.glsl", context, stage);
     shadergen.emitLineBreak(stage);
 }
 

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -55,7 +55,7 @@ void HeightToNormalNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContex
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
         // Emit sampling functions
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-        shadergen.emitInclude("libraries/stdlib/genglsl/lib/mx_sampling.glsl", context, stage);
+        shadergen.emitLibraryInclude("stdlib/genglsl/lib/mx_sampling.glsl", context, stage);
         shadergen.emitLineBreak(stage);
     END_SHADER_STAGE(shader, Stage::PIXEL)
 }

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -50,7 +50,7 @@ void LightNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
         const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
-        shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, context, stage);
+        shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, FilePath(), context, stage);
         shadergen.emitLineBreak(stage);
 
         context.pushClosureContext(&_callEmission);

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -275,7 +275,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
             "        )\n"
             "    )\n"
             ");";
-        emitBlock(textureMaterial, context, stage);
+        emitBlock(textureMaterial, FilePath(), context, stage);
     }
     else if (graph.hasClassification(ShaderNode::Classification::SHADER))
     {
@@ -285,7 +285,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
         emitScopeEnd(stage);
 
         static const string shaderMaterial = "in material(finalOutput__);";
-        emitBlock(shaderMaterial, context, stage);
+        emitBlock(shaderMaterial, FilePath(), context, stage);
     }
     else
     {

--- a/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
@@ -20,7 +20,7 @@ ShaderNodeImplPtr BlurNodeOsl::create()
 void BlurNodeOsl::emitSamplingFunctionDefinition(const ShaderNode& /*node*/, GenContext& context, ShaderStage& stage) const
 {
     const ShaderGenerator& shadergen = context.getShaderGenerator();
-    shadergen.emitInclude("libraries/stdlib/genosl/lib/mx_sampling" + shadergen.getSyntax().getSourceFileExtension(), context, stage);
+    shadergen.emitLibraryInclude("stdlib/genosl/lib/mx_sampling.osl", context, stage);
     shadergen.emitLineBreak(stage);
 }
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -193,7 +193,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     ShaderGraph& graph = shader->getGraph();
     ShaderStage& stage = shader->getStage(Stage::PIXEL);
 
-    emitIncludes(stage, context);
+    emitLibraryIncludes(stage, context);
 
     // Add global constants and type definitions
     emitTypeDefinitions(context, stage);
@@ -204,11 +204,11 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     // depending on the vertical flip flag.
     if (context.getOptions().fileTextureVerticalFlip)
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + OslShaderGenerator::TARGET + "/lib/mx_transform_uv_vflip.osl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv_vflip.osl";
     }
     else
     {
-        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "libraries/stdlib/" + OslShaderGenerator::TARGET + "/lib/mx_transform_uv.osl";
+        _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv.osl";
     }
 
     // Emit function definitions for all nodes
@@ -428,7 +428,7 @@ void OslShaderGenerator::emitFunctionBodyBegin(const ShaderNode& node, GenContex
     }
 }
 
-void OslShaderGenerator::emitIncludes(ShaderStage& stage, GenContext& context) const
+void OslShaderGenerator::emitLibraryIncludes(ShaderStage& stage, GenContext& context) const
 {
     static const string INCLUDE_PREFIX = "#include \"";
     static const string INCLUDE_SUFFIX = "\"";
@@ -439,7 +439,7 @@ void OslShaderGenerator::emitIncludes(ShaderStage& stage, GenContext& context) c
 
     for (const string& file : INCLUDE_FILES)
     {
-        FilePath path = context.resolveSourceFile(file);
+        FilePath path = context.resolveSourceFile(file, FilePath());
 
         // Force path to use slash since backslash even if escaped 
         // gives problems when saving the source code to file.

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -55,7 +55,7 @@ protected:
     virtual ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;
 
     /// Emit include headers needed by the generated shader code.
-    virtual void emitIncludes(ShaderStage& stage, GenContext& context) const;
+    virtual void emitLibraryIncludes(ShaderStage& stage, GenContext& context) const;
 
     /// Emit a block of shader inputs.
     virtual void emitShaderInputs(const VariableBlock& inputs, ShaderStage& stage) const;

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -48,22 +48,30 @@ class MX_GENSHADER_API GenContext
         return _options;
     }
 
-    /// Add to the search path used for finding source code.
+    /// Register a user search path for finding source code during
+    /// code generation.
     void registerSourceCodeSearchPath(const FilePath& path)
     {
         _sourceCodeSearchPath.append(path);
     }
 
-    /// Add to the search path used for finding source code.
+    /// Register a user search path for finding source code during
+    /// code generation.
     void registerSourceCodeSearchPath(const FileSearchPath& path)
     {
         _sourceCodeSearchPath.append(path);
     }
 
-    /// Resolve a file using the registered search paths.
-    FilePath resolveSourceFile(const FilePath& filename) const
+    /// Resolve a source code filename, first checking the given local path
+    /// then checking any file paths registered by the user.
+    FilePath resolveSourceFile(const FilePath& filename, const FilePath& localPath) const
     {
-        return _sourceCodeSearchPath.find(filename);
+        FileSearchPath searchPath = _sourceCodeSearchPath;
+        if (!localPath.isEmpty())
+        {
+            searchPath.prepend(localPath);
+        }
+        return searchPath.find(filename);
     }
 
     /// Add reserved words that should not be used as
@@ -182,31 +190,16 @@ class MX_GENSHADER_API GenContext
   protected:
     GenContext() = delete;
 
-    // Shader generator.
     ShaderGeneratorPtr _sg;
-
-    // Generation options.
     GenOptions _options;
-
-    // Search path for finding source files.
     FileSearchPath _sourceCodeSearchPath;
-
-    // Set of globally reserved words.
     StringSet _reservedWords;
 
-    // Cached shader node implementations.
     std::unordered_map<string, ShaderNodeImplPtr> _nodeImpls;
-
-    // User data
     std::unordered_map<string, vector<GenUserDataPtr>> _userData;
-
-    // List of input suffixes
     std::unordered_map<const ShaderInput*, string> _inputSuffix;
-
-    // List of output suffixes
     std::unordered_map<const ShaderOutput*, string> _outputSuffix;
 
-    // Contexts for closure evaluation.
     vector<ClosureContext*> _closureContexts;
 };
 

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -11,6 +11,8 @@
 
 #include <MaterialXGenShader/Export.h>
 
+#include <MaterialXFormat/File.h>
+
 MATERIALX_NAMESPACE_BEGIN
 
 /// Type of shader interface to be generated
@@ -67,6 +69,7 @@ class MX_GENSHADER_API GenOptions
         shaderInterfaceType(SHADER_INTERFACE_COMPLETE),
         fileTextureVerticalFlip(false),
         addUpstreamDependencies(true),
+        libraryPrefix("libraries"),
         hwTransparency(false),
         hwSpecularEnvironmentMethod(SPECULAR_ENVIRONMENT_FIS),
         hwDirectionalAlbedoMethod(DIRECTIONAL_ALBEDO_ANALYTIC),
@@ -107,6 +110,11 @@ class MX_GENSHADER_API GenOptions
     /// Sets whether to include upstream dependencies 
     /// for the element to generate a shader for.
     bool addUpstreamDependencies;
+
+    /// The standard library prefix, which will be applied to
+    /// calls to emitLibraryInclude during code generation.
+    /// Defaults to "libraries".
+    FilePath libraryPrefix;
 
     /// Sets if transparency is needed or not for HW shaders.
     /// If a surface shader has potential of being transparent

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -32,13 +32,13 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
     _functionSource = impl.getAttribute("sourcecode");
     if (_functionSource.empty())
     {
-        FilePath file(impl.getAttribute("file"));
-        file = context.resolveSourceFile(file);
-        _functionSource = readFile(file);
+        FilePath localPath = FilePath(impl.getActiveSourceUri()).getParentPath();
+        _sourceFilename = context.resolveSourceFile(impl.getAttribute("file"), localPath);
+        _functionSource = readFile(_sourceFilename);
         if (_functionSource.empty())
         {
-            throw ExceptionShaderGenError("Failed to get source code from file '" + file.asString() +
-                "' used by implementation '" + impl.getName() + "'");
+            throw ExceptionShaderGenError("Failed to get source code from file '" + _sourceFilename.asString() +
+                                          "' used by implementation '" + impl.getName() + "'");
         }
     }
 
@@ -74,7 +74,7 @@ void SourceCodeNode::emitFunctionDefinition(const ShaderNode&, GenContext& conte
         if (!_inlined && !_functionSource.empty())
         {
             const ShaderGenerator& shadergen = context.getShaderGenerator();
-            shadergen.emitBlock(_functionSource, context, stage);
+            shadergen.emitBlock(_functionSource, _sourceFilename, context, stage);
             shadergen.emitLineBreak(stage);
         }
     END_SHADER_STAGE(stage, Stage::PIXEL)

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.h
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.h
@@ -8,6 +8,8 @@
 
 #include <MaterialXGenShader/ShaderNodeImpl.h>
 
+#include <MaterialXFormat/File.h>
+
 MATERIALX_NAMESPACE_BEGIN
 
 /// Node implementation using data-driven static source code.
@@ -26,6 +28,7 @@ protected:
     bool _inlined;
     string _functionName;
     string _functionSource;
+    FilePath _sourceFilename;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -74,14 +74,17 @@ void ShaderGenerator::emitComment(const string& str, ShaderStage& stage) const
     stage.addComment(str);
 }
 
-void ShaderGenerator::emitBlock(const string& str, GenContext& context, ShaderStage& stage) const
+void ShaderGenerator::emitBlock(const string& str, const FilePath& sourceFilename, GenContext& context, ShaderStage& stage) const
 {
-    stage.addBlock(str, context);
+    stage.addBlock(str, sourceFilename, context);
 }
 
-void ShaderGenerator::emitInclude(const string& file, GenContext& context, ShaderStage& stage) const
+void ShaderGenerator::emitLibraryInclude(const FilePath& filename, GenContext& context, ShaderStage& stage) const
 {
-    stage.addInclude(file, context);
+    FilePath libraryPrefix = context.getOptions().libraryPrefix;
+    FilePath fullFilename = libraryPrefix.isEmpty() ? filename : libraryPrefix / filename;
+    FilePath resolvedFilename = context.resolveSourceFile(fullFilename, FilePath());
+    stage.addInclude(fullFilename, resolvedFilename, context);
 }
 
 void ShaderGenerator::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -16,6 +16,8 @@
 #include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/Syntax.h>
 
+#include <MaterialXFormat/File.h>
+
 #include <MaterialXCore/Exception.h>
 
 MATERIALX_NAMESPACE_BEGIN
@@ -69,11 +71,12 @@ class MX_GENSHADER_API ShaderGenerator
     virtual void emitComment(const string& str, ShaderStage& stage) const;
 
     /// Add a block of code.
-    virtual void emitBlock(const string& str, GenContext& context, ShaderStage& stage) const;
+    virtual void emitBlock(const string& str, const FilePath& sourceFilename, GenContext& context, ShaderStage& stage) const;
 
-    /// Add the contents of an include file. Making sure it is 
-    /// only included once for the shader stage.
-    virtual void emitInclude(const string& file, GenContext& context, ShaderStage& stage) const;
+    /// Add the contents of a standard library include file if not already present.
+    /// The library file prefix of the given context, if any, will be prepended
+    /// to the given filename.
+    virtual void emitLibraryInclude(const FilePath& filename, GenContext& context, ShaderStage& stage) const;
 
     /// Add a value.
     template<typename T>

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -15,6 +15,8 @@
 #include <MaterialXGenShader/ShaderGraph.h>
 #include <MaterialXGenShader/Syntax.h>
 
+#include <MaterialXFormat/File.h>
+
 #include <MaterialXCore/Node.h>
 
 #include <sstream>
@@ -222,11 +224,10 @@ public:
     void addComment(const string& str);
 
     /// Add a block of code.
-    void addBlock(const string& str, GenContext& context);
+    void addBlock(const string& str, const FilePath& sourceFilename, GenContext& context);
 
-    /// Add the contents of an include file. Making sure it is 
-    /// only included once for the shader stage.
-    void addInclude(const string& file, GenContext& context);
+    /// Add the contents of an include file if not already present.
+    void addInclude(const FilePath& includeFilename, const FilePath& sourceFilename, GenContext& context);
 
     /// Add a value.
     template<typename T>

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -55,7 +55,8 @@ bool getShaderSource(mx::GenContext& context,
             return true;
         }
         sourcePath = implementation->getFile();
-        mx::FilePath resolvedPath = context.resolveSourceFile(sourcePath);
+        mx::FilePath localPath = mx::FilePath(implementation->getSourceUri()).getParentPath();
+        mx::FilePath resolvedPath = context.resolveSourceFile(sourcePath, localPath);
         sourceContents = mx::readFile(resolvedPath);
         resolvedSource = resolvedPath.asString();
         return !sourceContents.empty();


### PR DESCRIPTION
This changelist adds support for relative includes of shader source files in code generation, and makes all file includes relative within the MaterialX data libraries.

This allows clients to use arbitrary naming conventions for the root folder of their MaterialX data libraries, with "libraries" being the default name in the MaterialX distribution.