### PR TITLE
Add in flipV on geometry support

### DIFF
--- a/javascript/MaterialXView/source/helper.js
+++ b/javascript/MaterialXView/source/helper.js
@@ -126,7 +126,7 @@ function fromMatrix(matrix, dimension)
  * @param {mx.Uniforms} uniforms
  * @param {THREE.textureLoader} textureLoader
  */
-function toThreeUniform(type, value, name, uniforms, textureLoader, searchPath)
+function toThreeUniform(type, value, name, uniforms, textureLoader, searchPath, flipY)
 {
     let outValue;  
     switch (type)
@@ -159,7 +159,7 @@ function toThreeUniform(type, value, name, uniforms, textureLoader, searchPath)
                 let fullPath = searchPath + IMAGE_PATH_SEPARATOR + value;
                 const texture = textureLoader.load(fullPath);
                 // Set address & filtering mode
-                setTextureParameters(texture, name, uniforms);
+                setTextureParameters(texture, name, uniforms, flipY);
                 outValue = texture;
             } 
             break;
@@ -222,7 +222,7 @@ function getMinFilter(type, generateMipmaps)
  * @param {mx.Uniforms} uniforms
  * @param {mx.TextureFilter.generateMipmaps} generateMipmaps
  */
-function setTextureParameters(texture, name, uniforms, generateMipmaps = true)
+function setTextureParameters(texture, name, uniforms, flipY = true, generateMipmaps = true)
 {
     const idx = name.lastIndexOf(IMAGE_PROPERTY_SEPARATOR);
     const base = name.substring(0, idx) || name;
@@ -239,7 +239,7 @@ function setTextureParameters(texture, name, uniforms, generateMipmaps = true)
     texture.magFilter = THREE.LinearFilter;
     texture.minFilter = getMinFilter(filterType, generateMipmaps);
 
-    texture.flipY = false;
+    texture.flipY = flipY;
 }
 
 /**
@@ -305,7 +305,7 @@ export function registerLights(mx, lights, genContext)
  * @param {mx.shaderStage} shaderStage
  * @param {THREE.TextureLoader} textureLoader
  */
-export function getUniformValues(shaderStage, textureLoader, searchPath)
+export function getUniformValues(shaderStage, textureLoader, searchPath, flipY)
 {
     let threeUniforms = {};
 
@@ -318,7 +318,8 @@ export function getUniformValues(shaderStage, textureLoader, searchPath)
                 const variable = uniforms.get(i);                
                 const value = variable.getValue()?.getData();
                 const name = variable.getVariable();
-                threeUniforms[name] = new THREE.Uniform(toThreeUniform(variable.getType().getName(), value, name, uniforms, textureLoader, searchPath));
+                threeUniforms[name] = new THREE.Uniform(toThreeUniform(variable.getType().getName(), value, name, uniforms, 
+                                                        textureLoader, searchPath, flipY));
             }
         }
     });

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -50,7 +50,6 @@ function init()
     let geometrySelect = document.getElementById('geometry');
     geometrySelect.value = scene.getGeometryURL();
     geometrySelect.addEventListener('change', (e) => {
-        scene.setFlipGeometryV(e.target.value == "Geometry/shaderball.glb"); 
         scene.setGeometryURL(e.target.value);
         scene.loadGeometry(viewer, orbitControls);
     });
@@ -96,7 +95,6 @@ function init()
 
         // Load geometry  
         let scene = viewer.getScene();
-        scene.setFlipGeometryV(scene.getGeometryURL() == "Geometry/shaderball.glb"); 
         scene.loadGeometry(viewer, orbitControls);
 
         // Load materials

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -50,6 +50,7 @@ function init()
     let geometrySelect = document.getElementById('geometry');
     geometrySelect.value = scene.getGeometryURL();
     geometrySelect.addEventListener('change', (e) => {
+        scene.setFlipGeometryV(e.target.value == "Geometry/shaderball.glb"); 
         scene.setGeometryURL(e.target.value);
         scene.loadGeometry(viewer, orbitControls);
     });
@@ -93,8 +94,10 @@ function init()
         // Initialize viewer + lighting
         await viewer.initialize(mxIn, renderer, loadedRadianceTexture, loadedLightSetup, loadedIrradianceTexture);
 
-        // Load geometry
-        viewer.getScene().loadGeometry(viewer, orbitControls);
+        // Load geometry  
+        let scene = viewer.getScene();
+        scene.setFlipGeometryV(scene.getGeometryURL() == "Geometry/shaderball.glb"); 
+        scene.loadGeometry(viewer, orbitControls);
 
         // Load materials
         viewer.getMaterial().loadMaterials(viewer, materialFilename);

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -36,9 +36,9 @@ export class Scene
         this._scene.background.convertSRGBToLinear();
 
         const aspectRatio = window.innerWidth / window.innerHeight;
-        const cameraNearDist = 0.01;
-        const cameraFarDist = 5000.0;
-        const cameraFOV = 45.0;
+        const cameraNearDist = 0.05;
+        const cameraFarDist = 100.0;
+        const cameraFOV = 60.0;
         this._camera = new THREE.PerspectiveCamera(cameraFOV, aspectRatio, cameraNearDist, cameraFarDist);
 
         this.#_gltfLoader = new GLTFLoader();
@@ -46,6 +46,18 @@ export class Scene
         this.#_normalMat = new THREE.Matrix3();
         this.#_viewProjMat = new THREE.Matrix4();
         this.#_worldViewPos = new THREE.Vector3();
+    }
+
+    // Set whether to flip UVs in V for loaded geometry
+    setFlipGeometryV(val)
+    {
+        this.#_flipV = val;
+    }
+
+    // Get whether to flip UVs in V for loaded geometry
+    getFlipGeometryV()
+    {
+        return this.#_flipV;
     }
 
     // Utility to perform geometry file load
@@ -99,6 +111,9 @@ export class Scene
         const bbox = new THREE.Box3().setFromObject(this._scene);
         const bsphere = new THREE.Sphere();
         bbox.getBoundingSphere(bsphere);
+
+        let theScene = viewer.getScene();
+        let flipV = theScene.getFlipGeometryV();
     
         this._scene.traverse((child) => {
             if (child.isMesh) {
@@ -113,6 +128,15 @@ export class Scene
                     }
     
                     child.geometry.setAttribute('uv', new THREE.BufferAttribute(new Float32Array(uvs), 2));
+                }
+                else if (flipV)
+                {
+                    const uvCount = child.geometry.attributes.position.count;
+                    const uvs = child.geometry.attributes.uv.array;
+                    for (let i = 0; i < uvCount; i++) {
+                        let v = 1.0-(uvs[i*2 +1]);
+                        uvs[i*2+1] = v;
+                    }
                 }
     
                 if (!child.geometry.attributes.normal) {
@@ -304,6 +328,8 @@ export class Scene
     #_geometryURL = '';
     // Geometry loader
     #_gltfLoader = null;
+    // Flip V coordinate of texture coordinates
+    #_flipV = false;
 
     // Scene
     #_scene = null;

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -328,8 +328,9 @@ export class Scene
     #_geometryURL = '';
     // Geometry loader
     #_gltfLoader = null;
-    // Flip V coordinate of texture coordinates
-    #_flipV = false;
+    // Flip V coordinate of texture coordinates.
+    // Set to true to be consistent with desktop viewer.
+    #_flipV = true;
 
     // Scene
     #_scene = null;
@@ -667,9 +668,11 @@ export class Material
         let vShader = shader.getSourceCode("vertex");
         let fShader = shader.getSourceCode("pixel");
 
+        let theScene = viewer.getScene();
+        let flipV = theScene.getFlipGeometryV();
         let uniforms = {
-            ...getUniformValues(shader.getStage('vertex'), textureLoader, searchPath),
-            ...getUniformValues(shader.getStage('pixel'), textureLoader, searchPath),
+            ...getUniformValues(shader.getStage('vertex'), textureLoader, searchPath, flipV),
+            ...getUniformValues(shader.getStage('pixel'), textureLoader, searchPath, flipV),
         }
 
         Object.assign(uniforms, {

--- a/javascript/build_javascript_win.bat
+++ b/javascript/build_javascript_win.bat
@@ -25,6 +25,5 @@ if NOT ["%errorlevel%"]==["0"] pause
 cd ../MaterialXView
 call npm install
 call npm run build
-call npm install http-server -g
-call http-server . -p 8000
+call npm run start
 if NOT ["%errorlevel%"]==["0"] pause


### PR DESCRIPTION
Fixes #991.

* Add in a flip "V" for geometry load. This is a generally useful option.
* The option is currently always enabled for geometry which is loaded. This is to be consistent in orientation with desktop and orientation used for 2d placement.
* Images when loaded to GPU have an option to be flipped. This is now enabled based on the geometry orientation option (which is true).

### Results (Desktop on left)
![web_desktop_orentation_fix2](https://user-images.githubusercontent.com/49369885/175129711-247e6199-064a-493f-8b01-01713f21116f.png)
![web_desktop_orentation_fix1](https://user-images.githubusercontent.com/49369885/175129715-5b57e3d0-1e0e-4920-9f3a-e740b5e5a441.PNG)

