### PR TITLE
Fix typo in TransformNormalNodeGlsl

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
@@ -20,7 +20,7 @@ void TransformNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContex
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const ShaderOutput* output = node.getOutput();
         shadergen.emitLineBegin(stage);
-        shadergen.emitOutput(output, true, false, context, stage);
+        shadergen.emitOutput(output, false, false, context, stage);
         shadergen.emitString(" = normalize(" + output->getVariable() + ")", stage);
         shadergen.emitLineEnd(stage);
     END_SHADER_STAGE(stage, Stage::PIXEL)


### PR DESCRIPTION
This changelist fixes a typo in TransformNormalNodeGlsl::emitFunctionCall, setting includeType to false so that the output variable is only declared once.