### PR TITLE
Fix numerical warnings in GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -348,7 +348,7 @@ vec3 mx_fresnel_airy(float cosTheta, vec3 ior, vec3 extinction, float tf_thickne
 
     // Assume vacuum on the outside
     float eta1 = 1.0;
-    float eta2 = tf_ior;
+    float eta2 = max(tf_ior, eta1);
 
     // Optical path difference
     float cosTheta2 = sqrt(1.0 - mx_square(eta1/eta2) * (1.0 - mx_square(cosTheta)));
@@ -362,7 +362,8 @@ vec3 mx_fresnel_airy(float cosTheta, vec3 ior, vec3 extinction, float tf_thickne
 
     // Second interface
     vec2 R23, phi23;
-    mx_fresnel_conductor_polarized(cosTheta2, eta2, ior.x, extinction.x, R23, phi23);
+    float eta3 = max(ior.x, eta2);
+    mx_fresnel_conductor_polarized(cosTheta2, eta2, eta3, extinction.x, R23, phi23);
 
     // Phase shift
     vec2 phi2 = phi21 + phi23;


### PR DESCRIPTION
This changelist adds guards to the GLSL implementation of thin-film rendering, addressing numerical warnings and visual artifacts in situations where eta values decrease between interfaces.  Without these guards, the computation requires the computation of an imaginary square root, which is undefined behavior in GLSL.