### PR TITLE
Add material examples

### DIFF
--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_carpaint.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_carpaint.mtlx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <gltf_pbr name="SR_carpaint" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.0518895, 0.29606, 0.425324" />
+    <input name="metallic" type="float" value="0" />
+    <input name="roughness" type="float" value="0.4" />
+    <input name="clearcoat" type="float" value="1" />
+  </gltf_pbr>
+  <surfacematerial name="PBR_Car_Paint" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_carpaint" />
+  </surfacematerial>
+</materialx>

--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_glass.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_glass.mtlx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <gltf_pbr name="SR_glass" type="surfaceshader">
+    <input name="metallic" type="float" value="0" />
+    <input name="roughness" type="float" value="0.01" />
+    <input name="transmission" type="float" value="1" />
+    <input name="ior" type="float" value="1.52" />
+  </gltf_pbr>
+  <surfacematerial name="PBR_Glass" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_glass" />
+  </surfacematerial>
+</materialx>

--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_gold.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_gold.mtlx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <gltf_pbr name="SR_gold" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.944, 0.776, 0.373" />
+    <input name="roughness" type="float" value="0.02" />
+  </gltf_pbr>
+  <surfacematerial name="PBR_Gold" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_gold" />
+  </surfacematerial>
+</materialx>

--- a/resources/Materials/Examples/GltfPbr/gltf_pbr_plastic.mtlx
+++ b/resources/Materials/Examples/GltfPbr/gltf_pbr_plastic.mtlx
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <gltf_pbr name="SR_plastic" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.104704, 0.241883, 0.818" />
+    <input name="metallic" type="float" value="0" />
+    <input name="roughness" type="float" value="0.324675" />
+  </gltf_pbr>
+  <surfacematerial name="PBR_Plastic" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_plastic" />
+  </surfacematerial>
+</materialx>

--- a/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_carpaint.mtlx
+++ b/resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_carpaint.mtlx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<materialx version="1.38" colorspace="lin_rec709">
+  <UsdPreviewSurface name="SR_carpaint" type="surfaceshader">
+    <input name="diffuseColor" type="color3" value="0.0518895, 0.29606, 0.425324" />
+    <input name="roughness" type="float" value="0.4" />
+    <input name="clearcoat" type="float" value="1" />
+    <input name="clearcoatRoughness" type="float" value="0" />
+  </UsdPreviewSurface>
+  <surfacematerial name="USD_Car_Paint" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="SR_carpaint" />
+  </surfacematerial>
+</materialx>


### PR DESCRIPTION
This changelist adds a handful of new material examples based on the glTF PBR and UsdPreviewSurface shading models, providing broader coverage in visual validation.  These materials were generated from existing Standard Surface examples using shader translation.