### PR TITLE
Fix issue with thin-film in standard_surface implementation

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -260,12 +260,6 @@
       <input name="mix" type="float" interfacename="transmission" />
     </mix>
 
-    <!-- Thin-film -->
-    <thin_film_bsdf name="thin_film_bsdf" type="BSDF">
-      <input name="thickness" type="float" interfacename="thin_film_thickness" />
-      <input name="ior" type="float" interfacename="thin_film_IOR" />
-    </thin_film_bsdf>
-
     <!-- Specular Layer -->
     <dielectric_bsdf name="specular_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="specular" />
@@ -280,10 +274,6 @@
     <layer name="specular_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="specular_bsdf" />
       <input name="base" type="BSDF" nodename="transmission_mix" />
-    </layer>
-    <layer name="specular_layer_with_thin_film" type="BSDF">
-      <input name="top" type="BSDF" nodename="thin_film_bsdf" />
-      <input name="base" type="BSDF" nodename="specular_layer" />
     </layer>
 
     <!-- Metal Layer -->
@@ -310,9 +300,19 @@
     </conductor_bsdf>
     <mix name="metalness_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="metal_bsdf" />
-      <input name="bg" type="BSDF" nodename="specular_layer_with_thin_film" />
+      <input name="bg" type="BSDF" nodename="specular_layer" />
       <input name="mix" type="float" interfacename="metalness" />
     </mix>
+
+    <!-- Thin-film Layer -->
+    <thin_film_bsdf name="thin_film_bsdf" type="BSDF">
+      <input name="thickness" type="float" interfacename="thin_film_thickness" />
+      <input name="ior" type="float" interfacename="thin_film_IOR" />
+    </thin_film_bsdf>
+    <layer name="thin_film_layer" type="BSDF">
+      <input name="top" type="BSDF" nodename="thin_film_bsdf" />
+      <input name="base" type="BSDF" nodename="metalness_mix" />
+    </layer>
 
     <!-- Coat Layer -->
     <mix name="coat_attenuation" type="color3">
@@ -320,8 +320,8 @@
       <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
       <input name="mix" type="float" interfacename="coat" />
     </mix>
-    <multiply name="metalness_mix_attenuated" type="BSDF">
-      <input name="in1" type="BSDF" nodename="metalness_mix" />
+    <multiply name="thin_film_layer_attenuated" type="BSDF">
+      <input name="in1" type="BSDF" nodename="thin_film_layer" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
     <roughness_anisotropy name="coat_roughness_vector" type="vector2">
@@ -340,7 +340,7 @@
     </dielectric_bsdf>
     <layer name="coat_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="coat_bsdf" />
-      <input name="base" type="BSDF" nodename="metalness_mix_attenuated" />
+      <input name="base" type="BSDF" nodename="thin_film_layer_attenuated" />
     </layer>
 
     <!-- Emission Layer -->


### PR DESCRIPTION
This change list improves the implementation of standard_surface. The thin-film BSDF operator is now applied to both the dielectric specular BSDF and the metal BSDF, following the Standard Surface specification.

This should resolve issue #922.
