### PR TITLE
Subclass GeomPropDef from TypedElement

### DIFF
--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -357,11 +357,11 @@ class MX_CORE_API GeomProp : public ValueElement
 /// as a reference to the "normal" geometric node with a space setting of
 /// "world", or a specific set of texture coordinates can be declared as a
 /// reference to the "texcoord" geometric node with an index setting of "1".
-class MX_CORE_API GeomPropDef : public Element
+class MX_CORE_API GeomPropDef : public TypedElement
 {
   public:
     GeomPropDef(ElementPtr parent, const string& name) :
-        Element(parent, CATEGORY, name)
+        TypedElement(parent, CATEGORY, name)
     {
     }
     virtual ~GeomPropDef() { }

--- a/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
@@ -56,7 +56,7 @@ void bindPyGeom(py::module& mod)
     py::class_<mx::GeomProp, mx::GeomPropPtr, mx::ValueElement>(mod, "GeomProp")
         .def_readonly_static("CATEGORY", &mx::GeomProp::CATEGORY);
 
-    py::class_<mx::GeomPropDef, mx::GeomPropDefPtr, mx::Element>(mod, "GeomPropDef")
+    py::class_<mx::GeomPropDef, mx::GeomPropDefPtr, mx::TypedElement>(mod, "GeomPropDef")
         .def("setGeomProp", &mx::GeomPropDef::setGeomProp)
         .def("hasGeomProp", &mx::GeomPropDef::hasGeomProp)
         .def("getGeomProp", &mx::GeomPropDef::getGeomProp)


### PR DESCRIPTION
This changelist updates the parent class of GeomPropDef from Element to TypedElement, providing it with access to the setType and getType methods.