### PR TITLE
Viewer UI improvements

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -898,16 +898,16 @@ void Viewer::createAdvancedSettings(Widget* parent)
         _outlineSelection = enable;
     });
 
-    _drawEnvironmentBox = new ng::CheckBox(advancedPopup, "Render Environment");
-    _drawEnvironmentBox->set_checked(_drawEnvironment);
-    _drawEnvironmentBox->set_callback([this](bool enable)
+    ng::CheckBox* drawEnvironmentBox = new ng::CheckBox(advancedPopup, "Render Environment");
+    drawEnvironmentBox->set_checked(_drawEnvironment);
+    drawEnvironmentBox->set_callback([this](bool enable)
     {
         _drawEnvironment = enable;
     });
 
-    _turntableEnabledCheckBox = new ng::CheckBox(advancedPopup, "Enable Turntable");
-    _turntableEnabledCheckBox->set_checked(_turntableEnabled);
-    _turntableEnabledCheckBox->set_callback([this](bool enable)
+    ng::CheckBox* turntableEnabledCheckBox = new ng::CheckBox(advancedPopup, "Enable Turntable");
+    turntableEnabledCheckBox->set_checked(_turntableEnabled);
+    turntableEnabledCheckBox->set_callback([this](bool enable)
     {
         toggleTurntable(enable);
     });
@@ -1063,6 +1063,10 @@ void Viewer::updateMaterialSelections()
                                      material->getMaterialNode() :
                                      material->getElement();
         std::string displayName = displayElem->getName();
+        if (displayName == "out")
+        {
+            displayName = displayElem->getParent()->getName();
+        }
         if (!material->getUdim().empty())
         {
             displayName += " (" + material->getUdim() + ")";
@@ -1807,19 +1811,6 @@ bool Viewer::keyboard_event(int key, int scancode, int action, int modifiers)
             updateMaterialSelectionUI();
         }
         return true;
-    }
-
-    if (key == GLFW_KEY_P  && action == GLFW_PRESS)
-    {
-        toggleTurntable(!_turntableEnabled);
-        _turntableEnabledCheckBox->set_checked(_turntableEnabled);
-        return true;
-    }
-
-    if (key == GLFW_KEY_V && action == GLFW_PRESS)
-    {
-        _drawEnvironment = !_drawEnvironment;
-        _drawEnvironmentBox->set_checked(_drawEnvironment);
     }
 
     if (key == GLFW_KEY_U && action == GLFW_PRESS)

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -291,7 +291,6 @@ class Viewer : public ng::Screen
     int _turntableSteps;
     int _turntableStep;
     mx::ScopedTimer _turntableTimer;
-    ng::CheckBox* _turntableEnabledCheckBox;
 
     mx::Vector3 _cameraPosition;
     mx::Vector3 _cameraTarget;
@@ -392,7 +391,6 @@ class Viewer : public ng::Screen
     bool _renderDoubleSided;
     bool _outlineSelection;
     bool _drawEnvironment;
-    ng::CheckBox* _drawEnvironmentBox;
 
     // Shader translation
     std::string _targetShader;


### PR DESCRIPTION
- Add support for default outputs in the material UI, improving the readability of test suite material examples.
- Remove hotkeys that duplicate checkboxes, in order to keep the interface as simple as possible.