### PR TITLE
Generalize viewer search paths

### DIFF
--- a/source/MaterialXFormat/Util.cpp
+++ b/source/MaterialXFormat/Util.cpp
@@ -200,4 +200,25 @@ void flattenFilenames(DocumentPtr doc, const FileSearchPath& searchPath, StringR
     }
 }
 
+FileSearchPath getSourceSearchPath(ConstDocumentPtr doc)
+{
+    StringSet pathSet;
+    for (ConstElementPtr elem : doc->traverseTree())
+    {
+        if (elem->hasSourceUri())
+        {
+            FilePath sourceFilename = FilePath(elem->getSourceUri());
+            pathSet.insert(sourceFilename.getParentPath());
+        }
+    }
+
+    FileSearchPath searchPath;
+    for (FilePath path : pathSet)
+    {
+        searchPath.append(path);
+    }
+
+    return searchPath;
+}
+
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXFormat/Util.h
+++ b/source/MaterialXFormat/Util.h
@@ -57,6 +57,9 @@ MX_FORMAT_API StringSet loadLibraries(const FilePathVec& libraryFolders,
 /// @param customResolver An optional custom resolver to apply.
 MX_FORMAT_API void flattenFilenames(DocumentPtr doc, const FileSearchPath& searchPath = FileSearchPath(), StringResolverPtr customResolver = nullptr);
 
+/// Return a file search path containing the parent folder of each source URI in the given document.
+MX_FORMAT_API FileSearchPath getSourceSearchPath(ConstDocumentPtr doc);
+
 MATERIALX_NAMESPACE_END
 
 #endif

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -276,6 +276,7 @@ class Viewer : public ng::Screen
     ng::Window* _window;
 
     mx::FilePath _materialFilename;
+    mx::FileSearchPath _materialSearchPath;
     mx::FilePath _meshFilename;
     mx::FilePath _envRadianceFilename;
 

--- a/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
@@ -25,4 +25,5 @@ void bindPyUtil(py::module& mod)
         py::arg("libraryFolders"), py::arg("searchPath"), py::arg("doc"), py::arg("excludeFiles") = mx::StringSet(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("flattenFilenames", &mx::flattenFilenames,
         py::arg("doc"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("customResolver") = (mx::StringResolverPtr) nullptr);
+    mod.def("getSourceSearchPath", &mx::getSourceSearchPath);
 }


### PR DESCRIPTION
This changelist generalizes the handling of source search paths in the MaterialX viewer, allowing documents to reference relative image paths from XIncluded content.