### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -47,7 +47,7 @@ const std::unordered_map<string, size_t> PortElement::CHANNELS_PATTERN_LENGTH = 
 // PortElement methods
 //
 
-void PortElement::setConnectedNode(NodePtr node)
+void PortElement::setConnectedNode(ConstNodePtr node)
 {
     if (node)
     {

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -61,6 +61,7 @@ class MX_CORE_API PortElement : public ValueElement
 
   protected:
     using NodePtr = shared_ptr<Node>;
+    using ConstNodePtr = shared_ptr<const Node>;
 
   public:
     /// @name Node Name
@@ -174,7 +175,7 @@ class MX_CORE_API PortElement : public ValueElement
     /// Set the node to which this element is connected.  The given node must
     /// belong to the same node graph.  If the node argument is null, then
     /// any existing node connection will be cleared.
-    void setConnectedNode(NodePtr node);
+    void setConnectedNode(ConstNodePtr node);
 
     /// Return the node, if any, to which this element is connected.
     virtual NodePtr getConnectedNode() const;

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -20,7 +20,7 @@ const string Backdrop::HEIGHT_ATTRIBUTE = "height";
 // Node methods
 //
 
-void Node::setConnectedNode(const string& inputName, NodePtr node)
+void Node::setConnectedNode(const string& inputName, ConstNodePtr node)
 {
     InputPtr input = getInput(inputName);
     if (!input)
@@ -234,16 +234,13 @@ bool Node::validate(string* message) const
 
 NodePtr GraphElement::addMaterialNode(const string& name, ConstNodePtr shaderNode)
 {
-    string category = SURFACE_MATERIAL_NODE_STRING;
+    bool isVolumeShader = shaderNode && shaderNode->getType() == VOLUME_SHADER_TYPE_STRING;
+    string category = isVolumeShader ? VOLUME_MATERIAL_NODE_STRING : SURFACE_MATERIAL_NODE_STRING;
     NodePtr materialNode = addNode(category, name, MATERIAL_TYPE_STRING);
     if (shaderNode)
     {
-        if (shaderNode->getType() == VOLUME_MATERIAL_NODE_STRING)
-        {
-            category = VOLUME_SHADER_TYPE_STRING;
-        }
         InputPtr input = materialNode->addInput(shaderNode->getType(), shaderNode->getType());
-        input->setNodeName(shaderNode->getName());
+        input->setConnectedNode(shaderNode);
     }
     return materialNode;
 }

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -64,7 +64,7 @@ class MX_CORE_API Node : public InterfaceElement
     /// Set the node to which the given input is connected, creating a
     /// child input if needed.  If the node argument is null, then any
     /// existing node connection on the input will be cleared.
-    void setConnectedNode(const string& inputName, NodePtr node);
+    void setConnectedNode(const string& inputName, ConstNodePtr node);
 
     /// Return the Node connected to the given input.  If the given input is
     /// not present, then an empty NodePtr is returned.

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -46,7 +46,7 @@ TEST_CASE("Document", "[document]")
     REQUIRE(nodeGraph->getDescendant("missingNode") == mx::ElementPtr());
 
     // Create a simple shader interface.
-    mx::NodeDefPtr simpleSrf = doc->addNodeDef("", "surfaceshader", "simpleSrf");
+    mx::NodeDefPtr simpleSrf = doc->addNodeDef("", mx::SURFACE_SHADER_TYPE_STRING, "simpleSrf");
     simpleSrf->setInputValue("diffColor", mx::Color3(1.0f));
     simpleSrf->setInputValue("specColor", mx::Color3(0.0f));
     mx::InputPtr roughness = simpleSrf->setInputValue("roughness", 0.25f);
@@ -89,7 +89,7 @@ TEST_CASE("Document", "[document]")
     mx::DocumentPtr customLibrary = mx::createDocument();
     customLibrary->setNamespace("custom");
     mx::NodeGraphPtr customNodeGraph = customLibrary->addNodeGraph("NG_custom");
-    mx::NodeDefPtr customNodeDef = customLibrary->addNodeDef("ND_simpleSrf", "surfaceshader", "simpleSrf");
+    mx::NodeDefPtr customNodeDef = customLibrary->addNodeDef("ND_simpleSrf", mx::SURFACE_SHADER_TYPE_STRING, "simpleSrf");
     mx::ImplementationPtr customImpl = customLibrary->addImplementation("IM_custom");
     customNodeGraph->addNodeInstance(customNodeDef, "custom1");
     customImpl->setNodeDef(customNodeDef);

--- a/source/MaterialXTest/MaterialXCore/Look.cpp
+++ b/source/MaterialXTest/MaterialXCore/Look.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Look", "[look]")
     mx::DocumentPtr doc = mx::createDocument();
 
     // Create a material and look.
-    mx::NodePtr shaderNode = doc->addNode("standard_surface", "", "surfaceshader");
+    mx::NodePtr shaderNode = doc->addNode("standard_surface", "", mx::SURFACE_SHADER_TYPE_STRING);
     mx::NodePtr materialNode = doc->addMaterialNode("", shaderNode);
     mx::LookPtr look = doc->addLook();
 

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -19,7 +19,7 @@ TEST_CASE("Material", "[material]")
     mx::DocumentPtr doc = mx::createDocument();
 
     // Create a base shader nodedef.
-    mx::NodeDefPtr simpleSrf = doc->addNodeDef("ND_simpleSrf", "surfaceshader", "simpleSrf");
+    mx::NodeDefPtr simpleSrf = doc->addNodeDef("ND_simpleSrf", mx::SURFACE_SHADER_TYPE_STRING, "simpleSrf");
     simpleSrf->setInputValue("diffColor", mx::Color3(1.0f));
     simpleSrf->setInputValue("specColor", mx::Color3(0.0f));
     simpleSrf->setInputValue("roughness", 0.25f);
@@ -30,7 +30,7 @@ TEST_CASE("Material", "[material]")
     REQUIRE(simpleSrf->getTokenValue("texId") == "01");
 
     // Create an inherited shader nodedef.
-    mx::NodeDefPtr anisoSrf = doc->addNodeDef("ND_anisoSrf", "surfaceshader", "anisoSrf");
+    mx::NodeDefPtr anisoSrf = doc->addNodeDef("ND_anisoSrf", mx::SURFACE_SHADER_TYPE_STRING, "anisoSrf");
     anisoSrf->setInheritsFrom(simpleSrf);
     anisoSrf->setInputValue("anisotropy", 0.0f);
     REQUIRE(anisoSrf->getInheritsFrom() == simpleSrf);
@@ -47,9 +47,9 @@ TEST_CASE("Material", "[material]")
     anisoSrf->setVersionString("2");
     shaderNode->setVersionString("2");
     REQUIRE(shaderNode->getNodeDef() == anisoSrf);
-    shaderNode->setType("volumeshader");
+    shaderNode->setType(mx::VOLUME_SHADER_TYPE_STRING);
     REQUIRE(shaderNode->getNodeDef() == nullptr);
-    shaderNode->setType("surfaceshader");
+    shaderNode->setType(mx::SURFACE_SHADER_TYPE_STRING);
     REQUIRE(shaderNode->getNodeDef() == anisoSrf);
 
     // Bind a shader input to a value.


### PR DESCRIPTION
- Fix const correctness of arguments in setConnectedNode.
- Fix category assignment in GraphElement::addMaterialNode.
- Use shader type string constants in unit tests.