### PR TITLE
Re-enable shadergen testing in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,8 +204,8 @@ jobs:
       run: |
         vcpkg/vcpkg install glslang --triplet=x64-windows
         glslangValidator.exe -v
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/ --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/ --path . --target essl --validator glslangValidator.exe
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface --path . --target essl --validator glslangValidator.exe
 
     - name: Static Analysis Tests
       if: matrix.static_analysis == 'ON' && runner.os == 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,7 +140,7 @@ jobs:
       run: |
         git clone https://github.com/Microsoft/vcpkg -b 2021.05.12 -c advice.detachedHead=false
         vcpkg/bootstrap-vcpkg.bat -disableMetrics
-        Add-Content $env:GITHUB_PATH "$PWD/vcpkg/installed/bin"
+        Add-Content $env:GITHUB_PATH "$PWD/build/installed/bin"
         Add-Content $env:GITHUB_PATH "$PWD/vcpkg/installed/x64-windows/bin"
         Add-Content $env:GITHUB_PATH "$PWD/vcpkg/installed/x64-windows/tools"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
           architecture: x64
           python: 3.9
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
-          #test_shaders: ON
+          test_shaders: ON
 
     steps:
     - name: Sync Repository
@@ -140,9 +140,9 @@ jobs:
       run: |
         git clone https://github.com/Microsoft/vcpkg -b 2021.05.12 -c advice.detachedHead=false
         vcpkg/bootstrap-vcpkg.bat -disableMetrics
-        echo $PWD/build/installed/bin | Out-File -FilePath $env:GITHUB_PATH -Append
-        echo $PWD/vcpkg/installed/x64-windows/bin | Out-File -FilePath $env:GITHUB_PATH -Append
-        echo $PWD/vcpkg/installed/x64-windows/tools | Out-File -FilePath $env:GITHUB_PATH -Append
+        Add-Content $env:GITHUB_PATH "$PWD/vcpkg/installed/bin"
+        Add-Content $env:GITHUB_PATH "$PWD/vcpkg/installed/x64-windows/bin"
+        Add-Content $env:GITHUB_PATH "$PWD/vcpkg/installed/x64-windows/tools"
 
     - name: Install Python ${{ matrix.python }}
       uses: actions/setup-python@v4
@@ -194,9 +194,9 @@ jobs:
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
         python Scripts/mxdoc.py --docType md ../libraries/pbrlib/pbrlib_defs.mtlx
         python Scripts/mxdoc.py --docType html ../libraries/bxdf/standard_surface.mtlx
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_gold.mtlx --path .. --target glsl
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_copper.mtlx --path .. --target osl
-        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface/standard_surface_jade.mtlx --path .. --target mdl
+        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface --path .. --target glsl
+        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface --path .. --target osl
+        python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface --path .. --target mdl
       working-directory: python
 
     - name: Shader Validation Tests
@@ -204,8 +204,8 @@ jobs:
       run: |
         vcpkg/vcpkg install glslang --triplet=x64-windows
         glslangValidator.exe -v
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx --path . --target essl --validator glslangValidator.exe
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/ --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
+        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/ --path . --target essl --validator glslangValidator.exe
 
     - name: Static Analysis Tests
       if: matrix.static_analysis == 'ON' && runner.os == 'macOS'

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -24,6 +24,18 @@ def validateCode(sourceCodeFile, codevalidator, codevalidatorArgs):
             return (out.output.decode(encoding='utf-8'))
     return ""
 
+def getMaterialXFiles(rootPath):
+    filelist = []
+    if os.path.isdir(rootPath): 
+        for subdir, dirs, files in os.walk(rootPath):
+            for file in files:
+                if file.endswith('mtlx'):
+                    filelist.append(os.path.join(subdir, file)) 
+    else:
+        filelist.append( rootPath )
+
+    return filelist
+
 def main():
     parser = argparse.ArgumentParser(description='Generate shader code for each material / shader in a document.')
     parser.add_argument('--path', dest='paths', action='append', nargs='+', help='An additional absolute search path location (e.g. "/projects/MaterialX")')
@@ -34,150 +46,154 @@ def main():
     parser.add_argument('--validatorArgs', dest='validatorArgs', nargs='?', const=' ', type=str, help='Optional arguments for code validator.')
     parser.add_argument('--vulkanGlsl', dest='vulkanCompliantGlsl', default=False, type=bool, help='Set to True to generate Vulkan-compliant GLSL when using the genglsl target.')
     parser.add_argument('--shaderInterfaceType', dest='shaderInterfaceType', default=0, type=int, help='Set the type of shader interface to be generated')
-    parser.add_argument(dest='inputFilename', help='Filename of the input document.')
+    parser.add_argument(dest='inputFilename', help='Path to input document or folder containing input documents.')
     opts = parser.parse_args()
 
-    doc = mx.createDocument()
-    try:
-        mx.readFromXmlFile(doc, opts.inputFilename)
-    except mx.ExceptionFileMissing as err:
-        print('Generation failed: "', err, '"')
-        sys.exit(-1)
+    filelist = getMaterialXFiles(opts.inputFilename)
 
-    stdlib = mx.createDocument()
-    searchPath = mx.FileSearchPath(os.path.dirname(opts.inputFilename))
-    libraryFolders = []
-    if opts.paths:
-        for pathList in opts.paths:
-            for path in pathList:
-                searchPath.append(path)
-    if opts.libraries:
-        for libraryList in opts.libraries:
-            for library in libraryList:
-                libraryFolders.append(library)
-    libraryFolders.append("libraries")
-    try:
-        mx.loadLibraries(libraryFolders, searchPath, stdlib)
-        doc.importLibrary(stdlib)
-    except err:
-        print('Generation failed: "', err, '"')
-        sys.exit(-1)
+    for inputFilename in filelist:        
+        doc = mx.createDocument()
+        try:
+            mx.readFromXmlFile(doc, inputFilename)
+        except mx.ExceptionFileMissing as err:
+            print('Generation failed: "', err, '"')
+            sys.exit(-1)
 
-    valid, msg = doc.validate()
-    if not valid:
-        print('Validation warnings for input document:')
-        print(msg)
-        sys.exit(-1)
+        print('---------- Generate code for file: ', inputFilename, '--------------------')
 
-    gentarget = 'glsl'
-    if opts.target:
-        gentarget = opts.target
-    if gentarget == 'osl':
-        shadergen = mx_gen_osl.OslShaderGenerator.create()
-    elif gentarget == 'mdl':
-        shadergen = mx_gen_mdl.MdlShaderGenerator.create()
-    elif gentarget == 'essl':
-        shadergen = mx_gen_glsl.EsslShaderGenerator.create()
-    elif gentarget == 'vulkan':
-        shadergen = mx_gen_glsl.VkShaderGenerator.create()
-    else:
-        shadergen = mx_gen_glsl.GlslShaderGenerator.create()
-            
-    context = mx_gen_shader.GenContext(shadergen)
-    context.registerSourceCodeSearchPath(searchPath)
+        stdlib = mx.createDocument()
+        searchPath = mx.FileSearchPath(os.path.dirname(inputFilename))
+        libraryFolders = []
+        if opts.paths:
+            for pathList in opts.paths:
+                for path in pathList:
+                    searchPath.append(path)
+        if opts.libraries:
+            for libraryList in opts.libraries:
+                for library in libraryList:
+                    libraryFolders.append(library)
+        libraryFolders.append("libraries")
+        try:
+            mx.loadLibraries(libraryFolders, searchPath, stdlib)
+            doc.importLibrary(stdlib)
+        except err:
+            print('Generation failed: "', err, '"')
+            sys.exit(-1)
 
-    # If we're generating Vulkan-compliant GLSL then set the binding context
-    if opts.vulkanCompliantGlsl:
-        bindingContext = mx_gen_glsl.GlslResourceBindingContext.create(0,0)
-        context.pushUserData('udbinding', bindingContext)
+        valid, msg = doc.validate()
+        if not valid:
+            print('Validation warnings for input document:')
+            print(msg)
 
-    genoptions = context.getOptions() 
-    if opts.shaderInterfaceType == 0 or opts.shaderInterfaceType == 1:
-        genoptions.shaderInterfaceType = mx_gen_shader.ShaderInterfaceType(opts.shaderInterfaceType)
-    else:
-        genoptions.shaderInterfaceType = mx_gen_shader.ShaderInterfaceType.SHADER_INTERFACE_COMPLETE
-
-    print('- Set up CMS ...')
-    cms = mx_gen_shader.DefaultColorManagementSystem.create(shadergen.getTarget())  
-    cms.loadLibrary(doc)
-    shadergen.setColorManagementSystem(cms)  
-
-    print('- Set up Units ...')
-    unitsystem = mx_gen_shader.UnitSystem.create(shadergen.getTarget())
-    registry = mx.UnitConverterRegistry.create()
-    distanceTypeDef = doc.getUnitTypeDef('distance')
-    registry.addUnitConverter(distanceTypeDef, mx.LinearUnitConverter.create(distanceTypeDef))
-    angleTypeDef = doc.getUnitTypeDef('angle')
-    registry.addUnitConverter(angleTypeDef, mx.LinearUnitConverter.create(angleTypeDef))
-    unitsystem.loadLibrary(stdlib)
-    unitsystem.setUnitConverterRegistry(registry)
-    shadergen.setUnitSystem(unitsystem)
-    genoptions.targetDistanceUnit = 'meter'
-
-    # Look for renderable nodes
-    nodes = mx_gen_shader.findRenderableElements(doc, False)
-    if not nodes:
-        nodes = doc.getMaterialNodes()
-        if not nodes:
-            nodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
-
-    pathPrefix = ''
-    if opts.outputPath and os.path.exists(opts.outputPath):
-        pathPrefix = opts.outputPath + os.path.sep
-    else:
-        pathPrefix = os.path.dirname(os.path.abspath(opts.inputFilename))
-    print('- Shader output path: ' + pathPrefix)
-
-    failedShaders = ""
-    for node in nodes:
-        nodeName = node.getName()
-        print('-- Generate code for node: ' + nodeName)
-        nodeName = mx.createValidName(nodeName)
-        shader = shadergen.generate(nodeName, node, context)        
-        if shader:
-            # Use extension of .vert and .frag as it's type is
-            # recognized by glslangValidator
-            if gentarget in ['glsl', 'essl', 'vulkan']:
-                pixelSource = shader.getSourceCode(mx_gen_shader.PIXEL_STAGE)
-                filename = pathPrefix + "/" + shader.getName() + "." + gentarget + ".frag"
-                print('--- Wrote pixel shader to: ' + filename)
-                file = open(filename, 'w+')
-                file.write(pixelSource)
-                file.close()
-                errors = validateCode(filename, opts.validator, opts.validatorArgs)                
-
-                vertexSource = shader.getSourceCode(mx_gen_shader.VERTEX_STAGE)
-                filename = pathPrefix + "/" + shader.getName() + "." + gentarget + ".vert"
-                print('--- Wrote vertex shader to: ' + filename)
-                file = open(filename, 'w+')
-                file.write(vertexSource)
-                file.close()
-                errors += validateCode(filename, opts.validator, opts.validatorArgs)
-
-            else:
-                pixelSource = shader.getSourceCode(mx_gen_shader.PIXEL_STAGE)
-                filename = pathPrefix + "/" + shader.getName() + "." + gentarget
-                print('--- Wrote pixel shader to: ' + filename)
-                file = open(filename, 'w+')
-                file.write(pixelSource)
-                file.close()
-                errors = validateCode(filename, opts.validator, opts.validatorArgs)
-
-            if errors != "":
-                print("--- Validation failed for node: ", nodeName)
-                print("----------------------------")
-                print('--- Error log: ', errors)
-                print("----------------------------")
-                failedShaders += (nodeName + ' ')
-            else:
-                print("--- Validation passed for node:", nodeName)
-
+        gentarget = 'glsl'
+        if opts.target:
+            gentarget = opts.target
+        if gentarget == 'osl':
+            shadergen = mx_gen_osl.OslShaderGenerator.create()
+        elif gentarget == 'mdl':
+            shadergen = mx_gen_mdl.MdlShaderGenerator.create()
+        elif gentarget == 'essl':
+            shadergen = mx_gen_glsl.EsslShaderGenerator.create()
+        elif gentarget == 'vulkan':
+            shadergen = mx_gen_glsl.VkShaderGenerator.create()
         else:
-            print("--- Validation failed for node:", nodeName)
-            failedShaders += (nodeName + ' ')
+            shadergen = mx_gen_glsl.GlslShaderGenerator.create()
+                
+        context = mx_gen_shader.GenContext(shadergen)
+        context.registerSourceCodeSearchPath(searchPath)
 
-    if failedShaders != "":
-        sys.exit(-1)
+        # If we're generating Vulkan-compliant GLSL then set the binding context
+        if opts.vulkanCompliantGlsl:
+            bindingContext = mx_gen_glsl.GlslResourceBindingContext.create(0,0)
+            context.pushUserData('udbinding', bindingContext)
+
+        genoptions = context.getOptions() 
+        if opts.shaderInterfaceType == 0 or opts.shaderInterfaceType == 1:
+            genoptions.shaderInterfaceType = mx_gen_shader.ShaderInterfaceType(opts.shaderInterfaceType)
+        else:
+            genoptions.shaderInterfaceType = mx_gen_shader.ShaderInterfaceType.SHADER_INTERFACE_COMPLETE
+
+        print('- Set up CMS ...')
+        cms = mx_gen_shader.DefaultColorManagementSystem.create(shadergen.getTarget())  
+        cms.loadLibrary(doc)
+        shadergen.setColorManagementSystem(cms)  
+
+        print('- Set up Units ...')
+        unitsystem = mx_gen_shader.UnitSystem.create(shadergen.getTarget())
+        registry = mx.UnitConverterRegistry.create()
+        distanceTypeDef = doc.getUnitTypeDef('distance')
+        registry.addUnitConverter(distanceTypeDef, mx.LinearUnitConverter.create(distanceTypeDef))
+        angleTypeDef = doc.getUnitTypeDef('angle')
+        registry.addUnitConverter(angleTypeDef, mx.LinearUnitConverter.create(angleTypeDef))
+        unitsystem.loadLibrary(stdlib)
+        unitsystem.setUnitConverterRegistry(registry)
+        shadergen.setUnitSystem(unitsystem)
+        genoptions.targetDistanceUnit = 'meter'
+
+        # Look for renderable nodes
+        nodes = mx_gen_shader.findRenderableElements(doc, False)
+        if not nodes:
+            nodes = doc.getMaterialNodes()
+            if not nodes:
+                nodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
+
+        pathPrefix = ''
+        if opts.outputPath and os.path.exists(opts.outputPath):
+            pathPrefix = opts.outputPath + os.path.sep
+        else:
+            pathPrefix = os.path.dirname(os.path.abspath(inputFilename))
+        print('- Shader output path: ' + pathPrefix)
+
+        failedShaders = ""
+        for node in nodes:
+            nodeName = node.getName()
+            print('-- Generate code for node: ' + nodeName)
+            nodeName = mx.createValidName(nodeName)
+            shader = shadergen.generate(nodeName, node, context)        
+            if shader:
+                # Use extension of .vert and .frag as it's type is
+                # recognized by glslangValidator
+                if gentarget in ['glsl', 'essl', 'vulkan']:
+                    pixelSource = shader.getSourceCode(mx_gen_shader.PIXEL_STAGE)
+                    filename = pathPrefix + "/" + shader.getName() + "." + gentarget + ".frag"
+                    print('--- Wrote pixel shader to: ' + filename)
+                    file = open(filename, 'w+')
+                    file.write(pixelSource)
+                    file.close()
+                    errors = validateCode(filename, opts.validator, opts.validatorArgs)                
+
+                    vertexSource = shader.getSourceCode(mx_gen_shader.VERTEX_STAGE)
+                    filename = pathPrefix + "/" + shader.getName() + "." + gentarget + ".vert"
+                    print('--- Wrote vertex shader to: ' + filename)
+                    file = open(filename, 'w+')
+                    file.write(vertexSource)
+                    file.close()
+                    errors += validateCode(filename, opts.validator, opts.validatorArgs)
+
+                else:
+                    pixelSource = shader.getSourceCode(mx_gen_shader.PIXEL_STAGE)
+                    filename = pathPrefix + "/" + shader.getName() + "." + gentarget
+                    print('--- Wrote pixel shader to: ' + filename)
+                    file = open(filename, 'w+')
+                    file.write(pixelSource)
+                    file.close()
+                    errors = validateCode(filename, opts.validator, opts.validatorArgs)
+
+                if errors != "":
+                    print("--- Validation failed for node: ", nodeName)
+                    print("----------------------------")
+                    print('--- Error log: ', errors)
+                    print("----------------------------")
+                    failedShaders += (nodeName + ' ')
+                else:
+                    print("--- Validation passed for node:", nodeName)
+
+            else:
+                print("--- Validation failed for node:", nodeName)
+                failedShaders += (nodeName + ' ')
+
+        if failedShaders != "":
+            sys.exit(-1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Fix:
* Fix CI workflow to add `vcpkg` binary search paths properly for PowerShell
* Generalize `generateshader` to allow testing of folder paths vs just single file paths and update CI workflow.

## Tests
The following now runs properly:
```
 vcpkg/vcpkg install glslang --triplet=x64-windows
  glslangValidator.exe -v
  python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/ --path . --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
  python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface/ --path . --target essl --validator glslangValidator.exe
```