### PR TITLE
Fix spelling in GlslProgram::addStage

### DIFF
--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -68,9 +68,9 @@ void GlslProgram::setStages(ShaderPtr shader)
     clearInputLists();
 }
 
-void GlslProgram::addStage(const string& stage, const string& sourcCode)
+void GlslProgram::addStage(const string& stage, const string& sourceCode)
 {
-    _stages[stage] = sourcCode;
+    _stages[stage] = sourceCode;
 }
 
 const string& GlslProgram::getStageSourceCode(const string& stage) const

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -50,8 +50,8 @@ class MX_RENDERGLSL_API GlslProgram
     /// Set the code stages based on a list of stage strings.
     /// Refer to the ordering of stages as defined by a HwShader.
     /// @param stage Name of the shader stage.
-    /// @param sourcCode Source code of the shader stage.
-    void addStage(const string& stage, const string& sourcCode);
+    /// @param sourceCode Source code of the shader stage.
+    void addStage(const string& stage, const string& sourceCode);
 
     /// Get source code string for a given stage.
     /// @return Shader stage string. String is empty if not found.


### PR DESCRIPTION
This changelist fixes the spelling of "sourceCode" in the GlslProgram::addStage method.