### PR TITLE
Static analysis fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,7 +211,7 @@ jobs:
       if: matrix.static_analysis == 'ON' && runner.os == 'macOS'
       run: |
         brew install cppcheck
-        cppcheck --project=build/compile_commands.json --max-configs=1 --error-exitcode=1 --suppress=*:*/Catch/* --suppress=*:*/External/* --suppress=*:*JsMaterialX/* --suppress=*:*/NanoGUI/* --suppress=*:*/PugiXML/* --suppress=*:*/PyBind11/* --suppress=toomanyconfigs
+        cppcheck --project=build/compile_commands.json --error-exitcode=1 --suppress=*:*/Catch/* --suppress=*:*/External/* --suppress=*:*/NanoGUI/* --suppress=*:*/PugiXML/*
 
     - name: Initialize Virtual Framebuffer
       if: matrix.test_render == 'ON' && runner.os == 'Linux'

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -244,7 +244,6 @@ FilePathVec FilePath::getSubDirectories() const
             }
             if (d_type == DT_DIR)
             {
-                FilePath newDir = *this / path;
                 FilePathVec newDirs = newDir.getSubDirectories();
                 dirs.insert(dirs.end(), newDirs.begin(), newDirs.end());
             }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -224,7 +224,7 @@ void documentFromXml(DocumentPtr doc,
     }
 }
 
-void validateParseResult(xml_parse_result& result, const FilePath& filename = FilePath())
+void validateParseResult(const xml_parse_result& result, const FilePath& filename = FilePath())
 {
     if (result)
     {

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
@@ -86,7 +86,7 @@ BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
 END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
-const string EsslShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
+string EsslShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
 {
     return EMPTY_STRING;
 }
@@ -96,9 +96,9 @@ HwResourceBindingContextPtr EsslShaderGenerator::getResourceBindingContext(GenCo
     HwResourceBindingContextPtr resoureBindingCtx = GlslShaderGenerator::getResourceBindingContext(context);
     if (resoureBindingCtx) 
     {
-      throw ExceptionShaderGenError("The EsslShaderGenerator does not support resource binding.");
+        throw ExceptionShaderGenError("The EsslShaderGenerator does not support resource binding.");
     }
-    return resoureBindingCtx;
+    return nullptr;
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.h
@@ -30,7 +30,7 @@ class MX_GENGLSL_API EsslShaderGenerator : public GlslShaderGenerator
     /// Return the version string for the ESSL version this generator is for
     const string& getVersion() const override { return VERSION; }
 
-    const string getVertexDataPrefix(const VariableBlock& vertexData) const override;
+    string getVertexDataPrefix(const VariableBlock& vertexData) const override;
 
     /// Unique identifier for this generator target
     static const string TARGET;

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -479,7 +479,7 @@ HwResourceBindingContextPtr GlslShaderGenerator::getResourceBindingContext(GenCo
     return context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
 }
 
-const string GlslShaderGenerator::getVertexDataPrefix(const VariableBlock& vertexData) const
+string GlslShaderGenerator::getVertexDataPrefix(const VariableBlock& vertexData) const
 {
     return vertexData.getInstance() + ".";
 }

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -45,7 +45,7 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     ShaderNodeImplPtr getImplementation(const NodeDef& nodedef, GenContext& context) const override;
 
     /// Determine the prefix of vertex data variables. 
-    virtual const string getVertexDataPrefix(const VariableBlock& vertexData) const;
+    virtual string getVertexDataPrefix(const VariableBlock& vertexData) const;
 
   public:
     /// Unique identifier for this generator target

--- a/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h
@@ -17,7 +17,7 @@ public:
     static ShaderNodeImplPtr create();
 
 protected:
-    virtual string getHomogeneousCoordinate(const ShaderInput* in, GenContext& context) const;
+    virtual string getHomogeneousCoordinate(const ShaderInput* in, GenContext& context) const override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
@@ -129,10 +129,8 @@ void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, 
 
         if (sampleCount > 1)
         {
-            const string MX_WEIGHT_ARRAY_SIZE_STRING("MX_WEIGHT_ARRAY_SIZE");
             const string MX_CONVOLUTION_PREFIX_STRING("mx_convolution_");
             const string SAMPLES_POSTFIX_STRING("_samples");
-            const string WEIGHT_POSTFIX_STRING("_weights");
 
             // Set up sample array
             string sampleName(output->getVariable() + SAMPLES_POSTFIX_STRING);

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -124,7 +124,7 @@ GLFramebuffer::~GLFramebuffer()
 
 void GLFramebuffer::resize(unsigned int width, unsigned int height)
 {
-    if (width * height <= 0)
+    if (width * height == 0)
     {
         return;
     }

--- a/source/MaterialXRenderHw/SimpleWindow.h
+++ b/source/MaterialXRenderHw/SimpleWindow.h
@@ -60,13 +60,6 @@ class MX_RENDERHW_API SimpleWindow
     // Default constructor
     SimpleWindow();
 
-    // Clear internal state information
-    void clearInternalState()
-    {
-        _width = _height = 0;
-        _id = 0;
-    }
-
     // Wrapper for platform specific window resources
     WindowWrapperPtr _windowWrapper;
 

--- a/source/MaterialXRenderHw/SimpleWindowLinux.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowLinux.cpp
@@ -14,10 +14,10 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-SimpleWindow::SimpleWindow()
+SimpleWindow::SimpleWindow() :
+    _width(0),
+    _height(0)
 {
-    clearInternalState();
-
     // Give a unique ID to this window.
     static unsigned int windowCount = 1;
     _id = windowCount;

--- a/source/MaterialXRenderHw/SimpleWindowMac.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowMac.cpp
@@ -10,10 +10,10 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-SimpleWindow::SimpleWindow()
+SimpleWindow::SimpleWindow() :
+    _width(0),
+    _height(0)
 {
-    clearInternalState();
-
     // Give a unique identifier to this window.
     static unsigned int windowCount = 1;
     _id = windowCount;

--- a/source/MaterialXRenderHw/SimpleWindowWindows.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowWindows.cpp
@@ -11,10 +11,10 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-SimpleWindow::SimpleWindow()
+SimpleWindow::SimpleWindow() :
+    _width(0),
+    _height(0)
 {
-    clearInternalState();
-
     // Give a unique ID to this window.
     //
     static unsigned int windowCount = 1;


### PR DESCRIPTION
- Remove a duplicate variable definition in FilePath::getSubDirectories.
- Remove unused variables in BlurNodeMdl::emitFunctionCall.
- Remove an unneeded helper method in SimpleWindow::SimpleWindow.
- Clarify ambiguous logic in EsslShaderGenerator::getVertexDataPrefix.
- Additional minor fixes for correctness.