### PR TITLE
Normal and tangent fixes

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.cpp
@@ -50,7 +50,7 @@ void NormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& contex
             if (!normal->isEmitted())
             {
                 normal->setEmitted();
-                shadergen.emitLine(prefix + normal->getVariable() + " = (" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(" + HW::T_IN_NORMAL + ",0.0)).xyz", stage);
+                shadergen.emitLine(prefix + normal->getVariable() + " = normalize((" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(" + HW::T_IN_NORMAL + ", 0.0)).xyz)", stage);
             }
         }
         else

--- a/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
@@ -50,7 +50,7 @@ void TangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             if (!tangent->isEmitted())
             {
                 tangent->setEmitted();
-                shadergen.emitLine(prefix + tangent->getVariable() + " = (" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(" + HW::T_IN_TANGENT + ",0.0)).xyz", stage);
+                shadergen.emitLine(prefix + tangent->getVariable() + " = normalize((" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(" + HW::T_IN_TANGENT + ", 0.0)).xyz)", stage);
             }
         }
         else

--- a/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
@@ -25,7 +25,7 @@ void TangentNodeGlsl::createVariables(const ShaderNode& node, GenContext&, Shade
     const int space = spaceInput ? spaceInput->getValue()->asA<int>() : OBJECT_SPACE;
     if (space == WORLD_SPACE)
     {
-        addStageUniform(HW::PRIVATE_UNIFORMS, Type::MATRIX44, HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX, vs);
+        addStageUniform(HW::PRIVATE_UNIFORMS, Type::MATRIX44, HW::T_WORLD_MATRIX, vs);
         addStageConnector(HW::VERTEX_DATA, Type::VECTOR3, HW::T_TANGENT_WORLD, vs, ps);
     }
     else
@@ -50,7 +50,7 @@ void TangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             if (!tangent->isEmitted())
             {
                 tangent->setEmitted();
-                shadergen.emitLine(prefix + tangent->getVariable() + " = normalize((" + HW::T_WORLD_INVERSE_TRANSPOSE_MATRIX + " * vec4(" + HW::T_IN_TANGENT + ", 0.0)).xyz)", stage);
+                shadergen.emitLine(prefix + tangent->getVariable() + " = normalize((" + HW::T_WORLD_MATRIX + " * vec4(" + HW::T_IN_TANGENT + ", 0.0)).xyz)", stage);
             }
         }
         else

--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
@@ -12,6 +12,20 @@ ShaderNodeImplPtr TransformNormalNodeGlsl::create()
     return std::make_shared<TransformNormalNodeGlsl>();
 }
 
+void TransformNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
+{
+    TransformVectorNodeGlsl::emitFunctionCall(node, context, stage);
+
+    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        const ShaderOutput* output = node.getOutput();
+        shadergen.emitLineBegin(stage);
+        shadergen.emitOutput(output, true, false, context, stage);
+        shadergen.emitString(" = normalize(" + output->getVariable() + ")", stage);
+        shadergen.emitLineEnd(stage);
+    END_SHADER_STAGE(stage, Stage::PIXEL)
+}
+
 const string& TransformNormalNodeGlsl::getMatrix(const string& fromSpace, const string& toSpace) const
 {
     if ((fromSpace == MODEL || fromSpace == OBJECT) && toSpace == WORLD)

--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h
@@ -17,7 +17,9 @@ public:
     static ShaderNodeImplPtr create();
 
 protected:
-    virtual const string& getMatrix(const string& fromSpace, const string& toSpace) const;
+    void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
+
+    const string& getMatrix(const string& fromSpace, const string& toSpace) const override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -310,7 +310,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                                     float floatValue = (v < vectorSize) ? input[v] : 0.0f;
                                     normal[v] = floatValue;
                                 }
-                                normal = normalMatrix.transformVector(normal);
+                                normal = normalMatrix.transformVector(normal).getNormalized();
                                 for (cgltf_size v = 0; v < desiredVectorSize; v++)
                                 {
                                     buffer.push_back(normal[v]);

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -136,6 +136,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
         for (size_t mtx=0; mtx < positionMatrices.size(); mtx++)
         {
             const Matrix44& positionMatrix = positionMatrices[mtx];
+            const Matrix44 normalMatrix = positionMatrix.getInverse().getTranspose();
             
             for (cgltf_size primitiveIndex = 0; primitiveIndex < cmesh->primitives_count; ++primitiveIndex)
             {
@@ -309,7 +310,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                                     float floatValue = (v < vectorSize) ? input[v] : 0.0f;
                                     normal[v] = floatValue;
                                 }
-                                normal = positionMatrix.transformNormal(normal);
+                                normal = normalMatrix.transformVector(normal);
                                 for (cgltf_size v = 0; v < desiredVectorSize; v++)
                                 {
                                     buffer.push_back(normal[v]);

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -221,7 +221,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
 
                     bool isPositionStream = (attribute->type == cgltf_attribute_type_position);
                     bool isNormalStream = (attribute->type == cgltf_attribute_type_normal);
-                    bool isTexCoordSteram = (attribute->type == cgltf_attribute_type_texcoord);
+                    bool isTexCoordStream = (attribute->type == cgltf_attribute_type_texcoord);
                     if (isPositionStream)
                     {
                         // Create position stream
@@ -321,7 +321,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                                 {
                                     float floatValue = (v < vectorSize) ? input[v] : 0.0f;
                                     // Perform v-flip
-                                    if (isTexCoordSteram && v == 1)
+                                    if (isTexCoordStream && v == 1)
                                     {
                                         if (!texcoordVerticalFlip)
                                         {

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -286,7 +286,8 @@ void MeshStream::transform(const Matrix44 &matrix)
              getType() == MeshStream::TANGENT_ATTRIBUTE ||
              getType() == MeshStream::BITANGENT_ATTRIBUTE)
     {
-        Matrix44 normalMatrix = matrix.getInverse().getTranspose();
+        bool isNormalStream = (getType() == MeshStream::NORMAL_ATTRIBUTE);
+        Matrix44 transformMatrix = isNormalStream ? matrix.getInverse().getTranspose() : matrix;
 
         for (size_t i=0; i<numElements; i++)
         {
@@ -295,7 +296,7 @@ void MeshStream::transform(const Matrix44 &matrix)
             {
                 vec[j] = _data[i*stride + j];
             }
-            vec = normalMatrix.transformVector(vec).getNormalized();
+            vec = transformMatrix.transformVector(vec).getNormalized();
             for (size_t k=0; k<stride; k++)
             {
                 _data[i*stride + k] = vec[k];

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -295,7 +295,7 @@ void MeshStream::transform(const Matrix44 &matrix)
             {
                 vec[j] = _data[i*stride + j];
             }
-            vec = normalMatrix.transformVector(vec);
+            vec = normalMatrix.transformVector(vec).getNormalized();
             for (size_t k=0; k<stride; k++)
             {
                 _data[i*stride + k] = vec[k];

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -286,6 +286,8 @@ void MeshStream::transform(const Matrix44 &matrix)
              getType() == MeshStream::TANGENT_ATTRIBUTE ||
              getType() == MeshStream::BITANGENT_ATTRIBUTE)
     {
+        Matrix44 normalMatrix = matrix.getInverse().getTranspose();
+
         for (size_t i=0; i<numElements; i++)
         {
             Vector3 vec(0.0, 0.0, 0.0);
@@ -293,7 +295,7 @@ void MeshStream::transform(const Matrix44 &matrix)
             {
                 vec[j] = _data[i*stride + j];
             }
-            vec = matrix.transformNormal(vec);
+            vec = normalMatrix.transformVector(vec);
             for (size_t k=0; k<stride; k++)
             {
                 _data[i*stride + k] = vec[k];


### PR DESCRIPTION
Hi @jstone-lucasfilm!

I recently tried to test a .mtlx file generated by my converter and ran into some rendering artifacts in MaterialXView:

![before](https://user-images.githubusercontent.com/3663466/167286440-24b0ff34-4d82-4d77-a1f6-27363b19945e.png)

Further investigation revealed that the normals were not normalized after a matrix multiplication in the glTF loader.
I have also identified more situations where I believe normalization is necessary.

Plus, it seems like tangents and bitangents were incorrectly transformed with the normal matrix:
https://pbr-book.org/3ed-2018/Geometry_and_Transformations/Applying_Transformations#Normals

After the changes, the model renders as follows:

![after](https://user-images.githubusercontent.com/3663466/167286444-01526322-6f82-42b9-8639-6211e0e9ba90.png)

You can find the model here: [ToyCar.zip](https://github.com/AcademySoftwareFoundation/MaterialX/files/8646544/ToyCar.zip)
