### PR TITLE
Remove duplicate bindings in documents

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -389,17 +389,17 @@
       <input name="index" type="integer" uniform="true" interfacename="uvindex" />
     </texcoord>
     <gltf_image name="image" type="color4">
-      <input name="file" type="filename" uniform="true" interfacename="file" value="" />
-      <input name="default" type="color4" interfacename="default" value="0, 0, 0, 0" />
+      <input name="file" type="filename" uniform="true" interfacename="file" />
+      <input name="default" type="color4" interfacename="default" />
       <input name="uvindex" type="integer" interfacename="uvindex" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
-      <input name="scale" type="vector2" interfacename="scale" value="1, 1" />
-      <input name="rotate" type="float" interfacename="rotate" value="0" />
-      <input name="offset" type="vector2" interfacename="offset" value="0, 0" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
+      <input name="scale" type="vector2" interfacename="scale" />
+      <input name="rotate" type="float" interfacename="rotate" />
+      <input name="offset" type="vector2" interfacename="offset" />
       <input name="operationorder" type="integer" value="0" />
       <input name="uaddressmode" type="string" uniform="true" value="periodic" />
       <input name="vaddressmode" type="string" uniform="true" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </gltf_image>
     <multiply name="modulate_color" type="color4">
       <input name="in1" type="color4" interfacename="color" />
@@ -461,11 +461,11 @@
     </texcoord>
     <image name="image" type="color3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
-      <input name="default" type="color3" interfacename="default" value="0, 0, 0" />
+      <input name="default" type="color3" interfacename="default" />
       <input name="texcoord" type="vector2" nodename="place2d" />
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </image>
     <divide name="invert_scale" type="vector2">
       <input name="in1" type="vector2" value="1.0, 1.0" />
@@ -481,11 +481,11 @@
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
       <input name="offset" type="vector2" nodename="negate_offset" />
-      <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
+      <input name="operationorder" type="integer" interfacename="operationorder" />
     </place2d>
     <multiply name="scale_image" type="color3">
       <input name="in1" type="color3" interfacename="factor" />
@@ -531,11 +531,11 @@
     </texcoord>
     <image name="image" type="color4">
       <input name="file" type="filename" uniform="true" interfacename="file" />
-      <input name="default" type="color4" interfacename="default" value="0, 0, 0, 0" />
+      <input name="default" type="color4" interfacename="default" />
       <input name="texcoord" type="vector2" nodename="place2d" />
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </image>
     <divide name="invert_scale" type="vector2">
       <input name="in1" type="vector2" value="1.0, 1.0" />
@@ -551,11 +551,11 @@
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
       <input name="offset" type="vector2" nodename="negate_offset" />
-      <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
+      <input name="operationorder" type="integer" interfacename="operationorder" />
     </place2d>
     <multiply name="scale_image" type="color4">
       <input name="in1" type="color4" interfacename="factor" />
@@ -601,11 +601,11 @@
     </texcoord>
     <image name="image" type="float">
       <input name="file" type="filename" uniform="true" interfacename="file" />
-      <input name="default" type="float" interfacename="default" value="0" />
+      <input name="default" type="float" interfacename="default" />
       <input name="texcoord" type="vector2" nodename="place2d" />
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </image>
     <divide name="invert_scale" type="vector2">
       <input name="in1" type="vector2" value="1.0, 1.0" />
@@ -621,11 +621,11 @@
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
       <input name="offset" type="vector2" nodename="negate_offset" />
-      <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
+      <input name="operationorder" type="integer" interfacename="operationorder" />
     </place2d>
     <multiply name="scale_image" type="float">
       <input name="in1" type="float" interfacename="factor" />
@@ -669,11 +669,11 @@
     </texcoord>
     <image name="image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
-      <input name="default" type="vector3" interfacename="default" value="0, 0, 0" />
+      <input name="default" type="vector3" interfacename="default" />
       <input name="texcoord" type="vector2" nodename="place2d" />
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </image>
     <divide name="invert_scale" type="vector2">
       <input name="in1" type="vector2" value="1.0, 1.0" />
@@ -689,11 +689,11 @@
     </multiply>
     <place2d name="place2d" type="vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
       <input name="offset" type="vector2" nodename="negate_offset" />
-      <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
+      <input name="operationorder" type="integer" interfacename="operationorder" />
     </place2d>
     <output name="out" type="vector3" nodename="image" />
   </nodegraph>
@@ -733,11 +733,11 @@
     </texcoord>
     <image name="image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
-      <input name="default" type="vector3" interfacename="default" value="0.5, 0.5, 1" />
+      <input name="default" type="vector3" interfacename="default" />
       <input name="texcoord" type="vector2" nodename="place2d" />
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </image>
     <normalmap name="normalmap" type="vector3">
       <input name="in" type="vector3" nodename="image" />
@@ -756,11 +756,11 @@
     </multiply>
     <place2d name="place2d" type="vector2" nodedef="ND_place2d_vector2">
       <input name="texcoord" type="vector2" nodename="texcoord1" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 1" />
-      <input name="scale" type="vector2" nodename="invert_scale" value="1, 1" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
+      <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
       <input name="offset" type="vector2" nodename="negate_offset" />
-      <input name="operationorder" type="integer" interfacename="operationorder" value="0" />
+      <input name="operationorder" type="integer" interfacename="operationorder" />
     </place2d>
     <output name="out" type="vector3" nodename="normalmap" />
   </nodegraph>
@@ -798,21 +798,21 @@
     <input name="thicknessMin" type="float" value="100" />
     <input name="thicknessMax" type="float" value="400" />
     <mix name="mixThickness" type="float" nodedef="ND_mix_float">
-      <input name="fg" type="float" interfacename="thicknessMin" value="0" />
-      <input name="bg" type="float" interfacename="thicknessMax" value="0" />
+      <input name="fg" type="float" interfacename="thicknessMin" />
+      <input name="bg" type="float" interfacename="thicknessMax" />
       <input name="mix" type="float" nodename="extract" />
     </mix>
     <gltf_image name="thickness_image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
-      <input name="default" type="vector3" interfacename="default" value="0, 0, 0" />
-      <input name="uvindex" type="integer" interfacename="uvindex" value="0" />
-      <input name="pivot" type="vector2" interfacename="pivot" value="0, 0" />
-      <input name="scale" type="vector2" interfacename="scale" value="1, 1" />
-      <input name="rotate" type="float" interfacename="rotate" value="0" />
-      <input name="offset" type="vector2" interfacename="offset" value="0, 0" />
-      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" value="periodic" />
-      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" value="periodic" />
-      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" value="linear" />
+      <input name="default" type="vector3" interfacename="default" />
+      <input name="uvindex" type="integer" interfacename="uvindex" />
+      <input name="pivot" type="vector2" interfacename="pivot" />
+      <input name="scale" type="vector2" interfacename="scale" />
+      <input name="rotate" type="float" interfacename="rotate" />
+      <input name="offset" type="vector2" interfacename="offset" />
+      <input name="uaddressmode" type="string" uniform="true" interfacename="uaddressmode" />
+      <input name="vaddressmode" type="string" uniform="true" interfacename="vaddressmode" />
+      <input name="filtertype" type="string" uniform="true" interfacename="filtertype" />
     </gltf_image>
     <extract name="extract" type="float">
       <input name="in" type="vector3" nodename="thickness_image" />

--- a/resources/Materials/TestSuite/libraries/metal/libraries/metal_definition.mtlx
+++ b/resources/Materials/TestSuite/libraries/metal/libraries/metal_definition.mtlx
@@ -17,18 +17,18 @@
     <output name="out" type="surfaceshader" nodename="standard_surface_metal" />
     <standard_surface name="standard_surface_metal" type="surfaceshader">
       <input name="base" type="float" value="0.8" />
-      <input name="base_color" type="color3" value="1, 1, 1" interfacename="MetalF0" />
+      <input name="base_color" type="color3" interfacename="MetalF0" />
       <input name="diffuse_roughness" type="float" value="0" />
       <input name="specular" type="float" value="1" />
-      <input name="specular_color" type="color3" value="1, 1, 1" interfacename="SurfaceAlbedo" />
-      <input name="specular_roughness" type="float" value="0.1" interfacename="SurfaceRoughness" />
+      <input name="specular_color" type="color3" interfacename="SurfaceAlbedo" />
+      <input name="specular_roughness" type="float" interfacename="SurfaceRoughness" />
       <input name="specular_IOR" type="float" value="1.52" />
-      <input name="specular_anisotropy" type="float" value="0" interfacename="SurfaceAnisotropy" />
-      <input name="specular_rotation" type="float" value="0" interfacename="SurfaceRotation" />
+      <input name="specular_anisotropy" type="float" interfacename="SurfaceAnisotropy" />
+      <input name="specular_rotation" type="float" interfacename="SurfaceRotation" />
       <input name="metalness" type="float" value="1" />
-      <input name="normal" type="vector3" value="1, 1, 1" interfacename="SurfaceNormal" />
+      <input name="normal" type="vector3" interfacename="SurfaceNormal" />
       <input name="tangent" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="opacity" type="color3" value="1, 1, 1" interfacename="SurfaceCutout" />
+      <input name="opacity" type="color3" interfacename="SurfaceCutout" />
       <input name="coat" type="float" value="0" />
       <input name="coat_color" type="color3" value="1, 1, 1" />
       <input name="coat_roughness" type="float" value="0.1" />

--- a/resources/Materials/TestSuite/pbrlib/bsdf/bsdf_graph.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/bsdf_graph.mtlx
@@ -37,7 +37,7 @@
       <input name="specularColor" type="color3" value="1.0, 1.0, 1.0" />
     </mybsdf>
     <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" value="" nodename="mybsdf1" />
+      <input name="bsdf" type="BSDF" nodename="mybsdf1" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" value="1.0" />
     </surface>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/mix_bsdf.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/mix_bsdf.mtlx
@@ -47,10 +47,10 @@
   </nodedef>
   <nodegraph name="IMP_substratebsdf" nodedef="ND_substratebsdf">
     <oren_nayar_diffuse_bsdf name="diffuse" type="BSDF">
-      <input name="color" type="color3" interfacename="albedo" value="0.9, 0.1, 0.1" />
+      <input name="color" type="color3" interfacename="albedo" />
     </oren_nayar_diffuse_bsdf>
     <translucent_bsdf name="subsurface2" type="BSDF">
-      <input name="color" type="color3" interfacename="subsurface" value="0.1, 0.1, 0.8" />
+      <input name="color" type="color3" interfacename="subsurface" />
     </translucent_bsdf>
     <mix name="mix1" type="BSDF">
       <input name="fg" type="BSDF" nodename="diffuse" />
@@ -69,17 +69,17 @@
   </nodedef>
   <nodegraph name="IMP_substrateshader" nodedef="ND_substrateshader">
     <substratebsdf name="substrate1" type="BSDF">
-      <input name="albedo" type="color3" value="0.8, 0.2, 0.1" interfacename="albedo" />
-      <input name="subsurface" type="color3" value="0.1, 0.1, 0.8" interfacename="subsurface" />
-      <input name="subsurface_weight" type="float" value="0.0" interfacename="subsurface_weight" />
+      <input name="albedo" type="color3" interfacename="albedo" />
+      <input name="subsurface" type="color3" interfacename="subsurface" />
+      <input name="subsurface_weight" type="float" interfacename="subsurface_weight" />
     </substratebsdf>
     <uniform_edf name="edf1" type="EDF">
-      <input name="color" type="color3" value="0.0, 0.0, 0.0" interfacename="emission" />
+      <input name="color" type="color3" interfacename="emission" />
     </uniform_edf>
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="substrate1" />
       <input name="edf" type="EDF" nodename="edf1" />
-      <input name="opacity" type="float" value="1.0" interfacename="opacity" />
+      <input name="opacity" type="float" interfacename="opacity" />
     </surface>
     <output name="out" type="surfaceshader" nodename="surface1" />
   </nodegraph>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/transmission.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/transmission.mtlx
@@ -25,12 +25,12 @@
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
     </oren_nayar_diffuse_bsdf>
     <mix name="mix1" type="BSDF">
-      <input name="fg" type="BSDF" value="" nodename="diffuse_brdf2" />
-      <input name="bg" type="BSDF" value="" nodename="dielectric_btdf1" />
+      <input name="fg" type="BSDF" nodename="diffuse_brdf2" />
+      <input name="bg" type="BSDF" nodename="dielectric_btdf1" />
       <input name="mix" type="float" interfacename="transmission" />
     </mix>
     <surface name="surface3" type="surfaceshader">
-      <input name="bsdf" type="BSDF" value="" nodename="mix1" />
+      <input name="bsdf" type="BSDF" nodename="mix1" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" value="1.0000" />
     </surface>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/vertical_layering.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/vertical_layering.mtlx
@@ -200,7 +200,7 @@
         <input name="base" type="BSDF" nodename="mybsdf1" />
       </layer>
       <surface name="surface1" type="surfaceshader">
-        <input name="bsdf" type="BSDF" value="" nodename="layer1" />
+        <input name="bsdf" type="BSDF" nodename="layer1" />
       </surface>
       <output name="out" type="surfaceshader" nodename="surface1" />
     </nodegraph>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/nodegraph_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/nodegraph_surfaceshader.mtlx
@@ -2,7 +2,7 @@
 <materialx version="1.38">
   <nodegraph name="lighting1">
     <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" value="" nodename="diffusebsdf1" />
+      <input name="bsdf" type="BSDF" nodename="diffusebsdf1" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" value="1.0" />
     </surface>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/shader_ops.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/shader_ops.mtlx
@@ -2,8 +2,8 @@
 <materialx version="1.38">
   <nodegraph name="nodegraph1">
     <mix name="mix_surface_shader" type="surfaceshader">
-      <input name="fg" type="surfaceshader" value="" nodename="standard_surface1" />
-      <input name="bg" type="surfaceshader" value="" nodename="standard_surface2" />
+      <input name="fg" type="surfaceshader" nodename="standard_surface1" />
+      <input name="bg" type="surfaceshader" nodename="standard_surface2" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <standard_surface name="standard_surface1" type="surfaceshader">

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/sheen.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/sheen.mtlx
@@ -20,7 +20,7 @@
       <input name="roughness" type="float" interfacename="sheen_roughness" />
     </sheen_bsdf>
     <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" value="" nodename="sheen1" />
+      <input name="bsdf" type="BSDF" nodename="sheen1" />
       <input name="edf" type="EDF" value="" />
       <input name="opacity" type="float" value="1.0" />
     </surface>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/surface_ops.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/surface_ops.mtlx
@@ -18,28 +18,28 @@
       <input name="normal" type="vector3" value="0.0, 0.0, 0.0" />
     </sheen_bsdf>
     <mix name="mix_edf1" type="EDF">
-      <input name="fg" type="EDF" value="" nodename="Emission_EDF" />
+      <input name="fg" type="EDF" nodename="Emission_EDF" />
       <input name="bg" type="EDF" value="" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <mix name="mix_surface1" type="surfaceshader">
-      <input name="fg" type="surfaceshader" value="" nodename="surface1" />
-      <input name="bg" type="surfaceshader" value="" nodename="surface2" />
+      <input name="fg" type="surfaceshader" nodename="surface1" />
+      <input name="bg" type="surfaceshader" nodename="surface2" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <mix name="mix_bsdf1" type="BSDF">
-      <input name="fg" type="BSDF" value="" nodename="sheen_brdf1" />
-      <input name="bg" type="BSDF" value="" nodename="subsurface_brdf1" />
+      <input name="fg" type="BSDF" nodename="sheen_brdf1" />
+      <input name="bg" type="BSDF" nodename="subsurface_brdf1" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <surface name="surface1" type="surfaceshader">
-      <input name="bsdf" type="BSDF" value="" nodename="conductor_brdf1" />
-      <input name="edf" type="EDF" value="" nodename="mix_edf1" />
+      <input name="bsdf" type="BSDF" nodename="conductor_brdf1" />
+      <input name="edf" type="EDF" nodename="mix_edf1" />
       <input name="opacity" type="float" value="1.0000" />
     </surface>
     <surface name="surface2" type="surfaceshader">
-      <input name="bsdf" type="BSDF" value="" nodename="SchlickBRDF" />
-      <input name="edf" type="EDF" value="" nodename="Emission_EDF" />
+      <input name="bsdf" type="BSDF" nodename="SchlickBRDF" />
+      <input name="edf" type="EDF" nodename="Emission_EDF" />
       <input name="opacity" type="float" value="1.0" />
     </surface>
     <uniform_edf name="Emission_EDF" type="EDF">

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_nodedef_test.mtlx
@@ -60,7 +60,7 @@
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
     <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF">
-      <input name="color" type="color3" interfacename="diffuse_color" value="0.18, 0.18, 0.18" />
+      <input name="color" type="color3" interfacename="diffuse_color" />
     </burley_diffuse_bsdf>
     <convert name="convert" type="color3">
       <input name="in" type="float" nodename="ramp4" />
@@ -82,7 +82,7 @@
     <texcoord name="texcoord" type="vector2" />
     <multiply name="multiply" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord" />
-      <input name="in2" type="vector2" interfacename="repeat" value="4, 4" />
+      <input name="in2" type="vector2" interfacename="repeat" />
     </multiply>
     <modulo name="modulo" type="vector2">
       <input name="in1" type="vector2" nodename="multiply" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_test.mtlx
@@ -42,7 +42,7 @@
     <input name="diffuse_color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="repeat" type="vector2" value="4, 4" />
     <burley_diffuse_bsdf name="burley_diffuse_bsdf" type="BSDF">
-      <input name="color" type="color3" interfacename="diffuse_color" value="0.18, 0.18, 0.18" />
+      <input name="color" type="color3" interfacename="diffuse_color" />
     </burley_diffuse_bsdf>
     <convert name="convert" type="color3">
       <input name="in" type="float" nodename="ramp4" />
@@ -64,7 +64,7 @@
     <texcoord name="texcoord" type="vector2" />
     <multiply name="multiply" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord" />
-      <input name="in2" type="vector2" interfacename="repeat" value="4, 4" />
+      <input name="in2" type="vector2" interfacename="repeat" />
     </multiply>
     <modulo name="modulo" type="vector2">
       <input name="in1" type="vector2" nodename="multiply" />

--- a/resources/Materials/TestSuite/stdlib/application/unique_identifiers.mtlx
+++ b/resources/Materials/TestSuite/stdlib/application/unique_identifiers.mtlx
@@ -18,10 +18,10 @@
     </multiply>
     <multiply name="multiply1" type="float">
       <input name="in1" type="float" nodename="constant" uivisible="true" />
-      <input name="in2" type="float" interfacename="out1" value="1" uivisible="true" />
+      <input name="in2" type="float" interfacename="out1" uivisible="true" />
     </multiply>
     <swizzle name="swizzle" type="float">
-      <input name="in" type="vector2" interfacename="out3" value="0, 0" uivisible="true" />
+      <input name="in" type="vector2" interfacename="out3" uivisible="true" />
     </swizzle>
     <output name="out" type="float" nodename="multiply" />
     <output name="out2" type="float" nodename="multiply1" />

--- a/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
@@ -3,7 +3,7 @@
   <nodegraph name="height_to_normal">
     <input name="file" type="filename" uniform="true" value="resources/Images/plain_heightmap.png" />
     <tiledimage name="tiledimage" type="float">
-      <input name="file" type="filename" uniform="true" interfacename="file" value="resources/Images/plain_heightmap.png" />
+      <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="uvtiling" type="vector2" value="10, 10" />
     </tiledimage>
     <heighttonormal name="heighttonormal" type="vector3">

--- a/resources/Materials/TestSuite/stdlib/definition/definition_using_definitions.mtlx
+++ b/resources/Materials/TestSuite/stdlib/definition/definition_using_definitions.mtlx
@@ -50,7 +50,7 @@
       <input name="in2" type="float" nodename="pow2_surfaniso0" />
     </subtract>
     <constant name="surface_rotation_param" type="float">
-      <input name="value" type="float" value="0" interfacename="surface_rotation" />
+      <input name="value" type="float" interfacename="surface_rotation" />
     </constant>
     <divide name="div_rotation0" type="float">
       <input name="in1" type="float" nodename="surface_rotation_param" />
@@ -60,7 +60,7 @@
       <input name="in1" type="float" nodename="div_rotation0" />
     </modulo>
     <constant name="layered_f0_param" type="float">
-      <input name="value" type="float" value="1" interfacename="layered_f0" />
+      <input name="value" type="float" interfacename="layered_f0" />
     </constant>
     <sqrt name="sqrt_layeredf0" type="float">
       <input name="in" type="float" nodename="layered_f0_param" />
@@ -78,10 +78,10 @@
       <input name="in2" type="float" nodename="oneminus_sqrtlayeredf0" />
     </divide>
     <constant name="layered_roughness_param" type="float">
-      <input name="value" type="float" value="1" interfacename="layered_roughness" />
+      <input name="value" type="float" interfacename="layered_roughness" />
     </constant>
     <constant name="layered_anisotropy_param" type="float">
-      <input name="value" type="float" value="1" interfacename="layered_anisotropy" />
+      <input name="value" type="float" interfacename="layered_anisotropy" />
     </constant>
     <subtract name="oneminus_layeraniso0" type="float">
       <input name="in1" type="float" value="1.0" />
@@ -107,7 +107,7 @@
       <input name="in2" type="float" nodename="pow2_layeraniso0" />
     </subtract>
     <constant name="layered_rotation_param" type="float">
-      <input name="value" type="float" value="0" interfacename="layered_rotation" />
+      <input name="value" type="float" interfacename="layered_rotation" />
     </constant>
     <divide name="div_rotation1" type="float">
       <input name="in1" type="float" nodename="layered_rotation_param" />
@@ -117,13 +117,13 @@
       <input name="in1" type="float" nodename="div_rotation1" />
     </modulo>
     <constant name="layered_fraction_param" type="float">
-      <input name="value" type="float" value="0" interfacename="layered_fraction" />
+      <input name="value" type="float" interfacename="layered_fraction" />
     </constant>
     <constant name="layered_diffuse_param" type="color3">
-      <input name="value" type="color3" value="1, 1, 1" interfacename="layered_diffuse" />
+      <input name="value" type="color3" interfacename="layered_diffuse" />
     </constant>
     <constant name="layered_bottom_f0_param" type="color3">
-      <input name="value" type="color3" value="1, 1, 1" interfacename="layered_bottom_f0" />
+      <input name="value" type="color3" interfacename="layered_bottom_f0" />
     </constant>
     <subtract name="oneminus_layerfraction" type="float">
       <input name="in1" type="float" value="1.0" />
@@ -148,9 +148,9 @@
       <input name="value2" type="boolean" value="true" />
     </ifequal>
     <standard_surface name="standard_surface0" type="surfaceshader" version="1.0.1">
-      <input name="normal" type="vector3" value="1, 1, 1" defaultgeomprop="Nobject" interfacename="layered_normal" />
-      <input name="coat_normal" type="vector3" value="1, 1, 1" defaultgeomprop="Nobject" interfacename="surface_normal" />
-      <input name="opacity" type="color3" value="1, 1, 1" interfacename="surface_cutout" />
+      <input name="normal" type="vector3" defaultgeomprop="Nobject" interfacename="layered_normal" />
+      <input name="coat_normal" type="vector3" defaultgeomprop="Nobject" interfacename="surface_normal" />
+      <input name="opacity" type="color3" interfacename="surface_cutout" />
       <input name="coat" type="float" nodename="coat_value" />
       <input name="metalness" type="float" nodename="layered_fraction_value" />
       <input name="specular" type="float" value="0.0" />
@@ -182,12 +182,12 @@
   </nodedef>
   <nodegraph name="NG_bitmap_color3" nodedef="ND_bitmap_color3">
     <divide name="total_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0" interfacename="uv_scale" />
+      <input name="in1" type="vector2" interfacename="uv_scale" />
       <input name="in2" type="vector2" interfacename="realworld_scale" />
     </divide>
     <add name="total_offset" type="vector2">
       <input name="in1" type="vector2" interfacename="realworld_offset" />
-      <input name="in2" type="vector2" value="0.0, 0.0" interfacename="uv_offset" />
+      <input name="in2" type="vector2" interfacename="uv_offset" />
     </add>
     <multiply name="rotation_angle_param" type="float">
       <input name="in1" type="float" interfacename="rotation_angle" />
@@ -238,12 +238,12 @@
   </nodedef>
   <nodegraph name="NG_normal_map" nodedef="ND_normal_map">
     <divide name="total_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0" interfacename="uv_scale" />
+      <input name="in1" type="vector2" interfacename="uv_scale" />
       <input name="in2" type="vector2" interfacename="realworld_scale" />
     </divide>
     <add name="total_offset" type="vector2">
       <input name="in1" type="vector2" interfacename="realworld_offset" />
-      <input name="in2" type="vector2" value="0.0, 0.0" interfacename="uv_offset" />
+      <input name="in2" type="vector2" interfacename="uv_offset" />
     </add>
     <multiply name="rotation_angle_param" type="float">
       <input name="in1" type="float" interfacename="rotation_angle" />
@@ -295,12 +295,12 @@
   </nodedef>
   <nodegraph name="NG_bitmap_remap_float" nodedef="ND_bitmap_remap_float">
     <divide name="total_scale" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0" interfacename="uv_scale" />
+      <input name="in1" type="vector2" interfacename="uv_scale" />
       <input name="in2" type="vector2" interfacename="realworld_scale" />
     </divide>
     <add name="total_offset" type="vector2">
       <input name="in1" type="vector2" interfacename="realworld_offset" />
-      <input name="in2" type="vector2" value="0.0, 0.0" interfacename="uv_offset" />
+      <input name="in2" type="vector2" interfacename="uv_offset" />
     </add>
     <multiply name="rotation_angle_param" type="float">
       <input name="in1" type="float" interfacename="rotation_angle" />

--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/cascade_nodegraphs.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/cascade_nodegraphs.mtlx
@@ -4,23 +4,23 @@
     <input name="file" type="filename" uniform="true" value="resources/Images/cloth.png" />
     <input name="file1" type="filename" uniform="true" value="resources/Images/grid.png" />
     <image name="upstream_image" type="color3">
-      <input name="file" type="filename" uniform="true" interfacename="file" value="resources/Images/cloth.png" />
+      <input name="file" type="filename" uniform="true" interfacename="file" />
     </image>
     <image name="upstream_image1" type="color3">
-      <input name="file" type="filename" uniform="true" interfacename="file1" value="resources/Images/grid.png" />
+      <input name="file" type="filename" uniform="true" interfacename="file1" />
     </image>
     <output name="out" type="color3" nodename="upstream_image" />
     <output name="out1" type="color3" nodename="upstream_image1" />
   </nodegraph>
   <nodegraph name="upstream2">
-    <input name="upstream2_in1" type="color3" nodegraph="upstream3" output="out" value="0, 1, 0" />
-    <input name="upstream2_in2" type="color3" nodegraph="upstream3" output="out1" value="0, 1, 0" />
+    <input name="upstream2_in1" type="color3" nodegraph="upstream3" output="out" />
+    <input name="upstream2_in2" type="color3" nodegraph="upstream3" output="out1" />
     <multiply name="multiply_by_image" type="color3">
-      <input name="in1" type="color3" interfacename="upstream2_in1" value="0, 1, 0" />
+      <input name="in1" type="color3" interfacename="upstream2_in1" />
       <input name="in2" type="color3" nodename="image" />
     </multiply>
     <multiply name="make_red" type="color3">
-      <input name="in1" type="color3" interfacename="upstream2_in2" value="0, 1, 0" />
+      <input name="in1" type="color3" interfacename="upstream2_in2" />
       <input name="in2" type="color3" value="1, 0.1, 0.1" />
     </multiply>
     <image name="image" type="color3">
@@ -30,14 +30,14 @@
     <output name="upstream2_out2" type="color3" nodename="make_red" />
   </nodegraph>
   <nodegraph name="upstream1">
-    <input name="upstream1_in1" type="color3" nodegraph="upstream2" output="upstream2_out1" value="0, 1, 0" />
-    <input name="upstream1_in2" type="color3" nodegraph="upstream2" output="upstream2_out2" value="0, 1, 0" />
+    <input name="upstream1_in1" type="color3" nodegraph="upstream2" output="upstream2_out1" />
+    <input name="upstream1_in2" type="color3" nodegraph="upstream2" output="upstream2_out2" />
     <multiply name="make_yellow" type="color3">
-      <input name="in1" type="color3" interfacename="upstream1_in1" value="0, 1, 0" />
+      <input name="in1" type="color3" interfacename="upstream1_in1" />
       <input name="in2" type="color3" value="1, 1, 0" />
     </multiply>
     <multiply name="remove_red" type="color3">
-      <input name="in1" type="color3" interfacename="upstream1_in2" value="0, 1, 0" />
+      <input name="in1" type="color3" interfacename="upstream1_in2" />
       <input name="in2" type="color3" value="0, 1, 1" />
     </multiply>
     <output name="upstream1_out1" type="color3" nodename="make_yellow" />

--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_multioutput.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_multioutput.mtlx
@@ -3,7 +3,7 @@
   <nodegraph name="green_graph" >
     <input name="in" type="color3" value="0, 1, 0" />
     <separate3 name="green_node" type="multioutput" nodedef="ND_separate3_color3" >
-      <input name="in" type="color3" interfacename="in" value="0, 1, 0"  />
+      <input name="in" type="color3" interfacename="in" />
       <output name="outr" type="float" />
       <output name="outg" type="float" />
       <output name="outb" type="float" />

--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx
@@ -5,36 +5,36 @@
     <input name="file" type="filename" value="resources/Images/grid.png" />
     <input name="file2" type="filename" value="resources/Images/cloth.png" />
     <image name="image" type="color3">
-      <input name="file" type="filename" interfacename="file" value="resources/Images/grid.png" />
+      <input name="file" type="filename" interfacename="file" />
     </image>
     <image name="image2" type="color3">
-      <input name="file" type="filename" interfacename="file2" value="resources/Images/cloth.png" />
+      <input name="file" type="filename" interfacename="file2" />
     </image>
     <output name="graph_out_image" type="color3" nodename="image" />
     <output name="graph_out_image2" type="color3" nodename="image2" />
   </nodegraph>
   <nodegraph name="graph_graph">
-    <input name="input" type="color3" nodegraph="upstream_graph" output="graph_out_image" value="1, 0, 0" />
-    <input name="input2" type="color3" nodegraph="upstream_graph" output="graph_out_image2" value="1, 0, 0" />
+    <input name="input" type="color3" nodegraph="upstream_graph" output="graph_out_image" />
+    <input name="input2" type="color3" nodegraph="upstream_graph" output="graph_out_image2" />
     <multiply name="multiply" type="color3">
-      <input name="in1" type="color3" interfacename="input" value="1, 0, 0" />
+      <input name="in1" type="color3" interfacename="input" />
       <input name="in2" type="color3" value="0.4, 0.4, 0.4" />
     </multiply>
     <multiply name="multiply2" type="color3">
-      <input name="in1" type="color3" interfacename="input2" value="1, 0, 0" />
+      <input name="in1" type="color3" interfacename="input2" />
       <input name="in2" type="color3" value="0.4, 0.4, 0.4" />
     </multiply>
     <output name="graph_graph_out" type="color3" nodename="multiply" />
     <output name="graph_graph_out2" type="color3" nodename="multiply2" />
   </nodegraph>
   <nodegraph name="surf_graph_graph">
-    <input name="input" type="color3" nodegraph="graph_graph" output="graph_graph_out" value="1, 1, 1" />
-    <input name="input2" type="color3" nodegraph="graph_graph" output="graph_graph_out2" value="1, 1, 1" />
+    <input name="input" type="color3" nodegraph="graph_graph" output="graph_graph_out" />
+    <input name="input2" type="color3" nodegraph="graph_graph" output="graph_graph_out2" />
     <standard_surface name="default_shader" type="surfaceshader">
-      <input name="base_color" type="color3" interfacename="input" value="1, 1, 1" />
+      <input name="base_color" type="color3" interfacename="input" />
     </standard_surface>
     <standard_surface name="default_shader2" type="surfaceshader">
-      <input name="base_color" type="color3" interfacename="input2" value="1, 1, 1" />
+      <input name="base_color" type="color3" interfacename="input2" />
     </standard_surface>
     <output name="surf_graph_graph_out" type="surfaceshader" nodename="default_shader" />
     <output name="surf_graph_graph_out2" type="surfaceshader" nodename="default_shader2" />
@@ -51,10 +51,10 @@
     <input name="nd_file" type="filename" uniform="true" value="resources/Images/grid.png" />
     <input name="nd_file2" type="filename" uniform="true" value="resources/Images/cloth.png" />
     <image name="image" type="color3">
-      <input name="file" type="filename" uniform="true" interfacename="nd_file" value="resources/Images/grid.png" />
+      <input name="file" type="filename" uniform="true" interfacename="nd_file" />
     </image>
     <image name="image2" type="color3">
-      <input name="file" type="filename" uniform="true" interfacename="nd_file2" value="resources/Images/cloth.png" />
+      <input name="file" type="filename" uniform="true" interfacename="nd_file2" />
     </image>
     <output name="nd_graph_out_image" type="color3" nodename="image" />
     <output name="nd_graph_out_image2" type="color3" nodename="image2" />
@@ -64,27 +64,27 @@
     <output name="nd_graph_out_image2" type="color3" />
   </upstream_graph_def>
   <nodegraph name="nd_graph_graph">
-    <input name="nd_input" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image" value="1, 0, 0" />
-    <input name="nd_input2" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image2" value="1, 0, 0" />
+    <input name="nd_input" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image" />
+    <input name="nd_input2" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image2" />
     <multiply name="multiply" type="color3">
-      <input name="in1" type="color3" interfacename="nd_input" value="1, 0, 0" />
+      <input name="in1" type="color3" interfacename="nd_input" />
       <input name="in2" type="color3" value="0.4, 0.4, 0.4" />
     </multiply>
     <multiply name="multiply2" type="color3">
-      <input name="in1" type="color3" interfacename="nd_input2" value="1, 0, 0" />
+      <input name="in1" type="color3" interfacename="nd_input2" />
       <input name="in2" type="color3" value="0.4, 0.4, 0.4" />
     </multiply>
     <output name="nd_graph_graph_out" type="color3" nodename="multiply" />
     <output name="nd_graph_graph_out2" type="color3" nodename="multiply2" />
   </nodegraph>
   <nodegraph name="ng_surf_graph_graph">
-    <input name="nd_input" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image" value="1, 1, 1" />
-    <input name="nd_input2" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image2" value="1, 1, 1" />
+    <input name="nd_input" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image" />
+    <input name="nd_input2" type="color3" nodename="upstream_graph_instance" output="nd_graph_out_image2" />
     <standard_surface name="default_shader" type="surfaceshader">
-      <input name="base_color" type="color3" interfacename="nd_input" value="1, 1, 1" />
+      <input name="base_color" type="color3" interfacename="nd_input" />
     </standard_surface>
     <standard_surface name="default_shader2" type="surfaceshader">
-      <input name="base_color" type="color3" interfacename="nd_input2" value="1, 1, 1" />
+      <input name="base_color" type="color3" interfacename="nd_input2" />
     </standard_surface>
     <output name="nd_surf_graph_graph_out" type="surfaceshader" nodename="default_shader" />
     <output name="nd_surf_graph_graph_out2" type="surfaceshader" nodename="default_shader2" />
@@ -105,17 +105,17 @@
     <input name="file" type="filename" value="resources/Images/cloth.png" />
   </image>
   <nodegraph name="graph_to_node">
-    <input name="input" type="color3" nodename="upstream_image" value="0, 1, 0" />
+    <input name="input" type="color3" nodename="upstream_image" />
     <multiply name="multiply" type="color3">
-      <input name="in1" type="color3" interfacename="input" value="0, 1, 0" />
+      <input name="in1" type="color3" interfacename="input" />
       <input name="in2" type="color3" value="0.4, 0.4, 0.4" />
     </multiply>
     <output name="node_graph_out" type="color3" nodename="multiply" />
   </nodegraph>
   <nodegraph name="surf_graph_node">
-    <input name="input" type="color3" nodegraph="graph_to_node" value="1, 1, 1" />
+    <input name="input" type="color3" nodegraph="graph_to_node" />
     <standard_surface name="default_shader" type="surfaceshader">
-      <input name="base_color" type="color3" interfacename="input" value="1, 1, 1" />
+      <input name="base_color" type="color3" interfacename="input" />
     </standard_surface>
     <output name="surf_graph_node_out" type="surfaceshader" nodename="default_shader" />
   </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/nodegraph_inputs/surfacematerial_nodegraph_to_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/stdlib/nodegraph_inputs/surfacematerial_nodegraph_to_surfaceshader.mtlx
@@ -5,7 +5,7 @@
     <input name="base_color" type="color3" value="0.3,0.8,0.1" />
   </standard_surface>
   <nodegraph name="green_material_graph">
-    <input name="input_shader" type="surfaceshader" nodename="standard_surface" value="" />
+    <input name="input_shader" type="surfaceshader" nodename="standard_surface" />
     <surfacematerial name="green_surfacematerial" type="material">
       <input name="surfaceshader" type="surfaceshader" interfacename="input_shader" />
       <input name="displacementshader" type="displacementshader" value="" />

--- a/resources/Materials/TestSuite/stdlib/texture/tokenGraph.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/tokenGraph.mtlx
@@ -6,7 +6,7 @@
       <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
       <input name="Image_Filename" type="filename" uniform="true" value="resources/Images/cloth.[Image_Extension]" />
       <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3" >
-         <input name="file" type="filename" uniform="true" interfacename="Image_Filename" value="resources/images/cloth.[Image_Extension]"/>
+         <input name="file" type="filename" uniform="true" interfacename="Image_Filename" />
       </tiledimage>
       <output name="out_png" type="color3" nodename="tiledimage" />
    </nodegraph>

--- a/resources/Materials/TestSuite/stdlib/upgrade/1_37_to_1_38.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_37_to_1_38.mtlx
@@ -29,7 +29,7 @@
    </nodedef>
    <nodegraph name="NG_Test" nodedef="ND_Test">
       <add name="add" type="float">
-         <input name="in1" type="float" value="1.0" interfacename="add" />
+         <input name="in1" type="float" interfacename="add" />
          <input name="in2" type="float" value="1.0" />
       </add>
       <add name="add1" type="float">

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -592,18 +592,6 @@ TEST_CASE("Tokens", "[nodegraph]")
             const std::string tokenString = DELIMITER_PREFIX + token->getName() + DELIMITER_POSTFIX;
             REQUIRE(substitutions.count(tokenString));
         }
-
-        // Test that one of the tokens was used
-        REQUIRE(input->getValueString() == std::string("resources/images/cloth.[Image_Extension]"));
-        REQUIRE(input->getResolvedValueString() == std::string("resources/images/cloth." + extensionStrings[i]));
-
-        // Modify and test that both of the tokens was used
-        input->setValueString("resources/images/cloth_[Image_Resolution].[Image_Extension]");
-        REQUIRE(input->getResolvedValueString() == std::string("resources/images/cloth_" + resolutionStrings[i] + "." + extensionStrings[i]));
-
-        // Modify and test without proper delimiters
-        input->setValueString("resources/images/cloth_<Image_Resolution>.<Image_Extension>");
-        REQUIRE(input->getResolvedValueString() == std::string("resources/images/cloth_<Image_Resolution>.<Image_Extension>"));
     }
 }
 


### PR DESCRIPTION
This changelist removes duplicate data bindings from the library and example documents in MaterialX, allowing this case to be potentially flagged as a validation warning in a future update.

Additionally, a handful of unit tests that depended upon duplicate bindings being present have been removed from the test suite.