### PR TITLE
Fix "unbind geometry" MaterialXView OpenGL errors on MacOS

### DIFF
--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -432,11 +432,6 @@ void GlslProgram::unbindGeometry()
     glBindBuffer(GL_ARRAY_BUFFER, UNDEFINED_OPENGL_RESOURCE_ID);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, UNDEFINED_OPENGL_RESOURCE_ID);
 
-    // Disable vertex attribute arrays.
-    for (int i : _enabledStreamLocations)
-    {
-        glDisableVertexAttribArray(i);
-    }
     _enabledStreamLocations.clear();
 
     // Release attribute buffers.


### PR DESCRIPTION
In `GlslProgram::unbindGeometry`, glDisableVertexAttribArray is called. According to the [specification](http://registry.khronos.org/OpenGL-Refpages/gl4/html/glEnableVertexAttribArray.xhtml), this requires a vertex array to be bound, which is not the case. On MacOS, the driver seems to be less lenient and returns an error which is then printed as "OpenGL error after program unbind geometry: 1282".

Since we destroy the vertex array a few lines later, there's no need to disable the attributes.

Removing the glDisableVertexAttribArray calls fixes the errors.