### PR TITLE
Provide a frame transform for UV texture coordinates

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2333,8 +2333,23 @@
   <!--
     Node: <place2d> Supplemental Node
     Transform incoming UV texture coordinates for 2D texture placement.
+    Sequence of transformation (in the order of application): -pivot, scale, rotate, translate, pivot.
   -->
   <nodedef name="ND_place2d_vector2" node="place2d" nodegroup="math">
+    <input name="texcoord" type="vector2" value="0.0, 0.0" />
+    <input name="pivot" type="vector2" value="0.0,0.0" />
+    <input name="scale" type="vector2" value="1.0,1.0" />
+    <input name="rotate" type="float" value="0.0" unittype="angle" unit="degree" />
+    <input name="offset" type="vector2" value="0.0,0.0" />
+    <output name="out" type="vector2" defaultinput="texcoord" />
+  </nodedef>
+
+  <!--
+    Node: <place2dframe> Supplemental Node
+    Transform incoming UV texture coordinates for 2D texture placement.
+    Sequence of transformation (in the order of application): -pivot, translate, rotate, scale, pivot.
+  -->
+  <nodedef name="ND_place2dframe_vector2" node="place2dframe" nodegroup="math">
     <input name="texcoord" type="vector2" value="0.0, 0.0" />
     <input name="pivot" type="vector2" value="0.0,0.0" />
     <input name="scale" type="vector2" value="1.0,1.0" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2332,8 +2332,8 @@
 
   <!--
     Node: <place2d> Supplemental Node
-    Transform incoming UV texture coordinates for 2D texture placement.
-    Sequence of transformation (in the order of application): -pivot, scale, rotate, translate, pivot.
+    Transform incoming UV texture coordinates from one 2D frame of reference to another.
+    The order of transformation is: -pivot, scale, rotate, translate, pivot.
   -->
   <nodedef name="ND_place2d_vector2" node="place2d" nodegroup="math">
     <input name="texcoord" type="vector2" value="0.0, 0.0" />
@@ -2346,17 +2346,10 @@
 
   <!--
     Node: <place2dframe> Supplemental Node
-    Transform incoming UV texture coordinates for 2D texture placement.
-    Sequence of transformation (in the order of application): -pivot, translate, rotate, scale, pivot.
+    Transform incoming UV texture coordinates from one 2D frame of reference to another.
+    The order of transformation is: -pivot, translate, rotate, scale, pivot.
   -->
-  <nodedef name="ND_place2dframe_vector2" node="place2dframe" nodegroup="math">
-    <input name="texcoord" type="vector2" value="0.0, 0.0" />
-    <input name="pivot" type="vector2" value="0.0,0.0" />
-    <input name="scale" type="vector2" value="1.0,1.0" />
-    <input name="rotate" type="float" value="0.0" unittype="angle" unit="degree" />
-    <input name="offset" type="vector2" value="0.0,0.0" />
-    <output name="out" type="vector2" defaultinput="texcoord" />
-  </nodedef>
+  <nodedef name="ND_place2dframe_vector2" node="place2dframe" inherit="ND_place2d_vector2" />
 
   <!--
     Node: <arrayappend>

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2333,7 +2333,11 @@
   <!--
     Node: <place2d> Supplemental Node
     Transform incoming UV texture coordinates from one 2D frame of reference to another.
-    The order of transformation is: -pivot, scale, rotate, translate, pivot.
+    operationorder (integer enum): the order in which to perform the transform operations.
+    "0" or "SRT" performs -pivot, scale, rotate, translate, +pivot as per the original
+    implementation matching the behavior of certain DCC packages, and "1" or "TRS" performs
+    -pivot, translate, rotate, scale, +pivot which does not introduce texture shear.
+    Default is 0 "SRT" for backward compatibility.
   -->
   <nodedef name="ND_place2d_vector2" node="place2d" nodegroup="math">
     <input name="texcoord" type="vector2" value="0.0, 0.0" />
@@ -2341,15 +2345,9 @@
     <input name="scale" type="vector2" value="1.0,1.0" />
     <input name="rotate" type="float" value="0.0" unittype="angle" unit="degree" />
     <input name="offset" type="vector2" value="0.0,0.0" />
+    <input name="operationorder" type="integer" value="0" enum="SRT, TRS" enumvalues="0, 1" />
     <output name="out" type="vector2" defaultinput="texcoord" />
   </nodedef>
-
-  <!--
-    Node: <place2dframe> Supplemental Node
-    Transform incoming UV texture coordinates from one 2D frame of reference to another.
-    The order of transformation is: -pivot, translate, rotate, scale, pivot.
-  -->
-  <nodedef name="ND_place2dframe_vector2" node="place2dframe" inherit="ND_place2d_vector2" />
 
   <!--
     Node: <arrayappend>

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1046,6 +1046,7 @@
   <!--
     Node: <place2d>
     Transform incoming UV texture coordinates for 2D texture placement.
+    Sequence of transformation (in the order of application): -pivot, scale, rotate, translate, pivot.
   -->
   <nodegraph name="NG_place2d_vector2" nodedef="ND_place2d_vector2">
     <subtract name="N_subpivot" type="vector2">
@@ -1066,6 +1067,35 @@
     </subtract>
     <add name="N_addpivot" type="vector2">
       <input name="in1" type="vector2" nodename="N_applyoffset" />
+      <input name="in2" type="vector2" interfacename="pivot" />
+    </add>
+    <output name="out" type="vector2" nodename="N_addpivot" />
+  </nodegraph>
+
+  <!--
+    Node: <place2dframe>
+    Transform incoming UV texture coordinates for 2D texture placement.
+    Sequence of transformation (in the order of application): -pivot, translate, rotate, scale, pivot.
+  -->
+  <nodegraph name="NG_place2dframe_vector2" nodedef="ND_place2dframe_vector2">
+    <subtract name="N_subpivot" type="vector2">
+      <input name="in1" type="vector2" interfacename="texcoord" />
+      <input name="in2" type="vector2" interfacename="pivot" />
+    </subtract>
+    <subtract name="N_applyoffset" type="vector2">
+      <input name="in1" type="vector2" nodename="N_subpivot" />
+      <input name="in2" type="vector2" interfacename="offset" />
+    </subtract>
+    <rotate2d name="N_applyrot" type="vector2">
+      <input name="in" type="vector2" nodename="N_applyoffset" />
+      <input name="amount" type="float" interfacename="rotate" />
+    </rotate2d>
+    <divide name="N_applyscale" type="vector2">
+      <input name="in1" type="vector2" nodename="N_applyrot" />
+      <input name="in2" type="vector2" interfacename="scale" />
+    </divide>
+    <add name="N_addpivot" type="vector2">
+      <input name="in1" type="vector2" nodename="N_applyscale" />
       <input name="in2" type="vector2" interfacename="pivot" />
     </add>
     <output name="out" type="vector2" nodename="N_addpivot" />

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1046,10 +1046,13 @@
   <!--
     Node: <place2d>
     Transform incoming UV texture coordinates from one 2D frame of reference to another.
-    The order of transformation is: -pivot, scale, rotate, translate, pivot.
+    operationorder (integer enum): the order in which to perform the transform operations.
+    "0" or "SRT" performs -pivot, scale, rotate, translate, +pivot as per the original
+    implementation matching the behavior of certain DCC packages, and "1" or "TRS" performs
+    -pivot, translate, rotate, scale, +pivot which does not introduce texture shear.
+    Default is 0 "SRT" for backward compatibility.
   -->
-  <implementation name="IMPL_place2d_vector2" nodedef="ND_place2d_vector2" nodegraph="NG_place2d_vector2" />
-  <nodegraph name="NG_place2d_vector2">
+  <nodegraph name="NG_place2d_vector2" nodedef="ND_place2d_vector2">
     <subtract name="N_subpivot" type="vector2">
       <input name="in1" type="vector2" interfacename="texcoord" />
       <input name="in2" type="vector2" interfacename="pivot" />
@@ -1070,37 +1073,28 @@
       <input name="in1" type="vector2" nodename="N_applyoffset" />
       <input name="in2" type="vector2" interfacename="pivot" />
     </add>
-    <output name="out" type="vector2" nodename="N_addpivot" />
-  </nodegraph>
-
-  <!--
-    Node: <place2dframe>
-    Transform incoming UV texture coordinates from one 2D frame of reference to another.
-    The order of transformation is: -pivot, translate, rotate, scale, pivot.
-  -->
-  <implementation name="IMPL_place2dframe_vector2" nodedef="ND_place2dframe_vector2" nodegraph="NG_place2dframe_vector2" />
-  <nodegraph name="NG_place2dframe_vector2">
-    <subtract name="N_subpivot" type="vector2">
-      <input name="in1" type="vector2" interfacename="texcoord" />
-      <input name="in2" type="vector2" interfacename="pivot" />
-    </subtract>
-    <subtract name="N_applyoffset" type="vector2">
+    <subtract name="N_applyoffset2" type="vector2">
       <input name="in1" type="vector2" nodename="N_subpivot" />
       <input name="in2" type="vector2" interfacename="offset" />
     </subtract>
-    <rotate2d name="N_applyrot" type="vector2">
-      <input name="in" type="vector2" nodename="N_applyoffset" />
+    <rotate2d name="N_applyrot2" type="vector2">
+      <input name="in" type="vector2" nodename="N_applyoffset2" />
       <input name="amount" type="float" interfacename="rotate" />
     </rotate2d>
-    <divide name="N_applyscale" type="vector2">
-      <input name="in1" type="vector2" nodename="N_applyrot" />
+    <divide name="N_applyscale2" type="vector2">
+      <input name="in1" type="vector2" nodename="N_applyrot2" />
       <input name="in2" type="vector2" interfacename="scale" />
     </divide>
-    <add name="N_addpivot" type="vector2">
-      <input name="in1" type="vector2" nodename="N_applyscale" />
+    <add name="N_addpivot2" type="vector2">
+      <input name="in1" type="vector2" nodename="N_applyscale2" />
       <input name="in2" type="vector2" interfacename="pivot" />
     </add>
-    <output name="out" type="vector2" nodename="N_addpivot" />
+    <switch name="N_switch_operationorder" type="vector2">
+      <input name="in1" type="vector2" nodename="N_addpivot" />
+      <input name="in2" type="vector2" nodename="N_addpivot2" />
+      <input name="which" type="integer" interfacename="operationorder" />
+    </switch>
+    <output name="out" type="vector2" nodename="N_switch_operationorder" />
   </nodegraph>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1045,10 +1045,11 @@
 
   <!--
     Node: <place2d>
-    Transform incoming UV texture coordinates for 2D texture placement.
-    Sequence of transformation (in the order of application): -pivot, scale, rotate, translate, pivot.
+    Transform incoming UV texture coordinates from one 2D frame of reference to another.
+    The order of transformation is: -pivot, scale, rotate, translate, pivot.
   -->
-  <nodegraph name="NG_place2d_vector2" nodedef="ND_place2d_vector2">
+  <implementation name="IMPL_place2d_vector2" nodedef="ND_place2d_vector2" nodegraph="NG_place2d_vector2" />
+  <nodegraph name="NG_place2d_vector2">
     <subtract name="N_subpivot" type="vector2">
       <input name="in1" type="vector2" interfacename="texcoord" />
       <input name="in2" type="vector2" interfacename="pivot" />
@@ -1074,10 +1075,11 @@
 
   <!--
     Node: <place2dframe>
-    Transform incoming UV texture coordinates for 2D texture placement.
-    Sequence of transformation (in the order of application): -pivot, translate, rotate, scale, pivot.
+    Transform incoming UV texture coordinates from one 2D frame of reference to another.
+    The order of transformation is: -pivot, translate, rotate, scale, pivot.
   -->
-  <nodegraph name="NG_place2dframe_vector2" nodedef="ND_place2dframe_vector2">
+  <implementation name="IMPL_place2dframe_vector2" nodedef="ND_place2dframe_vector2" nodegraph="NG_place2dframe_vector2" />
+  <nodegraph name="NG_place2dframe_vector2">
     <subtract name="N_subpivot" type="vector2">
       <input name="in1" type="vector2" interfacename="texcoord" />
       <input name="in2" type="vector2" interfacename="pivot" />

--- a/resources/Materials/TestSuite/stdlib/math/transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/transform.mtlx
@@ -175,21 +175,8 @@
       <input name="scale" type="vector2" value="2.0,2.0" />
       <input name="rotate" type="float" value="1.0" unittype="angle" unit="radian" />
       <input name="offset" type="vector2" value="0.2,0.2" />
+      <input name="operationorder" type="integer" value="0" />
     </place2d>
-    <output name="out" type="vector2" nodename="place2d1_1" />
-  </nodegraph>
-  <!-- place2dframe -->
-  <nodegraph name="place2dframe_vector2">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" value="0" />
-    </texcoord>
-    <place2dframe name="place2d1_1" type="vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1" />
-      <input name="pivot" type="vector2" value="0.5,0.5" />
-      <input name="scale" type="vector2" value="2.0,1.0" />
-      <input name="rotate" type="float" value="1.0" unittype="angle" unit="radian" />
-      <input name="offset" type="vector2" value="0.2,0.2" />
-    </place2dframe>
     <output name="out" type="vector2" nodename="place2d1_1" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/math/transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/transform.mtlx
@@ -175,7 +175,6 @@
       <input name="scale" type="vector2" value="2.0,2.0" />
       <input name="rotate" type="float" value="1.0" unittype="angle" unit="radian" />
       <input name="offset" type="vector2" value="0.2,0.2" />
-      <input name="operationorder" type="integer" value="0" />
     </place2d>
     <output name="out" type="vector2" nodename="place2d1_1" />
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/math/transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/transform.mtlx
@@ -178,4 +178,18 @@
     </place2d>
     <output name="out" type="vector2" nodename="place2d1_1" />
   </nodegraph>
+  <!-- place2dframe -->
+  <nodegraph name="place2dframe_vector2">
+    <texcoord name="texcoord1" type="vector2">
+      <input name="index" type="integer" value="0" />
+    </texcoord>
+    <place2dframe name="place2d1_1" type="vector2">
+      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="pivot" type="vector2" value="0.5,0.5" />
+      <input name="scale" type="vector2" value="2.0,1.0" />
+      <input name="rotate" type="float" value="1.0" unittype="angle" unit="radian" />
+      <input name="offset" type="vector2" value="0.2,0.2" />
+    </place2dframe>
+    <output name="out" type="vector2" nodename="place2d1_1" />
+  </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/texture/image_transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_transform.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodegraph name="test_place2d">
+  <nodegraph name="test_place2d_SRT">
     <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
@@ -14,9 +14,10 @@
       <input name="rotate" type="float" value="30.0" unittype="angle" unit="degree" />
       <input name="scale" type="vector2" value="2.0, 1.0" />
       <input name="pivot" type="vector2" value="0.5, 0.5" />
+      <input name="operationorder" type="integer" value="0" />
     </place2d>
   </nodegraph>
-  <nodegraph name="test_place2dframe">
+  <nodegraph name="test_place2d_TRS">
     <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
@@ -24,12 +25,13 @@
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" />
-    <place2dframe name="a_place2d" type="vector2">
+    <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
       <input name="offset" type="vector2" value="0.2, 0.2" />
       <input name="rotate" type="float" value="30.0" unittype="angle" unit="degree" />
       <input name="scale" type="vector2" value="2.0, 1.0" />
       <input name="pivot" type="vector2" value="0.5, 0.5" />
-    </place2dframe>
+      <input name="operationorder" type="integer" value="1" />
+    </place2d>
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/texture/image_transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_transform.mtlx
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <nodegraph name="test_place2d">
+    <image name="image_number_1" type="color3">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+      <input name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" nodename="a_place2d" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" />
+    <place2d name="a_place2d" type="vector2">
+      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="offset" type="vector2" value="0.0, 0.0" />
+      <input name="rotate" type="float" value="30.0" unittype="angle" unit="degree" />
+      <input name="scale" type="vector2" value="2.0, 1.0" />
+      <input name="pivot" type="vector2" value="0.5, 0.5" />
+    </place2d>
+  </nodegraph>
+  <nodegraph name="test_place2dframe">
+    <image name="image_number_1" type="color3">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+      <input name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" nodename="a_place2d" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
+    <texcoord name="texcoord1" type="vector2" />
+    <place2dframe name="a_place2d" type="vector2">
+      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="offset" type="vector2" value="0.2, 0.2" />
+      <input name="rotate" type="float" value="30.0" unittype="angle" unit="degree" />
+      <input name="scale" type="vector2" value="2.0, 1.0" />
+      <input name="pivot" type="vector2" value="0.5, 0.5" />
+    </place2dframe>
+  </nodegraph>
+</materialx>

--- a/resources/Materials/TestSuite/stdlib/texture/image_transform.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/image_transform.mtlx
@@ -1,12 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <nodegraph name="test_place2d_SRT">
-    <image name="image_number_1" type="color3">
-      <input name="file" type="filename" value="resources/Images/grid.png" />
-      <input name="default" type="color3" value="1.0, 0.0, 0.0" />
-      <input name="texcoord" type="vector2" nodename="a_place2d" />
-    </image>
-    <output name="out" type="color3" nodename="image_number_1" />
     <texcoord name="texcoord1" type="vector2" />
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
@@ -16,14 +10,14 @@
       <input name="pivot" type="vector2" value="0.5, 0.5" />
       <input name="operationorder" type="integer" value="0" />
     </place2d>
-  </nodegraph>
-  <nodegraph name="test_place2d_TRS">
     <image name="image_number_1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" />
       <input name="default" type="color3" value="1.0, 0.0, 0.0" />
       <input name="texcoord" type="vector2" nodename="a_place2d" />
     </image>
     <output name="out" type="color3" nodename="image_number_1" />
+  </nodegraph>
+  <nodegraph name="test_place2d_TRS">
     <texcoord name="texcoord1" type="vector2" />
     <place2d name="a_place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
@@ -33,5 +27,11 @@
       <input name="pivot" type="vector2" value="0.5, 0.5" />
       <input name="operationorder" type="integer" value="1" />
     </place2d>
+    <image name="image_number_1" type="color3">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+      <input name="default" type="color3" value="1.0, 0.0, 0.0" />
+      <input name="texcoord" type="vector2" nodename="a_place2d" />
+    </image>
+    <output name="out" type="color3" nodename="image_number_1" />
   </nodegraph>
 </materialx>


### PR DESCRIPTION
A proposed fix for #1021
Adding a new `place2dframe` node that changes the order of the operations from
`place2d`: -pivot, scale, rotate, translate, pivot
into
`place2dframe`: -pivot, translate, rotate, scale, pivot
test_place2d_out_glsl:
![test_place2d_out_glsl](https://user-images.githubusercontent.com/42956093/178904625-3a075227-f31a-4856-b87f-f4c26d2c3571.png)
test_place2dframe_out_glsl:
![test_place2dframe_out_glsl](https://user-images.githubusercontent.com/42956093/178904668-9dd39e64-474c-446c-a015-2bcf675855d3.png)


