### PR TITLE
Improvements to gltf_pbr translation graph

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -29,7 +29,6 @@
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
     <output name="emissive_out" type="color3" />
-    <output name="emissive_strength_out" type="float" />
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -95,9 +94,12 @@
       <input name="in1" type="color3" interfacename="sheen_color" />
       <input name="in2" type="float" interfacename="sheen" />
     </multiply>
-    <dot name="sheen_roughness" type="float">
-      <input name="in" type="float" interfacename="sheen_roughness" />
-    </dot>
+    <ifgreater name="sheen_roughness" type="float">
+      <input name="value1" type="float" interfacename="sheen" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="float" interfacename="sheen_roughness" />
+      <input name="in2" type="float" value="0" />
+    </ifgreater>
 
     <!-- Clearcoat -->
     <ifequal name="clearcoat" type="float">
@@ -111,12 +113,10 @@
     </dot>
 
     <!-- Emission -->
-    <dot name="emissive" type="color3">
-      <input name="in" type="color3" interfacename="emission_color" />
-    </dot>
-    <dot name="emissive_strength" type="float">
-      <input name="in" type="float" interfacename="emission" />
-    </dot>
+    <multiply name="emissive" type="color3">
+      <input name="in1" type="color3" interfacename="emission_color" />
+      <input name="in2" type="float" interfacename="emission" />
+    </multiply>
 
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
@@ -129,7 +129,6 @@
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />
-    <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
 
   </nodegraph>
 </materialx>


### PR DESCRIPTION
- Leave glTF PBR emissive and emissive_strength at their defaults when Standard Surface emission is zero.
- Leave glTF PBR sheen_roughness at its default when Standard Surface sheen is zero.