### PR TITLE
Assign materials in document order for MaterialXView

### DIFF
--- a/resources/Materials/TestSuite/stdlib/geometric/look_assignment_order.mtlx
+++ b/resources/Materials/TestSuite/stdlib/geometric/look_assignment_order.mtlx
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <!-- Simple test to check look assignment order. The target geometry
+       is assumed to be the default shader ball with the intended
+       result being that the Preview mesh is "blue" and the Calibration mesh is
+       "red.
+  -->    
+  <standard_surface name="Red_Shader" type="surfaceshader">
+    <input name="base_color" type="color3" value="1, 0, 0" />
+  </standard_surface>
+  <surfacematerial name="Red_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Red_Shader" />
+  </surfacematerial>
+
+  <standard_surface name="Blue_Shader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0, 0, 1" />
+  </standard_surface>
+  <surfacematerial name="Blue_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Blue_Shader" />
+  </surfacematerial>
+
+  <look name="Look">
+    <materialassign name="Red_Preview" geom="/Preview_Mesh" material="Red_Material" />
+    <materialassign name="Blue_Preview" geom="/Preview_Mesh" material="Blue_Material" />
+    <materialassign name="Blue_Calibration" geom="/Calibration_Mesh" material="Blue_Material" />
+    <materialassign name="Red_Calibration" geom="/Calibration_Mesh" material="Red_Material" />
+  </look>
+</materialx>

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1310,8 +1310,8 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                 }
             }
        
-            // For document assignment we must go in order of assignments for looks
-            // with later assignments superceding earlier ones.
+            // Apply material assignments in the order in which they are declared within the document,
+            // with later assignments superseding earlier ones.
             for (mx::LookPtr look : doc->getLooks())
             {
                 for (mx::MaterialAssignPtr matAssign : look->getMaterialAssigns())


### PR DESCRIPTION
Fixes #1108 (desktop)

## Fix
* The previous ordering for MaterialXView (desktop) was by materials found which does not necessarily match the order for assignments in any existing look. Change to go once through any looks.
* No changes are required for web as this already traverses by look.

## Results
* Test:
```XML
<?xml version="1.0"?>
<materialx version="1.38">
  <!-- Simple test to check look assignment order. The target geometry
       is assumed to be the default shader ball with the intended
       result being that the Preview mesh is "blue" and the Calibration mesh is
       "red.
  -->    
  <standard_surface name="Red_Shader" type="surfaceshader">
    <input name="base_color" type="color3" value="1, 0, 0" />
  </standard_surface>
  <surfacematerial name="Red_Material" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="Red_Shader" />
  </surfacematerial>

  <standard_surface name="Blue_Shader" type="surfaceshader">
    <input name="base_color" type="color3" value="0, 0, 1" />
  </standard_surface>
  <surfacematerial name="Blue_Material" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="Blue_Shader" />
  </surfacematerial>

  <look name="Look">
    <materialassign name="Red_Preview" geom="/Preview_Mesh" material="Red_Material" />
    <materialassign name="Blue_Preview" geom="/Preview_Mesh" material="Blue_Material" />
    <materialassign name="Blue_Calibration" geom="/Calibration_Mesh" material="Blue_Material" />
    <materialassign name="Red_Calibration" geom="/Calibration_Mesh" material="Red_Material" />
  </look>
</materialx>

```
* Web results on left with sample file, and desktop on right for comparison
![image](https://user-images.githubusercontent.com/49369885/197409193-9bab0966-1209-4d72-b91c-42b4193e5af2.png)
 