### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -235,16 +235,13 @@ bool Node::validate(string* message) const
 NodePtr GraphElement::addMaterialNode(const string& name, ConstNodePtr shaderNode)
 {
     string category = SURFACE_MATERIAL_NODE_STRING;
+    NodePtr materialNode = addNode(category, name, MATERIAL_TYPE_STRING);
     if (shaderNode)
     {
         if (shaderNode->getType() == VOLUME_MATERIAL_NODE_STRING)
         {
             category = VOLUME_SHADER_TYPE_STRING;
         }
-    }
-    NodePtr materialNode = addNode(category, name, MATERIAL_TYPE_STRING);
-    if (shaderNode)
-    {
         InputPtr input = materialNode->addInput(shaderNode->getType(), shaderNode->getType());
         input->setNodeName(shaderNode->getName());
     }

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1389,12 +1389,6 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
         targetUnitSpace = globalTargetUnitSpace;
     }
 
-    // Don't perform unit conversion if targetUnitSpace is unspecified.
-    if (targetUnitSpace.empty())
-    {
-        return;
-    }
-
     // TODO: Consider this to be an optimization option as
     // this allows for the source and target unit to be the same value
     // while still allowing target unit updates on a compiled shader as the

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -73,7 +73,7 @@ const std::string DEFAULT_MESH_PREFIX = "MESH_";
 // List of path names which match to meshes
 using GLTFMeshPathList = std::unordered_map<cgltf_mesh*, StringVec>;
 
-void computeMeshPaths(GLTFMeshPathList& meshPaths, cgltf_node* cnode,  FilePath path, size_t nodeCount, size_t meshCount)
+void computeMeshPaths(GLTFMeshPathList& meshPaths, cgltf_node* cnode, FilePath path, size_t nodeCount, size_t meshCount)
 {
     FilePath prevPath = path;
     string cnodeName = cnode->name ? string(cnode->name) : DEFAULT_NODE_PREFIX + std::to_string(nodeCount++);
@@ -99,9 +99,6 @@ void computeMeshPaths(GLTFMeshPathList& meshPaths, cgltf_node* cnode,  FilePath 
     {
         computeMeshPaths(meshPaths, cnode->children[i], path, nodeCount, meshCount);
     }
-
-    // Pop path name
-    path = prevPath;
 }
 
 } // anonymous namespace

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -165,8 +165,7 @@ class MX_RENDER_API Half
         sign >>= shiftSign; // logical shift
         s.si = mulN;
         int32_t subN = (int32_t) std::min(s.f * v.f, (float) maxF); // correct subnormals
-        s.si = subN;
-        v.si ^= (s.si ^ v.si) & -(minN > v.si);
+        v.si ^= (subN ^ v.si) & -(minN > v.si);
         v.si ^= (infN ^ v.si) & -((infN > v.si) & (v.si > maxN));
         v.si ^= (nanN ^ v.si) & -((nanN > v.si) & (v.si > infN));
         v.ui >>= shift; // logical shift


### PR DESCRIPTION
- Simplify logic in GraphElement::addMaterialNode.
- Remove duplicate check in ShaderGraph::populateUnitTransformMap.
- Remove unneeded assignment in computeMeshPaths.
- Remove unneeded intermediate in Half::toFloat16.