### PR TITLE
Adds a Unified Noise node

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -983,7 +983,7 @@
     
     The noise types are:
     
-       0 - Noise (noise2d/noise3d)
+       0 - Perlin (noise2d/noise3d)
        1 - Cell (cellnoise2d/cellnoise3d)
        2 - Worley (worley2d/worley3d)
        3 - Fractal (fractal3d)

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -991,18 +991,17 @@
     The output is 1 channel, with controls to adjust the output range.
   -->
   <nodedef name="ND_unifiednoise2d_float" node="unifiednoise2d" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" uifolder="Common" value="0, 0" />
-    <input name="freq" type="vector2" uiname="Frequency" uifolder="Common" value="1, 1" />
-    <input name="offset" type="vector2" uiname="Offset" uifolder="Common" value="0, 0" />
-    <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="outmin" type="float" uiname="Output Min" uifolder="Post Process" value="0" />
-    <input name="outmax" type="float" uiname="Output Max" uifolder="Post Process" value="1" />
-    <input name="outgamma" type="float" uiname="Output Gamma" uifolder="Post Process" uisoftmin="0.0" uisoftmax="3.0" value="1" />
-    <input name="clampoutput" type="boolean" uiname="Clamp Output" uifolder="Post Process" value="true" />
-    <input name="octaves" type="integer" uiname="Octaves" uifolder="Fractal" value="3" />
-    <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" />
-    <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" />
-    <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Noise,Cell,Worley,Fractal" enumvalues="0,1,2,3"/>
+    <input name="texcoord" type="vector2" uifolder="Common" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." />
+    <input name="freq" type="vector2" uiname="Frequency" uifolder="Common" value="1, 1" doc="Adjusts the noise frequency, with higher values producing smaller noise shapes. Default is (1,1)." />
+    <input name="offset" type="vector2" uiname="Offset" uifolder="Common" value="0, 0" doc="Shift the noise in 2d space. Default is (0,0)." />
+    <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjust uniformity of Worley noise; for other noise types jitters the results." />
+    <input name="outmin" type="float" uiname="Output Min" uifolder="Post Process" value="0" doc="The lowest values fit to the noise. Default is 0.0." />
+    <input name="outmax" type="float" uiname="Output Max" uifolder="Post Process" value="1" doc="The highest values fit to the noise. Default is 1.0." />
+    <input name="clampoutput" type="boolean" uiname="Clamp Output" uifolder="Post Process" value="true" doc="Clamp the output to the min and max output values." />
+    <input name="octaves" type="integer" uiname="Octaves" uifolder="Fractal" value="3" doc="The number of octaves of Fractal noise to be generated. Default is 3." />
+    <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" doc="The exponential scale between successive octaves of Fractal noise. Default is 2.0." />
+    <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="The rate at which noise amplitude is diminished for each octave of Fractal noise. Default is 0.5." />
+    <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Perlin,Cell,Worley,Fractal" enumvalues="0,1,2,3" doc="Menu to select the type of noise: Perlin, Cell, Worley, or Fractal. Default is Perlin." />
     <output name="out" type="float" />
   </nodedef>
   
@@ -1011,18 +1010,17 @@
     The 3d flavor of <unifiednoise2d>.
   -->
   <nodedef name="ND_unifiednoise3d_float" node="unifiednoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" uifolder="Common" value="0, 0, 0" />
-    <input name="freq" type="vector3" uiname="Frequency" uifolder="Common" value="1, 1, 1" />
-    <input name="offset" type="vector3" uiname="Offset" uifolder="Common" value="0, 0, 0" />
-    <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" />
-    <input name="outmin" type="float" uiname="Output Min" uifolder="Post Process" value="0" />
-    <input name="outmax" type="float" uiname="Output Max" uifolder="Post Process" value="1" />
-    <input name="outgamma" type="float" uiname="Output Gamma" uifolder="Post Process" uisoftmin="0.0" uisoftmax="3.0" value="1" />
-    <input name="clampoutput" type="boolean" uiname="Clamp Output" uifolder="Post Process" value="true" />
-    <input name="octaves" type="integer" uiname="Octaves" uifolder="Fractal" value="3" />
-    <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" />
-    <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" />
-    <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Noise,Cell,Worley,Fractal" enumvalues="0,1,2,3"/>
+    <input name="position" type="vector3" uifolder="Common" defaultgeomprop="Pobject" doc="The input 3d space. Default is position in object-space." />
+    <input name="freq" type="vector3" uiname="Frequency" uifolder="Common" value="1, 1, 1" doc="Adjusts the noise frequency, with higher values producing smaller noise shapes. Default is (1,1,1)." />
+    <input name="offset" type="vector3" uiname="Offset" uifolder="Common" value="0, 0, 0" doc="Shift the noise in 3d space. Default is (0,0,0)." />
+    <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjust uniformity of Worley noise; for other noise types jitters the results." />
+    <input name="outmin" type="float" uiname="Output Min" uifolder="Post Process" value="0" doc="The lowest values fit to the noise. Default is 0.0." />
+    <input name="outmax" type="float" uiname="Output Max" uifolder="Post Process" value="1" doc="The highest values fit to the noise. Default is 1.0." />
+    <input name="clampoutput" type="boolean" uiname="Clamp Output" uifolder="Post Process" value="true" doc="Clamp the output to the min and max output values." />
+    <input name="octaves" type="integer" uiname="Octaves" uifolder="Fractal" value="3" doc="The number of octaves of Fractal noise to be generated. Default is 3." />
+    <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" doc="The exponential scale between successive octaves of Fractal noise. Default is 2.0." />
+    <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="The rate at which noise amplitude is diminished for each octave of Fractal noise. Default is 0.5." />
+    <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Perlin,Cell,Worley,Fractal" enumvalues="0,1,2,3" doc="Menu to select the type of noise: Perlin, Cell, Worley, or Fractal. Default is Perlin." />
     <output name="out" type="float" />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -973,6 +973,59 @@
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
 
+  <!--
+    Node: <unifiednoise2d>
+    Combines the available noises into an artist-friendly node, adding controls
+    to adjust frequency, offset, jitter, etc... Where possible controls have
+    been unified between noises; any noise-specific controls should live in a
+    dedicated folder. These folders should be hidden by artist tools, unless their
+    corresponding noise type is selected.
+    
+    The noise types are:
+    
+       0 - Noise (noise2d/noise3d)
+       1 - Cell (cellnoise2d/cellnoise3d)
+       2 - Worley (worley2d/worley3d)
+       3 - Fractal (fractal3d)
+    
+    The output is 1 channel, with controls to adjust the output range.
+  -->
+  <nodedef name="ND_unifiednoise2d_float" node="unifiednoise2d" nodegroup="procedural2d">
+    <input name="texcoord" type="vector2" uifolder="Common" value="0, 0" />
+    <input name="freq" type="vector2" uiname="Frequency" uifolder="Common" value="1, 1" />
+    <input name="offset" type="vector2" uiname="Offset" uifolder="Common" value="0, 0" />
+    <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+    <input name="outmin" type="float" uiname="Output Min" uifolder="Post Process" value="0" />
+    <input name="outmax" type="float" uiname="Output Max" uifolder="Post Process" value="1" />
+    <input name="outgamma" type="float" uiname="Output Gamma" uifolder="Post Process" uisoftmin="0.0" uisoftmax="3.0" value="1" />
+    <input name="clampoutput" type="boolean" uiname="Clamp Output" uifolder="Post Process" value="true" />
+    <input name="octaves" type="integer" uiname="Octaves" uifolder="Fractal" value="3" />
+    <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" />
+    <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" />
+    <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Noise,Cell,Worley,Fractal" enumvalues="0,1,2,3"/>
+    <output name="out" type="float" />
+  </nodedef>
+  
+  <!--
+    Node: <unifiednoise3d>
+    The 3d flavor of <unifiednoise2d>.
+  -->
+  <nodedef name="ND_unifiednoise3d_float" node="unifiednoise3d" nodegroup="procedural3d">
+    <input name="position" type="vector3" uifolder="Common" value="0, 0, 0" />
+    <input name="freq" type="vector3" uiname="Frequency" uifolder="Common" value="1, 1, 1" />
+    <input name="offset" type="vector3" uiname="Offset" uifolder="Common" value="0, 0, 0" />
+    <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" />
+    <input name="outmin" type="float" uiname="Output Min" uifolder="Post Process" value="0" />
+    <input name="outmax" type="float" uiname="Output Max" uifolder="Post Process" value="1" />
+    <input name="outgamma" type="float" uiname="Output Gamma" uifolder="Post Process" uisoftmin="0.0" uisoftmax="3.0" value="1" />
+    <input name="clampoutput" type="boolean" uiname="Clamp Output" uifolder="Post Process" value="true" />
+    <input name="octaves" type="integer" uiname="Octaves" uifolder="Fractal" value="3" />
+    <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" />
+    <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" />
+    <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Noise,Cell,Worley,Fractal" enumvalues="0,1,2,3"/>
+    <output name="out" type="float" />
+  </nodedef>
+
   <!-- ======================================================================== -->
   <!-- Geometric nodes                                                          -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1032,16 +1032,26 @@
     Combined 2d noises for artists.
   -->
   <nodegraph name="NG_unifiednoise2d_float" nodedef="ND_unifiednoise2d_float">
+    <input name="texcoord" type="vector2" />
+    <input name="freq" type="vector2" />
+    <input name="offset" type="vector2" />
+    <input name="jitter" type="float" />
+    <input name="outmin" type="float" />
+    <input name="outmax" type="float" />
+    <input name="clampoutput" type="boolean" />
+    <input name="octaves" type="integer" />
+    <input name="lacunarity" type="float" />
+    <input name="diminish" type="float" />
+    <input name="type" type="integer" />
+    <output name="out" type="float" nodename="N_range" />
     <range name="N_range" type="float">
       <input name="in" type="float" nodename="N_switch_type" />
-      <input name="gamma" type="float" interfacename="outgamma" />
       <input name="outlow" type="float" interfacename="outmin" />
       <input name="outhigh" type="float" interfacename="outmax" />
       <input name="doclamp" type="boolean" interfacename="clampoutput" />
       <input name="inlow" type="float" value="0" />
       <input name="inhigh" type="float" value="1" />
     </range>
-    <output name="out" type="float" nodename="N_range" />
     <switch name="N_switch_type" type="float">
       <input name="in1" type="float" nodename="N_perlin_noise2d" />
       <input name="in2" type="float" nodename="N_cellnoise2d" />
@@ -1103,16 +1113,26 @@
     Combined 3d noises for artists.
   -->
   <nodegraph name="NG_unifiednoise3d_float" nodedef="ND_unifiednoise3d_float">
+    <input name="texcoord" type="vector2" />
+    <input name="freq" type="vector2" />
+    <input name="offset" type="vector2" />
+    <input name="jitter" type="float" />
+    <input name="outmin" type="float" />
+    <input name="outmax" type="float" />
+    <input name="clampoutput" type="boolean" />
+    <input name="octaves" type="integer" />
+    <input name="lacunarity" type="float" />
+    <input name="diminish" type="float" />
+    <input name="type" type="integer" />
+    <output name="out" type="float" nodename="N_range" />
     <range name="N_range" type="float">
       <input name="in" type="float" nodename="N_switch_type" />
-      <input name="gamma" type="float" interfacename="outgamma" />
       <input name="outlow" type="float" interfacename="outmin" />
       <input name="outhigh" type="float" interfacename="outmax" />
       <input name="doclamp" type="boolean" interfacename="clampoutput" />
       <input name="inlow" type="float" value="0" />
       <input name="inhigh" type="float" value="1" />
     </range>
-    <output name="out" type="float" nodename="N_range" />
     <switch name="N_switch_type" type="float">
       <input name="in1" type="float" nodename="N_perlin_noise3d" />
       <input name="in2" type="float" nodename="N_cellnoise3d" />

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1026,6 +1026,143 @@
     </mix>
     <output name="out" type="vector4" nodename="N_mix_vector4" />
   </nodegraph>
+  
+  <!--
+    <unifiednoise2d>
+    Combined 2d noises for artists.
+  -->
+  <nodegraph name="NG_unifiednoise2d_float" nodedef="ND_unifiednoise2d_float">
+    <range name="N_range" type="float">
+      <input name="in" type="float" nodename="N_switch_type" value="0" />
+      <input name="gamma" type="float" interfacename="outgamma" value="1" />
+      <input name="outlow" type="float" interfacename="outmin" value="0" />
+      <input name="outhigh" type="float" interfacename="outmax" value="1" />
+      <input name="doclamp" type="boolean" interfacename="clampoutput" value="true" />
+      <input name="inlow" type="float" value="0" />
+      <input name="inhigh" type="float" value="1" />
+    </range>
+    <output name="out" type="float" nodename="N_range" />
+    <switch name="N_switch_type" type="float">
+      <input name="in1" type="float" nodename="N_perlin_noise2d" value="0" />
+      <input name="in2" type="float" nodename="N_cellnoise2d" value="0" />
+      <input name="in3" type="float" nodename="N_worleynoise2d" value="0" />
+      <input name="in4" type="float" nodename="N_fractal3d" value="1" />
+      <input name="which" type="integer" interfacename="type" value="0" />
+      <input name="in5" type="float" value="0" />
+    </switch>
+    <noise2d name="N_perlin_noise2d" type="float">
+      <input name="texcoord" type="vector2" nodename="N_apply_cell_jitter" value="0, 0" />
+      <input name="amplitude" type="float" value="0.5" />
+      <input name="pivot" type="float" value="0.5" />
+    </noise2d>
+    <cellnoise2d name="N_cellnoise2d" type="float">
+      <input name="texcoord" type="vector2" nodename="N_apply_cell_jitter" value="0, 0" />
+    </cellnoise2d>
+    <worleynoise2d name="N_worleynoise2d" type="float">
+      <input name="texcoord" type="vector2" nodename="N_apply_offset" value="0, 0" />
+      <input name="jitter" type="float" interfacename="jitter" value="1" />
+    </worleynoise2d>
+    <fractal3d name="N_fractal3d" type="float">
+      <input name="octaves" type="integer" interfacename="octaves" value="3" />
+      <input name="lacunarity" type="float" interfacename="lacunarity" value="2" />
+      <input name="diminish" type="float" interfacename="diminish" value="0.5" />
+      <input name="position" type="vector3" nodename="N_combine_with_jitter" value="0, 0, 0" />
+      <input name="amplitude" type="float" value="1" />
+    </fractal3d>
+    <rotate2d name="N_apply_cell_jitter" type="vector2">
+      <input name="in" type="vector2" nodename="N_apply_offset" value="0, 0" />
+      <input name="amount" type="float" nodename="N_cell_jitter_mult" value="0" />
+    </rotate2d>
+    <add name="N_apply_offset" type="vector2">
+      <input name="in1" type="vector2" nodename="N_apply_freq" value="0, 0" />
+      <input name="in2" type="vector2" interfacename="offset" value="0, 0" />
+    </add>
+    <combine3 name="N_combine_with_jitter" type="vector3">
+      <input name="in1" type="float" nodename="N_separate" output="outx" value="0" />
+      <input name="in2" type="float" nodename="N_separate" output="outy" value="0" />
+      <input name="in3" type="float" nodename="N_cell_jitter_mult" value="0" />
+    </combine3>
+    <multiply name="N_cell_jitter_mult" type="float">
+      <input name="in1" type="float" nodename="N_jitter_minus_1" value="0" />
+      <input name="in2" type="float" value="90000" />
+    </multiply>
+    <multiply name="N_apply_freq" type="vector2">
+      <input name="in1" type="vector2" interfacename="texcoord" value="0, 0" />
+      <input name="in2" type="vector2" interfacename="freq" value="1, 1" />
+    </multiply>
+    <separate2 name="N_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="N_apply_offset" value="0, 0" />
+    </separate2>
+    <subtract name="N_jitter_minus_1" type="float">
+      <input name="in1" type="float" interfacename="jitter" value="0" />
+      <input name="in2" type="float" value="1" />
+    </subtract>
+  </nodegraph>
+  
+  <!--
+    <unifiednoise3d>
+    Combined 3d noises for artists.
+  -->
+  <nodegraph name="NG_unifiednoise3d_float" nodedef="ND_unifiednoise3d_float">
+    <range name="N_range" type="float">
+      <input name="in" type="float" nodename="N_switch_type" value="0" />
+      <input name="gamma" type="float" interfacename="outgamma" value="1" />
+      <input name="outlow" type="float" interfacename="outmin" value="0" />
+      <input name="outhigh" type="float" interfacename="outmax" value="1" />
+      <input name="doclamp" type="boolean" interfacename="clampoutput" value="true" />
+      <input name="inlow" type="float" value="0" />
+      <input name="inhigh" type="float" value="1" />
+    </range>
+    <output name="out" type="float" nodename="N_range" />
+    <switch name="N_switch_type" type="float">
+      <input name="in1" type="float" nodename="N_perlin_noise3d" value="0" />
+      <input name="in2" type="float" nodename="N_cellnoise3d" value="0" />
+      <input name="in3" type="float" nodename="N_worleynoise3d" value="0" />
+      <input name="in4" type="float" nodename="N_fractal3d" value="1" />
+      <input name="which" type="integer" interfacename="type" value="0" />
+      <input name="in5" type="float" value="0" />
+    </switch>
+    <noise3d name="N_perlin_noise3d" type="float">
+      <input name="position" type="vector3" nodename="N_apply_cell_jitter" value="0, 0, 0" />
+      <input name="amplitude" type="float" value="0.5" />
+      <input name="pivot" type="float" value="0.5" />
+    </noise3d>
+    <cellnoise3d name="N_cellnoise3d" type="float">
+      <input name="position" type="vector3" nodename="N_apply_cell_jitter" value="0, 0, 0" />
+    </cellnoise3d>
+    <worleynoise3d name="N_worleynoise3d" type="float">
+      <input name="position" type="vector3" nodename="N_apply_offset" value="0, 0, 0" />
+      <input name="jitter" type="float" interfacename="jitter" value="1" />
+    </worleynoise3d>
+    <fractal3d name="N_fractal3d" type="float">
+      <input name="octaves" type="integer" interfacename="octaves" value="3" />
+      <input name="lacunarity" type="float" interfacename="lacunarity" value="2" />
+      <input name="diminish" type="float" interfacename="diminish" value="0.5" />
+      <input name="position" type="vector3" nodename="N_apply_cell_jitter" value="0, 0, 0" />
+      <input name="amplitude" type="float" value="1" />
+    </fractal3d>
+    <rotate3d name="N_apply_cell_jitter" type="vector3">
+      <input name="in" type="vector3" nodename="N_apply_offset" value="0, 0, 0" />
+      <input name="amount" type="float" nodename="N_cell_jitter_mult" value="0" />
+      <input name="axis" type="vector3" value="0.1, 1, 0" />
+    </rotate3d>
+    <add name="N_apply_offset" type="vector3">
+      <input name="in1" type="vector3" nodename="N_apply_freq" value="0, 0, 0" />
+      <input name="in2" type="vector3" interfacename="offset" value="0, 0, 0" />
+    </add>
+    <multiply name="N_cell_jitter_mult" type="float">
+      <input name="in1" type="float" nodename="N_jitter_minus_one" value="0" />
+      <input name="in2" type="float" value="90000" />
+    </multiply>
+    <multiply name="N_apply_freq" type="vector3">
+      <input name="in1" type="vector3" interfacename="position" value="0, 0, 0" />
+      <input name="in2" type="vector3" interfacename="freq" value="1, 1, 1" />
+    </multiply>
+    <subtract name="N_jitter_minus_one" type="float">
+      <input name="in1" type="float" interfacename="jitter" value="0" />
+      <input name="in2" type="float" value="1" />
+    </subtract>
+  </nodegraph>
 
   <!-- ======================================================================== -->
   <!-- Geometric nodes                                                          -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1113,9 +1113,9 @@
     Combined 3d noises for artists.
   -->
   <nodegraph name="NG_unifiednoise3d_float" nodedef="ND_unifiednoise3d_float">
-    <input name="texcoord" type="vector2" />
-    <input name="freq" type="vector2" />
-    <input name="offset" type="vector2" />
+    <input name="position" type="vector3" />
+    <input name="freq" type="vector3" />
+    <input name="offset" type="vector3" />
     <input name="jitter" type="float" />
     <input name="outmin" type="float" />
     <input name="outmax" type="float" />

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1033,68 +1033,67 @@
   -->
   <nodegraph name="NG_unifiednoise2d_float" nodedef="ND_unifiednoise2d_float">
     <range name="N_range" type="float">
-      <input name="in" type="float" nodename="N_switch_type" value="0" />
-      <input name="gamma" type="float" interfacename="outgamma" value="1" />
-      <input name="outlow" type="float" interfacename="outmin" value="0" />
-      <input name="outhigh" type="float" interfacename="outmax" value="1" />
-      <input name="doclamp" type="boolean" interfacename="clampoutput" value="true" />
+      <input name="in" type="float" nodename="N_switch_type" />
+      <input name="gamma" type="float" interfacename="outgamma" />
+      <input name="outlow" type="float" interfacename="outmin" />
+      <input name="outhigh" type="float" interfacename="outmax" />
+      <input name="doclamp" type="boolean" interfacename="clampoutput" />
       <input name="inlow" type="float" value="0" />
       <input name="inhigh" type="float" value="1" />
     </range>
     <output name="out" type="float" nodename="N_range" />
     <switch name="N_switch_type" type="float">
-      <input name="in1" type="float" nodename="N_perlin_noise2d" value="0" />
-      <input name="in2" type="float" nodename="N_cellnoise2d" value="0" />
-      <input name="in3" type="float" nodename="N_worleynoise2d" value="0" />
-      <input name="in4" type="float" nodename="N_fractal3d" value="1" />
-      <input name="which" type="integer" interfacename="type" value="0" />
-      <input name="in5" type="float" value="0" />
+      <input name="in1" type="float" nodename="N_perlin_noise2d" />
+      <input name="in2" type="float" nodename="N_cellnoise2d" />
+      <input name="in3" type="float" nodename="N_worleynoise2d" />
+      <input name="in4" type="float" nodename="N_fractal3d" />
+      <input name="which" type="integer" interfacename="type" />
     </switch>
     <noise2d name="N_perlin_noise2d" type="float">
-      <input name="texcoord" type="vector2" nodename="N_apply_cell_jitter" value="0, 0" />
+      <input name="texcoord" type="vector2" nodename="N_apply_cell_jitter" />
       <input name="amplitude" type="float" value="0.5" />
       <input name="pivot" type="float" value="0.5" />
     </noise2d>
     <cellnoise2d name="N_cellnoise2d" type="float">
-      <input name="texcoord" type="vector2" nodename="N_apply_cell_jitter" value="0, 0" />
+      <input name="texcoord" type="vector2" nodename="N_apply_cell_jitter" />
     </cellnoise2d>
     <worleynoise2d name="N_worleynoise2d" type="float">
-      <input name="texcoord" type="vector2" nodename="N_apply_offset" value="0, 0" />
-      <input name="jitter" type="float" interfacename="jitter" value="1" />
+      <input name="texcoord" type="vector2" nodename="N_apply_offset" />
+      <input name="jitter" type="float" interfacename="jitter" />
     </worleynoise2d>
     <fractal3d name="N_fractal3d" type="float">
-      <input name="octaves" type="integer" interfacename="octaves" value="3" />
-      <input name="lacunarity" type="float" interfacename="lacunarity" value="2" />
-      <input name="diminish" type="float" interfacename="diminish" value="0.5" />
-      <input name="position" type="vector3" nodename="N_combine_with_jitter" value="0, 0, 0" />
+      <input name="octaves" type="integer" interfacename="octaves" />
+      <input name="lacunarity" type="float" interfacename="lacunarity" />
+      <input name="diminish" type="float" interfacename="diminish" />
+      <input name="position" type="vector3" nodename="N_combine_with_jitter" />
       <input name="amplitude" type="float" value="1" />
     </fractal3d>
     <rotate2d name="N_apply_cell_jitter" type="vector2">
-      <input name="in" type="vector2" nodename="N_apply_offset" value="0, 0" />
-      <input name="amount" type="float" nodename="N_cell_jitter_mult" value="0" />
+      <input name="in" type="vector2" nodename="N_apply_offset" />
+      <input name="amount" type="float" nodename="N_cell_jitter_mult" />
     </rotate2d>
     <add name="N_apply_offset" type="vector2">
-      <input name="in1" type="vector2" nodename="N_apply_freq" value="0, 0" />
-      <input name="in2" type="vector2" interfacename="offset" value="0, 0" />
+      <input name="in1" type="vector2" nodename="N_apply_freq" />
+      <input name="in2" type="vector2" interfacename="offset" />
     </add>
     <combine3 name="N_combine_with_jitter" type="vector3">
-      <input name="in1" type="float" nodename="N_separate" output="outx" value="0" />
-      <input name="in2" type="float" nodename="N_separate" output="outy" value="0" />
-      <input name="in3" type="float" nodename="N_cell_jitter_mult" value="0" />
+      <input name="in1" type="float" nodename="N_separate" output="outx" />
+      <input name="in2" type="float" nodename="N_separate" output="outy" />
+      <input name="in3" type="float" nodename="N_cell_jitter_mult" />
     </combine3>
     <multiply name="N_cell_jitter_mult" type="float">
-      <input name="in1" type="float" nodename="N_jitter_minus_1" value="0" />
+      <input name="in1" type="float" nodename="N_jitter_minus_1" />
       <input name="in2" type="float" value="90000" />
     </multiply>
     <multiply name="N_apply_freq" type="vector2">
-      <input name="in1" type="vector2" interfacename="texcoord" value="0, 0" />
-      <input name="in2" type="vector2" interfacename="freq" value="1, 1" />
+      <input name="in1" type="vector2" interfacename="texcoord" />
+      <input name="in2" type="vector2" interfacename="freq" />
     </multiply>
     <separate2 name="N_separate" type="multioutput">
-      <input name="in" type="vector2" nodename="N_apply_offset" value="0, 0" />
+      <input name="in" type="vector2" nodename="N_apply_offset" />
     </separate2>
     <subtract name="N_jitter_minus_1" type="float">
-      <input name="in1" type="float" interfacename="jitter" value="0" />
+      <input name="in1" type="float" interfacename="jitter" />
       <input name="in2" type="float" value="1" />
     </subtract>
   </nodegraph>
@@ -1105,61 +1104,60 @@
   -->
   <nodegraph name="NG_unifiednoise3d_float" nodedef="ND_unifiednoise3d_float">
     <range name="N_range" type="float">
-      <input name="in" type="float" nodename="N_switch_type" value="0" />
-      <input name="gamma" type="float" interfacename="outgamma" value="1" />
-      <input name="outlow" type="float" interfacename="outmin" value="0" />
-      <input name="outhigh" type="float" interfacename="outmax" value="1" />
-      <input name="doclamp" type="boolean" interfacename="clampoutput" value="true" />
+      <input name="in" type="float" nodename="N_switch_type" />
+      <input name="gamma" type="float" interfacename="outgamma" />
+      <input name="outlow" type="float" interfacename="outmin" />
+      <input name="outhigh" type="float" interfacename="outmax" />
+      <input name="doclamp" type="boolean" interfacename="clampoutput" />
       <input name="inlow" type="float" value="0" />
       <input name="inhigh" type="float" value="1" />
     </range>
     <output name="out" type="float" nodename="N_range" />
     <switch name="N_switch_type" type="float">
-      <input name="in1" type="float" nodename="N_perlin_noise3d" value="0" />
-      <input name="in2" type="float" nodename="N_cellnoise3d" value="0" />
-      <input name="in3" type="float" nodename="N_worleynoise3d" value="0" />
-      <input name="in4" type="float" nodename="N_fractal3d" value="1" />
-      <input name="which" type="integer" interfacename="type" value="0" />
-      <input name="in5" type="float" value="0" />
+      <input name="in1" type="float" nodename="N_perlin_noise3d" />
+      <input name="in2" type="float" nodename="N_cellnoise3d" />
+      <input name="in3" type="float" nodename="N_worleynoise3d" />
+      <input name="in4" type="float" nodename="N_fractal3d" />
+      <input name="which" type="integer" interfacename="type" />
     </switch>
     <noise3d name="N_perlin_noise3d" type="float">
-      <input name="position" type="vector3" nodename="N_apply_cell_jitter" value="0, 0, 0" />
+      <input name="position" type="vector3" nodename="N_apply_cell_jitter" />
       <input name="amplitude" type="float" value="0.5" />
       <input name="pivot" type="float" value="0.5" />
     </noise3d>
     <cellnoise3d name="N_cellnoise3d" type="float">
-      <input name="position" type="vector3" nodename="N_apply_cell_jitter" value="0, 0, 0" />
+      <input name="position" type="vector3" nodename="N_apply_cell_jitter" />
     </cellnoise3d>
     <worleynoise3d name="N_worleynoise3d" type="float">
-      <input name="position" type="vector3" nodename="N_apply_offset" value="0, 0, 0" />
-      <input name="jitter" type="float" interfacename="jitter" value="1" />
+      <input name="position" type="vector3" nodename="N_apply_offset" />
+      <input name="jitter" type="float" interfacename="jitter" />
     </worleynoise3d>
     <fractal3d name="N_fractal3d" type="float">
-      <input name="octaves" type="integer" interfacename="octaves" value="3" />
-      <input name="lacunarity" type="float" interfacename="lacunarity" value="2" />
-      <input name="diminish" type="float" interfacename="diminish" value="0.5" />
-      <input name="position" type="vector3" nodename="N_apply_cell_jitter" value="0, 0, 0" />
+      <input name="octaves" type="integer" interfacename="octaves" />
+      <input name="lacunarity" type="float" interfacename="lacunarity" />
+      <input name="diminish" type="float" interfacename="diminish" />
+      <input name="position" type="vector3" nodename="N_apply_cell_jitter" />
       <input name="amplitude" type="float" value="1" />
     </fractal3d>
     <rotate3d name="N_apply_cell_jitter" type="vector3">
-      <input name="in" type="vector3" nodename="N_apply_offset" value="0, 0, 0" />
-      <input name="amount" type="float" nodename="N_cell_jitter_mult" value="0" />
+      <input name="in" type="vector3" nodename="N_apply_offset" />
+      <input name="amount" type="float" nodename="N_cell_jitter_mult" />
       <input name="axis" type="vector3" value="0.1, 1, 0" />
     </rotate3d>
     <add name="N_apply_offset" type="vector3">
-      <input name="in1" type="vector3" nodename="N_apply_freq" value="0, 0, 0" />
-      <input name="in2" type="vector3" interfacename="offset" value="0, 0, 0" />
+      <input name="in1" type="vector3" nodename="N_apply_freq" />
+      <input name="in2" type="vector3" interfacename="offset" />
     </add>
     <multiply name="N_cell_jitter_mult" type="float">
-      <input name="in1" type="float" nodename="N_jitter_minus_one" value="0" />
+      <input name="in1" type="float" nodename="N_jitter_minus_one" />
       <input name="in2" type="float" value="90000" />
     </multiply>
     <multiply name="N_apply_freq" type="vector3">
-      <input name="in1" type="vector3" interfacename="position" value="0, 0, 0" />
-      <input name="in2" type="vector3" interfacename="freq" value="1, 1, 1" />
+      <input name="in1" type="vector3" interfacename="position" />
+      <input name="in2" type="vector3" interfacename="freq" />
     </multiply>
     <subtract name="N_jitter_minus_one" type="float">
-      <input name="in1" type="float" interfacename="jitter" value="0" />
+      <input name="in1" type="float" interfacename="jitter" />
       <input name="in2" type="float" value="1" />
     </subtract>
   </nodegraph>


### PR DESCRIPTION
Adds a unified noise node, for artists to have a single noise node that unifies shared controls (such as frequency and offset).  A common complaint we hear from artists, is the MaterialX noises are too bare, they are missing the very basics of frequency/offset, and even some post-processing, which requires creating all sorts of nodes. Rather than modify all of the existing noises, it seemed a slightly higher-level node to encompass shared features made more sense (and would be easier to adopt).

Jitter is treated as a common control; it behaves like jitter does on the standard worley noise, and for the non-Worley noises it scrambles the input. The fractal controls are unique to that particular noise type, so an artist tool would probably hide those parameters when the noise type is not set to fractal.

Thanks!

![unifiednoise_nodes](https://user-images.githubusercontent.com/458856/192576523-0dc692d1-2bde-444b-8bd7-60ea760d3837.png)