### PR TITLE
Transmission rendering improvements in GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -10,17 +10,17 @@ float mx_latlong_compute_lod(float alpha)
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
     N = mx_forward_facing_normal(N, V);
-    vec3 L = reflect(-V, N);
+    vec3 L = fd.refraction ? mx_refraction_solid_sphere(-V, N, fd.ior.x) : -reflect(V, N);
 
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     float avgAlpha = mx_average_alpha(alpha);
     vec3 F = mx_compute_fresnel(NdotV, fd);
     float G = mx_ggx_smith_G2(NdotV, NdotV, avgAlpha);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_compute_lod(avgAlpha), $envRadiance);
+    vec3 FG = fd.refraction ? vec3(1.0) - (F * G) : F * G;
 
-    return Li * F * G * comp;
+    vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_compute_lod(avgAlpha), $envRadiance);
+    return Li * FG;
 }
 
 vec3 mx_environment_irradiance(vec3 N)

--- a/libraries/pbrlib/genglsl/lib/mx_transmission_opacity.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_transmission_opacity.glsl
@@ -1,0 +1,6 @@
+#include "mx_microfacet_specular.glsl"
+
+vec3 mx_surface_transmission(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
+{
+    return vec3(1.0);
+}

--- a/libraries/pbrlib/genglsl/lib/mx_transmission_refract.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_transmission_refract.glsl
@@ -1,0 +1,15 @@
+#include "mx_microfacet_specular.glsl"
+
+vec3 mx_surface_transmission(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
+{
+    if ($refractionEnv)
+    {
+        // Approximate the appearance of dielectric transmission as glossy
+        // environment map refraction, ignoring any scene geometry that might
+        // be visible through the surface.
+        fd.refraction = true;
+        return mx_environment_radiance(N, V, X, alpha, distribution, fd);
+    }
+
+    return $refractionColor;
+}

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -44,7 +44,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
 
 void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
-    if (weight < M_FLOAT_EPS || scatter_mode == 0)
+    if (weight < M_FLOAT_EPS)
     {
         return;
     }
@@ -71,12 +71,10 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
     vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
-    // For now, we approximate the appearance of dielectric transmission as
-    // glossy environment map refraction, ignoring any scene geometry that
-    // might be visible through the surface.
-    fd.refraction = true;
-    vec3 Li = $refractionEnv ? mx_environment_radiance(N, V, X, safeAlpha, distribution, fd) : $refractionColor;
-    bsdf.response = Li * tint * weight;
+    if (scatter_mode != 0)
+    {
+        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd) * tint * weight;
+    }
 }
 
 void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -36,7 +36,7 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
 
 void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
-    if (weight < M_FLOAT_EPS || scatter_mode == 0)
+    if (weight < M_FLOAT_EPS)
     {
         return;
     }
@@ -55,14 +55,12 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
-    // For now, we approximate the appearance of Schlick transmission as
-    // glossy environment map refraction, ignoring any scene geometry that
-    // might be visible through the surface.
-    float avgF0 = dot(color0, vec3(1.0 / 3.0));
-    fd.refraction = true;
-    fd.ior.x = mx_f0_to_ior(avgF0);
-    vec3 Li = $refractionEnv ? mx_environment_radiance(N, V, X, safeAlpha, distribution, fd) : $refractionColor;
-    bsdf.response = Li * color0 * weight;
+    if (scatter_mode != 0)
+    {
+        float avgF0 = dot(color0, vec3(1.0 / 3.0));
+        fd.ior = vec3(mx_f0_to_ior(avgF0));
+        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd) * color0 * weight;
+    }
 }
 
 void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -365,6 +365,24 @@ void GlslShaderGenerator::emitSpecularEnvironment(GenContext& context, ShaderSta
     emitLineBreak(stage);
 }
 
+void GlslShaderGenerator::emitTransmissionRender(GenContext& context, ShaderStage& stage) const
+{
+    int transmissionMethod = context.getOptions().hwTransmissionRenderMethod;
+    if (transmissionMethod == TRANSMISSION_REFRACTION)
+    {
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_transmission_refract.glsl", context, stage);
+    }
+    else if (transmissionMethod == TRANSMISSION_OPACITY)
+    {
+        emitLibraryInclude("pbrlib/genglsl/lib/mx_transmission_opacity.glsl", context, stage);
+    }
+    else
+    {
+        throw ExceptionShaderGenError("Invalid transmission render specified: '" + std::to_string(transmissionMethod) + "'");
+    }
+    emitLineBreak(stage);
+}
+
 void GlslShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
 {
     emitLine("#version " + getVersion(), stage, false);
@@ -548,6 +566,7 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
             emitLine("#define " + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + " " + std::to_string(maxLights), stage, false);
         }
         emitSpecularEnvironment(context, stage);
+        emitTransmissionRender(context, stage);
 
         if (context.getOptions().hwMaxActiveLightSources > 0)
         {

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -75,6 +75,9 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     /// Emit specular environment lookup code
     virtual void emitSpecularEnvironment(GenContext& context, ShaderStage& stage) const;
 
+    /// Emit transmission rendering code
+    virtual void emitTransmissionRender(GenContext& context, ShaderStage& stage) const;
+
     /// Emit function definitions for lighting code
     virtual void emitLightFunctionDefinitions(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const;
 

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -207,7 +207,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             }
             else
             {
-                shadergen.emitLine(outTransparency + " += " + bsdf->getOutput()->getVariable() + ".throughput", stage);
+                shadergen.emitLine(outTransparency + " += " + bsdf->getOutput()->getVariable() + ".response", stage);
             }
             shadergen.emitScopeEnd(stage);
             context.popClosureContext();


### PR DESCRIPTION
- Unify transmission computations between GLSL render options, addressing inconsistencies in the interaction between transmission and surface opacity.
- Add support for transmission refraction using prefiltered environment maps.
- Remove duplicated energy compensation in prefiltered environment maps.