### PR TITLE
Fix incorrect glTF PBR default input values

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <nodedef name="ND_gltf_pbr_surfaceshader" node="gltf_pbr" nodegroup="pbr" doc="glTF PBR" version="0.0.1" isdefaultversion="true">
-    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Base Color" uifolder="Base" />
-    <input name="metallic" type="float" value="0" uimin="0" uimax="1" uiname="Metallic" uifolder="Base" />
-    <input name="roughness" type="float" value="0" uimin="0" uimax="1" uiname="Roughness" uifolder="Base" />
+    <input name="base_color" type="color3" value="1, 1, 1" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Base Color" uifolder="Base" />
+    <input name="metallic" type="float" value="1" uimin="0" uimax="1" uiname="Metallic" uifolder="Base" />
+    <input name="roughness" type="float" value="1" uimin="0" uimax="1" uiname="Roughness" uifolder="Base" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Base" />
-    <input name="occlusion" type="float" value="0" uimin="0" uimax="1" uiname="Occlusion" uifolder="Base" />
+    <input name="occlusion" type="float" value="1" uimin="0" uimax="1" uiname="Occlusion" uifolder="Base" />
     <input name="transmission" type="float" value="0" uimin="0" uimax="1" uiname="Transmission" uifolder="Base" />
     <input name="specular" type="float" value="1" uimin="0" uimax="1" uiname="Specular" uifolder="Base" />
     <input name="specular_color" type="color3" value="1, 1, 1" uimin="0, 0, 0" uisoftmax="1, 1, 1" uiname="Specular Color" uifolder="Base" />
     <input name="ior" uniform="true" type="float" value="1.5" uimin="1" uisoftmax="3" uiname="Index of Refraction" uifolder="Base" />
-    <input name="alpha" type="float" value="0" uimin="0" uimax="1" uiname="Alpha" uifolder="Alpha" />
+    <input name="alpha" type="float" value="1" uimin="0" uimax="1" uiname="Alpha" uifolder="Alpha" />
     <input name="alpha_mode" uniform="true" type="integer" enum="OPAQUE, MASK, BLEND" enumvalues="0, 1, 2" value="0" uiname="Alpha Mode" uifolder="Alpha" />
     <input name="alpha_cutoff" uniform="true" type="float" value="0.5" uimin="0" uimax="1" uiname="Alpha Cutoff" uifolder="Alpha" />
     <input name="sheen_color" type="color3" value="0, 0, 0" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Sheen Color" uifolder="Sheen" />

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -91,7 +91,7 @@ namespace
         // Inputs on a surface shader which are checked for transparency
         const OpaqueTestPairList inputPairList = { {"opacity", 1.0f},
                                                    {"existence", 1.0f},
-                                                   {"alpha", 0.0f},
+                                                   {"alpha", 1.0f},
                                                    {"transmission", 0.0f} };
 
 


### PR DESCRIPTION
Hi! I've noticed that some of the default input values used in the glTF PBR implementation do not match the glTF specification.

The following table compares current default values to what I think they should be:

| glTF PBR input       | MaterialX default value | Spec value | Spec section
| ---                  | ---                     | ---        | ---
| base_color           | 0.8, 0.8, 0.8           | 1, 1, 1    | [5.22](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material-pbrmetallicroughness)
| metallic             | 0                       | 1          | [5.22](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material-pbrmetallicroughness)
| roughness            | 0                       | 1          | [5.22](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material-pbrmetallicroughness)
| normal               | Nworld                  | -
| occlusion            | 0                       | 1?         | [3.9.3](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#additional-textures)
| transmission         | 0                       | 0          | [KHR_materials_transmission](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_transmission#properties)
| specular             | 1                       | 1          | [KHR_materials_specular](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular#overview)
| specular_color       | 1, 1, 1                 | 1, 1, 1    | [KHR_materials_specular](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular#overview)
| ior                  | 1.5                     | 1.5        | [KHR_materials_ior](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_ior#extending-materials)
| alpha                | 0                       | 1          | [5.22](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material-pbrmetallicroughness)
| alpha_mode           | OPAQUE                  | OPAQUE     | [5.19](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material)
| alpha_cutoff         | 0.5                     | 0.5        | [5.19](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material)
| sheen_color          | 0, 0, 0                 | 0, 0, 0    | [KHR_materials_sheen](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_sheen#sheen)
| sheen_roughness      | 0                       | 0          | [KHR_materials_sheen](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_sheen#sheen)
| clearcoat            | 0                       | 0          | [KHR_materials_clearcoat](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_clearcoat#clearcoat)
| clearcoat_roughness  | 0                       | 0          | [KHR_materials_clearcoat](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_clearcoat#clearcoat)
| clearcoat_normal     | Nworld                  | -
| emissive             | 0, 0, 0                 | 0, 0, 0    | [5.19](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#reference-material)
| emissive_strength    | 1                       | 1          | [KHR_materials_emissive_strength](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength#parameters)
| thickness            | 0                       | 0          | [KHR_materials_volume](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume#properties)
| attenuation_distance | inf                     | inf        | [KHR_materials_volume](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume#properties)
| attenuation_color    | 1, 1, 1                 | 1, 1, 1    | [KHR_materials_volume](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_volume#properties)

Although it does not seem to be explicitly stated, I assume `occlusion` to be `1.0` rather than `0.0`, because [`1.0` means a fully unoccluded area](https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#additional-textures).

CC-ing @proog128 here because he authored the initial version.