### PR TITLE
Fix build error when OSL or MDL is disabled in cmake options

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1413,6 +1413,7 @@ void Viewer::saveShaderSource(mx::GenContext& context)
                 new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved ESSL source: ",
                     sourceFilename.asString() + "_essl_*.glsl");
             }
+#if MATERIALX_BUILD_GEN_OSL
             else if (context.getShaderGenerator().getTarget() == mx::OslShaderGenerator::TARGET)
             {
                 mx::ShaderPtr shader = createShader(elem->getNamePath(), context, elem);
@@ -1421,6 +1422,8 @@ void Viewer::saveShaderSource(mx::GenContext& context)
                 writeTextFile(pixelShader, sourceFilename);
                 new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved OSL source: ", sourceFilename);
             }
+#endif
+#if MATERIALX_BUILD_GEN_MDL
             else if (context.getShaderGenerator().getTarget() == mx::MdlShaderGenerator::TARGET)
             {
                 mx::ShaderPtr shader = createShader(elem->getNamePath(), context, elem);
@@ -1429,6 +1432,7 @@ void Viewer::saveShaderSource(mx::GenContext& context)
                 writeTextFile(pixelShader, sourceFilename);
                 new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved MDL source: ", sourceFilename);
             }
+#endif
         }
     }
     catch (std::exception& e)


### PR DESCRIPTION
If MDL or OSL is disabled by build options Viewer.cpp would not compile.