### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -169,7 +169,7 @@ void Document::initialize()
 }
 
 NodeDefPtr Document::addNodeDefFromGraph(const NodeGraphPtr nodeGraph, const string& nodeDefName, const string& node,
-                                         const string& version, bool isDefaultVersion, const string& group, string& newGraphName)
+                                         const string& version, bool isDefaultVersion, const string& group, const string& newGraphName)
 {
     if (getNodeDef(nodeDefName))
     {

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -344,7 +344,7 @@ class MX_CORE_API Document : public GraphElement
     /// @param nodeGroup Optional node group for the new declaration. The Default value is an emptry string.
     /// @return New declaration if successful.
     NodeDefPtr addNodeDefFromGraph(const NodeGraphPtr nodeGraph, const string& nodeDefName, const string& node, const string& version,
-                                   bool isDefaultVersion, const string& nodeGroup, string& newGraphName);
+                                   bool isDefaultVersion, const string& nodeGroup, const string& newGraphName);
 
     /// Return the NodeDef, if any, with the given name.
     NodeDefPtr getNodeDef(const string& name) const

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -29,7 +29,7 @@ void GlslResourceBindingContext::initialize()
 
 void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage& stage)
 {
-    ShaderGenerator& generator = context.getShaderGenerator();
+    const ShaderGenerator& generator = context.getShaderGenerator();
 
     // Write shader stage directives for Vulkan compliance if required
     if (_separateBindingLocation)

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -212,14 +212,14 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
         AggregateTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition, members)
     {}
 
-    string getValue(const Value& value, bool uniform) const
+    string getValue(const Value& value, bool uniform) const override
     {
         ScopedFloatFormatting fmt(Value::FloatFormatFixed, 3);
         StringVec values = splitString(value.getValueString(), ",");
         return getValue(values, uniform);
     }
 
-    string getValue(const StringVec& values, bool /*uniform*/) const
+    string getValue(const StringVec& values, bool /*uniform*/) const override
     {
         if (values.empty())
         {

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -402,10 +402,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
         }
     }
 
-    if (data)
-    {
-        cgltf_free(data);
-    }
+    cgltf_free(data);
 
     return true;
 }

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -122,7 +122,7 @@ unsigned int GlslProgram::build()
 
     // Create vertex shader
     GLuint vertexShaderId = UNDEFINED_OPENGL_RESOURCE_ID;
-    string &vertexShaderSource = _stages[Stage::VERTEX];
+    const string &vertexShaderSource = _stages[Stage::VERTEX];
     if (vertexShaderSource.length())
     {
         vertexShaderId = glCreateShader(GL_VERTEX_SHADER);
@@ -153,7 +153,7 @@ unsigned int GlslProgram::build()
 
     // Create fragment shader
     GLuint fragmentShaderId = UNDEFINED_OPENGL_RESOURCE_ID;
-    string& fragmentShaderSource = _stages[Stage::PIXEL];
+    const string& fragmentShaderSource = _stages[Stage::PIXEL];
     if (fragmentShaderSource.length())
     {
         fragmentShaderId = glCreateShader(GL_FRAGMENT_SHADER);
@@ -522,7 +522,7 @@ void GlslProgram::bindTextures(ImageHandlerPtr imageHandler)
 
     // Bind textures based on uniforms found in the program
     const GlslProgram::InputMap& uniformList = getUniformsList();
-    VariableBlock& publicUniforms = _shader->getStage(Stage::PIXEL).getUniformBlock(HW::PUBLIC_UNIFORMS);
+    const VariableBlock& publicUniforms = _shader->getStage(Stage::PIXEL).getUniformBlock(HW::PUBLIC_UNIFORMS);
     for (const auto& uniform : uniformList)
     {
         GLenum uniformType = uniform.second->gltype;

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -91,7 +91,7 @@ class MX_RENDERGLSL_API GlslProgram
         /// Size.
         int size;
         /// Input type string. Will only be non-empty if initialized stages with a HwShader
-        std::string typeString;
+        string typeString;
         /// Input value. Will only be non-empty if initialized stages with a HwShader and a value was set during
         /// shader generation.
         MaterialX::ValuePtr value;
@@ -105,18 +105,18 @@ class MX_RENDERGLSL_API GlslProgram
         string colorspace;
 
         /// Program input constructor
-        Input(int inputLocation, int inputType, int inputSize, string inputPath)
-            : location(inputLocation)
-            , gltype(inputType)
-            , size(inputSize)
-            , isConstant(false)
-            , path(inputPath)
+        Input(int inputLocation, int inputType, int inputSize, const string& inputPath) :
+            location(inputLocation),
+            gltype(inputType),
+            size(inputSize),
+            isConstant(false),
+            path(inputPath)
         { }
     };
     /// Program input structure shared pointer type
     using InputPtr = std::shared_ptr<Input>;
     /// Program input shaded pointer map type
-    using InputMap = std::unordered_map<std::string, InputPtr>;
+    using InputMap = std::unordered_map<string, InputPtr>;
 
     /// Get list of program input uniforms.
     /// The program must have been created successfully first.
@@ -135,7 +135,7 @@ class MX_RENDERGLSL_API GlslProgram
     /// @param variableList List of program inputs to search
     /// @param foundList Returned list of found program inputs. Empty if none found.
     /// @param exactMatch Search for exact variable name match.
-    void findInputs(const std::string& variable,
+    void findInputs(const string& variable,
                     const InputMap& variableList,
                     InputMap& foundList,
                     bool exactMatch);
@@ -218,7 +218,7 @@ class MX_RENDERGLSL_API GlslProgram
 
     // Utility to find a uniform value in an uniform list.
     // If uniform cannot be found a null pointer will be return.
-    MaterialX::ValuePtr findUniformValue(const std::string& uniformName, const InputMap& uniformList);
+    ValuePtr findUniformValue(const string& uniformName, const InputMap& uniformList);
 
     // Bind an individual texture to a program uniform location
     ImagePtr bindTexture(unsigned int uniformType, int uniformLocation, const FilePath& filePath,
@@ -251,7 +251,7 @@ class MX_RENDERGLSL_API GlslProgram
 
     // Attribute buffer resource handles
     // for each attribute identifier in the program
-    std::unordered_map<std::string, unsigned int> _attributeBufferIds;
+    std::unordered_map<string, unsigned int> _attributeBufferIds;
 
     // Attribute indexing buffer handle
     std::map<MeshPartitionPtr, unsigned int> _indexBufferIds;
@@ -260,7 +260,7 @@ class MX_RENDERGLSL_API GlslProgram
     unsigned int _vertexArray;
 
     // Program texture map
-    std::unordered_map<std::string, unsigned int> _programTextures;
+    std::unordered_map<string, unsigned int> _programTextures;
 
     // Enabled vertex stream program locations
     std::set<int> _enabledStreamLocations;


### PR DESCRIPTION
- Add const and override modifiers for clarity.
- Remove duplicate namespace qualifiers.
- Remove duplicate null checks.