### PR TITLE
Enable generation from material nodes

### DIFF
--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -108,12 +108,12 @@ def main():
     shadergen.setUnitSystem(unitsystem)
     genoptions.targetDistanceUnit = 'meter'
 
-    # Look for shader nodes
-    shaderNodes = mx_gen_shader.findRenderableElements(doc, False)
-    if not shaderNodes:
-        shaderNodes = doc.getMaterialNodes()
-        if not shaderNodes:
-            shaderNodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
+    # Look for renderable nodes
+    nodes = mx_gen_shader.findRenderableElements(doc, False)
+    if not nodes:
+        nodes = doc.getMaterialNodes()
+        if not nodes:
+            nodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
 
     pathPrefix = ''
     if opts.outputPath and os.path.exists(opts.outputPath):
@@ -123,12 +123,12 @@ def main():
     print('- Shader output path: ' + pathPrefix)
 
     failedShaders = ""
-    for shaderNode in shaderNodes:
+    for node in nodes:
 
-        shaderNodeName = shaderNode.getName()
-        print('-- Generate code for node: ' + shaderNodeName)
-        shaderNodeName = mx.createValidName(shaderNodeName)
-        shader = shadergen.generate(shaderNodeName, shaderNode, context)        
+        nodeName = node.getName()
+        print('-- Generate code for node: ' + nodeName)
+        nodeName = mx.createValidName(nodeName)
+        shader = shadergen.generate(nodeName, node, context)        
         if shader:
             # Use extension of .vert and .frag as it's type is
             # recognized by glslangValidator
@@ -159,17 +159,17 @@ def main():
                 errors = validateCode(filename, opts.validator, opts.validatorArgs)
 
             if errors != "":
-                print("--- Validation failed for node: ", shaderNodeName)
+                print("--- Validation failed for node: ", nodeName)
                 print("----------------------------")
                 print('--- Error log: ', errors)
                 print("----------------------------")
-                failedShaders += (shaderNodeName + ' ')
+                failedShaders += (nodeName + ' ')
             else:
-                print("--- Validation passed for node:", shaderNodeName)
+                print("--- Validation passed for node:", nodeName)
 
         else:
-            print("--- Validation failed for node:", shaderNodeName)
-            failedShaders += (shaderNodeName + ' ')
+            print("--- Validation failed for node:", nodeName)
+            failedShaders += (nodeName + ' ')
 
     if failedShaders != "":
         sys.exit(-1)

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -111,9 +111,7 @@ def main():
     # Look for shader nodes
     shaderNodes = mx_gen_shader.findRenderableElements(doc, False)
     if not shaderNodes:
-        materials = doc.getMaterialNodes()
-        for material in materials:       
-            shaderNodes += mx.getShaderNodes(material, mx.SURFACE_SHADER_TYPE_STRING)
+        shaderNodes = doc.getMaterialNodes()
         if not shaderNodes:
             shaderNodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
 
@@ -126,11 +124,6 @@ def main():
 
     failedShaders = ""
     for shaderNode in shaderNodes:
-        # Material nodes are not supported directly for generation so find upstream
-        # shader nodes.
-        if shaderNode.getCategory() == 'surfacematerial':
-            shaderNodes += mx.getShaderNodes(shaderNode, mx.SURFACE_SHADER_TYPE_STRING)
-            continue
 
         shaderNodeName = shaderNode.getName()
         print('-- Generate code for node: ' + shaderNodeName)
@@ -166,16 +159,16 @@ def main():
                 errors = validateCode(filename, opts.validator, opts.validatorArgs)
 
             if errors != "":
-                print("Validation failed for shader: ", shaderNodeName)
-                print("-------------------------")
-                print('Error log: ', errors)
-                print("-------------------------")
+                print("--- Validation failed for node: ", shaderNodeName)
+                print("----------------------------")
+                print('--- Error log: ', errors)
+                print("----------------------------")
                 failedShaders += (shaderNodeName + ' ')
             else:
-                print("Validation passed for shader: ", shaderNodeName)
+                print("--- Validation passed for node:", shaderNodeName)
 
         else:
-            print("Validation failed for shader: ", shaderNodeName)
+            print("--- Validation failed for node:", shaderNodeName)
             failedShaders += (shaderNodeName + ' ')
 
     if failedShaders != "":

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -124,7 +124,6 @@ def main():
 
     failedShaders = ""
     for node in nodes:
-
         nodeName = node.getName()
         print('-- Generate code for node: ' + nodeName)
         nodeName = mx.createValidName(nodeName)


### PR DESCRIPTION
Remove conversion of material nodes to surface shader nodes now that material nodes are supported.
This was added with https://github.com/AcademySoftwareFoundation/MaterialX/pull/981.

### CI Results
Note that now displacement shader (if any) is included and prefixing (scoping) of shader uniforms with material node name.
```
- Set up CMS ...
- Set up Units ...
- Shader output path: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurface
-- Generate code for node: Tiled_Brass
--- Wrote pixel shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.glsl.frag
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.glsl.frag -V --aml
--- Wrote vertex shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.glsl.vert
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.glsl.vert -V --aml
--- Validation passed for node: Tiled_Brass
-- Generate code for node: Greysphere_Calibration
--- Wrote pixel shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.glsl.frag
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.glsl.frag -V --aml
--- Wrote vertex shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.glsl.vert
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.glsl.vert -V --aml
--- Validation passed for node: Greysphere_Calibration
- Set up CMS ...
- Set up Units ...
- Shader output path: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurface
-- Generate code for node: Tiled_Brass
--- Wrote pixel shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.essl.frag
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.essl.frag
--- Wrote vertex shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.essl.vert
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceTiled_Brass.essl.vert
--- Validation passed for node: Tiled_Brass
-- Generate code for node: Greysphere_Calibration
--- Wrote pixel shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.essl.frag
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.essl.frag
--- Wrote vertex shader to: D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.essl.vert
----- Run: glslangValidator.exe D:\a\MaterialX\MaterialX\resources\Materials\Examples\StandardSurfaceGreysphere_Calibration.essl.vert
--- Validation passed for node: Greysphere_Calibration
```

