### PR TITLE
Adds a Color Correct node

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2917,9 +2917,18 @@
     <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." value="0.5" />
     <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" doc="Multplier which increases or decreases color brightness by 2^value." value="0" />
     <output name="out" type="color3" />
-    <output name="r" type="float" />
-    <output name="g" type="float" />
-    <output name="b" type="float" />
+  </nodedef>
+    <nodedef name="ND_colorcorrect_color4" node="colorcorrect" nodegroup="adjustment">
+    <input name="in" type="color4" uiname="Input Color" value="1, 1, 1, 0" />
+    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" />
+    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" />
+    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" />
+    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" doc="Multiplier increases lighter color values, leaving black values unchanged." value="1" />
+    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" doc="Linearly increase or decrease the color contrast." value="1" />
+    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." value="0.5" />
+    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" doc="Multplier which increases or decreases color brightness by 2^value." value="0" />
+    <output name="out" type="color4" />
   </nodedef>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2918,7 +2918,7 @@
     <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" doc="Multplier which increases or decreases color brightness by 2^value." value="0" />
     <output name="out" type="color3" />
   </nodedef>
-    <nodedef name="ND_colorcorrect_color4" node="colorcorrect" nodegroup="adjustment">
+  <nodedef name="ND_colorcorrect_color4" node="colorcorrect" nodegroup="adjustment">
     <input name="in" type="color4" uiname="Input Color" value="1, 1, 1, 0" />
     <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" />
     <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2907,28 +2907,28 @@
     Combines various adjustment nodes into one, artist-friendly color correction node.
   -->
   <nodedef name="ND_colorcorrect_color3" node="colorcorrect" nodegroup="adjustment">
-    <input name="in" type="color3" uiname="Input Color" value="1, 1, 1" />
-    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" />
-    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" doc="Multiplier increases lighter color values, leaving black values unchanged." value="1" />
-    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" doc="Linearly increase or decrease the color contrast." value="1" />
-    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." value="0.5" />
-    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" doc="Multplier which increases or decreases color brightness by 2^value." value="0" />
+    <input name="in" type="color3" uiname="Input Color" value="1, 1, 1" doc="The input color to be adjusted." />
+    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Rotates the color hue, with values wrapping at 0-1 boundaries." />
+    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjusts the input color saturation level." />
+    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" doc="Applies a gamma correction to the color." />
+    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Raise the dark color values, leaving the white values unchanged." />
+    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0"  value="1" doc="Multiplier increases lighter color values, leaving black values unchanged."/>
+    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Linearly increase or decrease the color contrast." />
+    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." />
+    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" value="0" doc="Multplier which increases or decreases color brightness by 2^value." />
     <output name="out" type="color3" />
   </nodedef>
   <nodedef name="ND_colorcorrect_color4" node="colorcorrect" nodegroup="adjustment">
-    <input name="in" type="color4" uiname="Input Color" value="1, 1, 1, 0" />
-    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" />
-    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" />
-    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" doc="Multiplier increases lighter color values, leaving black values unchanged." value="1" />
-    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" doc="Linearly increase or decrease the color contrast." value="1" />
-    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." value="0.5" />
-    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" doc="Multplier which increases or decreases color brightness by 2^value." value="0" />
-    <output name="out" type="color4" />
+    <input name="in" type="color4" uiname="Input Color" value="1, 1, 1, 0" doc="The input color to be adjusted." />
+    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Rotates the color hue, with values wrapping at 0-1 boundaries." />
+    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjusts the input color saturation level." />
+    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" doc="Applies a gamma correction to the color." />
+    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" doc="Raise the dark color values, leaving the white values unchanged." />
+    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0"  value="1" doc="Multiplier increases lighter color values, leaving black values unchanged."/>
+    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Linearly increase or decrease the color contrast." />
+    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." />
+    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" value="0" doc="Multplier which increases or decreases color brightness by 2^value." />
+    <output name="out" type="color3" />
   </nodedef>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2905,6 +2905,7 @@
   <!--
     Node: <colorcorrect> Supplemental Node
     Combines various adjustment nodes into one, artist-friendly color correction node.
+    The color4 signature does not touch the alpha channel.
   -->
   <nodedef name="ND_colorcorrect_color3" node="colorcorrect" nodegroup="adjustment">
     <input name="in" type="color3" uiname="Input Color" value="1, 1, 1" doc="The input color to be adjusted." />
@@ -2928,7 +2929,7 @@
     <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Linearly increase or decrease the color contrast." />
     <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." />
     <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" value="0" doc="Multplier which increases or decreases color brightness by 2^value." />
-    <output name="out" type="color3" />
+    <output name="out" type="color4" />
   </nodedef>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2901,6 +2901,26 @@
     <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
+  
+  <!--
+    Node: <colorcorrect> Supplemental Node
+    Combines various adjustment nodes into one, artist-friendly color correction node.
+  -->
+  <nodedef name="ND_colorcorrect_color3" node="colorcorrect" nodegroup="adjustment">
+    <input name="in" type="color3" uiname="Input Color" value="1, 1, 1" />
+    <input name="hue" type="float" uiname="Hue" uisoftmin="0.0" uisoftmax="1.0" value="0" />
+    <input name="saturation" type="float" uiname="Saturation" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+    <input name="gamma" type="float" uiname="Gamma" uisoftmin="0.0" uisoftmax="3.0" value="1" />
+    <input name="lift" type="float" uiname="Lift" uisoftmin="0.0" uisoftmax="1.0" value="0" />
+    <input name="gain" type="float" uiname="Gain" uisoftmin="0.0" uisoftmax="1.0" doc="Multiplier increases lighter color values, leaving black values unchanged." value="1" />
+    <input name="contrast" type="float" uiname="Contrast" uisoftmin="0.0" uisoftmax="1.0" doc="Linearly increase or decrease the color contrast." value="1" />
+    <input name="contrastpivot" type="float" uiname="Contrast Pivot" uisoftmin="0.0" uisoftmax="1.0" doc="Pivot value around which contrast applies. This value will not change as contrast is adjusted." value="0.5" />
+    <input name="exposure" type="float" uiname="Exposure" uisoftmin="-1.0" uisoftmax="1.0" doc="Multplier which increases or decreases color brightness by 2^value." value="0" />
+    <output name="out" type="color3" />
+    <output name="r" type="float" />
+    <output name="g" type="float" />
+    <output name="b" type="float" />
+  </nodedef>
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1894,34 +1894,34 @@
   -->
   <nodegraph name="NG_colorcorrect_color3" nodedef="ND_colorcorrect_color3">
     <multiply name="N_exposure" type="color3">
-      <input name="in1" type="color3" nodename="N_contrast" value="0, 0, 0" />
-      <input name="in2" type="float" nodename="N_exposurepwr" value="1" />
+      <input name="in1" type="color3" nodename="N_contrast" />
+      <input name="in2" type="float" nodename="N_exposurepwr" />
     </multiply>
     <output name="out" type="color3" nodename="N_exposure" />
     <contrast name="N_contrast" type="color3">
-      <input name="in" type="color3" nodename="N_gain" value="0, 0, 0" />
-      <input name="amount" type="float" interfacename="contrast" value="1" />
-      <input name="pivot" type="float" interfacename="contrastpivot" value="0.5" />
+      <input name="in" type="color3" nodename="N_gain" />
+      <input name="amount" type="float" interfacename="contrast" />
+      <input name="pivot" type="float" interfacename="contrastpivot" />
     </contrast>
     <power name="N_exposurepwr" type="float">
-      <input name="in2" type="float" interfacename="exposure" value="1" />
+      <input name="in2" type="float" interfacename="exposure" />
       <input name="in1" type="float" value="2" />
     </power>
     <multiply name="N_gain" type="color3">
-      <input name="in1" type="color3" nodename="N_liftadd" value="0, 0, 0" />
-      <input name="in2" type="float" interfacename="gain" value="1" />
+      <input name="in1" type="color3" nodename="N_liftadd" />
+      <input name="in2" type="float" interfacename="gain" />
     </multiply>
     <add name="N_liftadd" type="color3">
-      <input name="in1" type="color3" nodename="N_liftmult" value="0, 0, 0" />
-      <input name="in2" type="float" interfacename="lift" value="0" />
+      <input name="in1" type="color3" nodename="N_liftmult" />
+      <input name="in2" type="float" interfacename="lift" />
     </add>
     <multiply name="N_liftmult" type="color3">
-      <input name="in1" type="color3" nodename="N_gamma" value="0, 0, 0" />
-      <input name="in2" type="float" nodename="N_liftsubtract" value="1" />
+      <input name="in1" type="color3" nodename="N_gamma" />
+      <input name="in2" type="float" nodename="N_liftsubtract" />
     </multiply>
     <range name="N_gamma" type="color3">
-      <input name="in" type="color3" nodename="N_saturation" value="0, 0, 0" />
-      <input name="gamma" type="float" interfacename="gamma" value="1" />
+      <input name="in" type="color3" nodename="N_saturation" />
+      <input name="gamma" type="float" interfacename="gamma" />
       <input name="inlow" type="float" value="0" />
       <input name="inhigh" type="float" value="1" />
       <input name="outlow" type="float" value="0" />
@@ -1929,78 +1929,54 @@
       <input name="doclamp" type="boolean" value="false" />
     </range>
     <subtract name="N_liftsubtract" type="float">
-      <input name="in2" type="float" interfacename="lift" value="0" />
+      <input name="in2" type="float" interfacename="lift"/>
       <input name="in1" type="float" value="1" />
     </subtract>
     <saturate name="N_saturation" type="color3">
-      <input name="in" type="color3" nodename="N_hsvadjust" value="0, 0, 0" />
-      <input name="amount" type="float" interfacename="saturation" value="1" />
-      <input name="lumacoeffs" type="color3" value="0.272229, 0.674082, 0.0536895" />
+      <input name="in" type="color3" nodename="N_hsvadjust" />
+      <input name="amount" type="float" interfacename="saturation"/>
+      <input name="lumacoeffs" type="color3" />
     </saturate>
     <hsvadjust name="N_hsvadjust" type="color3">
-      <input name="in" type="color3" interfacename="in" value="0, 0, 0" />
-      <input name="amount" type="vector3" nodename="N_parm2hue" value="0, 1, 1" />
+      <input name="in" type="color3" interfacename="in" />
+      <input name="amount" type="vector3" nodename="N_parm2hue" />
     </hsvadjust>
     <combine3 name="N_parm2hue" type="vector3">
-      <input name="in1" type="float" interfacename="hue" value="0" />
+      <input name="in1" type="float" interfacename="hue" />
       <input name="in2" type="float" value="1" />
       <input name="in3" type="float" value="1" />
     </combine3>
   </nodegraph>
   <nodegraph name="NG_colorcorrect_color4" nodedef="ND_colorcorrect_color4">
-    <multiply name="N_exposure" type="color4">
-      <input name="in1" type="color4" nodename="N_contrast" value="0, 0, 0, 0" />
-      <input name="in2" type="float" nodename="N_exposurepwr" value="1" />
-    </multiply>
-    <output name="out" type="color4" nodename="N_exposure" />
-    <contrast name="N_contrast" type="color4">
-      <input name="in" type="color4" nodename="N_gain" value="0, 0, 0, 0" />
-      <input name="amount" type="float" interfacename="contrast" value="1" />
-      <input name="pivot" type="float" interfacename="contrastpivot" value="0.5" />
-    </contrast>
-    <power name="N_exposurepwr" type="float">
-      <input name="in2" type="float" interfacename="exposure" value="1" />
-      <input name="in1" type="float" value="2" />
-    </power>
-    <multiply name="N_gain" type="color4">
-      <input name="in1" type="color4" nodename="N_liftadd" value="0, 0, 0, 0" />
-      <input name="in2" type="float" interfacename="gain" value="1" />
-    </multiply>
-    <add name="N_liftadd" type="color4">
-      <input name="in1" type="color4" nodename="N_liftmult" value="0, 0, 0, 0" />
-      <input name="in2" type="float" interfacename="lift" value="0" />
-    </add>
-    <multiply name="N_liftmult" type="color4">
-      <input name="in1" type="color4" nodename="N_gamma" value="0, 0, 0, 0" />
-      <input name="in2" type="float" nodename="N_liftsubtract" value="1" />
-    </multiply>
-    <range name="N_gamma" type="color4">
-      <input name="in" type="color4" nodename="N_saturation" value="0, 0, 0, 0" />
-      <input name="gamma" type="float" interfacename="gamma" value="1" />
-      <input name="inlow" type="float" value="0" />
-      <input name="inhigh" type="float" value="1" />
-      <input name="outlow" type="float" value="0" />
-      <input name="outhigh" type="float" value="1" />
-      <input name="doclamp" type="boolean" value="false" />
-    </range>
-    <subtract name="N_liftsubtract" type="float">
-      <input name="in2" type="float" interfacename="lift" value="0" />
-      <input name="in1" type="float" value="1" />
-    </subtract>
-    <saturate name="N_saturation" type="color4">
-      <input name="in" type="color4" nodename="N_hsvadjust" value="0, 0, 0, 0" />
-      <input name="amount" type="float" interfacename="saturation" value="1" />
-      <input name="lumacoeffs" type="color3" value="0.272229, 0.674082, 0.0536895" />
-    </saturate>
-    <hsvadjust name="N_hsvadjust" type="color4">
-      <input name="in" type="color4" interfacename="in" value="0, 0, 0, 0" />
-      <input name="amount" type="vector3" nodename="N_parm2hue" value="0, 1, 1" />
-    </hsvadjust>
-    <combine3 name="N_parm2hue" type="vector3">
-      <input name="in1" type="float" interfacename="hue" value="0" />
-      <input name="in2" type="float" value="1" />
-      <input name="in3" type="float" value="1" />
+    <output name="out" type="color4" nodename="N_combine_with_alpha" />
+    <separate4 name="N_split_color4" type="multioutput">
+      <input name="in" type="color4" interfacename="in" />
+    </separate4>
+    <combine3 name="N_combine_color" type="color3">
+      <input name="in1" type="float" nodename="N_split_color4" output="outr" />
+      <input name="in2" type="float" nodename="N_split_color4" output="outg" />
+      <input name="in3" type="float" nodename="N_split_color4" output="outb" />
     </combine3>
+    <colorcorrect name="N_colorcorrect" type="color3">
+      <input name="in" type="color3" nodename="N_combine_color" />
+      <input name="hue" type="float" interfacename="hue" />
+      <input name="saturation" type="float" interfacename="saturation" />
+      <input name="gamma" type="float" interfacename="gamma" />
+      <input name="lift" type="float" interfacename="lift" />
+      <input name="gain" type="float" interfacename="gain" />
+      <input name="contrast" type="float" interfacename="contrast" />
+      <input name="contrastpivot" type="float" interfacename="contrastpivot"  />
+      <input name="exposure" type="float" interfacename="exposure" />
+    </colorcorrect>
+    <separate3 name="N_split_color" type="multioutput">
+      <input name="in" type="color3" nodename="N_colorcorrect" />
+    </separate3>
+    <combine4 name="N_combine_with_alpha" type="color4">
+      <input name="in1" type="float" nodename="N_split_color" output="outr" />
+      <input name="in2" type="float" nodename="N_split_color" output="outg" />
+      <input name="in3" type="float" nodename="N_split_color" output="outb" />
+      <input name="in4" type="float" nodename="N_split_color4" output="outa" />
+    </combine4>
   </nodegraph>
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1893,11 +1893,20 @@
     Combines various adjustment nodes into one, artist-friendly color correction node.
   -->
   <nodegraph name="NG_colorcorrect_color3" nodedef="ND_colorcorrect_color3">
+    <input name="in" type="color3" />
+    <input name="hue" type="float" />
+    <input name="saturation" type="float" />
+    <input name="gamma" type="float" />
+    <input name="lift" type="float" />
+    <input name="gain" type="float" />
+    <input name="contrast" type="float" />
+    <input name="contrastpivot" type="float" />
+    <input name="exposure" type="float" />
+    <output name="out" type="color3" nodename="N_exposure" />
     <multiply name="N_exposure" type="color3">
       <input name="in1" type="color3" nodename="N_contrast" />
       <input name="in2" type="float" nodename="N_exposurepwr" />
     </multiply>
-    <output name="out" type="color3" nodename="N_exposure" />
     <contrast name="N_contrast" type="color3">
       <input name="in" type="color3" nodename="N_gain" />
       <input name="amount" type="float" interfacename="contrast" />
@@ -1948,6 +1957,15 @@
     </combine3>
   </nodegraph>
   <nodegraph name="NG_colorcorrect_color4" nodedef="ND_colorcorrect_color4">
+    <input name="in" type="color4" />
+    <input name="hue" type="float" />
+    <input name="saturation" type="float" />
+    <input name="gamma" type="float" />
+    <input name="lift" type="float" />
+    <input name="gain" type="float" />
+    <input name="contrast" type="float" />
+    <input name="contrastpivot" type="float" />
+    <input name="exposure" type="float" />
     <output name="out" type="color4" nodename="N_combine_with_alpha" />
     <separate4 name="N_split_color4" type="multioutput">
       <input name="in" type="color4" interfacename="in" />

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1892,18 +1892,12 @@
     Node: <colorcorrect> Supplemental Node
     Combines various adjustment nodes into one, artist-friendly color correction node.
   -->
-<nodegraph name="NG_colorcorrect_color3" nodedef="ND_colorcorrect_color3">
+  <nodegraph name="NG_colorcorrect_color3" nodedef="ND_colorcorrect_color3">
     <multiply name="N_exposure" type="color3">
       <input name="in1" type="color3" nodename="N_contrast" value="0, 0, 0" />
       <input name="in2" type="float" nodename="N_exposurepwr" value="1" />
     </multiply>
     <output name="out" type="color3" nodename="N_exposure" />
-    <separate3 name="N_mtlxseparate3c1" type="multioutput">
-      <input name="in" type="color3" nodename="N_exposure" value="0, 0, 0" />
-    </separate3>
-    <output name="r" type="float" nodename="N_mtlxseparate3c1" output="outr" />
-    <output name="g" type="float" nodename="N_mtlxseparate3c1" output="outg" />
-    <output name="b" type="float" nodename="N_mtlxseparate3c1" output="outb" />
     <contrast name="N_contrast" type="color3">
       <input name="in" type="color3" nodename="N_gain" value="0, 0, 0" />
       <input name="amount" type="float" interfacename="contrast" value="1" />
@@ -1945,6 +1939,61 @@
     </saturate>
     <hsvadjust name="N_hsvadjust" type="color3">
       <input name="in" type="color3" interfacename="in" value="0, 0, 0" />
+      <input name="amount" type="vector3" nodename="N_parm2hue" value="0, 1, 1" />
+    </hsvadjust>
+    <combine3 name="N_parm2hue" type="vector3">
+      <input name="in1" type="float" interfacename="hue" value="0" />
+      <input name="in2" type="float" value="1" />
+      <input name="in3" type="float" value="1" />
+    </combine3>
+  </nodegraph>
+  <nodegraph name="NG_colorcorrect_color4" nodedef="ND_colorcorrect_color4">
+    <multiply name="N_exposure" type="color4">
+      <input name="in1" type="color4" nodename="N_contrast" value="0, 0, 0, 0" />
+      <input name="in2" type="float" nodename="N_exposurepwr" value="1" />
+    </multiply>
+    <output name="out" type="color4" nodename="N_exposure" />
+    <contrast name="N_contrast" type="color4">
+      <input name="in" type="color4" nodename="N_gain" value="0, 0, 0, 0" />
+      <input name="amount" type="float" interfacename="contrast" value="1" />
+      <input name="pivot" type="float" interfacename="contrastpivot" value="0.5" />
+    </contrast>
+    <power name="N_exposurepwr" type="float">
+      <input name="in2" type="float" interfacename="exposure" value="1" />
+      <input name="in1" type="float" value="2" />
+    </power>
+    <multiply name="N_gain" type="color4">
+      <input name="in1" type="color4" nodename="N_liftadd" value="0, 0, 0, 0" />
+      <input name="in2" type="float" interfacename="gain" value="1" />
+    </multiply>
+    <add name="N_liftadd" type="color4">
+      <input name="in1" type="color4" nodename="N_liftmult" value="0, 0, 0, 0" />
+      <input name="in2" type="float" interfacename="lift" value="0" />
+    </add>
+    <multiply name="N_liftmult" type="color4">
+      <input name="in1" type="color4" nodename="N_gamma" value="0, 0, 0, 0" />
+      <input name="in2" type="float" nodename="N_liftsubtract" value="1" />
+    </multiply>
+    <range name="N_gamma" type="color4">
+      <input name="in" type="color4" nodename="N_saturation" value="0, 0, 0, 0" />
+      <input name="gamma" type="float" interfacename="gamma" value="1" />
+      <input name="inlow" type="float" value="0" />
+      <input name="inhigh" type="float" value="1" />
+      <input name="outlow" type="float" value="0" />
+      <input name="outhigh" type="float" value="1" />
+      <input name="doclamp" type="boolean" value="false" />
+    </range>
+    <subtract name="N_liftsubtract" type="float">
+      <input name="in2" type="float" interfacename="lift" value="0" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <saturate name="N_saturation" type="color4">
+      <input name="in" type="color4" nodename="N_hsvadjust" value="0, 0, 0, 0" />
+      <input name="amount" type="float" interfacename="saturation" value="1" />
+      <input name="lumacoeffs" type="color3" value="0.272229, 0.674082, 0.0536895" />
+    </saturate>
+    <hsvadjust name="N_hsvadjust" type="color4">
+      <input name="in" type="color4" interfacename="in" value="0, 0, 0, 0" />
       <input name="amount" type="vector3" nodename="N_parm2hue" value="0, 1, 1" />
     </hsvadjust>
     <combine3 name="N_parm2hue" type="vector3">

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1887,6 +1887,72 @@
     </mix>
     <output name="out" type="color4" nodename="N_mix_color4" />
   </nodegraph>
+  
+  <!--
+    Node: <colorcorrect> Supplemental Node
+    Combines various adjustment nodes into one, artist-friendly color correction node.
+  -->
+<nodegraph name="NG_colorcorrect_color3" nodedef="ND_colorcorrect_color3">
+    <multiply name="N_exposure" type="color3">
+      <input name="in1" type="color3" nodename="N_contrast" value="0, 0, 0" />
+      <input name="in2" type="float" nodename="N_exposurepwr" value="1" />
+    </multiply>
+    <output name="out" type="color3" nodename="N_exposure" />
+    <separate3 name="N_mtlxseparate3c1" type="multioutput">
+      <input name="in" type="color3" nodename="N_exposure" value="0, 0, 0" />
+    </separate3>
+    <output name="r" type="float" nodename="N_mtlxseparate3c1" output="outr" />
+    <output name="g" type="float" nodename="N_mtlxseparate3c1" output="outg" />
+    <output name="b" type="float" nodename="N_mtlxseparate3c1" output="outb" />
+    <contrast name="N_contrast" type="color3">
+      <input name="in" type="color3" nodename="N_gain" value="0, 0, 0" />
+      <input name="amount" type="float" interfacename="contrast" value="1" />
+      <input name="pivot" type="float" interfacename="contrastpivot" value="0.5" />
+    </contrast>
+    <power name="N_exposurepwr" type="float">
+      <input name="in2" type="float" interfacename="exposure" value="1" />
+      <input name="in1" type="float" value="2" />
+    </power>
+    <multiply name="N_gain" type="color3">
+      <input name="in1" type="color3" nodename="N_liftadd" value="0, 0, 0" />
+      <input name="in2" type="float" interfacename="gain" value="1" />
+    </multiply>
+    <add name="N_liftadd" type="color3">
+      <input name="in1" type="color3" nodename="N_liftmult" value="0, 0, 0" />
+      <input name="in2" type="float" interfacename="lift" value="0" />
+    </add>
+    <multiply name="N_liftmult" type="color3">
+      <input name="in1" type="color3" nodename="N_gamma" value="0, 0, 0" />
+      <input name="in2" type="float" nodename="N_liftsubtract" value="1" />
+    </multiply>
+    <range name="N_gamma" type="color3">
+      <input name="in" type="color3" nodename="N_saturation" value="0, 0, 0" />
+      <input name="gamma" type="float" interfacename="gamma" value="1" />
+      <input name="inlow" type="float" value="0" />
+      <input name="inhigh" type="float" value="1" />
+      <input name="outlow" type="float" value="0" />
+      <input name="outhigh" type="float" value="1" />
+      <input name="doclamp" type="boolean" value="false" />
+    </range>
+    <subtract name="N_liftsubtract" type="float">
+      <input name="in2" type="float" interfacename="lift" value="0" />
+      <input name="in1" type="float" value="1" />
+    </subtract>
+    <saturate name="N_saturation" type="color3">
+      <input name="in" type="color3" nodename="N_hsvadjust" value="0, 0, 0" />
+      <input name="amount" type="float" interfacename="saturation" value="1" />
+      <input name="lumacoeffs" type="color3" value="0.272229, 0.674082, 0.0536895" />
+    </saturate>
+    <hsvadjust name="N_hsvadjust" type="color3">
+      <input name="in" type="color3" interfacename="in" value="0, 0, 0" />
+      <input name="amount" type="vector3" nodename="N_parm2hue" value="0, 1, 1" />
+    </hsvadjust>
+    <combine3 name="N_parm2hue" type="vector3">
+      <input name="in1" type="float" interfacename="hue" value="0" />
+      <input name="in2" type="float" value="1" />
+      <input name="in3" type="float" value="1" />
+    </combine3>
+  </nodegraph>
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->


### PR DESCRIPTION
Wraps up existing adjustment nodes into an artist-friendly color correction node.

Here are some example results from the Houdini docs, using Karma:

![hmtlxcolorcorrect_hue](https://user-images.githubusercontent.com/458856/192065836-d84b140e-9dc8-4d21-883a-f0e7418f1fbd.jpg)
![hmtlxcolorcorrect_exposure](https://user-images.githubusercontent.com/458856/192065838-31c02e3a-dd7c-4c78-9abf-6e674b958633.jpg)
