### PR TITLE
OIIO update to v2.3.17 for CI

### DIFF
--- a/source/MaterialXRender/External/OpenImageIO/FindOpenImageIO.cmake
+++ b/source/MaterialXRender/External/OpenImageIO/FindOpenImageIO.cmake
@@ -45,6 +45,11 @@ find_library ( OPENIMAGEIO_LIBRARY
                HINTS ${OPENIMAGEIO_ROOT_DIR}/lib
                PATH_SUFFIXES lib64 lib
                PATHS "${OPENIMAGEIO_ROOT_DIR}/lib" )
+find_library ( OPENIMAGEIO_UTIL_LIBRARY
+               NAMES OpenImageIO_Util${OIIO_LIBNAME_SUFFIX}
+               HINTS ${OPENIMAGEIO_ROOT_DIR}/lib
+               PATH_SUFFIXES lib64 lib
+               PATHS "${OPENIMAGEIO_ROOT_DIR}/lib" )
 find_path ( OPENIMAGEIO_INCLUDE_DIR
             NAMES OpenImageIO/imageio.h
             HINTS ${OPENIMAGEIO_ROOT_DIR}/include
@@ -66,10 +71,12 @@ if (EXISTS "${OIIO_VERSION_HEADER}")
     set (OPENIMAGEIO_VERSION "${OPENIMAGEIO_VERSION_MAJOR}.${OPENIMAGEIO_VERSION_MINOR}.${OPENIMAGEIO_VERSION_PATCH}")
 endif ()
 
-set ( OPENIMAGEIO_LIBRARIES ${OPENIMAGEIO_LIBRARY})
+set ( OPENIMAGEIO_LIBRARIES ${OPENIMAGEIO_LIBRARY} )
+list( APPEND OPENIMAGEIO_LIBRARIES ${OPENIMAGEIO_UTIL_LIBRARY} )
 get_filename_component (OPENIMAGEIO_LIBRARY_DIRS "${OPENIMAGEIO_LIBRARY}" DIRECTORY CACHE)
 
 if (NOT OpenImageIO_FIND_QUIETLY)
+    message ( STATUS "OpenImageIO version      = ${OPENIMAGEIO_VERSION}" )
     message ( STATUS "OpenImageIO includes     = ${OPENIMAGEIO_INCLUDE_DIR}" )
     message ( STATUS "OpenImageIO libraries    = ${OPENIMAGEIO_LIBRARIES}" )
     message ( STATUS "OpenImageIO library_dirs = ${OPENIMAGEIO_LIBRARY_DIRS}" )

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -10,6 +10,8 @@
     #pragma warning(disable: 4100)
     #pragma warning(disable: 4244)
     #pragma warning(disable: 4800)
+    #pragma warning(disable: 4267)
+    #pragma warning(disable: 4456)
 #endif
 
 #include <OpenImageIO/imageio.h>


### PR DESCRIPTION
* Update for more recent OIIO build. ( [2.3.17 - July 2022 ](https://github.com/OpenImageIO/oiio/releases/tag/v2.3.17.0)) available as download via vcpkg)
  * Need to include OpenImageUI_Util library as part of build so change discovery logic.
  * Minor update to ignore a few new type cast warnings.
