### PR TITLE
Moved setConnectedOutput from Input to PortElement

### DIFF
--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -123,6 +123,13 @@ class MX_CORE_API PortElement : public ValueElement
         return hasAttribute(OUTPUT_ATTRIBUTE);
     }
 
+    /// Set the output to which this input is connected.  If the output
+    /// argument is null, then any existing output connection will be cleared.
+    void setConnectedOutput(ConstOutputPtr output);
+
+    /// Return the output, if any, to which this input is connected.
+    virtual OutputPtr getConnectedOutput() const;
+
     /// Return the output string of this element.
     const string& getOutputString() const
     {
@@ -238,13 +245,6 @@ class MX_CORE_API Input : public PortElement
 
     /// Return the node, if any, to which this input is connected.
     NodePtr getConnectedNode() const override;
-
-    /// Set the output to which this input is connected.  If the output
-    /// argument is null, then any existing output connection will be cleared.
-    void setConnectedOutput(ConstOutputPtr output);
-
-    /// Return the output, if any, to which this input is connected.
-    virtual OutputPtr getConnectedOutput() const;
 
     /// Return the input on the parent graph corresponding to the interface name
     /// for this input.

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -29,7 +29,9 @@ void bindPyInterface(py::module& mod)
         .def("setChannels", &mx::PortElement::setChannels)
         .def("getChannels", &mx::PortElement::getChannels)
         .def("setConnectedNode", &mx::PortElement::setConnectedNode)
-        .def("getConnectedNode", &mx::PortElement::getConnectedNode);
+        .def("getConnectedNode", &mx::PortElement::getConnectedNode)
+        .def("setConnectedOutput", &mx::PortElement::setConnectedOutput)
+        .def("getConnectedOutput", &mx::PortElement::getConnectedOutput);
 
     py::class_<mx::Input, mx::InputPtr, mx::PortElement>(mod, "Input")
         .def("setDefaultGeomPropString", &mx::Input::setDefaultGeomPropString)
@@ -37,8 +39,6 @@ void bindPyInterface(py::module& mod)
         .def("getDefaultGeomPropString", &mx::Input::getDefaultGeomPropString)
         .def("getDefaultGeomProp", &mx::Input::getDefaultGeomProp)
         .def("getConnectedNode", &mx::Input::getConnectedNode)
-        .def("setConnectedOutput", &mx::Input::setConnectedOutput)
-        .def("getConnectedOutput", &mx::Input::getConnectedOutput)
         .def("getInterfaceInput", &mx::Input::getInterfaceInput)
         .def_readonly_static("CATEGORY", &mx::Input::CATEGORY);
 


### PR DESCRIPTION
From the slack discussion:

> Currently `setConnectedOutput`  is implemented only in `Input`  but not in `Output` meaning that if you want to connect some named output (from node that have several output connections) to the graph output you just can't do that. Only with some workaround and pass through node (like `add` with zero) because you can indicate specific output on the node input.

After browsing the source (originally I just used prebuilt python bindings) I've also discovered that I can use `Output::setOutputString` but still it's probably better if those functions are available on `PortElement`