### PR TITLE
Improvements to GLFramebuffer

### DIFF
--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -122,33 +122,6 @@ GLFramebuffer::~GLFramebuffer()
     }
 }
 
-void GLFramebuffer::resize(unsigned int width, unsigned int height)
-{
-    if (width * height == 0)
-    {
-        return;
-    }
-    if (width != _width || _height != height)
-    {
-        unbind();
-
-        int glType, glFormat, glInternalFormat;
-        GLTextureHandler::mapTextureFormatToGL(_baseType, _channelCount, true, glType, glFormat, glInternalFormat);
-
-        glBindTexture(GL_TEXTURE_2D, _colorTexture);
-        glTexImage2D(GL_TEXTURE_2D, 0, glInternalFormat, width, height, 0, glFormat, glType, nullptr);
-
-        glBindTexture(GL_TEXTURE_2D, _depthTexture);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
-
-        glBindTexture(GL_TEXTURE_2D, GlslProgram::UNDEFINED_OPENGL_RESOURCE_ID);
-        glDrawBuffer(GL_NONE);
-
-        _width = width;
-        _height = height;
-    }
-}
-
 void GLFramebuffer::bind()
 {
     if (!_framebuffer)

--- a/source/MaterialXRenderGlsl/GLFramebuffer.h
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.h
@@ -31,8 +31,17 @@ class MX_RENDERGLSL_API GLFramebuffer
     /// Destructor
     virtual ~GLFramebuffer();
 
-    /// Resize the framebuffer
-    void resize(unsigned int width, unsigned int height);
+    /// Return the width of the framebuffer.
+    unsigned int getWidth() const
+    {
+        return _width;
+    }
+
+    /// Return the height of the framebuffer.
+    unsigned int getHeight() const
+    {
+        return _height;
+    }
 
     /// Set the encode sRGB flag, which controls whether values written
     /// to the framebuffer are encoded to the sRGB color space.

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -136,11 +136,9 @@ void GlslRenderer::setSize(unsigned int width, unsigned int height)
 {
     if (_context->makeCurrent())
     {
-        if (_framebuffer)
-        {
-            _framebuffer->resize(width, height);
-        }
-        else
+        if (!_framebuffer ||
+             _framebuffer->getWidth() != width ||
+             _framebuffer->getHeight() != height)
         {
             _framebuffer = GLFramebuffer::create(width, height, 4, _baseType);
         }


### PR DESCRIPTION
- Add helper methods GLFramebuffer::getWidth and GLFramebuffer::getHeight.
- Remove duplicate construction logic in GLFramebuffer::resize, which is no longer consistent with the main constructor.
- Update GlslRenderer::setSize to use the new methods.