### PR TITLE
Patch to avoid conflicting "contrast" function name in OSL code gen

### DIFF
--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -327,7 +327,9 @@ OslSyntax::OslSyntax()
         "reflection", "transparent", "debug", "holdout", "subsurface", "sheen",
         "oren_nayar_diffuse_bsdf", "burley_diffuse_bsdf", "dielectric_bsdf", "conductor_bsdf", "generalized_schlick_bsdf", 
         "translucent_bsdf", "transparent_bsdf","subsurface_bssrdf", "sheen_bsdf", "uniform_edf", "anisotropic_vdf", 
-        "medium_vdf", "layer", "artistic_ior"
+        "medium_vdf", "layer", "artistic_ior",
+        // mx_funcs function names
+        "contrast"
     });
 
     //


### PR DESCRIPTION
Fixes #1106 
- Add "contrast" to disallowed list as it exists in mx_funcs.h and colorcorrect has a "contrast" arg so will conflict.
- @crydalch a small workaround to avoid a name conflict
- @niklasharrysson if you think this is a good way to go then I assume all mx_funcs.h function names should be
added.