### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Unit.cpp
+++ b/source/MaterialXCore/Unit.cpp
@@ -263,7 +263,7 @@ bool UnitConverterRegistry::convertToUnit(DocumentPtr doc, const string& unitTyp
         {
             const std::string type = input->getType();
             const ValuePtr value = input->getValue();
-            if (value && input->hasUnit() && (input->getUnitType() == unitType) && value)
+            if (value && input->hasUnit() && (input->getUnitType() == unitType))
             {
                 if (type == getTypeString<float>())
                 {

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -138,7 +138,7 @@ bool stringEndsWith(const string& str, const string& suffix)
 
 string trimSpaces(const string& str)
 {
-    const string SPACE(" ");
+    const char SPACE(' ');
 
     size_t start = str.find_first_not_of(SPACE);
     string result = (start == std::string::npos) ? EMPTY_STRING : str.substr(start);

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -34,7 +34,7 @@ void SourceCodeNodeMdl::initialize(const InterfaceElement& element, GenContext& 
     {
         if (_functionName.empty())
         {
-            size_t pos = _functionSource.find_first_of("(");
+            size_t pos = _functionSource.find_first_of('(');
             string functionName = _functionSource.substr(0, pos);
             _returnStruct = functionName + "__result";
         }

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -143,10 +143,8 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
 
         if (sampleCount > 1)
         {
-            const string MX_WEIGHT_ARRAY_SIZE_STRING("MX_WEIGHT_ARRAY_SIZE");
             const string MX_CONVOLUTION_PREFIX_STRING("mx_convolution_");
             const string SAMPLES_POSTFIX_STRING("_samples");
-            const string WEIGHT_POSTFIX_STRING("_weights");
 
             // Set up sample array
             string sampleName(output->getVariable() + SAMPLES_POSTFIX_STRING);

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -444,7 +444,6 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
     ElementPtr& root)
 {
     NodeDefPtr nodeDef = node->getNodeDef(EMPTY_STRING, true);
-    string message;
     if (!nodeDef)
     {
         throw ExceptionShaderGenError("Could not find a nodedef for shader node '" + node->getName() +

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -478,7 +478,6 @@ ImagePtr GlslProgram::bindTexture(unsigned int uniformType, int uniformLocation,
         uniformType >= GL_SAMPLER_1D && uniformType <= GL_SAMPLER_CUBE)
     {
         // Acquire the image.
-        string error;
         ImagePtr image = imageHandler->acquireImage(filePath);
         if (imageHandler->bindImage(image, samplingProperties))
         {

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -81,7 +81,7 @@ TextureBaker::TextureBaker(unsigned int width, unsigned int height, Image::BaseT
     }
 
     // Initialize our base renderer.
-    initialize();
+    GlslRenderer::initialize();
 
     // Initialize our image handler.
     _imageHandler = GLTextureHandler::create(StbImageLoader::create());

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -240,7 +240,6 @@ void OslRenderer::shadeOSL(const FilePath& dirPath, const string& shaderName, co
     // modifies this then this hard-coded string must also be modified.
     // The formatted string is "Output <outputName> to <outputFileName>".
     std::ifstream errorStream(errorFile);
-    string result;
     StringVec results;
     string line;
     string successfulOutputSubString("Output " + outputName + " to " +

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -156,7 +156,7 @@ class Viewer : public ng::Screen
     }
 
     // Request a capture of the current frame, writing it to the given filename.
-    void requestFrameCapture(const mx::FilePath filename)
+    void requestFrameCapture(const mx::FilePath& filename)
     {
         _captureRequested = true;
         _captureFilename = filename;


### PR DESCRIPTION
- Remove a duplicated test in UnitConverterRegistry::convertToUnit.
- Clarify an initialization call in the TextureBaker constructor.
- Call string::find_first_of with chars rather than strings for performance.
- Pass file paths by const reference for performance.
- Remove unused variables.