### PR TITLE
Restore exception in translateShader

### DIFF
--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -155,7 +155,7 @@ void ShaderTranslator::translateShader(NodePtr shader, const string& destCategor
     const string& sourceCategory = shader->getCategory();
     if (sourceCategory == destCategory)
     {
-        return;
+        throw Exception("The source shader \"" + shader->getNamePath() + "\" category is already \"" + destCategory + "\"");
     }
 
     DocumentPtr doc = shader->getDocument();


### PR DESCRIPTION
This changelist restores an exception that was removed from ShaderTranslator::translateShader, allowing the caller to tell whether a translation operation successfully modified the document.