### PR TITLE
Fix regressions with light shader node in GLSL

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -47,20 +47,24 @@ void LightNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shad
 
 void LightNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-        const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
+BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
-        shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, FilePath(), context, stage);
-        shadergen.emitLineBreak(stage);
+    shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, FilePath(), context, stage);
+    shadergen.emitLineBreak(stage);
 
+    const ShaderInput* edfInput = node.getInput("edf");
+    const ShaderNode* edf = edfInput->getConnectedSibling();
+    if (edf)
+    {
         context.pushClosureContext(&_callEmission);
-        shadergen.emitFunctionCall(node, context, stage);
+        shadergen.emitFunctionCall(*edf, context, stage);
         context.popClosureContext();
 
         shadergen.emitLineBreak(stage);
 
         shadergen.emitComment("Apply quadratic falloff and adjust intensity", stage);
-        shadergen.emitLine("result.intensity = " + node.getOutput()->getVariable() + " / (distance * distance)", stage);
+        shadergen.emitLine("result.intensity = " + edf->getOutput()->getVariable() + " / (distance * distance)", stage);
 
         const ShaderInput* intensity = node.getInput("intensity");
         const ShaderInput* exposure = node.getInput("exposure");
@@ -79,7 +83,12 @@ void LightNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context
             shadergen.emitString(")", stage);
             shadergen.emitLineEnd(stage);
         }
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
+    else
+    {
+        shadergen.emitLine("result.intensity = vec3(0.0)", stage);
+    }
+END_SHADER_STAGE(shader, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -509,7 +509,7 @@ void HwShaderGenerator::bindLightShader(const NodeDef& nodeDef, unsigned int lig
     {
         for (ShaderGraphInputSocket* inputSockets : graph->getInputSockets())
         {
-            inputSockets->setVariable("light." + inputSockets->getVariable());
+            inputSockets->setVariable("light." + inputSockets->getName());
         }
     }
 


### PR DESCRIPTION
This change list fixes a regression with light shader generation for GLSL. This should fix issue https://github.com/AcademySoftwareFoundation/MaterialX/issues/964.

Thanks @ashwinbhat for finding the issue and @bernardkwok for logging it.