### PR TITLE
Disable shader test in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
           architecture: x64
           python: 3.9
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
-          test_shaders: ON
+          #test_shaders: ON
 
     steps:
     - name: Sync Repository


### PR DESCRIPTION
This changelist disables a shader test flag in GitHub Actions, pending the resolution of a recent issue with the glslang package.