### PR TITLE
Improved persistence of viewer settings

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -585,9 +585,7 @@ void Viewer::createLoadMeshInterface(Widget* parent, const std::string& label)
 
             _meshRotation = mx::Vector3();
             _meshScale = 1.0f;
-            _cameraPosition = DEFAULT_CAMERA_POSITION;
             _cameraTarget = mx::Vector3();
-            _cameraViewAngle = DEFAULT_CAMERA_VIEW_ANGLE;
 
             initCamera();
         }


### PR DESCRIPTION
This changelist makes MaterialX viewer settings "cameraPosition" and "cameraViewAngle" persistent when the user loads a new mesh, providing a more consistent experience when validating materials across multiple meshes.