### PR TITLE
Change glTF PBR version from 0.0.1 to 2.0.1

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -758,7 +758,7 @@
       <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
       <input name="scale" type="vector2" nodename="invert_scale" value="1, 1" />
       <input name="rotate" type="float" nodename="negate_rotate" />
-      <input name="offset" type="vector2" nodename ="negate_offset" />
+      <input name="offset" type="vector2" nodename="negate_offset" />
       <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
     </place2d>
     <output name="out" type="vector3" nodename="normalmap" />

--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -30,6 +30,7 @@
   </nodedef>
 
   <nodegraph name="IMPL_gltf_pbr_surfaceshader" nodedef="ND_gltf_pbr_surfaceshader">
+
     <!-- Volume -->
 
     <convert name="attenuation_color_vec" type="vector3">
@@ -295,7 +296,7 @@
     <dielectric_bsdf name="clearcoat_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="clearcoat" />
       <input name="roughness" type="vector2" nodename="clearcoat_roughness_uv" />
-      <input name="ior" type="float" value="1.5"/>
+      <input name="ior" type="float" value="1.5" />
       <input name="normal" type="vector3" interfacename="clearcoat_normal" />
     </dielectric_bsdf>
 
@@ -361,8 +362,8 @@
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" uifolder="Image" />
     <input name="offset" type="vector2" value="0, 0" uifolder="Image" />
     <input name="operationorder" type="integer" value="1" uifolder="Image" />
-    <input name="uaddressmode" type="string" uniform="true" value="periodic" enum="constant,clamp,periodic,mirror" uifolder="Image"/>
-    <input name="vaddressmode" type="string" uniform="true" value="periodic" enum="constant,clamp,periodic,mirror" uifolder="Image"/>
+    <input name="uaddressmode" type="string" uniform="true" value="periodic" enum="constant,clamp,periodic,mirror" uifolder="Image" />
+    <input name="vaddressmode" type="string" uniform="true" value="periodic" enum="constant,clamp,periodic,mirror" uifolder="Image" />
     <input name="filtertype" type="string" uniform="true" value="linear" enum="closest,linear,cubic" uifolder="Image" />
     <input name="color" type="color4" value="1, 1, 1, 1" uifolder="Color" />
     <input name="geomcolor" type="color4" value="1, 1, 1, 1" uifolder="Color" uiname="Geometry Color" />
@@ -370,7 +371,7 @@
     <output name="outa" type="float" value="0" />
   </nodedef>
 
-  <nodegraph name="NG_gltf_colorimage" nodedef="ND_gltf_colorimage" >
+  <nodegraph name="NG_gltf_colorimage" nodedef="ND_gltf_colorimage">
     <input name="file" type="filename" uniform="true" value="" />
     <input name="default" type="color4" value="0, 0, 0, 0" />
     <input name="uvindex" type="integer" value="0" />
@@ -387,7 +388,7 @@
     <texcoord name="texcoord1" type="vector2">
       <input name="index" type="integer" uniform="true" interfacename="uvindex" />
     </texcoord>
-    <gltf_image name="image" type="color4" >
+    <gltf_image name="image" type="color4">
       <input name="file" type="filename" uniform="true" interfacename="file" value="" />
       <input name="default" type="color4" interfacename="default" value="0, 0, 0, 0" />
       <input name="uvindex" type="integer" interfacename="uvindex" />
@@ -467,16 +468,16 @@
       <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
     </image>
     <divide name="invert_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0"/>
-      <input name="in2" type="vector2" interfacename="scale"/>
+      <input name="in1" type="vector2" value="1.0, 1.0" />
+      <input name="in2" type="vector2" interfacename="scale" />
     </divide>
     <multiply name="negate_rotate" type="float">
-      <input name="in1" type="float" interfacename="rotate"/>
-      <input name="in2" type="float" value="-1.0"/>
+      <input name="in1" type="float" interfacename="rotate" />
+      <input name="in2" type="float" value="-1.0" />
     </multiply>
     <multiply name="negate_offset" type="vector2">
-      <input name="in1" type="vector2" interfacename="offset"/>
-      <input name="in2" type="vector2" value="-1.0, 1.0"/>
+      <input name="in1" type="vector2" interfacename="offset" />
+      <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
@@ -537,23 +538,23 @@
       <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
     </image>
     <divide name="invert_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0"/>
-      <input name="in2" type="vector2" interfacename="scale"/>
+      <input name="in1" type="vector2" value="1.0, 1.0" />
+      <input name="in2" type="vector2" interfacename="scale" />
     </divide>
     <multiply name="negate_rotate" type="float">
-      <input name="in1" type="float" interfacename="rotate"/>
-      <input name="in2" type="float" value="-1.0"/>
+      <input name="in1" type="float" interfacename="rotate" />
+      <input name="in2" type="float" value="-1.0" />
     </multiply>
     <multiply name="negate_offset" type="vector2">
-      <input name="in1" type="vector2" interfacename="offset"/>
-      <input name="in2" type="vector2" value="-1.0, 1.0"/>
+      <input name="in1" type="vector2" interfacename="offset" />
+      <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
       <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
-      <input name="offset" type="vector2" nodename="negate_offset"/>
+      <input name="offset" type="vector2" nodename="negate_offset" />
       <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
     </place2d>
     <multiply name="scale_image" type="color4">
@@ -607,16 +608,16 @@
       <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
     </image>
     <divide name="invert_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0"/>
-      <input name="in2" type="vector2" interfacename="scale"/>
+      <input name="in1" type="vector2" value="1.0, 1.0" />
+      <input name="in2" type="vector2" interfacename="scale" />
     </divide>
     <multiply name="negate_rotate" type="float">
-      <input name="in1" type="float" interfacename="rotate"/>
-      <input name="in2" type="float" value="-1.0"/>
+      <input name="in1" type="float" interfacename="rotate" />
+      <input name="in2" type="float" value="-1.0" />
     </multiply>
     <multiply name="negate_offset" type="vector2">
-      <input name="in1" type="vector2" interfacename="offset"/>
-      <input name="in2" type="vector2" value="-1.0, 1.0"/>
+      <input name="in1" type="vector2" interfacename="offset" />
+      <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
@@ -667,32 +668,32 @@
       <input name="index" type="integer" uniform="true" interfacename="uvindex" />
     </texcoord>
     <image name="image" type="vector3">
-      <input name="file" type="filename" uniform="true" interfacename="file"/>
-      <input name="default" type="vector3" interfacename="default" value="0, 0, 0"/>
-      <input name="texcoord" type="vector2" nodename="place2d"/>
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic"/>
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic"/>
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear"/>
+      <input name="file" type="filename" uniform="true" interfacename="file" />
+      <input name="default" type="vector3" interfacename="default" value="0, 0, 0" />
+      <input name="texcoord" type="vector2" nodename="place2d" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
     </image>
     <divide name="invert_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0"/>
-      <input name="in2" type="vector2" interfacename="scale"/>
+      <input name="in1" type="vector2" value="1.0, 1.0" />
+      <input name="in2" type="vector2" interfacename="scale" />
     </divide>
     <multiply name="negate_rotate" type="float">
-      <input name="in1" type="float" interfacename="rotate"/>
-      <input name="in2" type="float" value="-1.0"/>
+      <input name="in1" type="float" interfacename="rotate" />
+      <input name="in2" type="float" value="-1.0" />
     </multiply>
     <multiply name="negate_offset" type="vector2">
-      <input name="in1" type="vector2" interfacename="offset"/>
-      <input name="in2" type="vector2" value="-1.0, 1.0"/>
+      <input name="in1" type="vector2" interfacename="offset" />
+      <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1"/>
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1"/>
+      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
       <input name="offset" type="vector2" nodename="negate_offset" />
-      <input name="operationorder" type="integer" interfacename="operationorder" value="0"/>
+      <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
     </place2d>
     <output name="out" type="vector3" nodename="image" />
   </nodegraph>
@@ -742,18 +743,18 @@
       <input name="in" type="vector3" nodename="image" />
     </normalmap>
     <divide name="invert_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0"/>
-      <input name="in2" type="vector2" interfacename="scale"/>
+      <input name="in1" type="vector2" value="1.0, 1.0" />
+      <input name="in2" type="vector2" interfacename="scale" />
     </divide>
     <multiply name="negate_rotate" type="float">
-      <input name="in1" type="float" interfacename="rotate"/>
-      <input name="in2" type="float" value="-1.0"/>
+      <input name="in1" type="float" interfacename="rotate" />
+      <input name="in2" type="float" value="-1.0" />
     </multiply>
     <multiply name="negate_offset" type="vector2">
-      <input name="in1" type="vector2" interfacename="offset"/>
-      <input name="in2" type="vector2" value="-1.0, 1.0"/>
+      <input name="in1" type="vector2" interfacename="offset" />
+      <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
-    <place2d name="place2d" type="vector2" nodedef="ND_place2d_vector2" >
+    <place2d name="place2d" type="vector2" nodedef="ND_place2d_vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
       <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
       <input name="scale" type="vector2" nodename="invert_scale" value="1, 1" />
@@ -796,12 +797,12 @@
     <input name="filtertype" type="string" uniform="true" value="linear" />
     <input name="thicknessMin" type="float" value="100" />
     <input name="thicknessMax" type="float" value="400" />
-    <mix name="mixThickness" type="float" nodedef="ND_mix_float" >
+    <mix name="mixThickness" type="float" nodedef="ND_mix_float">
       <input name="fg" type="float" interfacename="thicknessMin" value="0" />
       <input name="bg" type="float" interfacename="thicknessMax" value="0" />
       <input name="mix" type="float" nodename="extract" />
     </mix>
-    <gltf_image name="thickness_image" type="vector3" >
+    <gltf_image name="thickness_image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="vector3" interfacename="default" value="0, 0, 0" />
       <input name="uvindex" type="integer" interfacename="uvindex" value="0" />
@@ -813,7 +814,7 @@
       <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
       <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
     </gltf_image>
-    <extract name="extract" type="float" >
+    <extract name="extract" type="float">
       <input name="in" type="vector3" nodename="thickness_image" />
       <input name="index" type="integer" uniform="true" value="1" />
     </extract>

--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -352,7 +352,7 @@
     Node: <gltf_colorimage> Supplemental Node
     Multiply a color4 image modulated by uniform color and geometry color. Default uniform and geometry colors are 1,1,1,1 which results in no change to the image.
   -->
-  <nodedef name="ND_gltf_colorimage" node="gltf_colorimage" version="0.0.1" isdefaultversion="true" nodegroup="texture2d">
+  <nodedef name="ND_gltf_colorimage" node="gltf_colorimage" version="1.0" isdefaultversion="true" nodegroup="texture2d">
     <input name="file" type="filename" uniform="true" value="" uifolder="Image" />
     <input name="default" type="color4" value="0, 0, 0, 0" uifolder="Image" />
     <input name="uvindex" type="integer" value="0" uifolder="Image" />	  

--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
-  <nodedef name="ND_gltf_pbr_surfaceshader" node="gltf_pbr" nodegroup="pbr" doc="glTF PBR" version="0.0.1" isdefaultversion="true">
+  <nodedef name="ND_gltf_pbr_surfaceshader" node="gltf_pbr" nodegroup="pbr" doc="glTF PBR" version="2.0.1" isdefaultversion="true">
     <input name="base_color" type="color3" value="1, 1, 1" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Base Color" uifolder="Base" />
     <input name="metallic" type="float" value="1" uimin="0" uimax="1" uiname="Metallic" uifolder="Base" />
     <input name="roughness" type="float" value="1" uimin="0" uimax="1" uiname="Roughness" uifolder="Base" />


### PR DESCRIPTION
Since the glTF PBR is pretty much complete in its current state and is publicly used, it seems appropriate to change the version number to 1.0. (For comparison: UsdPreviewSurface is at 2.3 and Standard Surface at 1.0.1.) It could also be kept in sync with the version of the [glTF spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html), in which it is described in detail (that would be 2.0.1.)

I'm not sure if this change should be seen as an "upgrade" and implemented using a separate NodeDef - please let me know your thoughts. Unlike `gltf_colorimage`, which has not been part of a release yet, `gltf_pbr` has been both part of 1.38.4 and 1.38.5.