### PR TITLE
Add a simple Bump node

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1105,10 +1105,12 @@
     Offset the surface normal by a scalar value.
   -->
   <nodedef name="ND_bump_vector3" node="bump" nodegroup="geometric">
-    <input name="height" type="float" uiname="Height" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="scale" type="float" uiname="Scale" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="normal" type="vector3" uiname="Normal" defaultgeomprop="Nworld" />
-    <output name="out" type="vector3" />
+    <input name="height" type="float" uiname="Height" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Amount to offset the surface normal." />
+    <input name="scale" type="float" uiname="Scale" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Scalar to adjust the height amount." />
+    <input name="space" type="string" value="tangent" enum="tangent, object" uniform="true" doc="The space to transform the normal from ('tangent' or 'object'); defaults to 'tangent'" />
+    <input name="normal" type="vector3" uiname="Normal" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
+    <input name="tangent" type="vector3" uiname="Tangent" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />
+    <output name="out" type="vector3" doc="Offset surface normal; connect this to a shader's 'normal' input." />
   </nodedef>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1104,10 +1104,10 @@
     Node: <bump>
     Offset the surface normal by a scalar value.
   -->
-  <nodedef name="ND_bump_vector3" node="bump" nodegroup="houdini">
+  <nodedef name="ND_bump_vector3" node="bump" nodegroup="geometric">
     <input name="height" type="float" uiname="Height" uisoftmin="0.0" uisoftmax="1.0" value="0" />
     <input name="scale" type="float" uiname="Scale" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="normal" type="vector3" uiname="Normal" value="0, 0, 0" />
+    <input name="normal" type="vector3" uiname="Normal" defaultgeomprop="Nworld" />
     <output name="out" type="vector3" />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1107,7 +1107,6 @@
   <nodedef name="ND_bump_vector3" node="bump" nodegroup="geometric">
     <input name="height" type="float" uiname="Height" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Amount to offset the surface normal." />
     <input name="scale" type="float" uiname="Scale" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Scalar to adjust the height amount." />
-    <input name="space" type="string" value="tangent" enum="tangent, object" uniform="true" doc="The space to transform the normal from ('tangent' or 'object'); defaults to 'tangent'" />
     <input name="normal" type="vector3" uiname="Normal" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
     <input name="tangent" type="vector3" uiname="Tangent" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />
     <output name="out" type="vector3" doc="Offset surface normal; connect this to a shader's 'normal' input." />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1100,6 +1100,17 @@
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
+  <!--
+    Node: <bump>
+    Offset the surface normal by a scalar value.
+  -->
+  <nodedef name="ND_bump_vector3" node="bump" nodegroup="houdini">
+    <input name="height" type="float" uiname="Height" uisoftmin="0.0" uisoftmax="1.0" value="0" />
+    <input name="scale" type="float" uiname="Scale" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+    <input name="normal" type="vector3" uiname="Normal" value="0, 0, 0" />
+    <output name="out" type="vector3" />
+  </nodedef>
+
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1031,6 +1031,21 @@
   <!-- Geometric nodes                                                          -->
   <!-- ======================================================================== -->
 
+  <nodegraph name="NG_bump_vector3" nodedef="ND_bump_vector3">
+    <normalmap name="N_normalmap" type="vector3">
+      <input name="in" type="vector3" nodename="N_heighttonormal" value="0.5, 0.5, 1" />
+      <input name="normal" type="vector3" interfacename="normal" value="0, 0, 0" />
+      <input name="space" type="string" value="tangent" />
+      <input name="scale" type="float" value="1" />
+      <input name="tangent" type="vector3" value="0, 0, 0" />
+    </normalmap>
+    <output name="out" type="vector3" nodename="N_normalmap" />
+    <heighttonormal name="N_heighttonormal" type="vector3">
+      <input name="in" type="float" interfacename="height" value="0" />
+      <input name="scale" type="float" interfacename="scale" value="1" />
+    </heighttonormal>
+  </nodegraph>
+
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1032,18 +1032,22 @@
   <!-- ======================================================================== -->
 
   <nodegraph name="NG_bump_vector3" nodedef="ND_bump_vector3">
+    <input name="height" type="float" />
+    <input name="scale" type="float" />
+    <input name="space" type="string" />
+    <input name="normal" type="vector3" />
+    <input name="tangent" type="vector3" />
+    <output name="out" type="vector3" nodename="N_normalmap" />
     <heighttonormal name="N_heighttonormal" type="vector3">
       <input name="in" type="float" interfacename="height" />
-      <input name="scale" type="float" interfacename="scale" />
     </heighttonormal>
     <normalmap name="N_normalmap" type="vector3">
       <input name="in" type="vector3" nodename="N_heighttonormal" />
       <input name="normal" type="vector3" interfacename="normal" />
-      <input name="space" type="string" value="tangent" />
-      <input name="scale" type="float" value="1" />
-      <input name="tangent" type="vector3" />
+      <input name="space" type="string" interfacename="space" />
+      <input name="scale" type="float" interfacename="scale" />
+      <input name="tangent" type="vector3" interfacename="tangent"/>
     </normalmap>
-    <output name="out" type="vector3" nodename="N_normalmap" />
   </nodegraph>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1033,16 +1033,16 @@
 
   <nodegraph name="NG_bump_vector3" nodedef="ND_bump_vector3">
     <normalmap name="N_normalmap" type="vector3">
-      <input name="in" type="vector3" nodename="N_heighttonormal" value="0.5, 0.5, 1" />
-      <input name="normal" type="vector3" interfacename="normal" value="0, 0, 0" />
+      <input name="in" type="vector3" nodename="N_heighttonormal" />
+      <input name="normal" type="vector3" interfacename="normal" />
       <input name="space" type="string" value="tangent" />
       <input name="scale" type="float" value="1" />
-      <input name="tangent" type="vector3" value="0, 0, 0" />
+      <input name="tangent" type="vector3" />
     </normalmap>
     <output name="out" type="vector3" nodename="N_normalmap" />
     <heighttonormal name="N_heighttonormal" type="vector3">
-      <input name="in" type="float" interfacename="height" value="0" />
-      <input name="scale" type="float" interfacename="scale" value="1" />
+      <input name="in" type="float" interfacename="height" />
+      <input name="scale" type="float" interfacename="scale" />
     </heighttonormal>
   </nodegraph>
 

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1032,11 +1032,6 @@
   <!-- ======================================================================== -->
 
   <nodegraph name="NG_bump_vector3" nodedef="ND_bump_vector3">
-    <input name="height" type="float" />
-    <input name="scale" type="float" />
-    <input name="normal" type="vector3" />
-    <input name="tangent" type="vector3" />
-    <output name="out" type="vector3" nodename="N_normalmap" />
     <heighttonormal name="N_heighttonormal" type="vector3">
       <input name="in" type="float" interfacename="height" />
     </heighttonormal>
@@ -1046,6 +1041,7 @@
       <input name="scale" type="float" interfacename="scale" />
       <input name="tangent" type="vector3" interfacename="tangent"/>
     </normalmap>
+    <output name="out" type="vector3" nodename="N_normalmap" />
   </nodegraph>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1034,7 +1034,6 @@
   <nodegraph name="NG_bump_vector3" nodedef="ND_bump_vector3">
     <input name="height" type="float" />
     <input name="scale" type="float" />
-    <input name="space" type="string" />
     <input name="normal" type="vector3" />
     <input name="tangent" type="vector3" />
     <output name="out" type="vector3" nodename="N_normalmap" />
@@ -1044,7 +1043,6 @@
     <normalmap name="N_normalmap" type="vector3">
       <input name="in" type="vector3" nodename="N_heighttonormal" />
       <input name="normal" type="vector3" interfacename="normal" />
-      <input name="space" type="string" interfacename="space" />
       <input name="scale" type="float" interfacename="scale" />
       <input name="tangent" type="vector3" interfacename="tangent"/>
     </normalmap>

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1032,6 +1032,10 @@
   <!-- ======================================================================== -->
 
   <nodegraph name="NG_bump_vector3" nodedef="ND_bump_vector3">
+    <heighttonormal name="N_heighttonormal" type="vector3">
+      <input name="in" type="float" interfacename="height" />
+      <input name="scale" type="float" interfacename="scale" />
+    </heighttonormal>
     <normalmap name="N_normalmap" type="vector3">
       <input name="in" type="vector3" nodename="N_heighttonormal" />
       <input name="normal" type="vector3" interfacename="normal" />
@@ -1040,10 +1044,6 @@
       <input name="tangent" type="vector3" />
     </normalmap>
     <output name="out" type="vector3" nodename="N_normalmap" />
-    <heighttonormal name="N_heighttonormal" type="vector3">
-      <input name="in" type="float" interfacename="height" />
-      <input name="scale" type="float" interfacename="scale" />
-    </heighttonormal>
   </nodegraph>
 
   <!-- ======================================================================== -->


### PR DESCRIPTION
This adds a MtlX Bump node. It simplifies adding bump to shaders by wrapping up the necessary nodes, which helps artists using MaterialX. Having a node called 'bump' also makes it easier to discover.

![mtlxbump](https://user-images.githubusercontent.com/458856/192027994-016330d8-eedd-41f1-8bc2-dd5e835a6641.png)

Thanks!