### PR TITLE
Build matrix improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,12 @@ jobs:
           python: 2.7
           cmake_config: -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_BUILD_VIEWER=OFF
 
-        - name: Linux_GCC_10_Python37
-          os: ubuntu-20.04
+        - name: Linux_GCC_7_Python37
+          os: ubuntu-18.04
           compiler: gcc
-          compiler_version: "10"
+          compiler_version: "7"
           python: 3.7
-          upload_shaders: ON
+          cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
         - name: Linux_GCC_11_Python39
           os: ubuntu-20.04
@@ -39,6 +39,13 @@ jobs:
           python: 3.9
           build_javascript: ON
 
+        - name: Linux_GCC_12_Python39
+          os: ubuntu-22.04
+          compiler: gcc
+          compiler_version: "12"
+          python: 3.9
+          upload_shaders: ON
+
         - name: Linux_Clang_9_Python27
           os: ubuntu-18.04
           compiler: clang
@@ -46,18 +53,24 @@ jobs:
           python: 2.7
           cmake_config: -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_Clang_11_Python37
+        - name: Linux_Clang_10_Python37
           os: ubuntu-20.04
           compiler: clang
-          compiler_version: "11"
+          compiler_version: "10"
           python: 3.7
           cmake_config: -DMATERIALX_DYNAMIC_ANALYSIS=ON
           dynamic_analysis: ON
 
         - name: Linux_Clang_12_Python39
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           compiler: clang
           compiler_version: "12"
+          python: 3.9
+
+        - name: Linux_Clang_13_Python39
+          os: ubuntu-22.04
+          compiler: clang
+          compiler_version: "13"
           python: 3.9
           test_render: ON
 

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -29,9 +29,11 @@ elseif(UNIX)
     include_directories(${X11_INCLUDE_DIR})
 endif()
 
-# Disable deprecation warnings for GLew source on Clang.
+# Disable warnings for GLew source.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wno-deprecated-declarations)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    add_compile_options(-Wno-address)
 endif()
 
 add_library(MaterialXRenderGlsl ${materialx_source} ${materialx_headers})

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Wno-deprecated)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(-Wno-format-truncation)
+        add_compile_options(-Wno-format-truncation -Wno-use-after-free)
     endif()
 
     # Disable NanoGUI compiler modifications for Clang


### PR DESCRIPTION
- Add GCC 12 build to GitHub Actions.
- Add Clang 13 build to GitHub Actions.
- Suppress new warnings in dependencies.