### PR TITLE
Web viewer profiling and optimizations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,7 @@ jobs:
     - name: Shader Validation Tests
       if: matrix.test_shaders == 'ON' && runner.os == 'Windows'
       run: |
+        vcpkg/vcpkg remove glslang
         vcpkg/vcpkg install glslang --triplet=x64-windows
         glslangValidator.exe -v
         python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,7 +155,7 @@ jobs:
         vcpkg/bootstrap-vcpkg.bat -disableMetrics
         echo $PWD/build/installed/bin | Out-File -FilePath $env:GITHUB_PATH -Append
         echo $PWD/vcpkg/installed/x64-windows/bin | Out-File -FilePath $env:GITHUB_PATH -Append
-        echo $PWD/vcpkg/installed/x64-windows/tools | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo $PWD/vcpkg/installed/x64-windows/tools/glslang | Out-File -FilePath $env:GITHUB_PATH -Append
 
     - name: Install Python ${{ matrix.python }}
       uses: actions/setup-python@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,11 +151,11 @@ jobs:
     - name: Install Dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
-        git clone https://github.com/Microsoft/vcpkg -b 2022.08.15 -c advice.detachedHead=false
+        git clone https://github.com/Microsoft/vcpkg -b 2021.05.12 -c advice.detachedHead=false
         vcpkg/bootstrap-vcpkg.bat -disableMetrics
         echo $PWD/build/installed/bin | Out-File -FilePath $env:GITHUB_PATH -Append
         echo $PWD/vcpkg/installed/x64-windows/bin | Out-File -FilePath $env:GITHUB_PATH -Append
-        echo $PWD/vcpkg/installed/x64-windows/tools/glslang | Out-File -FilePath $env:GITHUB_PATH -Append
+        echo $PWD/vcpkg/installed/x64-windows/tools | Out-File -FilePath $env:GITHUB_PATH -Append
 
     - name: Install Python ${{ matrix.python }}
       uses: actions/setup-python@v2
@@ -215,7 +215,6 @@ jobs:
     - name: Shader Validation Tests
       if: matrix.test_shaders == 'ON' && runner.os == 'Windows'
       run: |
-        vcpkg/vcpkg remove glslang
         vcpkg/vcpkg install glslang --triplet=x64-windows
         glslangValidator.exe -v
         python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
     - name: Install Dependencies (Windows)
       if: runner.os == 'Windows'
       run: |
-        git clone https://github.com/Microsoft/vcpkg -b 2021.05.12 -c advice.detachedHead=false
+        git clone https://github.com/Microsoft/vcpkg -b 2022.08.15 -c advice.detachedHead=false
         vcpkg/bootstrap-vcpkg.bat -disableMetrics
         echo $PWD/build/installed/bin | Out-File -FilePath $env:GITHUB_PATH -Append
         echo $PWD/vcpkg/installed/x64-windows/bin | Out-File -FilePath $env:GITHUB_PATH -Append

--- a/javascript/MaterialXView/index.ejs
+++ b/javascript/MaterialXView/index.ejs
@@ -37,6 +37,5 @@
       <canvas id="webglcanvas" tabindex="1" style="outline: none;"></canvas>
     </div>
     <script src="JsMaterialXGenShader.js"></script>
-    <script src="main.js"></script>
   </body>
 </html>

--- a/javascript/MaterialXView/source/helper.js
+++ b/javascript/MaterialXView/source/helper.js
@@ -38,34 +38,41 @@ export function prepareEnvTexture(texture, capabilities)
  */
 function RGBToRGBA_Float(texture)
 {
-    const rgbData = texture.image.data;
-    const length = (rgbData.length / 3) * 4;
-    let rgbaData;
+    const w = texture.image.width;
+    const h = texture.image.height;
+    const dataSize = texture.image.data.length; 
+    const stride = dataSize / (w *h);
+    // No need to convert to RGBA if already 4 channel.
+    if (stride == 3)
+    {
+        const rgbData = texture.image.data;
+        const length = (rgbData.length / 3) * 4;
+        let rgbaData;
 
     switch (texture.type)
     {
-        case THREE.FloatType:
-            rgbaData = new Float32Array(length);
-            break;
-        case THREE.HalfFloatType:
-            rgbaData = new Uint16Array(length);
-            break;
-        default:
-          break;
-    }
+            case THREE.FloatType:
+                rgbaData = new Float32Array(length);
+                break;
+            case THREE.HalfFloatType:
+                rgbaData = new Uint16Array(length);
+                break;
+            default:
+                break;
+        }
 
     if (rgbaData)
     {
         for (let i = 0; i < length / 4; i++)
         {
-            rgbaData[(i * 4) + 0] = rgbData[(i * 3) + 0];
-            rgbaData[(i * 4) + 1] = rgbData[(i * 3) + 1];
-            rgbaData[(i * 4) + 2] = rgbData[(i * 3) + 2];
-            rgbaData[(i * 4) + 3] = 1.0;
+                rgbaData[(i * 4) + 0] = rgbData[(i * 3) + 0];
+                rgbaData[(i * 4) + 1] = rgbData[(i * 3) + 1];
+                rgbaData[(i * 4) + 2] = rgbData[(i * 3) + 2];
+                rgbaData[(i * 4) + 3] = 1.0;
+            }
+            return new THREE.DataTexture(rgbaData, texture.image.width, texture.image.height, THREE.RGBAFormat, texture.type);
         }
-        return new THREE.DataTexture(rgbaData, texture.image.width, texture.image.height, THREE.RGBAFormat, texture.type);
     }
-
     return texture;
 }
 

--- a/javascript/MaterialXView/source/helper.js
+++ b/javascript/MaterialXView/source/helper.js
@@ -49,8 +49,8 @@ function RGBToRGBA_Float(texture)
         const length = (rgbData.length / 3) * 4;
         let rgbaData;
 
-    switch (texture.type)
-    {
+        switch (texture.type)
+        {
             case THREE.FloatType:
                 rgbaData = new Float32Array(length);
                 break;
@@ -61,10 +61,10 @@ function RGBToRGBA_Float(texture)
                 break;
         }
 
-    if (rgbaData)
-    {
-        for (let i = 0; i < length / 4; i++)
+        if (rgbaData)
         {
+            for (let i = 0; i < length / 4; i++)
+            {
                 rgbaData[(i * 4) + 0] = rgbData[(i * 3) + 0];
                 rgbaData[(i * 4) + 1] = rgbData[(i * 3) + 1];
                 rgbaData[(i * 4) + 2] = rgbData[(i * 3) + 2];

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -43,6 +43,7 @@ function init()
         viewer.getEditor().clearFolders();
         viewer.getMaterial().loadMaterials(viewer, materialFilename);
         viewer.getEditor().updateProperties(0.9);
+        viewer.getScene().setUpdateTransforms();
     });
 
     // Handle geometry selection changes
@@ -71,6 +72,9 @@ function init()
 
     // Set up controls
     orbitControls = new OrbitControls(scene.getCamera(), renderer.domElement);
+    orbitControls.addEventListener('change', () => {
+        viewer.getScene().setUpdateTransforms();
+    })  
 
     // Load model and shaders
 
@@ -114,8 +118,9 @@ function init()
 }
 
 function onWindowResize() 
-{
+{   
     viewer.getScene().updateCamera();
+    viewer.getScene().setUpdateTransforms(); 
     renderer.setSize(window.innerWidth, window.innerHeight);
 }
 
@@ -128,6 +133,7 @@ function animate()
         turntableStep = (turntableStep + 1) % 360;
         var turntableAngle = turntableStep * (360.0 / turntableSteps) / 180.0 * Math.PI;
         viewer.getScene()._scene.rotation.y = turntableAngle ;
+        viewer.getScene().setUpdateTransforms();
     }
 
     composer.render();

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -118,7 +118,7 @@ function init()
 }
 
 function onWindowResize() 
-{   
+{
     viewer.getScene().updateCamera();
     viewer.getScene().setUpdateTransforms(); 
     renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Updates
- Fix to avoid running 2 instance of the viewer as `HtmlWebpackPlugin` will inject code already to run an instance. 
Loading the main code again results in 2 competing instances being executed affecting all load / update time. (`index.ejs`)
- Avoid translating 4 channel IBLs again on load. Remapping is only required if is 3 channel of which the packaged IBL is not. (`helpers.js`)
- Avoid unnecessary geometry transform updates on every frame. (`viweer.js`)
- Restore texture uniform asynchronous load. This still appears to be the most costly in terms of material setup performance.
- Add some perf logging. 