### PR TITLE
Simplify color transforms in GLSL and OSL

### DIFF
--- a/libraries/stdlib/genglsl/lib/mx_transform_color.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_transform_color.glsl
@@ -2,12 +2,8 @@
 
 vec3 mx_srgb_texture_to_lin_rec709(vec3 color)
 {
-    vec3 breakPnt = vec3(0.03928571566939354, 0.03928571566939354, 0.03928571566939354);
-    vec3 slope = vec3(0.07738015800714493, 0.07738015800714493, 0.07738015800714493);
-    vec3 scale = vec3(0.9478672742843628, 0.9478672742843628, 0.9478672742843628);
-    vec3 offset = vec3(0.05213269963860512, 0.05213269963860512, 0.05213269963860512);
-    vec3 isAboveBreak = vec3(greaterThan(color, breakPnt));
-    vec3 powSeg = pow(max(vec3(0.0), scale * color + offset), vec3(2.4));
-    vec3 linSeg = color * slope;
-    return isAboveBreak * powSeg + (vec3(1.0) - isAboveBreak) * linSeg;
+    bvec3 isAbove = greaterThan(color, vec3(0.04045));
+    vec3 linSeg = color / 12.92;
+    vec3 powSeg = pow(max(color + vec3(0.055), vec3(0.0)) / 1.055, vec3(2.4));
+    return mix(linSeg, powSeg, isAbove);
 }

--- a/libraries/stdlib/genosl/lib/mx_transform_color.osl
+++ b/libraries/stdlib/genosl/lib/mx_transform_color.osl
@@ -1,13 +1,12 @@
+#define M_AP1_TO_REC709 matrix(1.705079555511475, -0.1297005265951157, -0.02416634373366833, 0.0, -0.6242334842681885, 1.138468623161316, -0.1246141716837883, 0.0, -0.0808461606502533, -0.008768022060394287, 1.148780584335327, 0.0, 0.0, 0.0, 0.0, 1.0)
+
 color mx_srgb_texture_to_lin_rec709(color inColor)
 {
-    color breakPnt = color(0.03928571566939354, 0.03928571566939354, 0.03928571566939354);
-    color slope = color(0.07738015800714493, 0.07738015800714493, 0.07738015800714493);
-    color scale = color(0.9478672742843628, 0.9478672742843628, 0.9478672742843628);
-    color offset = color(0.05213269963860512, 0.05213269963860512, 0.05213269963860512);
-    color isAboveBreak = color(inColor[0] > breakPnt[0] ? 1.0 : 0.0,
-                               inColor[1] > breakPnt[1] ? 1.0 : 0.0,
-                               inColor[2] > breakPnt[2] ? 1.0 : 0.0);
-    color powSeg = pow(max(color(0.0, 0.0, 0.0), scale * inColor + offset), color(2.4, 2.4, 2.4));
-    color linSeg = inColor * slope;
-    return isAboveBreak * powSeg + (color(1.0, 1.0, 1.0) - isAboveBreak) * linSeg;
+    float breakPnt = 0.04045;
+    color isAbove = color(inColor[0] > breakPnt ? 1.0 : 0.0,
+                          inColor[1] > breakPnt ? 1.0 : 0.0,
+                          inColor[2] > breakPnt ? 1.0 : 0.0);
+    color linSeg = inColor / 12.92;
+    color powSeg = pow(max(inColor + color(0.055), color(0.0)) / 1.055, color(2.4));
+    return mix(linSeg, powSeg, isAbove);
 }

--- a/libraries/stdlib/genosl/mx_ap1_to_rec709_color3.osl
+++ b/libraries/stdlib/genosl/mx_ap1_to_rec709_color3.osl
@@ -1,7 +1,7 @@
+#include "lib/mx_transform_color.osl"
+
 void mx_ap1_to_rec709_color3(color _in, output color result)
 {
-    vector4 outColor = vector4(_in[0], _in[1], _in[2], 0.);
-    matrix m = matrix(1.705079555511475, -0.1297005265951157, -0.02416634373366833, 0., -0.6242334842681885, 1.138468623161316, -0.1246141716837883, 0., -0.0808461606502533, -0.008768022060394287, 1.148780584335327, 0., 0., 0., 0., 1.);
-    vector4 resultVector4 = transform(m, outColor);
-    result = color(resultVector4.x, resultVector4.y, resultVector4.z);
+    vector outRgb = transform(M_AP1_TO_REC709, vector(_in[0], _in[1], _in[2]));
+    result = color(outRgb[0], outRgb[1], outRgb[2]);
 }

--- a/libraries/stdlib/genosl/mx_ap1_to_rec709_color4.osl
+++ b/libraries/stdlib/genosl/mx_ap1_to_rec709_color4.osl
@@ -1,7 +1,7 @@
+#include "lib/mx_transform_color.osl"
+
 void mx_ap1_to_rec709_color4(color4 _in, output color4 result)
 {
-    vector4 outColor = vector4(_in.rgb[0], _in.rgb[1], _in.rgb[2], _in.a);
-    matrix m = matrix(1.705079555511475, -0.1297005265951157, -0.02416634373366833, 0., -0.6242334842681885, 1.138468623161316, -0.1246141716837883, 0., -0.0808461606502533, -0.008768022060394287, 1.148780584335327, 0., 0., 0., 0., 1.);
-    vector4 resultVector4 = transform(m, outColor);
-    result = color4(color(resultVector4.x, resultVector4.y, resultVector4.z), resultVector4.w);
+    vector outRgb = transform(M_AP1_TO_REC709, vector(_in.rgb[0], _in.rgb[1], _in.rgb[2]));
+    result = color4(color(outRgb[0], outRgb[1], outRgb[2]), _in.a);
 }

--- a/libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color3.osl
+++ b/libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color3.osl
@@ -1,11 +1,8 @@
+#include "lib/mx_transform_color.osl"
+
 void mx_g22_ap1_to_lin_rec709_color3(color _in, output color result)
 {
-    color gamma = color(2.2, 2.2, 2.2);
-    color linearColor = pow( max( color(0., 0., 0.), _in ), gamma );
-
-    vector4 linearVector = vector4(linearColor[0], linearColor[1], linearColor[2], 0.);
-    matrix m = matrix(1.705079555511475, -0.1297005265951157, -0.02416634373366833, 0., -0.6242334842681885, 1.138468623161316, -0.1246141716837883, 0., -0.0808461606502533, -0.008768022060394287, 1.148780584335327, 0., 0., 0., 0., 1.);
-    vector4 resultVector = transform(m, linearVector);
-
-    result = color(resultVector.x, resultVector.y, resultVector.z);
+    color linearColor = pow(max(color(0.0), _in), color(2.2));
+    vector outRgb = transform(M_AP1_TO_REC709, vector(linearColor[0], linearColor[1], linearColor[2]));
+    result = color(outRgb[0], outRgb[1], outRgb[2]);
 }

--- a/libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color4.osl
+++ b/libraries/stdlib/genosl/mx_g22_ap1_to_lin_rec709_color4.osl
@@ -1,11 +1,8 @@
+#include "lib/mx_transform_color.osl"
+
 void mx_g22_ap1_to_lin_rec709_color4(color4 _in, output color4 result)
 {
-    color4 gamma = color4(color(2.2, 2.2, 2.2), 1.);
-    color4 linearColor = pow( max( color4(color(0., 0., 0.), 0.), _in ), gamma );
-
-    vector4 linearVector = vector4(linearColor.rgb[0], linearColor.rgb[1], linearColor.rgb[2], linearColor.a);
-    matrix m = matrix(1.705079555511475, -0.1297005265951157, -0.02416634373366833, 0., -0.6242334842681885, 1.138468623161316, -0.1246141716837883, 0., -0.0808461606502533, -0.008768022060394287, 1.148780584335327, 0., 0., 0., 0., 1.);
-    vector4 resultVector = transform(m, linearVector);
-
-    result = color4(color(resultVector.x, resultVector.y, resultVector.z), resultVector.w);
+    color linearColor = pow(max(color(0.0), _in.rgb), color(2.2));
+    vector outRgb = transform(M_AP1_TO_REC709, vector(linearColor[0], linearColor[1], linearColor[2]));
+    result = color4(color(outRgb[0], outRgb[1], outRgb[2]), _in.a);
 }


### PR DESCRIPTION
- Simplify the GLSL and OSL implementations of mx_srgb_texture_to_lin_rec709, improving their alignment with standard references such as https://en.wikipedia.org/wiki/SRGB.
- Add a shared M_AP1_TO_REC709 matrix to OSL, following the pattern for this transform in GLSL.