### PR TITLE
Add missing `nodegroup` to a few Lama definitions.

### DIFF
--- a/libraries/bxdf/lama/lama_add.mtlx
+++ b/libraries/bxdf/lama/lama_add.mtlx
@@ -2,7 +2,7 @@
 <materialx version="1.38" colorspace="acescg">
 
   <!-- LamaAdd for BSDFs -->
-  <nodedef name="ND_lama_add_bsdf" node="LamaAdd" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_add_bsdf" node="LamaAdd" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="material1" uiname="Material 1" type="BSDF" doc="First material to add." />
     <input name="material2" uiname="Material 2" type="BSDF" doc="Second material to add." />
     <input name="weight1" uiname="Weight 1" type="float" uimin="0.0" uimax="1.0" value="1.0" doc="Weight of the first material." />
@@ -26,7 +26,7 @@
   </nodegraph>
 
   <!-- LamaAdd for EDFs -->
-  <nodedef name="ND_lama_add_edf" node="LamaAdd" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_add_edf" node="LamaAdd" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="material1" uiname="Material 1" type="EDF" doc="First material to add." />
     <input name="material2" uiname="Material 2" type="EDF" doc="Second material to add." />
     <input name="weight1" uiname="Weight 1" type="float" uimin="0.0" uimax="1.0" value="1.0" doc="Weight of the first material." />

--- a/libraries/bxdf/lama/lama_diffuse.mtlx
+++ b/libraries/bxdf/lama/lama_diffuse.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="acescg">
-  <nodedef name="ND_lama_diffuse" node="LamaDiffuse" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_diffuse" node="LamaDiffuse" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="color" uiname="Color" type="color3" value="0.18, 0.18, 0.18"
            doc="Diffuse color (aka albedo), defining what ratio of light is reflected for each color channel." />
     <input name="roughness" uiname="Roughness" type="float" uimin="0.0" uimax="1.0" value="0.0" doc="Micro-facet distribution (Oren-Nayar) roughness." />

--- a/libraries/bxdf/lama/lama_layer.mtlx
+++ b/libraries/bxdf/lama/lama_layer.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="acescg">
   <!-- LamaLayer for BSDFs -->
-  <nodedef name="ND_lama_layer_bsdf" node="LamaLayer" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_layer_bsdf" node="LamaLayer" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="materialTop" uiname="Material Top" type="BSDF" 
            doc="Material used for the top slab. If not set, the base material will be used by itself." />
     <input name="materialBase" uiname="Material Base" type="BSDF" 

--- a/libraries/bxdf/lama/lama_mix.mtlx
+++ b/libraries/bxdf/lama/lama_mix.mtlx
@@ -2,7 +2,7 @@
 <materialx version="1.38" colorspace="acescg">
 
   <!-- LamaMix for BSDFs -->
-  <nodedef name="ND_lama_mix_bsdf" node="LamaMix" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_mix_bsdf" node="LamaMix" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="material1" uiname="Material 1" type="BSDF"
            doc="First material to mix." />
     <input name="material2" uiname="Material 2" type="BSDF"

--- a/libraries/bxdf/lama/lama_sss.mtlx
+++ b/libraries/bxdf/lama/lama_sss.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="acescg">
-  <nodedef name="ND_lama_sss" node="LamaSSS" doc="Lama SSS" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_sss" node="LamaSSS" nodegroup="pbr" doc="Lama SSS" version="1.0" isdefaultversion="true">
     <input name="color" type="color3" value="0.18, 0.18, 0.18" uiname="Color" uifolder="Main"
            doc="Diffuse color (aka albedo), defining what ratio of light is reflected -- or transmitted -- for each color channel." />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Main"

--- a/libraries/bxdf/lama/lama_translucent.mtlx
+++ b/libraries/bxdf/lama/lama_translucent.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="acescg">
-  <nodedef name="ND_lama_translucent" node="LamaTranslucent" version="1.0" isdefaultversion="true">
+  <nodedef name="ND_lama_translucent" node="LamaTranslucent" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="color" uiname="Color" type="color3" value="0.18, 0.18, 0.18"
            doc="Translucent color (aka albedo), defining what ratio of light is transmitted for each color channel." />
     <input name="roughness" uiname="Roughness" type="float" uimin="0.0" uimax="1.0" value="0.0"


### PR DESCRIPTION
Update #921 
Few small updates for Lama nodes so all nodes have `nodegroup`  tags.