### PR TITLE
Generalize InterfaceElement::getDeclaration method

### DIFF
--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -107,9 +107,9 @@ bool NodeDef::isVersionCompatible(const string& version) const
     return false;
 }
 
-ConstNodeDefPtr NodeDef::getDeclaration(const string&) const
+ConstInterfaceElementPtr NodeDef::getDeclaration(const string&) const
 {
-    return getSelf()->asA<NodeDef>();
+    return getSelf()->asA<InterfaceElement>();
 }
 
 //
@@ -140,7 +140,7 @@ bool Implementation::validate(string* message) const
     return InterfaceElement::validate(message) && res;
 }
 
-ConstNodeDefPtr Implementation::getDeclaration(const string&) const
+ConstInterfaceElementPtr Implementation::getDeclaration(const string&) const
 {
     return getNodeDef();
 }

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -165,7 +165,7 @@ class MX_CORE_API NodeDef : public InterfaceElement
 
     /// Return the first declaration of this interface, optionally filtered
     ///    by the given target name.
-    ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const override;
+    ConstInterfaceElementPtr getDeclaration(const string& target = EMPTY_STRING) const override;
 
     /// @}
 
@@ -287,7 +287,7 @@ class MX_CORE_API Implementation : public InterfaceElement
 
     /// Return the first declaration of this interface, optionally filtered
     ///    by the given target name.
-    ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const override;
+    ConstInterfaceElementPtr getDeclaration(const string& target = EMPTY_STRING) const override;
 
     /// @}
 

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -499,7 +499,7 @@ ValuePtr ValueElement::getDefaultValue() const
     ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
     if (interface)
     {
-        ConstNodeDefPtr decl = interface->getDeclaration();
+        ConstInterfaceElementPtr decl = interface->getDeclaration();
         if (decl)
         {
             ValueElementPtr value = decl->getActiveValueElement(getName());
@@ -519,7 +519,7 @@ const string& ValueElement::getActiveUnit() const
     ConstInterfaceElementPtr interface = parent ? parent->asA<InterfaceElement>() : nullptr;
     if (interface)
     {
-        ConstNodeDefPtr decl = interface->getDeclaration();
+        ConstInterfaceElementPtr decl = interface->getDeclaration();
         if (decl)
         {
             ValueElementPtr value = decl->getActiveValueElement(getName());
@@ -544,11 +544,11 @@ bool ValueElement::validate(string* message) const
     {
         validateRequire(isA<Input>() || isA<Token>(), res, message, "Only input and token elements support interface names");
         ConstNodeGraphPtr nodeGraph = getAncestorOfType<NodeGraph>();
-        NodeDefPtr nodeDef = nodeGraph ? nodeGraph->getNodeDef() : nullptr;
-        if (nodeDef)
+        ConstInterfaceElementPtr decl = nodeGraph ? nodeGraph->getDeclaration() : nullptr;
+        if (decl)
         {
-            ValueElementPtr valueElem = nodeDef->getActiveValueElement(getInterfaceName());
-            validateRequire(valueElem != nullptr, res, message, "Interface name not found in referenced NodeDef");
+            ValueElementPtr valueElem = decl->getActiveValueElement(getInterfaceName());
+            validateRequire(valueElem != nullptr, res, message, "Interface name not found in referenced declaration");
             if (valueElem)
             {
                 ConstPortElementPtr portElem = asA<PortElement>();

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -303,13 +303,12 @@ NodePtr Input::getConnectedNode() const
 
 InputPtr Input::getInterfaceInput() const
 {
-    const string& interfaceName = getInterfaceName();
-    if (!interfaceName.empty())
+    if (hasInterfaceName())
     {
         ConstNodeGraphPtr graph = getAncestorOfType<NodeGraph>();
         if (graph)
         {
-            return graph->getInput(interfaceName);
+            return graph->getInput(getInterfaceName());
         }
     }
     return nullptr;
@@ -334,32 +333,6 @@ bool Input::validate(string* message) const
     if (hasDefaultGeomPropString())
     {
         validateRequire(getDefaultGeomProp() != nullptr, res, message, "Invalid defaultgeomprop string");
-    }
-    if (hasInterfaceName())
-    {
-        ConstNodeGraphPtr nodeGraph = getAncestorOfType<NodeGraph>();
-        NodeDefPtr nodeDef = nodeGraph ? nodeGraph->getNodeDef() : nullptr;
-        if (nodeDef)
-        {
-            InputPtr interfaceInput = nodeDef->getActiveInput(getInterfaceName());
-            validateRequire(interfaceInput != nullptr, res, message, "Interface name not found in referenced NodeDef");
-            if (interfaceInput)
-            {
-                if (hasChannels())
-                {
-                    bool valid = validChannelsString(getChannels(), interfaceInput->getType(), getType());
-                    validateRequire(valid, res, message, "Invalid channels string for interface name");
-                }
-                else
-                {
-                    validateRequire(getType() == interfaceInput->getType(), res, message, "Interface name refers to input of a different type");
-                }
-            }
-        }
-        else
-        {
-            validateRequire(getInterfaceInput() != nullptr, res, message, "Interface name not found in containing NodeGraph");
-        }
     }
     if (parent->isA<Node>())
     {
@@ -562,7 +535,7 @@ ValuePtr InterfaceElement::getInputValue(const string& name, const string& targe
     }
 
     // Return the value, if any, stored in our declaration.
-    ConstNodeDefPtr decl = getDeclaration(target);
+    ConstInterfaceElementPtr decl = getDeclaration(target);
     if (decl)
     {
         input = decl->getInput(name);
@@ -632,9 +605,9 @@ void InterfaceElement::unregisterChildElement(ElementPtr child)
     }
 }
 
-ConstNodeDefPtr InterfaceElement::getDeclaration(const string&) const
+ConstInterfaceElementPtr InterfaceElement::getDeclaration(const string&) const
 {
-    return NodeDefPtr();
+    return InterfaceElementPtr();
 }
 
 bool InterfaceElement::hasExactInputMatch(ConstInterfaceElementPtr declaration, string* message) const

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -635,9 +635,9 @@ class MX_CORE_API InterfaceElement : public TypedElement
     ///    by the given target name.
     /// @param target An optional target name, which will be used to filter
     ///    the declarations that are considered.
-    /// @return A shared pointer to nodedef, or an empty shared pointer if
+    /// @return A shared pointer to declaration, or an empty shared pointer if
     ///    no declaration was found.
-    virtual ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const;
+    virtual ConstInterfaceElementPtr getDeclaration(const string& target = EMPTY_STRING) const;
 
     /// Return true if this instance has an exact input match with the given
     /// declaration, where each input of this the instance corresponds to a

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -159,17 +159,13 @@ OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)
         OutputPtr output;
         if (connectedInput)
         {
-            InputPtr interfaceInput = nullptr;
-            if (connectedInput->hasInterfaceName())
+            InputPtr interfaceInput = connectedInput->getInterfaceInput();
+            if (interfaceInput)
             {
-                interfaceInput = connectedInput->getInterfaceInput();
-                if (interfaceInput)
-                {
-                    outputName = interfaceInput->getOutputString();
-                    output = interfaceInput->getConnectedOutput();
-                }
+                output = interfaceInput->getConnectedOutput();
+                outputName = interfaceInput->getOutputString();
             }
-            if (!interfaceInput)
+            else
             {
                 output = connectedInput->getConnectedOutput();
             }
@@ -259,7 +255,7 @@ void GraphElement::flattenSubgraphs(const string& target, NodePredicate filter)
         using PortElementVec = vector<PortElementPtr>;
         std::vector<NodePtr> processNodeVec;
         std::unordered_map<NodePtr, NodeGraphPtr> graphImplMap;
-        std::unordered_map<NodePtr, ConstNodeDefPtr> declarationMap;
+        std::unordered_map<NodePtr, ConstInterfaceElementPtr> declarationMap;
         std::unordered_map<NodePtr, PortElementVec> downstreamPortMap;
         for (NodePtr node : nodeQueue)
         {
@@ -348,7 +344,7 @@ void GraphElement::flattenSubgraphs(const string& target, NodePredicate filter)
                         }
                         else
                         {
-                            ConstNodeDefPtr declaration = declarationMap[processNode];
+                            ConstInterfaceElementPtr declaration = declarationMap[processNode];
                             InputPtr declInput = declaration ? declaration->getActiveInput(destInput->getInterfaceName()) : nullptr;
                             if (declInput)
                             {
@@ -747,9 +743,18 @@ bool NodeGraph::validate(string* message) const
     return GraphElement::validate(message) && res;
 }
 
-ConstNodeDefPtr NodeGraph::getDeclaration(const string&) const
+ConstInterfaceElementPtr NodeGraph::getDeclaration(const string&) const
 {
-    return getNodeDef();
+    ConstNodeDefPtr nodeDef = getNodeDef();
+    if (nodeDef)
+    {
+        return nodeDef;
+    }
+    if (!hasNodeDefString())
+    {
+        return getSelf()->asA<InterfaceElement>();
+    }
+    return nullptr;
 }
 
 //

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -151,7 +151,7 @@ class MX_CORE_API Node : public InterfaceElement
 
     /// Return the first declaration of this interface, optionally filtered
     ///    by the given target name.
-    ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const override
+    ConstInterfaceElementPtr getDeclaration(const string& target = EMPTY_STRING) const override
     {
         return getNodeDef(target);
     }
@@ -364,7 +364,7 @@ class MX_CORE_API NodeGraph : public GraphElement
 
     /// Return the first declaration of this interface, optionally filtered
     ///    by the given target name.
-    ConstNodeDefPtr getDeclaration(const string& target = EMPTY_STRING) const override;
+    ConstInterfaceElementPtr getDeclaration(const string& target = EMPTY_STRING) const override;
 
     /// Add an interface name to an existing NodeDef associated with this NodeGraph.
     /// @param inputPath Path to an input descendant of this graph.

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -641,7 +641,7 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
         REQUIRE(newGraph->getNodeDefString() == newNodeDefName);
 
         // Check declaration was set up properly
-        mx::ConstNodeDefPtr decl = newGraph->getDeclaration();
+        mx::ConstInterfaceElementPtr decl = newGraph->getDeclaration();
         REQUIRE(decl->getName() == nodeDef->getName());
 
         // Arbitrarily add all unconnected inputs as interfaces


### PR DESCRIPTION
This changelist generalizes the InterfaceElement::getDeclaration method, broadening its return value from a NodeDefPtr to an InterfaceElementPtr.  This allows for more flexible behaviors in subclasses, where NodeGraph::getDeclaration can return a NodeDefPtr for a functional graph or a NodeGraphPtr for a compound graph.

Additional related improvements:
- Remove a section of Input::validate that now duplicates equivalent logic in ValueElement::validate.
- Simplify Input::getInterfaceInput and Node::getNodeDefOutput for clarity.