### PR TITLE
Fix TextureBaker image filename bug

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -129,6 +129,7 @@ FilePath TextureBaker::generateTextureFilename(const StringMap& filenameTemplate
     {
         std::stringstream hashStream;
         hashStream << std::hash<std::string>{}(bakedImageName);
+        hashStream << "." + getExtension();
         bakedImageName = hashStream.str();
     }
     return _outputImagePath / bakedImageName;


### PR DESCRIPTION
Fix texturebaker regression from image filename hashing.
https://github.com/AcademySoftwareFoundation/MaterialX/issues/961