### PR TITLE
Track File Dependencies in ShaderStage

### DIFF
--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -71,11 +71,18 @@ void SourceCodeNode::emitFunctionDefinition(const ShaderNode&, GenContext& conte
 {
     BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
         // Emit function definition for non-inlined functions
-        if (!_inlined && !_functionSource.empty())
+        if (!_functionSource.empty())
         {
-            const ShaderGenerator& shadergen = context.getShaderGenerator();
-            shadergen.emitBlock(_functionSource, _sourceFilename, context, stage);
-            shadergen.emitLineBreak(stage);
+            if (!_sourceFilename.isEmpty())
+            {
+                stage.addSourceDependency(_sourceFilename);
+            }
+            if (!_inlined)
+            {
+                const ShaderGenerator& shadergen = context.getShaderGenerator();
+                shadergen.emitBlock(_functionSource, _sourceFilename, context, stage);
+                shadergen.emitLineBreak(stage);
+            }
         }
     END_SHADER_STAGE(stage, Stage::PIXEL)
 }

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -340,6 +340,14 @@ void ShaderStage::addInclude(const FilePath& includeFilename, const FilePath& so
     }
 }
 
+void ShaderStage::addSourceDependency(const string& file)
+{
+    if (!_sourceDependencies.count(file))
+    {
+        _sourceDependencies.insert(file);
+    }
+}
+
 void ShaderStage::addFunctionDefinition(const ShaderNode& node, GenContext& context)
 {
     const ShaderNodeImpl& impl = node.getImplementation();

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -198,6 +198,18 @@ public:
     {
         return _outputs;
     }
+
+    /// Return a set of all include files
+    const StringSet& getIncludes() const
+    {
+        return _includes;
+    }
+
+    /// Return a set of all source dependencies
+    const StringSet& getSourceDependencies() const
+    {
+        return _sourceDependencies;
+    }
  
     /// Start a new scope using the given bracket type.
     void beginScope(Syntax::Punctuation punc = Syntax::CURLY_BRACKETS);
@@ -228,6 +240,9 @@ public:
 
     /// Add the contents of an include file if not already present.
     void addInclude(const FilePath& includeFilename, const FilePath& sourceFilename, GenContext& context);
+
+    /// Add a source file dependency for dependency tracking purposes
+    void addSourceDependency(const string& file);
 
     /// Add a value.
     template<typename T>
@@ -271,6 +286,9 @@ public:
 
     /// Set of include files that has been included.
     StringSet _includes;
+
+    /// Set of source file dependencies from source code nodes
+    StringSet _sourceDependencies;
 
     /// Set of hash ID's for functions that has been defined.
     std::set<size_t> _definedFunctions;

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -318,3 +318,52 @@ TEST_CASE("GenShader: Deterministic Generation", "[genshader]")
     }
 #endif
 }
+
+void checkPixelDependencies(mx::DocumentPtr libraries, mx::GenContext& context)
+{
+    const mx::FilePath testFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/GltfPbr/gltf_pbr_boombox.mtlx");
+    const mx::string testElement = "Material_boombox";
+
+    mx::DocumentPtr testDoc = mx::createDocument();
+    mx::readFromXmlFile(testDoc, testFile);
+    testDoc->importLibrary(libraries);
+
+    mx::ElementPtr element = testDoc->getChild(testElement);
+    CHECK(element);
+
+    mx::ShaderPtr shader = context.getShaderGenerator().generate(testElement, element, context);
+    std::set<std::string> dependencies = shader->getStage("pixel").getSourceDependencies();
+    for (auto dependency : dependencies) {
+        mx::FilePath path(dependency);
+        REQUIRE(path.exists() == true);
+    }
+}
+
+TEST_CASE("GenShader: Track Dependencies", "[genshader]")
+{
+    mx::DocumentPtr libraries = mx::createDocument();
+    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    mx::loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib", "libraries/bxdf" }, searchPath, libraries);
+
+#ifdef MATERIALX_BUILD_GEN_GLSL
+    {
+        mx::GenContext context(mx::GlslShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkPixelDependencies(libraries, context);
+    }
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
+    {
+        mx::GenContext context(mx::OslShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkPixelDependencies(libraries, context);
+    }
+#endif
+#ifdef MATERIALX_BUILD_GEN_MDL
+    {
+        mx::GenContext context(mx::MdlShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkPixelDependencies(libraries, context);
+    }
+#endif
+}

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderStage.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderStage.cpp
@@ -42,5 +42,7 @@ void bindPyShaderStage(py::module& mod)
         .def("getConstantBlock", static_cast<mx::VariableBlock& (mx::ShaderStage::*)()>(&mx::ShaderStage::getConstantBlock))
         .def("getUniformBlocks", &mx::ShaderStage::getUniformBlocks)
         .def("getInputBlocks", &mx::ShaderStage::getInputBlocks)
+        .def("getIncludes", &mx::ShaderStage::getIncludes)
+        .def("getSourceDependencies", &mx::ShaderStage::getSourceDependencies)
         .def("getOutputBlocks", &mx::ShaderStage::getOutputBlocks);
 }


### PR DESCRIPTION
**Changes**
This change allows an application to retrieve file dependencies from generated shaders caused by shader includes (via ShaderStage::addInclude) and SourceCodeNode source blocks taken from a file.

We add ShaderStage::getIncludes, ShaderStage::addSourceDependency, and ShaderStage::getSourceDependencies. SourceCodeNode is modified to call addSourceDependency.

**Testing**
A small unit test is added to verify getSourceDependencies returns valid files. We didn't want to make the test hardcode any dependencies as that would make it break when other parts of the library changed the set of dependencies.

**Motivation**
Use case: an application may want to cache generated or compiled shaders. In order to do a dependency check on the cache, it needs access to the set of input files that went into generation. There was no way to retrieve these two types of dependencies using the existing API.
