### PR TITLE
Update deprecated MacOS environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,12 +74,12 @@ jobs:
           cmake_config: -DMATERIALX_DYNAMIC_ANALYSIS=ON
           dynamic_analysis: ON
 
-        - name: MacOS_Xcode_10_Python27
-          os: macos-10.15
+        - name: MacOS_Xcode_11_Python37
+          os: macos-11
           compiler: xcode
-          compiler_version: "10.3"
-          python: 2.7
-          cmake_config: -DMATERIALX_PYTHON_VERSION=2 -DMATERIALX_BUILD_SHARED_LIBS=ON
+          compiler_version: "11.7"
+          cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
+          python: 3.7
 
         - name: MacOS_Xcode_12_Python37
           os: macos-11


### PR DESCRIPTION
This changelist updates a deprecated MacOS environment in our build matrix for GitHub Actions, switching from macos-10.15 to macos-11.