### PR TITLE
Add alpha to transparency detection

### DIFF
--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -91,6 +91,7 @@ namespace
         // Inputs on a surface shader which are checked for transparency
         const OpaqueTestPairList inputPairList = { {"opacity", 1.0f},
                                                    {"existence", 1.0f},
+                                                   {"alpha", 0.0f},
                                                    {"transmission", 0.0f} };
 
 


### PR DESCRIPTION
This changelist adds "alpha" to the list of shader inputs that are checked in transparency detection functions (e.g. mx::isTransparentSurface), making them inclusive of the conventions of the glTF PBR shading model.  Materials with non-zero or spatially-varying values for "alpha" will now be considered transparent by renderers that leverage these functions.