### PR TITLE
Standard Surface to glTF PBR Translation Graph

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -92,11 +92,6 @@
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
 
-    <multiply name="base_color" type="color3">
-      <input name="in1" type="color3" interfacename="base_color" />
-      <input name="in2" type="float" interfacename="base" />
-    </multiply>
-
     <dot name="metallic" type="float">
       <input name="in" type="float" interfacename="metalness" />
     </dot>
@@ -154,6 +149,10 @@
       <input name="in" type="float" interfacename="thin_film_IOR" />
     </dot>
 
+    <!-- <dot name="normal" type="vector3" >
+      <input name="in" type="vector3" interfacename="normal" />
+    </dot> -->
+
     <!-- Output color switch priority: transmission > coat color > base color -->
     <ifequal name="has_coat" type="float" >
       <input name="value1" type="float" interfacename="coat" />
@@ -161,65 +160,70 @@
       <input name="in1" type="float" value="0" />
       <input name="in2" type="float" value="1" />
     </ifequal>
-    <swizzle name="coat_color_r" type="float" >
+    <swizzle name="coat_r" type="float" >
       <input name="in" type="color3" interfacename="coat_color" />
       <input name="channels" type="string" value="r" />
     </swizzle>
-    <swizzle name="coat_color_g" type="float" >
+    <swizzle name="coat_g" type="float" >
       <input name="in" type="color3" interfacename="coat_color" />
       <input name="channels" type="string" value="g" />
     </swizzle>
-    <swizzle name="coat_color_b" type="float" >
+    <swizzle name="coat_b" type="float" >
       <input name="in" type="color3" interfacename="coat_color" />
       <input name="channels" type="string" value="b" />
     </swizzle>
-    <ifequal name="coat_r_default" type="float" >
-      <input name="value1" type="float" nodename="coat_color_r" />
+    <ifequal name="coat_r_is_default" type="float" >
+      <input name="value1" type="float" nodename="coat_r" />
       <input name="value2" type="float" value="0" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
     </ifequal>
-    <ifequal name="coat_g_default" type="float" >
-      <input name="value1" type="float" nodename="coat_color_g" />
+    <ifequal name="coat_g_is_default" type="float" >
+      <input name="value1" type="float" nodename="coat_g" />
       <input name="value2" type="float" value="0" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
     </ifequal>
-    <ifequal name="coat_b_default" type="float" >
-      <input name="value1" type="float" nodename="coat_color_b" />
+    <ifequal name="coat_b_is_default" type="float" >
+      <input name="value1" type="float" nodename="coat_b" />
       <input name="value2" type="float" value="0" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
     </ifequal>
-    <multiply name="accum_coat_color1" type="float" >
-      <input name="in1" type="float" nodename="coat_r_default" />
-      <input name="in2" type="float" nodename="coat_g_default" />
+    <multiply name="accum_coat_rg" type="float" >
+      <input name="in1" type="float" nodename="coat_r_is_default" />
+      <input name="in2" type="float" nodename="coat_g_is_default" />
     </multiply>
-    <multiply name="accum_coat_color2" type="float" > 
-      <input name="in1" type="float" nodename="accum_coat_color1" />
-      <input name="in2" type="float" nodename="coat_b_default" />
+    <multiply name="accum_coat_rgb" type="float" > 
+      <input name="in1" type="float" nodename="accum_coat_rg" />
+      <input name="in2" type="float" nodename="coat_b_is_default" />
     </multiply>
-    <subtract name="diff_coat_and_color" type="float" >
+    <subtract name="has_coat_and_coat_color" type="float" >
       <input name="in1" type="float" nodename="has_coat" />
-      <input name="in2" type="float" nodename="accum_coat_color2" />
+      <input name="in2" type="float" nodename="accum_coat_rgb" />
     </subtract>
 
     <!-- if we have coat and color is not default, apply over base color -->
-    <ifequal name="color_switch1" type="color3" >
-      <input name="value1" type="float" nodename="diff_coat_and_color" />
+    <ifequal name="base_layer_color" type="color3" >
+      <input name="value1" type="float" nodename="has_coat_and_coat_color" />
       <input name="value2" type="float" value="1" />
       <input name="in1" type="color3" interfacename="coat_color" />
-      <input name="in2" type="color3" nodename="base_color" />
+      <input name="in2" type="color3" interfacename="base_color" />
     </ifequal>
+    <!-- Attenuate result of coat or base by base factor -->
+    <multiply name="attenuated_baselayer" type="color3" >
+      <input name="in1" type="color3" nodename="base_layer_color" />
+      <input name="in2" type="float" interfacename="base" />
+    </multiply>
     <!-- if transmission, use transmission color -->
-    <ifequal name="color_switch2" type="color3" >
+    <ifequal name="color_switch" type="color3" >
       <input name="value1" type="float" interfacename="transmission" />
       <input name="value2" type="float" value="0" />
-      <input name="in1" type="color3" nodename="color_switch1" />
+      <input name="in1" type="color3" nodename="attenuated_baselayer" />
       <input name="in2" type="color3" interfacename="transmission_color" />
     </ifequal>
 
-    <output name="base_color_out" type="color3" nodename="color_switch2" />
+    <output name="base_color_out" type="color3" nodename="color_switch" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
     <output name="transmission_out" type="float" nodename="transmission" />
@@ -232,6 +236,7 @@
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />
     <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
+    <!-- <output name="normal_out" type="vector3" nodename="normal" /> -->
 
   </nodegraph>
 </materialx>

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -2,46 +2,46 @@
 <materialx version="1.38">
 
   <nodedef name="ND_standard_surface_to_gltf_pbr" node="standard_surface_to_gltf_pbr">
-    <input name="base" type="float" value="1.0" />
-    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
-    <!-- <input name="diffuse_roughness" type="float" value="0" /> -->
-    <input name="metalness" type="float" value="0" />
-    <input name="specular" type="float" value="1" />
-    <input name="specular_color" type="color3" value="1, 1, 1" />
-    <input name="specular_roughness" type="float" value="0.2" />
-    <input name="specular_IOR" type="float" value="1.5" />
-    <!-- <input name="specular_anisotropy" type="float" value="0" /> -->
-    <!-- <input name="specular_rotation" type="float" value="0" /> -->
-    <input name="transmission" type="float" value="0" />
-    <!-- <input name="transmission_color" type="color3" value="1, 1, 1" /> -->
-    <!-- <input name="transmission_depth" type="float" value="0" /> -->
-    <!-- <input name="transmission_scatter" type="color3" value="0, 0, 0" /> -->
-    <!-- <input name="transmission_scatter_anisotropy" type="float" value="0" /> -->
-    <!-- <input name="transmission_dispersion" type="float" value="0" /> -->
-    <!-- <input name="transmission_extra_roughness" type="float" value="0" /> -->
-    <!-- <input name="subsurface" type="float" value="0" /> -->
-    <!-- <input name="subsurface_color" type="color3" value="1, 1, 1" /> -->
-    <!-- <input name="subsurface_radius" type="color3" value="1, 1, 1" /> -->
-    <!-- <input name="subsurface_scale" type="float" value="1" /> -->
-    <!-- <input name="subsurface_anisotropy" type="float" value="0" /> -->
-    <!-- <input name="sheen" type="float" value="0" /> -->
-    <input name="sheen_color" type="color3" value="1, 1, 1" />
-    <input name="sheen_roughness" type="float" value="0.3" />
-    <input name="coat" type="float" value="0" />
-    <!-- <input name="coat_color" type="color3" value="1, 1, 1" /> -->
-    <input name="coat_roughness" type="float" value="0.1" />
-    <!-- <input name="coat_anisotropy" type="float" value="0.0" /> -->
-    <!-- <input name="coat_rotation" type="float" value="0.0" /> -->
-    <!-- <input name="coat_IOR" type="float" value="1.5" /> -->
+    <input name="base" type="float" />
+    <input name="base_color" type="color3" />
+    <!-- <input name="diffuse_roughness" type="float" /> -->
+    <input name="metalness" type="float" />
+    <input name="specular" type="float" />
+    <input name="specular_color" type="color3" />
+    <input name="specular_roughness" type="float" />
+    <input name="specular_IOR" type="float" />
+    <!-- <input name="specular_anisotropy" type="float" /> -->
+    <!-- <input name="specular_rotation" type="float" /> -->
+    <input name="transmission" type="float" />
+    <input name="transmission_color" type="color3" />
+    <!-- <input name="transmission_depth" type="float" /> -->
+    <!-- <input name="transmission_scatter" type="color3" /> -->
+    <!-- <input name="transmission_scatter_anisotropy" type="float" /> -->
+    <!-- <input name="transmission_dispersion" type="float" /> -->
+    <!-- <input name="transmission_extra_roughness" type="float" /> -->
+    <!-- <input name="subsurface" type="float" /> -->
+    <!-- <input name="subsurface_color" type="color3" /> -->
+    <!-- <input name="subsurface_radius" type="color3" /> -->
+    <!-- <input name="subsurface_scale" type="float" /> -->
+    <!-- <input name="subsurface_anisotropy" type="float" /> -->
+    <input name="sheen" type="float" />
+    <input name="sheen_color" type="color3" />
+    <input name="sheen_roughness" type="float" />
+    <input name="coat" type="float" />
+    <input name="coat_color" type="color3" />
+    <input name="coat_roughness" type="float" />
+    <!-- <input name="coat_anisotropy" type="float" /> -->
+    <!-- <input name="coat_rotation" type="float" /> -->
+    <!-- <input name="coat_IOR" type="float" /> -->
     <input name="coat_normal" type="vector3" />
-    <!-- <input name="coat_affect_color" type="float" value="0" /> -->
-    <!-- <input name="coat_affect_roughness" type="float" value="0" /> -->
-    <!-- <input name="thin_film_thickness" type="float" value="0" /> -->
-    <!-- <input name="thin_film_IOR" type="float" value="1.5" /> -->
-    <input name="emission" type="float" value="0" />
-    <input name="emission_color" type="color3" value="1, 1, 1" />
-    <!-- <input name="opacity" type="color3" value="1, 1, 1" /> -->
-    <!-- <input name="thin_walled" type="boolean" value="false" /> -->
+    <!-- <input name="coat_affect_color" type="float" /> -->
+    <!-- <input name="coat_affect_roughness" type="float" /> -->
+    <input name="thin_film_thickness" type="float" />
+    <input name="thin_film_IOR" type="float" />
+    <input name="emission" type="float" />
+    <input name="emission_color" type="color3" />
+    <!-- <input name="opacity" type="color3" /> -->
+    <!-- <input name="thin_walled" type="boolean" /> -->
     <!-- <input name="normal" type="vector3" /> -->
     <!-- <input name="tangent" type="vector3" /> -->
 
@@ -71,12 +71,12 @@
     <!-- <output name="alpha_cutoff_out" type="float" /> -->
 
     <!-- parameter accepted, visual mismatch -->
-    <!-- <output name="sheen_color_out" type="color3" /> -->
-    <!-- <output name="sheen_roughness_out" type="float" /> -->
+    <output name="sheen_color_out" type="color3" />
+    <output name="sheen_roughness_out" type="float" />
 
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
-    <output name="clearcoat_normal_out" type="vector3" />
+    <!-- <output name="clearcoat_normal_out" type="vector3" /> -->
 
     <output name="emissive_out" type="color3" />
     <output name="emissive_strength_out" type="float" />
@@ -85,6 +85,9 @@
     <!-- <output name="thickness_out" type="float" /> -->
     <!-- <output name="attenuation_distance_out" type="float" /> -->
     <!-- <output name="attenuation_color_out" type="color3" /> -->
+<!-- 
+    <output name="iridescence_thickness_maximum_out" type="float" />
+    <output name="iridescence_ior_out" type="float" /> -->
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -93,84 +96,142 @@
       <input name="in1" type="color3" interfacename="base_color" />
       <input name="in2" type="float" interfacename="base" />
     </multiply>
+
     <dot name="metallic" type="float">
       <input name="in" type="float" interfacename="metalness" />
     </dot>
+
     <dot name="roughness" type="float">
       <input name="in" type="float" interfacename="specular_roughness" />
     </dot>
-
-    <!-- passing normals results in black material -->
-    <!-- <dot name="normal" type="vector3">
-      <input name="in" type="vector3" interfacename="normal" />
-    </dot> -->
 
     <dot name="transmission" type="float">
       <input name="in" type="float" interfacename="transmission" />
     </dot>
 
-    <!-- specular -->
     <dot name="specular" type="float">
       <input name="in" type="float" interfacename="specular" />
     </dot>
+
     <dot name="specular_color" type="color3">
       <input name="in" type="color3" interfacename="specular_color" />
     </dot>
 
-    <!-- ranges differ -->
     <dot name="ior" type="float">
       <input name="in" type="float" interfacename="specular_IOR" />
     </dot>
 
-    <!-- sheen -->
-    <!-- <dot name="sheen_color" type="color3">
-      <input name="in" type="color3" interfacename="sheen_color" />
-    </dot>
+    <multiply name="sheen_color" type="color3">
+      <input name="in1" type="color3" interfacename="sheen_color" />
+      <input name="in2" type="float" interfacename="sheen" />
+    </multiply>
+
     <dot name="sheen_roughness" type="float">
       <input name="in" type="float" interfacename="sheen_roughness" />
-    </dot> -->
+    </dot>
 
-    <!-- clearcoat -->
     <dot name="clearcoat" type="float">
       <input name="in" type="float" interfacename="coat" />
     </dot>
+
     <dot name="clearcoat_roughness" type="float">
       <input name="in" type="float" interfacename="coat_roughness" />
     </dot>
-    <dot name="clearcoat_normal" type="vector3">
-      <input name="in" type="vector3" interfacename="coat_normal" />
-    </dot>
 
-    <!-- emission -->
     <dot name="emissive" type="color3">
       <input name="in" type="color3" interfacename="emission_color" />
     </dot>
+
     <dot name="emissive_strength" type="float">
       <input name="in" type="float" interfacename="emission" />
     </dot>
 
-    <output name="base_color_out" type="color3" nodename="base_color" />
+    <dot name="thin_film_thickness" type="float">
+      <input name="in" type="float" interfacename="thin_film_thickness" />
+    </dot>
+
+    <dot name="thin_film_IOR" type="float">
+      <input name="in" type="float" interfacename="thin_film_IOR" />
+    </dot>
+
+    <!-- Output color switch priority: transmission > coat color > base color -->
+    <ifequal name="has_coat" type="float" >
+      <input name="value1" type="float" interfacename="coat" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="float" value="0" />
+      <input name="in2" type="float" value="1" />
+    </ifequal>
+    <swizzle name="coat_color_r" type="float" >
+      <input name="in" type="color3" interfacename="coat_color" />
+      <input name="channels" type="string" value="r" />
+    </swizzle>
+    <swizzle name="coat_color_g" type="float" >
+      <input name="in" type="color3" interfacename="coat_color" />
+      <input name="channels" type="string" value="g" />
+    </swizzle>
+    <swizzle name="coat_color_b" type="float" >
+      <input name="in" type="color3" interfacename="coat_color" />
+      <input name="channels" type="string" value="b" />
+    </swizzle>
+    <ifequal name="coat_r_default" type="float" >
+      <input name="value1" type="float" nodename="coat_color_r" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" value="0" />
+    </ifequal>
+    <ifequal name="coat_g_default" type="float" >
+      <input name="value1" type="float" nodename="coat_color_g" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" value="0" />
+    </ifequal>
+    <ifequal name="coat_b_default" type="float" >
+      <input name="value1" type="float" nodename="coat_color_b" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" value="0" />
+    </ifequal>
+    <multiply name="accum_coat_color1" type="float" >
+      <input name="in1" type="float" nodename="coat_r_default" />
+      <input name="in2" type="float" nodename="coat_g_default" />
+    </multiply>
+    <multiply name="accum_coat_color2" type="float" > 
+      <input name="in1" type="float" nodename="accum_coat_color1" />
+      <input name="in2" type="float" nodename="coat_b_default" />
+    </multiply>
+    <subtract name="diff_coat_and_color" type="float" >
+      <input name="in1" type="float" nodename="has_coat" />
+      <input name="in2" type="float" nodename="accum_coat_color2" />
+    </subtract>
+
+    <!-- if we have coat and color is not default, apply over base color -->
+    <ifequal name="color_switch1" type="color3" >
+      <input name="value1" type="float" nodename="diff_coat_and_color" />
+      <input name="value2" type="float" value="1" />
+      <input name="in1" type="color3" interfacename="coat_color" />
+      <input name="in2" type="color3" nodename="base_color" />
+    </ifequal>
+    <!-- if transmission, use transmission color -->
+    <ifequal name="color_switch2" type="color3" >
+      <input name="value1" type="float" interfacename="transmission" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="color3" nodename="color_switch1" />
+      <input name="in2" type="color3" interfacename="transmission_color" />
+    </ifequal>
+
+    <output name="base_color_out" type="color3" nodename="color_switch2" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
-    <!-- <output name="normal_out" type="vector3" nodename="normal" /> -->
-    <!-- <output name="occlusion_out" type="float" nodename="occlusion" /> -->
     <output name="transmission_out" type="float" nodename="transmission" />
     <output name="specular_out" type="float" nodename="specular" />
     <output name="specular_color_out" type="color3" nodename="specular_color" />
     <output name="ior_out" type="float" nodename="ior" />
-    <!-- <output name="alpha_out" type="float" nodename="alpha" /> -->
-    <!-- <output name="alpha_mode_out" type="integer" nodename="alpha_mode" /> -->
-    <!-- <output name="alpha_cutoff_out" type="float" nodename="alpha_cutoff" /> -->
-    <!-- <output name="sheen_color_out" type="color3" nodename="sheen_color" /> -->
-    <!-- <output name="sheen_roughness_out" type="float" nodename="sheen_roughness" /> -->
+    <output name="sheen_color_out" type="color3" nodename="sheen_color" />
+    <output name="sheen_roughness_out" type="float" nodename="sheen_roughness" />
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
-    <output name="clearcoat_normal_out" type="vector3" nodename="clearcoat_normal" />
     <output name="emissive_out" type="color3" nodename="emissive" />
     <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
-    <!-- <output name="thickness_out" type="float" nodename="thickness" /> -->
-    <!-- <output name="attenuation_distance_out" type="float" nodename="attenuation_distance" /> -->
-    <!-- <output name="attenuation_color_out" type="color3" nodename="attenuation_color" /> -->
 
   </nodegraph>
 </materialx>

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -1,0 +1,183 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+
+  <nodedef name="ND_standard_surface_to_gltf_pbr" node="standard_surface_to_gltf_pbr">
+    <input name="base" type="float" value="1.0" />
+    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
+    <input name="base" type="float" value="0.8" />
+    <input name="base_color" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="diffuse_roughness" type="float" value="0" />
+    <input name="metalness" type="float" value="0" />
+    <input name="specular" type="float" value="1" />
+    <input name="specular_color" type="color3" value="1, 1, 1" />
+    <input name="specular_roughness" type="float" value="0.2" />
+    <input name="specular_IOR" type="float" value="1.5" />
+    <input name="specular_anisotropy" type="float" value="0" />
+    <input name="specular_rotation" type="float" value="0" />
+    <input name="transmission" type="float" value="0" />
+    <input name="transmission_color" type="color3" value="1, 1, 1" />
+    <input name="transmission_depth" type="float" value="0" />
+    <input name="transmission_scatter" type="color3" value="0, 0, 0" />
+    <input name="transmission_scatter_anisotropy" type="float" value="0" />
+    <input name="transmission_dispersion" type="float" value="0" />
+    <input name="transmission_extra_roughness" type="float" value="0" />
+    <input name="subsurface" type="float" value="0" />
+    <input name="subsurface_color" type="color3" value="1, 1, 1" />
+    <input name="subsurface_radius" type="color3" value="1, 1, 1" />
+    <input name="subsurface_scale" type="float" value="1" />
+    <input name="subsurface_anisotropy" type="float" value="0" />
+    <input name="sheen" type="float" value="0" />
+    <input name="sheen_color" type="color3" value="1, 1, 1" />
+    <input name="sheen_roughness" type="float" value="0.3" />
+    <input name="coat" type="float" value="0" />
+    <input name="coat_color" type="color3" value="1, 1, 1" />
+    <input name="coat_roughness" type="float" value="0.1" />
+    <input name="coat_anisotropy" type="float" value="0.0" />
+    <input name="coat_rotation" type="float" value="0.0" />
+    <input name="coat_IOR" type="float" value="1.5" />
+    <input name="coat_normal" type="vector3" />
+    <input name="coat_affect_color" type="float" value="0" />
+    <input name="coat_affect_roughness" type="float" value="0" />
+    <input name="thin_film_thickness" type="float" value="0" />
+    <input name="thin_film_IOR" type="float" value="1.5" />
+    <input name="emission" type="float" value="0" />
+    <input name="emission_color" type="color3" value="1, 1, 1" />
+    <input name="opacity" type="color3" value="1, 1, 1" />
+    <input name="thin_walled" type="boolean" value="false" />
+    <input name="normal" type="vector3" />
+    <input name="tangent" type="vector3" />
+
+    <output name="base_color_out" type="color3" />
+    <output name="metallic_out" type="float" />
+    <output name="roughness_out" type="float" />
+    <output name="normal_out" type="vector3" />
+    <output name="occlusion_out" type="float" />
+    <output name="transmission_out" type="float" />
+    <output name="specular_out" type="float" />
+    <output name="specular_color_out" type="color3" />
+    <output name="ior_out" type="float" />
+    <output name="alpha_out" type="float" />
+    <output name="alpha_mode_out" type="integer" />
+    <output name="alpha_cutoff_out" type="float" />
+    <output name="sheen_color_out" type="color3" />
+    <output name="sheen_roughness_out" type="float" />
+    <output name="clearcoat_out" type="float" />
+    <output name="clearcoat_roughness_out" type="float" />
+    <output name="clearcoat_normal_out" type="vector3" />
+    <output name="emissive_out" type="color3" />
+    <output name="emissive_strength_out" type="float" />
+    <output name="thickness_out" type="float" />
+    <output name="attenuation_distance_out" type="float" />
+    <output name="attenuation_color_out" type="color3" />
+  </nodedef>
+
+  <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
+
+    <multiply name="base_color" type="color3">
+      <input name="in1" type="color3" interfacename="base_color" />
+      <input name="in2" type="float" interfacename="base" />
+    </multiply>
+    <dot name="metallic" type="float">
+      <input name="in" type="float" interfacename="metalness" />
+    </dot>
+    <dot name="roughness" type="float">
+      <input name="in" type="float" interfacename="specular_roughness" />
+    </dot>
+    <!-- need modify normal? -->
+    <dot name="normal" type="vector3">
+      <input name="in" type="vector3" interfacename="normal" />
+    </dot>
+    <!-- occlusion value default assignment? -->
+    <dot name="occlusion" type="float">
+      <input name="in" type="float" value="0.0" />
+    </dot>
+    <dot name="transmission" type="float">
+      <input name="in" type="float" interfacename="transmission" />
+    </dot>
+
+    <!-- specular -->
+    <dot name="specular" type="float">
+      <input name="in" type="float" interfacename="specular" />
+    </dot>
+    <dot name="specular_color" type="color3">
+      <intput name="in" type="color3" interfacename="specular_color" />
+    </dot>
+    <!-- ui min values differ -->
+    <dot name="ior" type="float">
+      <input name="in" type="float" interfacename="specular_IOR" />
+    </dot>
+
+    <!-- alpha value default assignments? -->
+    <dot name="alpha" type="float">
+      <input name="in" type="float" value="0.0" />
+    </dot>
+    <dot name="alpha_mode" type="integer">
+      <input name="in" type="integer" value="0" />
+    </dot>
+    <dot name="alpha_cutoff" type="float">
+      <input name="in" type="float" value="0.5" />
+    </dot>
+
+    <!-- clearcoat -->
+    <dot name="sheen_color" type="color3">
+      <input name="in" type="color3" interfacename="sheen_color" />
+    </dot>
+    <dot name="sheen_roughness" type="float">
+      <input name="in" type="float" interfacename="sheen_roughenss" />
+    </dot>
+
+    <!-- clearcoat -->
+    <dot name="clearcoat" type="float">
+      <input name="in" type="float" interfacename="coat" />
+    </dot>
+    <dot name="clearcoat_roughness" type="float">
+      <input name="in" type="float" interfacename="coat_roughness" />
+    </dot>
+    <dot name="clearcoat_normal" type="vector3">
+      <input name="in" type="vector3" interfacename="coat_normal" />
+    </dot>
+
+    <!-- emission -->
+    <dot name="emissive" type="color3">
+      <input name="in" type="color3" interfacename="emission_color" />
+    </dot>
+    <dot name="emissive_strength" type="float">
+      <input name="in" type="float" interfacename="emission" />
+    </dot>
+
+    <!-- undocumented params -->
+    <dot name="thickness" type="float">
+      <input name="in" type="float" value="0.0" />
+    </dot>
+    <dot name="attenuation_distance" type="float">
+      <input name="in" type="float" value="0.0" />
+    </dot>
+    <dot name="attenuation_color" type="color3">
+      <input name="in" type="color3" value="0, 0, 0" />
+    </dot>
+
+    <output name="base_color_out" type="color3" nodename="base_color" />
+    <output name="metallic_out" type="float" nodename="metallic" />
+    <output name="roughness_out" type="float" nodename="roughness" />
+    <output name="normal_out" type="vector3" nodename="normal" />
+    <output name="occlusion_out" type="float" nodename="occlusion" />
+    <output name="transmission_out" type="float" nodename="transmission" />
+    <output name="specular_out" type="float" nodename="specular" />
+    <output name="specular_color_out" type="color3" nodename="specular_color" />
+    <output name="ior_out" type="float" nodename="ior" />
+    <output name="alpha_out" type="float" nodename="alpha" />
+    <output name="alpha_mode_out" type="integer" nodename="alpha_mode" />
+    <output name="alpha_cutoff_out" type="float" nodename="alpha_cutoff" />
+    <output name="sheen_color_out" type="color3" nodename="sheen_color" />
+    <output name="sheen_roughness_out" type="float" nodename="sheen_roughness" />
+    <output name="clearcoat_out" type="float" nodename="clearcoat" />
+    <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
+    <output name="clearcoat_normal_out" type="vector3" nodename="clearcoat_normal" />
+    <output name="emissive_out" type="color3" nodename="emissive" />
+    <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
+    <output name="thickness_out" type="float" nodename="thickness" />
+    <output name="attenuation_distance_out" type="float" nodename="attenuation_distance" />
+    <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />
+
+  </nodegraph>
+</materialx>

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -6,13 +6,13 @@
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
     <!-- <input name="diffuse_roughness" type="float" value="0" /> -->
     <input name="metalness" type="float" value="0" />
-    <!-- <input name="specular" type="float" value="1" /> -->
-    <!-- <input name="specular_color" type="color3" value="1, 1, 1" /> -->
+    <input name="specular" type="float" value="1" />
+    <input name="specular_color" type="color3" value="1, 1, 1" />
     <input name="specular_roughness" type="float" value="0.2" />
-    <!-- <input name="specular_IOR" type="float" value="1.5" /> -->
+    <input name="specular_IOR" type="float" value="1.5" />
     <!-- <input name="specular_anisotropy" type="float" value="0" /> -->
     <!-- <input name="specular_rotation" type="float" value="0" /> -->
-    <!-- <input name="transmission" type="float" value="0" /> -->
+    <input name="transmission" type="float" value="0" />
     <!-- <input name="transmission_color" type="color3" value="1, 1, 1" /> -->
     <!-- <input name="transmission_depth" type="float" value="0" /> -->
     <!-- <input name="transmission_scatter" type="color3" value="0, 0, 0" /> -->
@@ -56,14 +56,14 @@
     <!-- <output name="occlusion_out" type="float" /> -->
 
     <!-- parameter accepted, visual mismatch -->
-    <!-- <output name="transmission_out" type="float" /> -->
+    <output name="transmission_out" type="float" />
+
+    <output name="specular_out" type="float" />
+    <!-- parameter accepted, visual mismatch -->
+    <output name="specular_color_out" type="color3" />
 
     <!-- parameter accepted, visual mismatch -->
-    <!-- <output name="specular_out" type="float" /> -->
-    <!-- <output name="specular_color_out" type="color3" /> -->
-
-    <!-- parameter accepted, visual mismatch -->
-    <!-- <output name="ior_out" type="float" /> -->
+    <output name="ior_out" type="float" />
 
     <!-- inherited defaults -->
     <!-- <output name="alpha_out" type="float" /> -->
@@ -105,22 +105,22 @@
       <input name="in" type="vector3" interfacename="normal" />
     </dot> -->
 
-    <!-- <dot name="transmission" type="float">
+    <dot name="transmission" type="float">
       <input name="in" type="float" interfacename="transmission" />
-    </dot> -->
+    </dot>
 
     <!-- specular -->
-    <!-- <dot name="specular" type="float">
+    <dot name="specular" type="float">
       <input name="in" type="float" interfacename="specular" />
-    </dot> -->
-    <!-- <dot name="specular_color" type="color3">
+    </dot>
+    <dot name="specular_color" type="color3">
       <input name="in" type="color3" interfacename="specular_color" />
-    </dot> -->
+    </dot>
 
     <!-- ranges differ -->
-    <!-- <dot name="ior" type="float">
+    <dot name="ior" type="float">
       <input name="in" type="float" interfacename="specular_IOR" />
-    </dot> -->
+    </dot>
 
     <!-- sheen -->
     <!-- <dot name="sheen_color" type="color3">
@@ -154,10 +154,10 @@
     <output name="roughness_out" type="float" nodename="roughness" />
     <!-- <output name="normal_out" type="vector3" nodename="normal" /> -->
     <!-- <output name="occlusion_out" type="float" nodename="occlusion" /> -->
-    <!-- <output name="transmission_out" type="float" nodename="transmission" /> -->
-    <!-- <output name="specular_out" type="float" nodename="specular" /> -->
-    <!-- <output name="specular_color_out" type="color3" nodename="specular_color" /> -->
-    <!-- <output name="ior_out" type="float" nodename="ior" /> -->
+    <output name="transmission_out" type="float" nodename="transmission" />
+    <output name="specular_out" type="float" nodename="specular" />
+    <output name="specular_color_out" type="color3" nodename="specular_color" />
+    <output name="ior_out" type="float" nodename="ior" />
     <!-- <output name="alpha_out" type="float" nodename="alpha" /> -->
     <!-- <output name="alpha_mode_out" type="integer" nodename="alpha_mode" /> -->
     <!-- <output name="alpha_cutoff_out" type="float" nodename="alpha_cutoff" /> -->

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -4,71 +4,87 @@
   <nodedef name="ND_standard_surface_to_gltf_pbr" node="standard_surface_to_gltf_pbr">
     <input name="base" type="float" value="1.0" />
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
-    <input name="base" type="float" value="0.8" />
-    <input name="base_color" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="diffuse_roughness" type="float" value="0" />
+    <!-- <input name="diffuse_roughness" type="float" value="0" /> -->
     <input name="metalness" type="float" value="0" />
-    <input name="specular" type="float" value="1" />
-    <input name="specular_color" type="color3" value="1, 1, 1" />
+    <!-- <input name="specular" type="float" value="1" /> -->
+    <!-- <input name="specular_color" type="color3" value="1, 1, 1" /> -->
     <input name="specular_roughness" type="float" value="0.2" />
-    <input name="specular_IOR" type="float" value="1.5" />
-    <input name="specular_anisotropy" type="float" value="0" />
-    <input name="specular_rotation" type="float" value="0" />
-    <input name="transmission" type="float" value="0" />
-    <input name="transmission_color" type="color3" value="1, 1, 1" />
-    <input name="transmission_depth" type="float" value="0" />
-    <input name="transmission_scatter" type="color3" value="0, 0, 0" />
-    <input name="transmission_scatter_anisotropy" type="float" value="0" />
-    <input name="transmission_dispersion" type="float" value="0" />
-    <input name="transmission_extra_roughness" type="float" value="0" />
-    <input name="subsurface" type="float" value="0" />
-    <input name="subsurface_color" type="color3" value="1, 1, 1" />
-    <input name="subsurface_radius" type="color3" value="1, 1, 1" />
-    <input name="subsurface_scale" type="float" value="1" />
-    <input name="subsurface_anisotropy" type="float" value="0" />
-    <input name="sheen" type="float" value="0" />
+    <!-- <input name="specular_IOR" type="float" value="1.5" /> -->
+    <!-- <input name="specular_anisotropy" type="float" value="0" /> -->
+    <!-- <input name="specular_rotation" type="float" value="0" /> -->
+    <!-- <input name="transmission" type="float" value="0" /> -->
+    <!-- <input name="transmission_color" type="color3" value="1, 1, 1" /> -->
+    <!-- <input name="transmission_depth" type="float" value="0" /> -->
+    <!-- <input name="transmission_scatter" type="color3" value="0, 0, 0" /> -->
+    <!-- <input name="transmission_scatter_anisotropy" type="float" value="0" /> -->
+    <!-- <input name="transmission_dispersion" type="float" value="0" /> -->
+    <!-- <input name="transmission_extra_roughness" type="float" value="0" /> -->
+    <!-- <input name="subsurface" type="float" value="0" /> -->
+    <!-- <input name="subsurface_color" type="color3" value="1, 1, 1" /> -->
+    <!-- <input name="subsurface_radius" type="color3" value="1, 1, 1" /> -->
+    <!-- <input name="subsurface_scale" type="float" value="1" /> -->
+    <!-- <input name="subsurface_anisotropy" type="float" value="0" /> -->
+    <!-- <input name="sheen" type="float" value="0" /> -->
     <input name="sheen_color" type="color3" value="1, 1, 1" />
     <input name="sheen_roughness" type="float" value="0.3" />
     <input name="coat" type="float" value="0" />
-    <input name="coat_color" type="color3" value="1, 1, 1" />
+    <!-- <input name="coat_color" type="color3" value="1, 1, 1" /> -->
     <input name="coat_roughness" type="float" value="0.1" />
-    <input name="coat_anisotropy" type="float" value="0.0" />
-    <input name="coat_rotation" type="float" value="0.0" />
-    <input name="coat_IOR" type="float" value="1.5" />
+    <!-- <input name="coat_anisotropy" type="float" value="0.0" /> -->
+    <!-- <input name="coat_rotation" type="float" value="0.0" /> -->
+    <!-- <input name="coat_IOR" type="float" value="1.5" /> -->
     <input name="coat_normal" type="vector3" />
-    <input name="coat_affect_color" type="float" value="0" />
-    <input name="coat_affect_roughness" type="float" value="0" />
-    <input name="thin_film_thickness" type="float" value="0" />
-    <input name="thin_film_IOR" type="float" value="1.5" />
+    <!-- <input name="coat_affect_color" type="float" value="0" /> -->
+    <!-- <input name="coat_affect_roughness" type="float" value="0" /> -->
+    <!-- <input name="thin_film_thickness" type="float" value="0" /> -->
+    <!-- <input name="thin_film_IOR" type="float" value="1.5" /> -->
     <input name="emission" type="float" value="0" />
     <input name="emission_color" type="color3" value="1, 1, 1" />
-    <input name="opacity" type="color3" value="1, 1, 1" />
-    <input name="thin_walled" type="boolean" value="false" />
-    <input name="normal" type="vector3" />
-    <input name="tangent" type="vector3" />
+    <!-- <input name="opacity" type="color3" value="1, 1, 1" /> -->
+    <!-- <input name="thin_walled" type="boolean" value="false" /> -->
+    <!-- <input name="normal" type="vector3" /> -->
+    <!-- <input name="tangent" type="vector3" /> -->
 
     <output name="base_color_out" type="color3" />
     <output name="metallic_out" type="float" />
     <output name="roughness_out" type="float" />
-    <output name="normal_out" type="vector3" />
-    <output name="occlusion_out" type="float" />
-    <output name="transmission_out" type="float" />
-    <output name="specular_out" type="float" />
-    <output name="specular_color_out" type="color3" />
-    <output name="ior_out" type="float" />
-    <output name="alpha_out" type="float" />
-    <output name="alpha_mode_out" type="integer" />
-    <output name="alpha_cutoff_out" type="float" />
-    <output name="sheen_color_out" type="color3" />
-    <output name="sheen_roughness_out" type="float" />
+
+    <!-- normals do not translate -->
+    <!-- <output name="normal_out" type="vector3" /> -->
+
+    <!-- inherited default -->
+    <!-- <output name="occlusion_out" type="float" /> -->
+
+    <!-- parameter accepted, visual mismatch -->
+    <!-- <output name="transmission_out" type="float" /> -->
+
+    <!-- parameter accepted, visual mismatch -->
+    <!-- <output name="specular_out" type="float" /> -->
+    <!-- <output name="specular_color_out" type="color3" /> -->
+
+    <!-- parameter accepted, visual mismatch -->
+    <!-- <output name="ior_out" type="float" /> -->
+
+    <!-- inherited defaults -->
+    <!-- <output name="alpha_out" type="float" /> -->
+    <!-- <output name="alpha_mode_out" type="integer" /> -->
+    <!-- <output name="alpha_cutoff_out" type="float" /> -->
+
+    <!-- parameter accepted, visual mismatch -->
+    <!-- <output name="sheen_color_out" type="color3" /> -->
+    <!-- <output name="sheen_roughness_out" type="float" /> -->
+
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
     <output name="clearcoat_normal_out" type="vector3" />
+
     <output name="emissive_out" type="color3" />
     <output name="emissive_strength_out" type="float" />
-    <output name="thickness_out" type="float" />
-    <output name="attenuation_distance_out" type="float" />
-    <output name="attenuation_color_out" type="color3" />
+
+    <!-- inherited default -->
+    <!-- <output name="thickness_out" type="float" /> -->
+    <!-- <output name="attenuation_distance_out" type="float" /> -->
+    <!-- <output name="attenuation_color_out" type="color3" /> -->
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -83,48 +99,36 @@
     <dot name="roughness" type="float">
       <input name="in" type="float" interfacename="specular_roughness" />
     </dot>
-    <!-- need modify normal? -->
-    <dot name="normal" type="vector3">
+
+    <!-- passing normals results in black material -->
+    <!-- <dot name="normal" type="vector3">
       <input name="in" type="vector3" interfacename="normal" />
-    </dot>
-    <!-- occlusion value default assignment? -->
-    <dot name="occlusion" type="float">
-      <input name="in" type="float" value="0.0" />
-    </dot>
-    <dot name="transmission" type="float">
+    </dot> -->
+
+    <!-- <dot name="transmission" type="float">
       <input name="in" type="float" interfacename="transmission" />
-    </dot>
+    </dot> -->
 
     <!-- specular -->
-    <dot name="specular" type="float">
+    <!-- <dot name="specular" type="float">
       <input name="in" type="float" interfacename="specular" />
-    </dot>
-    <dot name="specular_color" type="color3">
-      <intput name="in" type="color3" interfacename="specular_color" />
-    </dot>
-    <!-- ui min values differ -->
-    <dot name="ior" type="float">
+    </dot> -->
+    <!-- <dot name="specular_color" type="color3">
+      <input name="in" type="color3" interfacename="specular_color" />
+    </dot> -->
+
+    <!-- ranges differ -->
+    <!-- <dot name="ior" type="float">
       <input name="in" type="float" interfacename="specular_IOR" />
-    </dot>
+    </dot> -->
 
-    <!-- alpha value default assignments? -->
-    <dot name="alpha" type="float">
-      <input name="in" type="float" value="0.0" />
-    </dot>
-    <dot name="alpha_mode" type="integer">
-      <input name="in" type="integer" value="0" />
-    </dot>
-    <dot name="alpha_cutoff" type="float">
-      <input name="in" type="float" value="0.5" />
-    </dot>
-
-    <!-- clearcoat -->
-    <dot name="sheen_color" type="color3">
+    <!-- sheen -->
+    <!-- <dot name="sheen_color" type="color3">
       <input name="in" type="color3" interfacename="sheen_color" />
     </dot>
     <dot name="sheen_roughness" type="float">
-      <input name="in" type="float" interfacename="sheen_roughenss" />
-    </dot>
+      <input name="in" type="float" interfacename="sheen_roughness" />
+    </dot> -->
 
     <!-- clearcoat -->
     <dot name="clearcoat" type="float">
@@ -145,39 +149,28 @@
       <input name="in" type="float" interfacename="emission" />
     </dot>
 
-    <!-- undocumented params -->
-    <dot name="thickness" type="float">
-      <input name="in" type="float" value="0.0" />
-    </dot>
-    <dot name="attenuation_distance" type="float">
-      <input name="in" type="float" value="0.0" />
-    </dot>
-    <dot name="attenuation_color" type="color3">
-      <input name="in" type="color3" value="0, 0, 0" />
-    </dot>
-
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
-    <output name="normal_out" type="vector3" nodename="normal" />
-    <output name="occlusion_out" type="float" nodename="occlusion" />
-    <output name="transmission_out" type="float" nodename="transmission" />
-    <output name="specular_out" type="float" nodename="specular" />
-    <output name="specular_color_out" type="color3" nodename="specular_color" />
-    <output name="ior_out" type="float" nodename="ior" />
-    <output name="alpha_out" type="float" nodename="alpha" />
-    <output name="alpha_mode_out" type="integer" nodename="alpha_mode" />
-    <output name="alpha_cutoff_out" type="float" nodename="alpha_cutoff" />
-    <output name="sheen_color_out" type="color3" nodename="sheen_color" />
-    <output name="sheen_roughness_out" type="float" nodename="sheen_roughness" />
+    <!-- <output name="normal_out" type="vector3" nodename="normal" /> -->
+    <!-- <output name="occlusion_out" type="float" nodename="occlusion" /> -->
+    <!-- <output name="transmission_out" type="float" nodename="transmission" /> -->
+    <!-- <output name="specular_out" type="float" nodename="specular" /> -->
+    <!-- <output name="specular_color_out" type="color3" nodename="specular_color" /> -->
+    <!-- <output name="ior_out" type="float" nodename="ior" /> -->
+    <!-- <output name="alpha_out" type="float" nodename="alpha" /> -->
+    <!-- <output name="alpha_mode_out" type="integer" nodename="alpha_mode" /> -->
+    <!-- <output name="alpha_cutoff_out" type="float" nodename="alpha_cutoff" /> -->
+    <!-- <output name="sheen_color_out" type="color3" nodename="sheen_color" /> -->
+    <!-- <output name="sheen_roughness_out" type="float" nodename="sheen_roughness" /> -->
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="clearcoat_normal_out" type="vector3" nodename="clearcoat_normal" />
     <output name="emissive_out" type="color3" nodename="emissive" />
     <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
-    <output name="thickness_out" type="float" nodename="thickness" />
-    <output name="attenuation_distance_out" type="float" nodename="attenuation_distance" />
-    <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />
+    <!-- <output name="thickness_out" type="float" nodename="thickness" /> -->
+    <!-- <output name="attenuation_distance_out" type="float" nodename="attenuation_distance" /> -->
+    <!-- <output name="attenuation_color_out" type="color3" nodename="attenuation_color" /> -->
 
   </nodegraph>
 </materialx>

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -14,7 +14,7 @@
     <!-- <input name="specular_rotation" type="float" /> -->
     <input name="transmission" type="float" />
     <input name="transmission_color" type="color3" />
-    <!-- <input name="transmission_depth" type="float" /> -->
+    <input name="transmission_depth" type="float" />
     <!-- <input name="transmission_scatter" type="color3" /> -->
     <!-- <input name="transmission_scatter_anisotropy" type="float" /> -->
     <!-- <input name="transmission_dispersion" type="float" /> -->
@@ -49,48 +49,33 @@
     <output name="metallic_out" type="float" />
     <output name="roughness_out" type="float" />
 
-    <!-- normals do not translate -->
     <!-- <output name="normal_out" type="vector3" /> -->
-
-    <!-- inherited default -->
     <!-- <output name="occlusion_out" type="float" /> -->
-
-    <!-- parameter accepted, visual mismatch -->
     <output name="transmission_out" type="float" />
-
     <output name="specular_out" type="float" />
-    <!-- parameter accepted, visual mismatch -->
     <output name="specular_color_out" type="color3" />
-
-    <!-- parameter accepted, visual mismatch -->
     <output name="ior_out" type="float" />
-
-    <!-- inherited defaults -->
     <!-- <output name="alpha_out" type="float" /> -->
     <!-- <output name="alpha_mode_out" type="integer" /> -->
     <!-- <output name="alpha_cutoff_out" type="float" /> -->
-
-    <!-- parameter accepted, visual mismatch -->
     <output name="sheen_color_out" type="color3" />
     <output name="sheen_roughness_out" type="float" />
-
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
     <!-- <output name="clearcoat_normal_out" type="vector3" /> -->
-
     <output name="emissive_out" type="color3" />
     <output name="emissive_strength_out" type="float" />
-
-    <!-- inherited default -->
-    <!-- <output name="thickness_out" type="float" /> -->
+    <output name="thickness_out" type="float" />
     <!-- <output name="attenuation_distance_out" type="float" /> -->
-    <!-- <output name="attenuation_color_out" type="color3" /> -->
-<!-- 
-    <output name="iridescence_thickness_maximum_out" type="float" />
-    <output name="iridescence_ior_out" type="float" /> -->
+    <output name="attenuation_color_out" type="color3" />
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
+
+    <multiply name="base_color" type="color3">
+      <input name="in1" type="color3" interfacename="base_color" />
+      <input name="in2" type="float" interfacename="base" />
+    </multiply>
 
     <dot name="metallic" type="float">
       <input name="in" type="float" interfacename="metalness" />
@@ -149,81 +134,15 @@
       <input name="in" type="float" interfacename="thin_film_IOR" />
     </dot>
 
-    <!-- <dot name="normal" type="vector3" >
-      <input name="in" type="vector3" interfacename="normal" />
-    </dot> -->
+    <dot name="thickness" type="float">
+      <input name="in" type="float" interfacename="transmission_depth" />
+    </dot>
 
-    <!-- Output color switch priority: transmission > coat color > base color -->
-    <ifequal name="has_coat" type="float" >
-      <input name="value1" type="float" interfacename="coat" />
-      <input name="value2" type="float" value="0" />
-      <input name="in1" type="float" value="0" />
-      <input name="in2" type="float" value="1" />
-    </ifequal>
-    <swizzle name="coat_r" type="float" >
-      <input name="in" type="color3" interfacename="coat_color" />
-      <input name="channels" type="string" value="r" />
-    </swizzle>
-    <swizzle name="coat_g" type="float" >
-      <input name="in" type="color3" interfacename="coat_color" />
-      <input name="channels" type="string" value="g" />
-    </swizzle>
-    <swizzle name="coat_b" type="float" >
-      <input name="in" type="color3" interfacename="coat_color" />
-      <input name="channels" type="string" value="b" />
-    </swizzle>
-    <ifequal name="coat_r_is_default" type="float" >
-      <input name="value1" type="float" nodename="coat_r" />
-      <input name="value2" type="float" value="0" />
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" value="0" />
-    </ifequal>
-    <ifequal name="coat_g_is_default" type="float" >
-      <input name="value1" type="float" nodename="coat_g" />
-      <input name="value2" type="float" value="0" />
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" value="0" />
-    </ifequal>
-    <ifequal name="coat_b_is_default" type="float" >
-      <input name="value1" type="float" nodename="coat_b" />
-      <input name="value2" type="float" value="0" />
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" value="0" />
-    </ifequal>
-    <multiply name="accum_coat_rg" type="float" >
-      <input name="in1" type="float" nodename="coat_r_is_default" />
-      <input name="in2" type="float" nodename="coat_g_is_default" />
-    </multiply>
-    <multiply name="accum_coat_rgb" type="float" > 
-      <input name="in1" type="float" nodename="accum_coat_rg" />
-      <input name="in2" type="float" nodename="coat_b_is_default" />
-    </multiply>
-    <subtract name="has_coat_and_coat_color" type="float" >
-      <input name="in1" type="float" nodename="has_coat" />
-      <input name="in2" type="float" nodename="accum_coat_rgb" />
-    </subtract>
+    <dot name="attenuation_color" type="color3">
+      <input name="in" type="color3" interfacename="transmission_color" />
+    </dot>
 
-    <!-- if we have coat and color is not default, apply over base color -->
-    <ifequal name="base_layer_color" type="color3" >
-      <input name="value1" type="float" nodename="has_coat_and_coat_color" />
-      <input name="value2" type="float" value="1" />
-      <input name="in1" type="color3" interfacename="coat_color" />
-      <input name="in2" type="color3" interfacename="base_color" />
-    </ifequal>
-    <!-- Attenuate result of coat or base by base factor -->
-    <multiply name="attenuated_baselayer" type="color3" >
-      <input name="in1" type="color3" nodename="base_layer_color" />
-      <input name="in2" type="float" interfacename="base" />
-    </multiply>
-    <!-- if transmission, use transmission color -->
-    <ifequal name="color_switch" type="color3" >
-      <input name="value1" type="float" interfacename="transmission" />
-      <input name="value2" type="float" value="0" />
-      <input name="in1" type="color3" nodename="attenuated_baselayer" />
-      <input name="in2" type="color3" interfacename="transmission_color" />
-    </ifequal>
-
-    <output name="base_color_out" type="color3" nodename="color_switch" />
+    <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
     <output name="transmission_out" type="float" nodename="transmission" />
@@ -236,7 +155,8 @@
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />
     <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
-    <!-- <output name="normal_out" type="vector3" nodename="normal" /> -->
+    <output name="thickness_out" type="float" nodename="thickness" />
+    <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />
 
   </nodegraph>
 </materialx>

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -13,8 +13,8 @@
     <!-- <input name="specular_anisotropy" type="float" /> -->
     <!-- <input name="specular_rotation" type="float" /> -->
     <input name="transmission" type="float" />
-    <input name="transmission_color" type="color3" />
-    <input name="transmission_depth" type="float" />
+    <!-- <input name="transmission_color" type="color3" /> -->
+    <!-- <input name="transmission_depth" type="float" /> -->
     <!-- <input name="transmission_scatter" type="color3" /> -->
     <!-- <input name="transmission_scatter_anisotropy" type="float" /> -->
     <!-- <input name="transmission_dispersion" type="float" /> -->
@@ -28,16 +28,16 @@
     <input name="sheen_color" type="color3" />
     <input name="sheen_roughness" type="float" />
     <input name="coat" type="float" />
-    <input name="coat_color" type="color3" />
+    <!-- <input name="coat_color" type="color3" /> -->
     <input name="coat_roughness" type="float" />
     <!-- <input name="coat_anisotropy" type="float" /> -->
     <!-- <input name="coat_rotation" type="float" /> -->
     <!-- <input name="coat_IOR" type="float" /> -->
-    <input name="coat_normal" type="vector3" />
+    <!-- <input name="coat_normal" type="vector3" /> -->
     <!-- <input name="coat_affect_color" type="float" /> -->
     <!-- <input name="coat_affect_roughness" type="float" /> -->
-    <input name="thin_film_thickness" type="float" />
-    <input name="thin_film_IOR" type="float" />
+    <!-- <input name="thin_film_thickness" type="float" /> -->
+    <!-- <input name="thin_film_IOR" type="float" /> -->
     <input name="emission" type="float" />
     <input name="emission_color" type="color3" />
     <!-- <input name="opacity" type="color3" /> -->
@@ -48,7 +48,6 @@
     <output name="base_color_out" type="color3" />
     <output name="metallic_out" type="float" />
     <output name="roughness_out" type="float" />
-
     <!-- <output name="normal_out" type="vector3" /> -->
     <!-- <output name="occlusion_out" type="float" /> -->
     <output name="transmission_out" type="float" />
@@ -65,9 +64,9 @@
     <!-- <output name="clearcoat_normal_out" type="vector3" /> -->
     <output name="emissive_out" type="color3" />
     <output name="emissive_strength_out" type="float" />
-    <output name="thickness_out" type="float" />
+    <!-- <output name="thickness_out" type="float" /> -->
     <!-- <output name="attenuation_distance_out" type="float" /> -->
-    <output name="attenuation_color_out" type="color3" />
+    <!-- <output name="attenuation_color_out" type="color3" /> -->
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -126,22 +125,6 @@
       <input name="in" type="float" interfacename="emission" />
     </dot>
 
-    <dot name="thin_film_thickness" type="float">
-      <input name="in" type="float" interfacename="thin_film_thickness" />
-    </dot>
-
-    <dot name="thin_film_IOR" type="float">
-      <input name="in" type="float" interfacename="thin_film_IOR" />
-    </dot>
-
-    <dot name="thickness" type="float">
-      <input name="in" type="float" interfacename="transmission_depth" />
-    </dot>
-
-    <dot name="attenuation_color" type="color3">
-      <input name="in" type="color3" interfacename="transmission_color" />
-    </dot>
-
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
@@ -155,8 +138,6 @@
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />
     <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
-    <output name="thickness_out" type="float" nodename="thickness" />
-    <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />
 
   </nodegraph>
 </materialx>


### PR DESCRIPTION
This PR introduces a simple nodegraph for mapping `standard_surface.mtlx` material documents to `gltf_pbr.mtlx` material documents. It was implemented as part of my Summer '22 internship with Autodesk as part of a larger Standard Surface => glTF export workflow.

The parameters supported by this translation are simply passed through, or multiplied in the case of weighted colors. 

<img alt="Translation workflow" src="https://user-images.githubusercontent.com/8890471/187583096-8678f1db-4e3e-4e12-a6af-9c2ed405a457.png">

_Courtesy Bernard Kwok, Pablo Delgado, "MaterialX Web Update"_

## Translation

We map properties as follows - items in the glTF PBR column are outputs, items in the Standard Surface column are inputs.

| glTF PBR            | Standard Surface             |
|---------------------|------------------------------|
| base_color          | multiply(base_color, base)   |
| metallic            | dot(metallic)                |
| roughness           | dot(specular_roughness)      |
| transmission        | dot(transmission)            |
| specular            | dot(specular)                |
| specular_color      | dot(specular_color)          |
| ior                 | dot(specular_ior)            |
| sheen_color         | multiply(sheen_color, sheen) |
| sheen_roughness     | dot(sheen_roughness)         |
| clearcoat           | dot(coat)                    |
| clearcoat_roughness | dot(coat_roughness)          |
| emissive            | dot(emission_color)          |
| emissive_strength   | dot(emission)                |

## Further work

### Transmission

Our mapping of transmission ([Standard Surface specular transmission](https://autodesk.github.io/standard-surface/#closures/speculartransmission)) to transmission (glTF KHR_materials_transmission) covers only the transmission weight. Better approximation of Standard Surface's transmission behavior should be possible via the [KHR_materials_volume properties](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#extending-materials) which are supported by the `gltf_pbr.mtlx` [node definition](https://github.com/AcademySoftwareFoundation/MaterialX/blob/f2e3fdb1436b1ee443e36284c62fbe87282a72c6/libraries/bxdf/gltf_pbr.mtlx#L23).

### Coat

We map Standard Surface's [coating](https://autodesk.github.io/standard-surface/#closures/coating) to [KHR_materials_clearcoat](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_clearcoat/README.md). KHR clearcoat does not support coat color; this behavior can be approximated by mixing incoming base color and coat color, but was not sufficiently explored in the course of this work and is omitted on this PR.

### Thin film

Standard Surface's [specular transmission](https://autodesk.github.io/standard-surface/#closures/speculartransmission) supports a thin film behavior that may be mappable to [KHR_materials_iridescence](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_iridescence#extending-materials), but this extension is not supported by the current implementation of the gltf_pbr node definition.

### Other behaviors

Any behaviors not listed on this PR were not explored and are not supported by this implementation of the translation nodegraph. 

## Other work

Other work implemented for this workflow includes pipelines for translating test materials to native `*.gltf` and rendering test scenes, there is some discussion on ASWF slack in `materialx-gltf` about where it may live.

<img alt="translation" src="https://user-images.githubusercontent.com/8890471/187586172-925a4d72-e551-42fb-9d29-f9c449d8209d.png">


