### PR TITLE
Improvements to node helper methods

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -29,7 +29,11 @@ void Node::setConnectedNode(const string& inputName, ConstNodePtr node)
     }
     if (node)
     {
-        input->setType(node->getType());
+        const string& type = node->getType();
+        if (type != MULTI_OUTPUT_TYPE_STRING)
+        {
+            input->setType(type);
+        }
     }
     input->setConnectedNode(node);
 }
@@ -521,6 +525,25 @@ vector<ElementPtr> GraphElement::topologicalSort() const
     }
 
     return result;
+}
+
+NodePtr GraphElement::addGeomNode(ConstGeomPropDefPtr geomPropDef, const string &namePrefix)
+{
+    string geomNodeName = namePrefix + "_" + geomPropDef->getName();
+    NodePtr geomNode = getNode(geomNodeName);
+    if (!geomNode)
+    {
+        geomNode = addNode(geomPropDef->getGeomProp(), geomNodeName, geomPropDef->getType());
+        if (geomPropDef->hasAttribute(GeomPropDef::SPACE_ATTRIBUTE))
+        {
+            geomNode->setInputValue(GeomPropDef::SPACE_ATTRIBUTE, geomPropDef->getAttribute(GeomPropDef::SPACE_ATTRIBUTE));
+        }
+        if (geomPropDef->hasAttribute(GeomPropDef::INDEX_ATTRIBUTE))
+        {
+            geomNode->setInputValue(GeomPropDef::INDEX_ATTRIBUTE, geomPropDef->getAttribute(GeomPropDef::INDEX_ATTRIBUTE), getTypeString<int>());
+        }
+    }
+    return geomNode;
 }
 
 string GraphElement::asStringDot() const

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -306,6 +306,10 @@ class MX_CORE_API GraphElement : public InterfaceElement
     /// @throws ExceptionFoundCycle if a cycle is encountered.
     vector<ElementPtr> topologicalSort() const;
 
+    /// If not yet present, add a geometry node to this graph matching the given property
+    /// definition and name prefix.
+    NodePtr addGeomNode(ConstGeomPropDefPtr geomPropDef, const string& namePrefix);
+
     /// Convert this graph to a string in the DOT language syntax.  This can be
     /// used to visualise the graph using GraphViz (http://www.graphviz.org).
     ///

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -48,6 +48,7 @@ void bindPyNode(py::module& mod)
         .def("flattenSubgraphs", &mx::GraphElement::flattenSubgraphs,
             py::arg("target") = mx::EMPTY_STRING, py::arg("filter") = nullptr)
         .def("topologicalSort", &mx::GraphElement::topologicalSort)
+        .def("addGeomNode", &mx::GraphElement::addGeomNode)
         .def("asStringDot", &mx::GraphElement::asStringDot);
 
     py::class_<mx::NodeGraph, mx::NodeGraphPtr, mx::GraphElement>(mod, "NodeGraph")


### PR DESCRIPTION
- Fix an edge case in Node::setConnectedNode, omitting a type copy when the upstream node is multi-output.
- Add helper method GraphElement::addGeomNode, allowing geometry nodes to be constructed from GeomPropDef elements.