### PR TITLE
Restore GCC 6 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Linux_GCC_7_Python27
+        - name: Linux_GCC_6_Python27
           os: ubuntu-18.04
           compiler: gcc
-          compiler_version: "7"
+          compiler_version: "6"
           python: 2.7
-          cmake_config: -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_BUILD_SHARED_LIBS=ON
+          cmake_config: -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_BUILD_VIEWER=OFF
 
         - name: Linux_GCC_10_Python37
           os: ubuntu-20.04

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -154,7 +154,7 @@ class MX_RENDER_API Half
     static constexpr int32_t const maxD = infC - maxC - 1;
     static constexpr int32_t const minD = minC - subC - 1;
 
-    static constexpr float const maxF = (float) 0x7FFFFFBF; // max int32 expressible as a flt32
+    static constexpr int32_t const maxF = 0x7FFFFFBF; // max int32 expressible as a flt32
 
     static uint16_t toFloat16(float value)
     {
@@ -164,7 +164,7 @@ class MX_RENDER_API Half
         v.si ^= sign;
         sign >>= shiftSign; // logical shift
         s.si = mulN;
-        int32_t subN = (int32_t) std::min(s.f * v.f, maxF); // correct subnormals
+        int32_t subN = (int32_t) std::min(s.f * v.f, (float) maxF); // correct subnormals
         s.si = subN;
         v.si ^= (s.si ^ v.si) & -(minN > v.si);
         v.si ^= (infN ^ v.si) & -((infN > v.si) & (v.si > maxN));


### PR DESCRIPTION
This changelist restores support for GCC 6 in MaterialXRender, extending the GitHub Actions build matrix to include this version of GCC.  The GCC 6 configuration in GitHub Actions is built without MaterialXView, as NanoGUI requires GCC 7 or newer.