### PR TITLE
Add TSC stakeholder

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -70,6 +70,7 @@ The current Stakeholders of the MaterialX TSC are:
 - Jonathan Litt - Epic Games
 - André Mazzone - ILM
 - Magnus Pettersson - IKEA
+- Brian Savery - AMD
 
 ### TSC Nomination and Succession
 


### PR DESCRIPTION
This changelist adds Brian Savery as the AMD stakeholder on the MaterialX TSC, as confirmed by vote at the last TSC meeting.