### PR TITLE
Clarify conversion in toFloat16

### DIFF
--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -154,6 +154,8 @@ class MX_RENDER_API Half
     static constexpr int32_t const maxD = infC - maxC - 1;
     static constexpr int32_t const minD = minC - subC - 1;
 
+    static constexpr float const maxF = (float) 0x7FFFFFBF; // max int32 expressible as a flt32
+
     static uint16_t toFloat16(float value)
     {
         Bits v, s;
@@ -162,7 +164,7 @@ class MX_RENDER_API Half
         v.si ^= sign;
         sign >>= shiftSign; // logical shift
         s.si = mulN;
-        int32_t subN = (int32_t) (s.f * v.f); // correct subnormals
+        int32_t subN = (int32_t) std::min(s.f * v.f, maxF); // correct subnormals
         s.si = subN;
         v.si ^= (s.si ^ v.si) & -(minN > v.si);
         v.si ^= (infN ^ v.si) & -((infN > v.si) & (v.si > maxN));

--- a/source/MaterialXTest/MaterialXRender/Render.cpp
+++ b/source/MaterialXTest/MaterialXRender/Render.cpp
@@ -24,15 +24,21 @@ namespace mx = MaterialX;
 
 TEST_CASE("Render: Half Float", "[rendercore]")
 {
-    const std::vector<float> values =
+    const std::vector<float> exactValues =
     {
         0.0f, 0.25f, 0.5f, 0.75f,
         1.0f, 8.0f, 64.0f, 512.0f,
         std::numeric_limits<float>::infinity()
     };
+    const std::vector<float> nearValues =
+    {
+        1.0f / 3.0f, 1.0f / 5.0f, 1.0f / 7.0f,
+        std::numeric_limits<float>::denorm_min()
+    };
     const std::vector<float> signs = { 1.0f, -1.0f };
 
-    for (float value : values)
+    // Test values with exact equivalence as float and half.
+    for (float value : exactValues)
     {
         for (float sign : signs)
         {
@@ -48,6 +54,19 @@ TEST_CASE("Render: Half Float", "[rendercore]")
             REQUIRE((h *= mx::Half(4.0f)) == (f *= 4.0f));
             REQUIRE((h /= mx::Half(4.0f)) == (f /= 4.0f));
             REQUIRE(-h == -f);
+        }
+    }
+
+    // Test values with near equivalence as float and half.
+    const float EPSILON = 0.001f;
+    for (float value : nearValues)
+    {
+        for (float sign : signs)
+        {
+            float f(value * sign);
+            mx::Half h(f);
+            REQUIRE(h != f);
+            REQUIRE(std::abs(h - f) < EPSILON);
         }
     }
 }


### PR DESCRIPTION
This changelist clarifies a float-to-int conversion in Half::toFloat16, removing a dependency on implementation-specific behavior.  Additionally, it extends unit tests to cover values without exact equivalence as float and half.