### PR TITLE
Fix initialization warning in GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_transmission_refract.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_transmission_refract.glsl
@@ -2,14 +2,19 @@
 
 vec3 mx_surface_transmission(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
+    vec3 transmission;
     if ($refractionEnv)
     {
-        // Approximate the appearance of dielectric transmission as glossy
+        // Approximate the appearance of surface transmission as glossy
         // environment map refraction, ignoring any scene geometry that might
         // be visible through the surface.
         fd.refraction = true;
-        return mx_environment_radiance(N, V, X, alpha, distribution, fd);
+        transmission = mx_environment_radiance(N, V, X, alpha, distribution, fd);
+    }
+    else
+    {
+        transmission = $refractionColor;
     }
 
-    return $refractionColor;
+    return transmission;
 }


### PR DESCRIPTION
This changelist refactors the implementation of mx_surface_transmission in GLSL, addressing an initialization warning when the function is called in WebGL.