### PR TITLE
Fix values for default gltf_pbr example

### DIFF
--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_default.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_default.mtlx
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="lin_rec709">
   <gltf_pbr name="SR_default" type="surfaceshader">
-    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
-    <input name="metallic" type="float" value="0" />
-    <input name="roughness" type="float" value="0" />
+    <input name="base_color" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="metallic" type="float" value="1" />
+    <input name="roughness" type="float" value="1" />
     <input name="normal" type="vector3" value="0, 0, 1" />
     <input name="occlusion" type="float" value="0" />
     <input name="transmission" type="float" value="0" />


### PR DESCRIPTION
### Change
Fix to make default gltf_pbr example shader to match the change defaults values updated as part of this [PR](
https://github.com/AcademySoftwareFoundation/MaterialX/pull/971)

### Comparison
| Correct render | Previous Render |
| ---------------  | ------------------ |
| <img src="https://user-images.githubusercontent.com/49369885/200665629-1b62e938-810e-4754-b391-60ab30007589.png" width=100%> | <img src="https://user-images.githubusercontent.com/49369885/200666010-67d71807-1648-4260-a4ce-9003296f46ab.png" width=100%> |

The main difference is that roughness and metallic have changed from 0 values to 1 values.
 
 ### Validation
 Tested this via conversion from MTLX to glTF. The cgltf write logic does not write out default values so should be a shader without any value overrides (as shown)
 ```JSON
 {
  "asset": {
    "generator": "MaterialX 1.38.71.38.4 to glTF generator",
    "version": "1.38.7",
    "min_version": "1.38.7"
  },
  "materials": [
    {
      "name": "SR_default",
      "pbrMetallicRoughness": {
      }
    }
  ]
}
 ```