### PR TITLE
Change naming of type 'material' in generated OSL code

### DIFF
--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -532,7 +532,7 @@ OslSyntax::OslSyntax()
     (
         Type::MATERIAL,
         std::make_shared<ScalarTypeSyntax>(
-            "material",
+            "MATERIAL",
             "null_closure",
             "0",
             "closure color")


### PR DESCRIPTION
This change list updates the name of data type 'material' in generated OSL code. This is to resolve a naming conflict were the name "material" is already used in some OSL systems.