### PR TITLE
Add transmission rendering option

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -119,14 +119,11 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         const ShaderNode* bsdf = bsdfInput->getConnectedSibling();
         if (bsdf)
         {
-            if (context.getOptions().hwTransparency)
-            {
-                shadergen.emitLineBegin(stage);
-                shadergen.emitString("float surfaceOpacity = ", stage);
-                shadergen.emitInput(node.getInput("opacity"), context, stage);
-                shadergen.emitLineEnd(stage);
-                shadergen.emitLineBreak(stage);
-            }
+            shadergen.emitLineBegin(stage);
+            shadergen.emitString("float surfaceOpacity = ", stage);
+            shadergen.emitInput(node.getInput("opacity"), context, stage);
+            shadergen.emitLineEnd(stage);
+            shadergen.emitLineBreak(stage);
 
             //
             // Handle direct lighting
@@ -196,7 +193,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         }
 
         //
-        // Handle surface transmission.
+        // Handle surface transmission and opacity.
         //
         if (bsdf)
         {
@@ -204,22 +201,23 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             shadergen.emitScopeBegin(stage);
             context.pushClosureContext(&_callTransmission);
             shadergen.emitFunctionCall(*bsdf, context, stage);
-            shadergen.emitLine(outColor + " += " + bsdf->getOutput()->getVariable() + ".response", stage);
+            if (context.getOptions().hwTransmissionRenderMethod == TRANSMISSION_REFRACTION)
+            {
+                shadergen.emitLine(outColor + " += " + bsdf->getOutput()->getVariable() + ".response", stage);
+            }
+            else
+            {
+                shadergen.emitLine(outTransparency + " += " + bsdf->getOutput()->getVariable() + ".throughput", stage);
+            }
             shadergen.emitScopeEnd(stage);
             context.popClosureContext();
-        }
 
-        //
-        // Handle surface opacity.
-        //
-        if (bsdf && context.getOptions().hwTransparency)
-        {
+            shadergen.emitLineBreak(stage);
             shadergen.emitComment("Compute and apply surface opacity", stage);
             shadergen.emitScopeBegin(stage);
             shadergen.emitLine(outColor + " *= surfaceOpacity", stage);
             shadergen.emitLine(outTransparency + " = mix(vec3(1.0), " + outTransparency + ", surfaceOpacity)", stage);
             shadergen.emitScopeEnd(stage);
-            shadergen.emitLineBreak(stage);
         }
 
         shadergen.emitScopeEnd(stage);

--- a/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
@@ -34,17 +34,14 @@ void UnlitSurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& 
         const ShaderInput* emissionColor = node.getInput("emission_color");
         shadergen.emitLine(outColor + " = " + shadergen.getUpstreamResult(emission, context) + " * " + shadergen.getUpstreamResult(emissionColor, context), stage);
         
-        if (context.getOptions().hwTransparency)
-        {
-            const ShaderInput* transmission = node.getInput("transmission");
-            const ShaderInput* transmissionColor = node.getInput("transmission_color");
-            shadergen.emitLine(outTransparency + " = " + shadergen.getUpstreamResult(transmission, context) + " * " + shadergen.getUpstreamResult(transmissionColor, context), stage);
+        const ShaderInput* transmission = node.getInput("transmission");
+        const ShaderInput* transmissionColor = node.getInput("transmission_color");
+        shadergen.emitLine(outTransparency + " = " + shadergen.getUpstreamResult(transmission, context) + " * " + shadergen.getUpstreamResult(transmissionColor, context), stage);
 
-            const ShaderInput* opacity = node.getInput("opacity");
-            const string surfaceOpacity = shadergen.getUpstreamResult(opacity, context);
-            shadergen.emitLine(outColor + " *= " + surfaceOpacity, stage);
-            shadergen.emitLine(outTransparency + " = mix(vec3(1.0), " + outTransparency + ", " + surfaceOpacity + ")", stage);
-        }
+        const ShaderInput* opacity = node.getInput("opacity");
+        const string surfaceOpacity = shadergen.getUpstreamResult(opacity, context);
+        shadergen.emitLine(outColor + " *= " + surfaceOpacity, stage);
+        shadergen.emitLine(outTransparency + " = mix(vec3(1.0), " + outTransparency + ", " + surfaceOpacity + ")", stage);
 
     END_SHADER_STAGE(stage, Stage::PIXEL)
 }

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -60,6 +60,16 @@ enum HwDirectionalAlbedoMethod
     DIRECTIONAL_ALBEDO_MONTE_CARLO
 };
 
+/// Method to use for transmission rendering
+enum HwTransmissionRenderMethod
+{
+    /// Use a refraction approximation for transmission rendering
+    TRANSMISSION_REFRACTION,
+
+    /// Use opacity for transmission rendering
+    TRANSMISSION_OPACITY,
+};
+
 /// @class GenOptions 
 /// Class holding options to configure shader generation.
 class MX_GENSHADER_API GenOptions
@@ -73,6 +83,7 @@ class MX_GENSHADER_API GenOptions
         hwTransparency(false),
         hwSpecularEnvironmentMethod(SPECULAR_ENVIRONMENT_FIS),
         hwDirectionalAlbedoMethod(DIRECTIONAL_ALBEDO_ANALYTIC),
+        hwTransmissionRenderMethod(TRANSMISSION_REFRACTION),
         hwWriteDepthMoments(false),
         hwShadowMap(false),
         hwAmbientOcclusion(false),
@@ -130,6 +141,10 @@ class MX_GENSHADER_API GenOptions
     /// Sets the method to use for directional albedo evaluation
     /// for HW shader targets.
     HwDirectionalAlbedoMethod hwDirectionalAlbedoMethod;
+
+    /// Sets the method to use for transmission rendering
+    /// for HW shader targets.
+    HwTransmissionRenderMethod hwTransmissionRenderMethod;
 
     /// Enables the writing of depth moments for HW shader targets.
     /// Defaults to false.

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -90,7 +90,8 @@ namespace
 
         // Inputs on a surface shader which are checked for transparency
         const OpaqueTestPairList inputPairList = { {"opacity", 1.0f},
-                                                   {"existence", 1.0f} };
+                                                   {"existence", 1.0f},
+                                                   {"transmission", 0.0f} };
 
 
         // Check against the interface if a node is passed in to check against

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -216,7 +216,7 @@ TEST_CASE("GenShader: Transparency Regression Check", "[genshader]")
         "Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx",
         "Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx",
     };
-    std::vector<bool> transparencyTest = { false, false, true, true, true };
+    std::vector<bool> transparencyTest = { false, true, true, true, true };
     for (size_t i=0; i<testFiles.size(); i++)
     {
         const mx::FilePath& testFile = resourcePath / testFiles[i];

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -854,6 +854,15 @@ void Viewer::createAdvancedSettings(Widget* parent)
         reloadShaders();
     });
 
+    ng::CheckBox* refractionBox = new ng::CheckBox(advancedPopup, "Transmission Refraction");
+    refractionBox->set_checked(_genContext.getOptions().hwTransmissionRenderMethod == mx::TRANSMISSION_REFRACTION);
+    refractionBox->set_callback([this](bool enable)
+    {
+        _genContext.getOptions().hwTransmissionRenderMethod = enable ? mx::TRANSMISSION_REFRACTION : mx::TRANSMISSION_OPACITY;
+        _genContextEssl.getOptions().hwTransmissionRenderMethod = _genContext.getOptions().hwTransmissionRenderMethod;
+        reloadShaders();
+    });
+
     Widget* albedoGroup = new Widget(advancedPopup);
     albedoGroup->set_layout(new ng::BoxLayout(ng::Orientation::Horizontal));
     new ng::Label(albedoGroup, "Albedo Method:");


### PR DESCRIPTION
This changelist adds an hwTransmissionRenderMethod option to the GenOptions class, selecting the transmission render method in hardware shading languages.

Initially, this option chooses between a single-pass refraction approximation (TRANSMISSION_REFRACTION) and the conversion of transmission to opacity (TRANSMISSION_OPACITY).