### PR TITLE
Fix color attribute parsing in glTF loader

### DIFF
--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -191,6 +191,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                 MeshStreamPtr colorStream = nullptr;
                 MeshStreamPtr texcoordStream = nullptr;
                 MeshStreamPtr tangentStream = nullptr;
+                int colorAttrIndex = 0;
 
                 // Read in vertex streams
                 for (cgltf_size prim = 0; prim < primitive->attributes_count; prim++)
@@ -243,12 +244,15 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                     }
                     else if (attribute->type == cgltf_attribute_type_color)
                     {
-                        colorStream = MeshStream::create("i_" + MeshStream::COLOR_ATTRIBUTE, MeshStream::COLOR_ATTRIBUTE, streamIndex);
+                        colorStream = MeshStream::create("i_" + MeshStream::COLOR_ATTRIBUTE + "_" + std::to_string(colorAttrIndex), MeshStream::COLOR_ATTRIBUTE, streamIndex);
+                        mesh->addStream(colorStream);
                         geomStream = colorStream;
                         if (vectorSize == 4)
                         {
+                            colorStream->setStride(MeshStream::STRIDE_4D);
                             desiredVectorSize = 4;
                         }
+                        colorAttrIndex++;
                     }
                     else if (attribute->type == cgltf_attribute_type_texcoord)
                     {

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -38,8 +38,9 @@ class MX_RENDER_API MeshStream
     static const string COLOR_ATTRIBUTE;
     static const string GEOMETRY_PROPERTY_ATTRIBUTE;
 
-    static const unsigned int STRIDE_3D = 3;
     static const unsigned int STRIDE_2D = 2;
+    static const unsigned int STRIDE_3D = 3;
+    static const unsigned int STRIDE_4D = 4;
     static const unsigned int DEFAULT_STRIDE = STRIDE_3D;
 
   public:


### PR DESCRIPTION
`<geomcolor>` wasn't properly working with this asset:
https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BoxVertexColors

You can try the fix with the following material:
```xml
<?xml version="1.0"?>
<materialx version="1.38" colorspace="lin_rec709">
  <geomcolor name="N_geomcolor" type="color4" />
  <convert name="N_convert" type="color3">
    <input name="in" type="color4" nodename="N_geomcolor" />
  </convert>
  <UsdPreviewSurface name="SR_missing_geomprop" type="surfaceshader">
    <input name="diffuseColor" type="color3" nodename="N_convert" />
  </UsdPreviewSurface>
  <surfacematerial name="MAT_missing_geomprop" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="SR_missing_geomprop" />
  </surfacematerial>
</materialx>
```

CC @bernardkwok