### PR TITLE
Fix failure of unit shader translation tests

### DIFF
--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -157,15 +157,11 @@ void ShaderTranslator::translateShader(NodePtr shader, const string& destCategor
 
     DocumentPtr doc = shader->getDocument();
     vector<OutputPtr> referencedOutputs = getConnectedOutputs(shader);
-    // Make sure to always clear this cache member otherwise the
-    // previous graph member (which could have been dealocated already) 
-    // could be used.
-    _graph = nullptr;
-    if (!referencedOutputs.empty())
+    if (!referencedOutputs.empty() && referencedOutputs[0]->getParent())
     {
-        _graph = referencedOutputs[0]->getParent() ? referencedOutputs[0]->getParent()->asA<NodeGraph>() : nullptr;
+        _graph = referencedOutputs[0]->getParent()->asA<NodeGraph>();
     }
-    if (!_graph)
+    else
     {
         _graph = doc->addNodeGraph();
     }

--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -157,6 +157,10 @@ void ShaderTranslator::translateShader(NodePtr shader, const string& destCategor
 
     DocumentPtr doc = shader->getDocument();
     vector<OutputPtr> referencedOutputs = getConnectedOutputs(shader);
+    // Make sure to always clear this cache member otherwise the
+    // previous graph member (which could have been dealocated already) 
+    // could be used.
+    _graph = nullptr;
     if (!referencedOutputs.empty())
     {
         _graph = referencedOutputs[0]->getParent() ? referencedOutputs[0]->getParent()->asA<NodeGraph>() : nullptr;

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -196,7 +196,7 @@ TEST_CASE("GenShader: Shader Translation", "[translate]")
             std::cout << "Shader translation of " << (testPath / mtlxFile).asString() << " failed" << std::endl;
             std::cout << "Validation errors: " << validationErrors << std::endl;
         }
-        CHECK(valid);
+        REQUIRE(valid);
     }
 }
 


### PR DESCRIPTION
Fixes #1005 

Clear cached graph member so it cannot be accidently reused. CI tests would not catch this as a new instance
of a ShaderTranslator was created for each test thus no possibility of reusing the same.
Change unit test to actually fail vs check failure.