### PR TITLE
Add validation check for missing data bindings

### DIFF
--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2099,7 +2099,6 @@
     <saturate name="N_saturation" type="color3">
       <input name="in" type="color3" nodename="N_hsvadjust" />
       <input name="amount" type="float" interfacename="saturation"/>
-      <input name="lumacoeffs" type="color3" />
     </saturate>
     <hsvadjust name="N_hsvadjust" type="color3">
       <input name="in" type="color3" interfacename="in" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/shader_ops.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/shader_ops.mtlx
@@ -77,8 +77,8 @@
       <input name="opacity" type="color3" value="1, 1, 1" />
     </standard_surface>
     <mix name="mix_surface_shader" type="surfaceshader">
-      <input name="fg" type="surfaceshader" value="" nodename="standard_surface1" />
-      <input name="bg" type="surfaceshader" value="" nodename="standard_surface2" />
+      <input name="fg" type="surfaceshader" nodename="standard_surface1" />
+      <input name="bg" type="surfaceshader" nodename="standard_surface2" />
       <input name="mix" type="float" value="0.7000" />
     </mix>
     <surfacematerial name="material" type="material">
@@ -108,8 +108,8 @@
       <input name="emission_color" type="color3" value="0, 0, 0" />
     </standard_surface>
     <mix name="mix_surface_shader" type="surfaceshader">
-      <input name="fg" type="surfaceshader" value="" nodename="standard_surface1" />
-      <input name="bg" type="surfaceshader" value="" nodename="standard_surface2" />
+      <input name="fg" type="surfaceshader" nodename="standard_surface1" />
+      <input name="bg" type="surfaceshader" nodename="standard_surface2" />
       <input name="mix" type="float" value="0.5000" />
     </mix>
     <surfacematerial name="material" type="material">

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -359,6 +359,12 @@ bool Input::validate(string* message) const
             validateRequire(getInterfaceInput() != nullptr, res, message, "Interface name not found in containing NodeGraph");
         }
     }
+    if (getParent()->isA<Node>())
+    {
+        bool hasValueBinding = hasValue();
+        bool hasConnection = hasNodeName() || hasNodeGraphString() || hasOutputString() || hasInterfaceName();
+        validateRequire(hasValueBinding || hasConnection, res, message, "Node input binds no value or connection");
+    }
     return PortElement::validate(message) && res;
 }
 

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -665,11 +665,15 @@ void NodeGraph::addInterfaceName(const string& inputPath, const string& interfac
     if (input && !input->getConnectedNode())
     {
         input->setInterfaceName(interfaceName);
-        ValuePtr value = input->getValue();
-        if (value)
+        InputPtr nodeDefInput = nodeDef->getInput(interfaceName);
+        if (!nodeDefInput)
         {
-            InputPtr nodeDefInput = nodeDef->addInput(interfaceName, input->getType());
-            nodeDefInput->setValueString(value->getValueString());
+            nodeDefInput = nodeDef->addInput(interfaceName, input->getType());
+        }
+        if (input->hasValue())
+        {
+            nodeDefInput->setValueString(input->getValueString());
+            input->removeAttribute(Input::VALUE_ATTRIBUTE);
         }
     }
 }


### PR DESCRIPTION
- Add a validation check for node inputs with missing data bindings.
- Update NodeGraph::addInterfaceName to avoid the creation of duplicate data bindings.
- Fix missing and duplicate data bindings in recent documents.