### PR TITLE
Add TSC stakeholder

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,6 +64,7 @@ The current Stakeholders of the MaterialX TSC are:
 
 - Eric Bourque - Autodesk
 - Fran Gonzalez - Pixar RenderMan
+- Dhruv Govil - Apple
 - Rafal Jaroszkiewicz - SideFX
 - Lee Kerley - Sony Pictures Imageworks
 - Lutz Kettner - NVIDIA


### PR DESCRIPTION
This changelist adds Dhruv Govil as the Apple stakeholder on the MaterialX TSC, as confirmed by vote at a recent TSC meeting.