### PR TITLE
Add uisoftmin attribute to IOR inputs

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -26,7 +26,7 @@
            doc="Color tint on the specular reflection." />
     <input name="specular_roughness" type="float" value="0.2" uimin="0.0" uimax="1.0" uiname="Specular Roughness" uifolder="Specular"
            doc="The roughness of the specular reflection. Lower numbers produce sharper reflections, higher numbers produce blurrier reflections." />
-    <input name="specular_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Index of Refraction" uifolder="Specular"
+    <input name="specular_IOR" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Index of Refraction" uifolder="Specular"
            doc="Index of refraction for specular reflection." />
     <input name="specular_anisotropy" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Specular Anisotropy" uifolder="Specular" uiadvanced="true"
            doc="The directional bias of reflected and transmitted light resulting in materials appearing rougher or glossier in certain directions." />
@@ -72,7 +72,7 @@
            doc="The amount of directional bias, or anisotropy, of the clear-coat layer." />
     <input name="coat_rotation" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Rotation" uifolder="Coat" uiadvanced="true"
            doc="The rotation of the anisotropic effect of the clear-coat layer." />
-    <input name="coat_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Coat Index of Refraction" uifolder="Coat"
+    <input name="coat_IOR" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Coat Index of Refraction" uifolder="Coat"
            doc="The index of refraction of the clear-coat layer." />
     <input name="coat_normal" type="vector3" defaultgeomprop="Nworld" uiname="Coat normal" uifolder="Coat"
            doc="Input normal for clear-coat layer" />
@@ -82,7 +82,7 @@
            doc="Controls the roughness of the specular reflection in the layers below the clear-coat." />
     <input name="thin_film_thickness" type="float" value="0" uimin="0.0" uisoftmax="2000.0" uiname="Thin Film Thickness" uifolder="Thin Film" uiadvanced="true"
            doc="The thickness of the thin film layer on a surface. Use for materials such as multitone car paint or soap bubbles." />
-    <input name="thin_film_IOR" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
+    <input name="thin_film_IOR" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
            doc="The index of refraction of the medium surrounding the material." />
     <input name="emission" type="float" value="0" uimin="0.0" uisoftmax="1.0" uiname="Emission" uifolder="Emission"
            doc="The amount of emitted incandescent light." />

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -17,7 +17,7 @@
     <input name="clearcoatRoughness" type="float" value="0.01" uimin="0.0" uimax="1.0" />
     <input name="opacity" type="float" value="1" uimin="0.0" uimax="1.0" />
     <input name="opacityThreshold" type="float" value="0" uimin="0.0" uimax="1.0" />
-    <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmax="3.0" />
+    <input name="ior" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" />
     <input name="normal" type="vector3" value="0, 0, 1" />
     <input name="displacement" type="float" value="0" />
     <input name="occlusion" type="float" value="1" uimin="0.0" uimax="1.0" />


### PR DESCRIPTION
The usual lower bound of ior values is 1.0 but can be lower for relative ior or for turning off fresnel completely. Having uisoftmin set allows user interfaces to have a slider with this range.