### PR TITLE
Remove legacy gitignore

### DIFF
--- a/source/MaterialXCore/.gitignore
+++ b/source/MaterialXCore/.gitignore
@@ -1,1 +1,0 @@
-Generated.h


### PR DESCRIPTION
This changelist removes a gitignore file that is no longer required in MaterialXCore, following the generated header improvements in #940.