### PR TITLE
Improvements to render testing

### DIFF
--- a/python/MaterialXTest/tests_to_html.bat
+++ b/python/MaterialXTest/tests_to_html.bat
@@ -1,0 +1,1 @@
+python tests_to_html.py -i ../../build

--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -98,7 +98,7 @@ def main(args=None):
             if curPath != sourcePath:
                 if curPath != "":
                     fh.write("</table>\n")
-                fh.write("<p>" + sourcePath + ":</p>\n")
+                fh.write("<p>" + os.path.normpath(sourcePath) + ":</p>\n")
                 fh.write("<table>\n")
                 curPath = sourcePath
 
@@ -119,12 +119,12 @@ def main(args=None):
 
             fh.write("<tr>\n")
             if fullSourcePath:
-                    fh.write("<td align='center'>" + sourceFile)
+                fh.write("<td align='center'>" + sourceFile)
             if args.ENABLE_TIMESTAMPS and os.path.isfile(fullSourcePath):
                 fh.write("<br>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullSourcePath))) + ")")
             fh.write("</td>\n")
             if fullDestPath:
-                    fh.write("<td align='center'>" + destFile)
+                fh.write("<td align='center'>" + destFile)
             if args.ENABLE_TIMESTAMPS and os.path.isfile(fullDestPath):
                 fh.write("<br>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullDestPath))) + ")")
             fh.write("</td>\n")

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -98,7 +98,7 @@
     <input name="extraLibraryPaths" type="string" value="" />
 
     <!-- List of document paths for render tests -->
-    <input name="renderTestPaths" type="string" value="resources/Materials/Examples,resources/Materials/TestSuite" />
+    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/stdlib/geometric,resources/Materials/TestSuite/stdlib/noise,resources/Materials/TestSuite/pbrlib" />
 
     <!-- Enable reference quality rendering. Default is false. -->
     <input name="enableReferenceQuality" type="boolean" value="false" />


### PR DESCRIPTION
- Improve the formatting of path strings in generated HTML.
- Add a simple wrapper script for generating HTML on Windows.
- Simplify the default list of document paths for render testing, focusing on the tests with the greatest visual significance.