### PR TITLE
Improve BSDF fallbacks in OSL

### DIFF
--- a/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
@@ -1,6 +1,6 @@
-void mx_subsurface_bsdf(float weight, color _color, vector radius, float anisotropy, vector _normal, output BSDF bsdf)
+void mx_subsurface_bsdf(float weight, color _color, vector radius, float anisotropy, normal N, output BSDF bsdf)
 {
     // TODO: Subsurface closure is not supported by vanilla OSL.
-    bsdf.response = _color * weight * translucent(_normal);
+    bsdf.response = _color * weight * diffuse(N);
     bsdf.throughput = color(0.0);
 }

--- a/libraries/pbrlib/genosl/mx_translucent_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_translucent_bsdf.osl
@@ -1,6 +1,5 @@
-void mx_translucent_bsdf(float weight, color _color, vector _normal, output BSDF bsdf)
+void mx_translucent_bsdf(float weight, color _color, normal N, output BSDF bsdf)
 {
-    // TODO: Subsurface closure is not supported by vanilla OSL.
-    bsdf.response = _color * weight * translucent(_normal);
+    bsdf.response = _color * weight * translucent(N);
     bsdf.throughput = color(0.0);
 }


### PR DESCRIPTION
This changelist improves the fallbacks for subsurface_bsdf and translucent_bsdf in vanilla OSL, providing better visual parity across languages for the MaterialX Chess Set.