### PR TITLE
Simplify matrix method signatures

### DIFF
--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -78,21 +78,21 @@ Color3 Color3::srgbToLinear() const
 // Matrix33 methods
 //
 
-template <> Matrix33 MatrixN<Matrix33, float, 3>::getTranspose() const
+Matrix33 Matrix33::getTranspose() const
 {
     return Matrix33(_arr[0][0], _arr[1][0], _arr[2][0],
                     _arr[0][1], _arr[1][1], _arr[2][1],
                     _arr[0][2], _arr[1][2], _arr[2][2]);
 }
 
-template <> float MatrixN<Matrix33, float, 3>::getDeterminant() const
+float Matrix33::getDeterminant() const
 {
     return _arr[0][0] * (_arr[1][1]*_arr[2][2] - _arr[2][1]*_arr[1][2]) +
            _arr[0][1] * (_arr[1][2]*_arr[2][0] - _arr[2][2]*_arr[1][0]) +
            _arr[0][2] * (_arr[1][0]*_arr[2][1] - _arr[2][0]*_arr[1][1]);
 }
 
-template <> Matrix33 MatrixN<Matrix33, float, 3>::getAdjugate() const
+Matrix33 Matrix33::getAdjugate() const
 {
     return Matrix33(
         _arr[1][1]*_arr[2][2] - _arr[2][1]*_arr[1][2],
@@ -159,7 +159,7 @@ Matrix33 Matrix33::createRotation(float angle)
 // Matrix44 methods
 //
 
-template <> Matrix44 MatrixN<Matrix44, float, 4>::getTranspose() const
+Matrix44 Matrix44::getTranspose() const
 {
     return Matrix44(_arr[0][0], _arr[1][0], _arr[2][0], _arr[3][0],
                     _arr[0][1], _arr[1][1], _arr[2][1], _arr[3][1],
@@ -167,7 +167,7 @@ template <> Matrix44 MatrixN<Matrix44, float, 4>::getTranspose() const
                     _arr[0][3], _arr[1][3], _arr[2][3], _arr[3][3]);
 }
 
-template <> float MatrixN<Matrix44, float, 4>::getDeterminant() const
+float Matrix44::getDeterminant() const
 {
     return _arr[0][0] * (_arr[1][1]*_arr[2][2]*_arr[3][3] + _arr[3][1]*_arr[1][2]*_arr[2][3] + _arr[2][1]*_arr[3][2]*_arr[1][3] -
                          _arr[1][1]*_arr[3][2]*_arr[2][3] - _arr[2][1]*_arr[1][2]*_arr[3][3] - _arr[3][1]*_arr[2][2]*_arr[1][3]) +
@@ -179,7 +179,7 @@ template <> float MatrixN<Matrix44, float, 4>::getDeterminant() const
                          _arr[1][0]*_arr[2][1]*_arr[3][2] - _arr[3][0]*_arr[1][1]*_arr[2][2] - _arr[2][0]*_arr[3][1]*_arr[1][2]);
 }
 
-template <> Matrix44 MatrixN<Matrix44, float, 4>::getAdjugate() const
+Matrix44 Matrix44::getAdjugate() const
 {
     return Matrix44(
         _arr[1][1]*_arr[2][2]*_arr[3][3] + _arr[3][1]*_arr[1][2]*_arr[2][3] + _arr[2][1]*_arr[3][2]*_arr[1][3] -

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -538,21 +538,6 @@ template <class M, class S, size_t N> class MatrixN : public MatrixBase
         return *this;
     }
 
-    /// Return the transpose of the matrix.
-    M getTranspose() const;
-
-    /// Return the determinant of the matrix.
-    S getDeterminant() const;
-
-    /// Return the adjugate of the matrix.
-    M getAdjugate() const;
-
-    /// Return the inverse of the matrix.
-    M getInverse() const
-    {
-        return getAdjugate() / getDeterminant();
-    }
-
     /// @}
     /// @name Iterators
     /// @{
@@ -609,6 +594,25 @@ class MX_CORE_API Matrix33 : public MatrixN<Matrix33, float, 3>
                  m20, m21, m22 };
     }
 
+    /// @name Matrix Operations
+    /// @{
+
+    /// Return the transpose of the matrix.
+    Matrix33 getTranspose() const;
+
+    /// Return the determinant of the matrix.
+    float getDeterminant() const;
+
+    /// Return the adjugate of the matrix.
+    Matrix33 getAdjugate() const;
+
+    /// Return the inverse of the matrix.
+    Matrix33 getInverse() const
+    {
+        return getAdjugate() / getDeterminant();
+    }
+
+    /// @}
     /// @name Vector Transformations
     /// @{
 
@@ -662,6 +666,25 @@ class MX_CORE_API Matrix44 : public MatrixN<Matrix44, float, 4>
                  m30, m31, m32, m33 };
     }
 
+    /// @name Matrix Operations
+    /// @{
+
+    /// Return the transpose of the matrix.
+    Matrix44 getTranspose() const;
+
+    /// Return the determinant of the matrix.
+    float getDeterminant() const;
+
+    /// Return the adjugate of the matrix.
+    Matrix44 getAdjugate() const;
+
+    /// Return the inverse of the matrix.
+    Matrix44 getInverse() const
+    {
+        return getAdjugate() / getDeterminant();
+    }
+
+    /// @}
     /// @name Vector Transformations
     /// @{
 


### PR DESCRIPTION
This changelist simplifies the signatures of the getTranspose, getDeterminant, and getAdjugate methods of the Matrix33 and Matrix44 classes, allowing them to be understood by non-compiling code parsers such as Doxygen.