### PR TITLE
Improvements to ShaderGen syntax

### DIFF
--- a/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
@@ -47,43 +47,47 @@ void EsslShaderGenerator::emitUniforms(GenContext& context, ShaderStage& stage) 
 
 void EsslShaderGenerator::emitInputs(GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
-    const VariableBlock& vertexInputs = stage.getInputBlock(HW::VERTEX_INPUTS);
-    if (!vertexInputs.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
     {
-        emitComment("Inputs block: " + vertexInputs.getName(), stage);
-        emitVariableDeclarations(vertexInputs, _syntax->getInputQualifier(), Syntax::SEMICOLON, context, stage, false);
-        emitLineBreak(stage);
+        const VariableBlock& vertexInputs = stage.getInputBlock(HW::VERTEX_INPUTS);
+        if (!vertexInputs.empty())
+        {
+            emitComment("Inputs block: " + vertexInputs.getName(), stage);
+            emitVariableDeclarations(vertexInputs, _syntax->getInputQualifier(), Syntax::SEMICOLON, context, stage, false);
+            emitLineBreak(stage);
+        }
     }
-END_SHADER_STAGE(stage, Stage::VERTEX)
 
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
-    if (!vertexData.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        emitVariableDeclarations(vertexData, _syntax->getInputQualifier(), Syntax::SEMICOLON, context, stage, false);
-        emitLineBreak(stage);
+        const VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
+        if (!vertexData.empty())
+        {
+            emitVariableDeclarations(vertexData, _syntax->getInputQualifier(), Syntax::SEMICOLON, context, stage, false);
+            emitLineBreak(stage);
+        }
     }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 void EsslShaderGenerator::emitOutputs(GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
-    const VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
-    if (!vertexData.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
     {
-        emitVariableDeclarations(vertexData,  _syntax->getOutputQualifier(), Syntax::SEMICOLON, context, stage, false);
+        const VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
+        if (!vertexData.empty())
+        {
+            emitVariableDeclarations(vertexData, _syntax->getOutputQualifier(), Syntax::SEMICOLON, context, stage, false);
+            emitLineBreak(stage);
+        }
+    }
+
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
+        emitComment("Pixel shader outputs", stage);
+        const VariableBlock& outputs = stage.getOutputBlock(HW::PIXEL_OUTPUTS);
+        emitVariableDeclarations(outputs, _syntax->getOutputQualifier(), Syntax::SEMICOLON, context, stage, false);
         emitLineBreak(stage);
     }
-END_SHADER_STAGE(stage, Stage::VERTEX)
-
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    emitComment("Pixel shader outputs", stage);
-    const VariableBlock& outputs = stage.getOutputBlock(HW::PIXEL_OUTPUTS);
-    emitVariableDeclarations(outputs, _syntax->getOutputQualifier(), Syntax::SEMICOLON, context, stage, false);
-    emitLineBreak(stage);
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 string EsslShaderGenerator::getVertexDataPrefix(const VariableBlock&) const

--- a/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.cpp
@@ -59,7 +59,8 @@ void BitangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
     const ShaderInput* spaceInput = node.getInput(SPACE);
     const int space = spaceInput ? spaceInput->getValue()->asA<int>() : OBJECT_SPACE;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         if (space == WORLD_SPACE)
@@ -109,9 +110,10 @@ void BitangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
                 }
             }
         }
-    END_SHADER_STAGE(stage, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         shadergen.emitLineBegin(stage);
@@ -127,7 +129,7 @@ void BitangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
             shadergen.emitString(" = normalize(" + prefix + bitangent->getVariable() + ")", stage);
         }
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.cpp
@@ -22,13 +22,14 @@ void FrameNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shad
 
 void FrameNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLineBegin(stage);
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + HW::T_FRAME, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.cpp
@@ -34,7 +34,8 @@ void GeomColorNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
     string index = indexInput ? indexInput->getValue()->getValueString() : "0";
     string variable = HW::T_COLOR + "_" + index;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* color = vertexData[variable];
@@ -43,9 +44,10 @@ void GeomColorNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
             color->setEmitted();
             shadergen.emitLine(prefix + color->getVariable() + " = " + HW::T_IN_COLOR + "_" + index, stage);
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         string suffix = "";
         if (output->getType() == Type::FLOAT)
         {
@@ -62,7 +64,7 @@ void GeomColorNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + prefix + color->getVariable() + suffix, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.cpp
@@ -43,7 +43,8 @@ void GeomPropValueNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext&
     const string geomname = geomPropInput->getValue()->getValueString();
     const string variable = HW::T_IN_GEOMPROP + "_" + geomname;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* geomprop = vertexData[variable];
@@ -52,17 +53,18 @@ void GeomPropValueNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext&
             shadergen.emitLine(prefix + geomprop->getVariable() + " = " + HW::T_IN_GEOMPROP + "_" + geomname, stage);
             geomprop->setEmitted();
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* geomprop = vertexData[variable];
-            shadergen.emitLineBegin(stage);
+        shadergen.emitLineBegin(stage);
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + prefix + geomprop->getVariable(), stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 ShaderNodeImplPtr GeomPropValueNodeGlslAsUniform::create()
@@ -85,7 +87,8 @@ void GeomPropValueNodeGlslAsUniform::createVariables(const ShaderNode& node, Gen
 
 void GeomPropValueNodeGlslAsUniform::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const ShaderInput* geomPropInput = node.getInput(GEOMPROP);
         if (!geomPropInput)
@@ -97,7 +100,7 @@ void GeomPropValueNodeGlslAsUniform::emitFunctionCall(const ShaderNode& node, Ge
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + HW::T_GEOMPROP + "_" + attrName, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -52,19 +52,21 @@ bool HeightToNormalNodeGlsl::acceptsInputType(const TypeDesc* type) const
 
 void HeightToNormalNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         // Emit sampling functions
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLibraryInclude("stdlib/genglsl/lib/mx_sampling.glsl", context, stage);
         shadergen.emitLineBreak(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 void HeightToNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-    
+
         const ShaderInput* inInput = node.getInput("in");
         const ShaderInput* scaleInput = node.getInput("scale");
 
@@ -78,8 +80,8 @@ void HeightToNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext
         // the variables to assign to the sample grid.
         //  
         StringVec sampleStrings;
-        emitInputSamplesUV(node, sampleCount, filterWidth, 
-                           filterSize, filterOffset, sampleSizeFunctionUV, 
+        emitInputSamplesUV(node, sampleCount, filterWidth,
+                           filterSize, filterOffset, sampleSizeFunctionUV,
                            context, stage, sampleStrings);
 
         const ShaderOutput* output = node.getOutput();
@@ -99,7 +101,7 @@ void HeightToNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext
         shadergen.emitInput(scaleInput, context, stage);
         shadergen.emitString(")", stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 const string& HeightToNormalNodeGlsl::getTarget() const

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -62,7 +62,8 @@ void LightCompoundNodeGlsl::createVariables(const ShaderNode&, GenContext& conte
 
 void LightCompoundNodeGlsl::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
         // Emit functions for all child nodes
@@ -83,7 +84,7 @@ void LightCompoundNodeGlsl::emitFunctionDefinition(const ShaderNode& node, GenCo
                 emitFunctionDefinition(cct, context, stage);
             }
         }
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 void LightCompoundNodeGlsl::emitFunctionDefinition(ClosureContext* cct, GenContext& context, ShaderStage& stage) const
@@ -127,10 +128,11 @@ void LightCompoundNodeGlsl::emitFunctionDefinition(ClosureContext* cct, GenConte
 
 void LightCompoundNodeGlsl::emitFunctionCall(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLine(_functionName + "(light, position, result)", stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -47,48 +47,49 @@ void LightNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shad
 
 void LightNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
-
-    shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, FilePath(), context, stage);
-    shadergen.emitLineBreak(stage);
-
-    const ShaderInput* edfInput = node.getInput("edf");
-    const ShaderNode* edf = edfInput->getConnectedSibling();
-    if (edf)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        context.pushClosureContext(&_callEmission);
-        shadergen.emitFunctionCall(*edf, context, stage);
-        context.popClosureContext();
+        const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
+        shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, FilePath(), context, stage);
         shadergen.emitLineBreak(stage);
 
-        shadergen.emitComment("Apply quadratic falloff and adjust intensity", stage);
-        shadergen.emitLine("result.intensity = " + edf->getOutput()->getVariable() + " / (distance * distance)", stage);
-
-        const ShaderInput* intensity = node.getInput("intensity");
-        const ShaderInput* exposure = node.getInput("exposure");
-
-        shadergen.emitLineBegin(stage);
-        shadergen.emitString("result.intensity *= ", stage);
-        shadergen.emitInput(intensity, context, stage);
-        shadergen.emitLineEnd(stage);
-
-        // Emit exposure adjustment only if it matters
-        if (exposure->getConnection() || (exposure->getValue() && exposure->getValue()->asA<float>() != 0.0f))
+        const ShaderInput* edfInput = node.getInput("edf");
+        const ShaderNode* edf = edfInput->getConnectedSibling();
+        if (edf)
         {
+            context.pushClosureContext(&_callEmission);
+            shadergen.emitFunctionCall(*edf, context, stage);
+            context.popClosureContext();
+
+            shadergen.emitLineBreak(stage);
+
+            shadergen.emitComment("Apply quadratic falloff and adjust intensity", stage);
+            shadergen.emitLine("result.intensity = " + edf->getOutput()->getVariable() + " / (distance * distance)", stage);
+
+            const ShaderInput* intensity = node.getInput("intensity");
+            const ShaderInput* exposure = node.getInput("exposure");
+
             shadergen.emitLineBegin(stage);
-            shadergen.emitString("result.intensity *= pow(2, ", stage);
-            shadergen.emitInput(exposure, context, stage);
-            shadergen.emitString(")", stage);
+            shadergen.emitString("result.intensity *= ", stage);
+            shadergen.emitInput(intensity, context, stage);
             shadergen.emitLineEnd(stage);
+
+            // Emit exposure adjustment only if it matters
+            if (exposure->getConnection() || (exposure->getValue() && exposure->getValue()->asA<float>() != 0.0f))
+            {
+                shadergen.emitLineBegin(stage);
+                shadergen.emitString("result.intensity *= pow(2, ", stage);
+                shadergen.emitInput(exposure, context, stage);
+                shadergen.emitString(")", stage);
+                shadergen.emitLineEnd(stage);
+            }
+        }
+        else
+        {
+            shadergen.emitLine("result.intensity = vec3(0.0)", stage);
         }
     }
-    else
-    {
-        shadergen.emitLine("result.intensity = vec3(0.0)", stage);
-    }
-END_SHADER_STAGE(shader, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
@@ -24,7 +24,8 @@ ShaderNodeImplPtr LightSamplerNodeGlsl::create()
 
 void LightSamplerNodeGlsl::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         // Emit light sampler function with all bound light types
@@ -48,7 +49,7 @@ void LightSamplerNodeGlsl::emitFunctionDefinition(const ShaderNode& node, GenCon
         }
 
         shadergen.emitFunctionBodyEnd(node, context, stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
@@ -66,10 +66,11 @@ void LightShaderNodeGlsl::createVariables(const ShaderNode&, GenContext& context
 
 void LightShaderNodeGlsl::emitFunctionCall(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLine(_functionName + "(light, position, result)", stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.cpp
@@ -41,7 +41,8 @@ void NormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& contex
     const ShaderInput* spaceInput = node.getInput(SPACE);
     const int space = spaceInput ? spaceInput->getValue()->asA<int>() : OBJECT_SPACE;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         if (space == WORLD_SPACE)
@@ -62,9 +63,10 @@ void NormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& contex
                 shadergen.emitLine(prefix + normal->getVariable() + " = " + HW::T_IN_NORMAL, stage);
             }
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         shadergen.emitLineBegin(stage);
@@ -80,7 +82,7 @@ void NormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& contex
             shadergen.emitString(" = normalize(" + prefix + normal->getVariable() + ")", stage);
         }
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
@@ -34,13 +34,14 @@ void NumLightsNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& 
 
 void NumLightsNodeGlsl::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLine(NUM_LIGHTS_FUNC_SIGNATURE, stage, false);
         shadergen.emitFunctionBodyBegin(node, context, stage);
         shadergen.emitLine("return min(" + HW::T_NUM_ACTIVE_LIGHT_SOURCES + ", " + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + ") ", stage);
         shadergen.emitFunctionBodyEnd(node, context, stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.cpp
@@ -40,7 +40,8 @@ void PositionNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& cont
     const ShaderInput* spaceInput = node.getInput(SPACE);
     const int space = spaceInput ? spaceInput->getValue()->asA<int>() : OBJECT_SPACE;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         if (space == WORLD_SPACE)
@@ -61,9 +62,10 @@ void PositionNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& cont
                 shadergen.emitLine(prefix + position->getVariable() + " = " + HW::T_IN_POSITION, stage);
             }
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         shadergen.emitLineBegin(stage);
@@ -79,7 +81,7 @@ void PositionNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& cont
             shadergen.emitString(" = " + prefix + position->getVariable(), stage);
         }
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -69,7 +69,8 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
 {
     const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* position = vertexData[HW::T_POSITION_WORLD];
@@ -93,9 +94,10 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
                 shadergen.emitLine(prefix + texcoord->getVariable() + " = " + HW::T_IN_TEXCOORD + "_0", stage);
             }
         }
-    END_SHADER_STAGE(stage, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
 
@@ -222,8 +224,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
 
         shadergen.emitScopeEnd(stage);
         shadergen.emitLineBreak(stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 void SurfaceNodeGlsl::emitLightLoop(const ShaderNode& node, GenContext& context, ShaderStage& stage, const string& outColor) const

--- a/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
@@ -44,7 +44,8 @@ void SurfaceShaderNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext&
 {
     const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* position = vertexData[HW::T_POSITION_WORLD];
@@ -53,11 +54,12 @@ void SurfaceShaderNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext&
             position->setEmitted();
             context.getShaderGenerator().emitLine(prefix + position->getVariable() + " = hPositionWorld.xyz", stage);
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         SourceCodeNode::emitFunctionCall(node, context, stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
@@ -41,7 +41,8 @@ void TangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
     const ShaderInput* spaceInput = node.getInput(SPACE);
     const int space = spaceInput ? spaceInput->getValue()->asA<int>() : OBJECT_SPACE;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         if (space == WORLD_SPACE)
@@ -62,9 +63,10 @@ void TangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
                 shadergen.emitLine(prefix + tangent->getVariable() + " = " + HW::T_IN_TANGENT, stage);
             }
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         shadergen.emitLineBegin(stage);
@@ -80,7 +82,7 @@ void TangentNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
             shadergen.emitString(" = normalize(" + prefix + tangent->getVariable() + ")", stage);
         }
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.cpp
@@ -35,7 +35,8 @@ void TexCoordNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& cont
     const string index = indexInput ? indexInput->getValue()->getValueString() : "0";
     const string variable = HW::T_TEXCOORD + "_" + index;
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* texcoord = vertexData[variable];
@@ -44,17 +45,18 @@ void TexCoordNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& cont
             shadergen.emitLine(prefix + texcoord->getVariable() + " = " + HW::T_IN_TEXCOORD + "_" + index, stage);
             texcoord->setEmitted();
         }
-    END_SHADER_STAGE(shader, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
         const string prefix = shadergen.getVertexDataPrefix(vertexData);
         ShaderPort* texcoord = vertexData[variable];
-            shadergen.emitLineBegin(stage);
+        shadergen.emitLineBegin(stage);
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + prefix + texcoord->getVariable(), stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.cpp
@@ -22,7 +22,8 @@ void TimeNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader& shade
 
 void TimeNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLineBegin(stage);
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
@@ -31,7 +32,7 @@ void TimeNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context,
         const string fps = fpsInput->getValue()->getValueString();
         shadergen.emitString(fps, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
@@ -16,14 +16,15 @@ void TransformNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContex
 {
     TransformVectorNodeGlsl::emitFunctionCall(node, context, stage);
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const ShaderOutput* output = node.getOutput();
         shadergen.emitLineBegin(stage);
         shadergen.emitOutput(output, false, false, context, stage);
         shadergen.emitString(" = normalize(" + output->getVariable() + ")", stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 const string& TransformNormalNodeGlsl::getMatrix(const string& fromSpace, const string& toSpace) const

--- a/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.cpp
@@ -32,7 +32,8 @@ void TransformVectorNodeGlsl::createVariables(const ShaderNode& node, GenContext
 
 void TransformVectorNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderInput* inInput = node.getInput("in");
@@ -58,8 +59,7 @@ void TransformVectorNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContex
         shadergen.emitString(getHomogeneousCoordinate(inInput, context), stage);
         shadergen.emitString(").xyz", stage);
         shadergen.emitLineEnd(stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 const string& TransformVectorNodeGlsl::getMatrix(const string& fromSpace, const string& toSpace) const

--- a/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
@@ -19,8 +19,8 @@ void UnlitSurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& 
 {
     const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         // Declare the output variable
         const ShaderOutput* output = node.getOutput();
         shadergen.emitLineBegin(stage);
@@ -33,7 +33,7 @@ void UnlitSurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& 
         const ShaderInput* emission = node.getInput("emission");
         const ShaderInput* emissionColor = node.getInput("emission_color");
         shadergen.emitLine(outColor + " = " + shadergen.getUpstreamResult(emission, context) + " * " + shadergen.getUpstreamResult(emissionColor, context), stage);
-        
+
         const ShaderInput* transmission = node.getInput("transmission");
         const ShaderInput* transmissionColor = node.getInput("transmission_color");
         shadergen.emitLine(outTransparency + " = " + shadergen.getUpstreamResult(transmission, context) + " * " + shadergen.getUpstreamResult(transmissionColor, context), stage);
@@ -42,8 +42,7 @@ void UnlitSurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& 
         const string surfaceOpacity = shadergen.getUpstreamResult(opacity, context);
         shadergen.emitLine(outColor + " *= " + surfaceOpacity, stage);
         shadergen.emitLine(outTransparency + " = mix(vec3(1.0), " + outTransparency + ", " + surfaceOpacity + ")", stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/VkShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/VkShaderGenerator.cpp
@@ -31,40 +31,42 @@ void VkShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
 
 void VkShaderGenerator::emitInputs(GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
-    const VariableBlock& vertexInputs = stage.getInputBlock(HW::VERTEX_INPUTS);
-    if (!vertexInputs.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
     {
-        emitComment("Inputs block: " + vertexInputs.getName(), stage);
-        for (size_t i = 0; i < vertexInputs.size(); ++i)
+        const VariableBlock& vertexInputs = stage.getInputBlock(HW::VERTEX_INPUTS);
+        if (!vertexInputs.empty())
         {
-            emitLineBegin(stage);
-            emitString("layout (location = " + std::to_string(i) + ") ", stage);
-            emitVariableDeclaration(vertexInputs[i], _syntax->getInputQualifier(), context, stage, false);
-            emitString(Syntax::SEMICOLON, stage);
-            emitLineEnd(stage, false);
+            emitComment("Inputs block: " + vertexInputs.getName(), stage);
+            for (size_t i = 0; i < vertexInputs.size(); ++i)
+            {
+                emitLineBegin(stage);
+                emitString("layout (location = " + std::to_string(i) + ") ", stage);
+                emitVariableDeclaration(vertexInputs[i], _syntax->getInputQualifier(), context, stage, false);
+                emitString(Syntax::SEMICOLON, stage);
+                emitLineEnd(stage, false);
+            }
+            emitLineBreak(stage);
         }
-        emitLineBreak(stage);
     }
-    END_SHADER_STAGE(stage, Stage::VERTEX)
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
-    if (!vertexData.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        emitComment("Inputs: " + vertexData.getName(), stage);
-        for (size_t i = 0; i < vertexData.size(); ++i)
+        const VariableBlock& vertexData = stage.getInputBlock(HW::VERTEX_DATA);
+        if (!vertexData.empty())
         {
+            emitComment("Inputs: " + vertexData.getName(), stage);
+            for (size_t i = 0; i < vertexData.size(); ++i)
+            {
 
-            emitLineBegin(stage);
-            emitString("layout (location = " + std::to_string(i) + ") ", stage);
-            emitVariableDeclaration(vertexData[i], _syntax->getInputQualifier(), context, stage, false);
-            emitString(Syntax::SEMICOLON, stage);
-            emitLineEnd(stage, false);
+                emitLineBegin(stage);
+                emitString("layout (location = " + std::to_string(i) + ") ", stage);
+                emitVariableDeclaration(vertexData[i], _syntax->getInputQualifier(), context, stage, false);
+                emitString(Syntax::SEMICOLON, stage);
+                emitLineEnd(stage, false);
+            }
+            emitLineBreak(stage);
         }
-        emitLineBreak(stage);
     }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 string VkShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
@@ -74,37 +76,38 @@ string VkShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
 
 void VkShaderGenerator::emitOutputs(GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
-    const VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
-    if (!vertexData.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
     {
-        for (size_t i = 0; i < vertexData.size(); ++i)
+        const VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
+        if (!vertexData.empty())
+        {
+            for (size_t i = 0; i < vertexData.size(); ++i)
+            {
+                emitLineBegin(stage);
+                emitString("layout (location = " + std::to_string(i) + ") ", stage);
+                emitVariableDeclaration(vertexData[i], _syntax->getOutputQualifier(), context, stage, false);
+                emitString(Syntax::SEMICOLON, stage);
+                emitLineEnd(stage, false);
+            }
+            emitLineBreak(stage);
+        }
+    }
+
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
+        const VariableBlock& outputs = stage.getOutputBlock(HW::PIXEL_OUTPUTS);
+
+        emitComment("Pixel shader outputs", stage);
+        for (size_t i = 0; i < outputs.size(); ++i)
         {
             emitLineBegin(stage);
             emitString("layout (location = " + std::to_string(i) + ") ", stage);
-            emitVariableDeclaration(vertexData[i], _syntax->getOutputQualifier(), context, stage, false);
+            emitVariableDeclaration(outputs[i], _syntax->getOutputQualifier(), context, stage, false);
             emitString(Syntax::SEMICOLON, stage);
             emitLineEnd(stage, false);
         }
         emitLineBreak(stage);
     }
-    END_SHADER_STAGE(stage, Stage::VERTEX)
-
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const VariableBlock& outputs = stage.getOutputBlock(HW::PIXEL_OUTPUTS);
-
-    emitComment("Pixel shader outputs", stage);
-    for (size_t i = 0; i < outputs.size(); ++i)
-    {
-        emitLineBegin(stage);
-        emitString("layout (location = " + std::to_string(i) + ") ", stage);
-        emitVariableDeclaration(outputs[i], _syntax->getOutputQualifier(), context, stage, false);
-        emitString(Syntax::SEMICOLON, stage);
-        emitLineEnd(stage, false);
-    }
-    emitLineBreak(stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 HwResourceBindingContextPtr VkShaderGenerator::getResourceBindingContext(GenContext& /*context*/) const

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
@@ -62,7 +62,8 @@ void BlurNodeMdl::emitSamplingFunctionDefinition(const ShaderNode&, GenContext&,
 
 void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderInput* inInput = node.getInput(IN_STRING);
@@ -183,7 +184,7 @@ void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, 
             shadergen.emitString(" = " + sampleStrings[0], stage);
             shadergen.emitLineEnd(stage);
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
@@ -26,7 +26,8 @@ void ClosureCompoundNodeMdl::addClassification(ShaderNode& node) const
 
 void ClosureCompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const Syntax& syntax = shadergen.getSyntax();
 
@@ -141,13 +142,13 @@ void ClosureCompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContex
         }
 
         shadergen.emitLineBreak(stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 void ClosureCompoundNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         // Emit calls for any closure dependencies upstream from this node.
@@ -183,7 +184,7 @@ void ClosureCompoundNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext
         // End function call
         shadergen.emitString(")", stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.cpp
@@ -20,16 +20,15 @@ ShaderNodeImplPtr ClosureSourceCodeNodeMdl::create()
 
 void ClosureSourceCodeNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         // Emit calls for any closure dependencies upstream from this node.
         shadergen.emitDependentFunctionCalls(node, context, stage, ShaderNode::Classification::CLOSURE);
 
         SourceCodeNodeMdl::emitFunctionCall(node, context, stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
@@ -19,7 +19,8 @@ ShaderNodeImplPtr CombineNodeMdl::create()
 
 void CombineNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         // Custom handling for color3 type input, all other types 
         // can are handled by our parent class below.
         // Custom handling is needed since in MDL color must be converted
@@ -87,8 +88,7 @@ void CombineNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& contex
         {
             CombineNode::emitFunctionCall(node, context, stage);
         }
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
@@ -31,7 +31,8 @@ void CompoundNodeMdl::initialize(const InterfaceElement& element, GenContext& co
 
 void CompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const Syntax& syntax = shadergen.getSyntax();
 
@@ -128,13 +129,13 @@ void CompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContext& cont
         }
 
         shadergen.emitLineBreak(stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 void CompoundNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         // Begin function call.
@@ -167,7 +168,7 @@ void CompoundNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& conte
         // End function call
         shadergen.emitString(")", stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -53,9 +53,10 @@ bool HeightToNormalNodeMdl::acceptsInputType(const TypeDesc* type) const
 
 void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-    
+
         const ShaderInput* inInput = node.getInput("in");
         const ShaderInput* scaleInput = node.getInput("scale");
 
@@ -69,8 +70,8 @@ void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext&
         // the variables to assign to the sample grid.
         //  
         StringVec sampleStrings;
-        emitInputSamplesUV(node, sampleCount, filterWidth, 
-                           filterSize, filterOffset, sampleSizeFunctionUV, 
+        emitInputSamplesUV(node, sampleCount, filterWidth,
+                           filterSize, filterOffset, sampleSizeFunctionUV,
                            context, stage, sampleStrings);
 
         const ShaderOutput* output = node.getOutput();
@@ -84,7 +85,7 @@ void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext&
         {
             shadergen.emitLineBegin(stage);
             shadergen.emitString("    " + sampleStrings[i], stage);
-            if (i+1 < sampleCount)
+            if (i + 1 < sampleCount)
             {
                 shadergen.emitLine(",", stage, false);
             }
@@ -97,7 +98,7 @@ void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext&
         shadergen.emitInput(scaleInput, context, stage);
         shadergen.emitString(")", stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 const string& HeightToNormalNodeMdl::getTarget() const

--- a/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.cpp
@@ -17,44 +17,43 @@ ShaderNodeImplPtr MaterialNodeMdl::create()
 
 void MaterialNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-    ShaderInput* surfaceshaderInput = node.getInput(ShaderNode::SURFACESHADER);
-
-    if (!surfaceshaderInput->getConnection())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Just declare the output variable with default value.
-        emitOutputVariables(node, context, stage);
-        return;
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
+        ShaderInput* surfaceshaderInput = node.getInput(ShaderNode::SURFACESHADER);
+
+        if (!surfaceshaderInput->getConnection())
+        {
+            // Just declare the output variable with default value.
+            emitOutputVariables(node, context, stage);
+            return;
+        }
+
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+
+        // Emit the function call for upstream surface shader.
+        const ShaderNode* surfaceshaderNode = surfaceshaderInput->getConnection()->getNode();
+        shadergen.emitFunctionCall(*surfaceshaderNode, context, stage);
+
+        shadergen.emitLineBegin(stage);
+
+        // Emit the output and funtion name.
+        shadergen.emitOutput(node.getOutput(), true, false, context, stage);
+        shadergen.emitString(" = mx::stdlib::mx_surfacematerial(", stage);
+
+        // Emit all inputs on the node.
+        string delim = "";
+        for (ShaderInput* input : node.getInputs())
+        {
+            shadergen.emitString(delim, stage);
+            shadergen.emitInput(input, context, stage);
+            delim = ", ";
+        }
+
+        // End function call
+        shadergen.emitString(")", stage);
+        shadergen.emitLineEnd(stage);
     }
-
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-
-    // Emit the function call for upstream surface shader.
-    const ShaderNode* surfaceshaderNode = surfaceshaderInput->getConnection()->getNode();
-    shadergen.emitFunctionCall(*surfaceshaderNode, context, stage);
-
-    shadergen.emitLineBegin(stage);
-
-    // Emit the output and funtion name.
-    shadergen.emitOutput(node.getOutput(), true, false, context, stage);
-    shadergen.emitString(" = mx::stdlib::mx_surfacematerial(", stage);
-
-    // Emit all inputs on the node.
-    string delim = "";
-    for (ShaderInput* input : node.getInputs())
-    {
-        shadergen.emitString(delim, stage);
-        shadergen.emitInput(input, context, stage);
-        delim = ", ";
-    }
-
-    // End function call
-    shadergen.emitString(")", stage);
-    shadergen.emitLineEnd(stage);
-
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -51,7 +51,8 @@ void SourceCodeNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContext&, S
 
 void SourceCodeNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         if (_inlined)
         {
@@ -143,7 +144,7 @@ void SourceCodeNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& con
             shadergen.emitString(")", stage);
             shadergen.emitLineEnd(stage);
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
@@ -53,7 +53,8 @@ const ShaderInput* findTransmissionIOR(const ShaderNode& node)
 
 void SurfaceNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const MdlShaderGenerator& shadergen = static_cast<const MdlShaderGenerator&>(context.getShaderGenerator());
 
         // Emit calls for the closure dependencies upstream from this node.
@@ -91,8 +92,7 @@ void SurfaceNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& contex
         // End function call
         shadergen.emitString(")", stage);
         shadergen.emitLineEnd(stage);
-
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenOsl/Nodes/MaterialNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/MaterialNodeOsl.cpp
@@ -30,44 +30,43 @@ void MaterialNodeOsl::emitFunctionDefinition(const ShaderNode&, GenContext& cont
 
 void MaterialNodeOsl::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-    ShaderInput* surfaceshaderInput = node.getInput(ShaderNode::SURFACESHADER);
-
-    if (!surfaceshaderInput->getConnection())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Just declare the output variable with default value.
-        emitOutputVariables(node, context, stage);
-        return;
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
+        ShaderInput* surfaceshaderInput = node.getInput(ShaderNode::SURFACESHADER);
+
+        if (!surfaceshaderInput->getConnection())
+        {
+            // Just declare the output variable with default value.
+            emitOutputVariables(node, context, stage);
+            return;
+        }
+
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+
+        // Emit the function call for upstream surface shader.
+        const ShaderNode* surfaceshaderNode = surfaceshaderInput->getConnection()->getNode();
+        shadergen.emitFunctionCall(*surfaceshaderNode, context, stage);
+
+        shadergen.emitLineBegin(stage);
+
+        // Emit the output and funtion name.
+        shadergen.emitOutput(node.getOutput(), true, false, context, stage);
+        shadergen.emitString(" = mx_surfacematerial(", stage);
+
+        // Emit all inputs on the node.
+        string delim = "";
+        for (ShaderInput* input : node.getInputs())
+        {
+            shadergen.emitString(delim, stage);
+            shadergen.emitInput(input, context, stage);
+            delim = ", ";
+        }
+
+        // End function call
+        shadergen.emitString(")", stage);
+        shadergen.emitLineEnd(stage);
     }
-
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-
-    // Emit the function call for upstream surface shader.
-    const ShaderNode* surfaceshaderNode = surfaceshaderInput->getConnection()->getNode();
-    shadergen.emitFunctionCall(*surfaceshaderNode, context, stage);
-
-    shadergen.emitLineBegin(stage);
-
-    // Emit the output and funtion name.
-    shadergen.emitOutput(node.getOutput(), true, false, context, stage);
-    shadergen.emitString(" = mx_surfacematerial(", stage);
-
-    // Emit all inputs on the node.
-    string delim = "";
-    for (ShaderInput* input : node.getInputs())
-    {
-        shadergen.emitString(delim, stage);
-        shadergen.emitInput(input, context, stage);
-        delim = ", ";
-    }
-
-    // End function call
-    shadergen.emitString(")", stage);
-    shadergen.emitLineEnd(stage);
-
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -70,14 +70,16 @@ void BlurNode::outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& 
 
 void BlurNode::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         emitSamplingFunctionDefinition(node, context, stage);
-    END_SHADER_STAGE(shader, Stage::PIXEL)
+    }
 }
 
 void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderInput* inInput = node.getInput(IN_STRING);
@@ -212,7 +214,7 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
             shadergen.emitString(" = " + sampleStrings[0], stage);
             shadergen.emitLineEnd(stage);
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ClosureAddNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureAddNode.cpp
@@ -20,55 +20,56 @@ ShaderNodeImplPtr ClosureAddNode::create()
 
 void ClosureAddNode::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-    ClosureContext* cct = context.getClosureContext();
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-
-    ShaderInput* in1 = node.getInput(IN1);
-    ShaderInput* in2 = node.getInput(IN2);
-
-    // If the add node has closure parameters set,
-    // we pass this on to both connected components.
-
-    if (in1->getConnection())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Make sure it's a connection to a sibling and not the graph interface.
-        ShaderNode* in1Node = in1->getConnection()->getNode();
-        if (in1Node->getParent() == node.getParent())
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        ClosureContext* cct = context.getClosureContext();
+
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
+
+        ShaderInput* in1 = node.getInput(IN1);
+        ShaderInput* in2 = node.getInput(IN2);
+
+        // If the add node has closure parameters set,
+        // we pass this on to both connected components.
+
+        if (in1->getConnection())
         {
-            ScopedSetClosureParams setParams(&node, in1Node, cct);
-            shadergen.emitFunctionCall(*in1Node, context, stage);
+            // Make sure it's a connection to a sibling and not the graph interface.
+            ShaderNode* in1Node = in1->getConnection()->getNode();
+            if (in1Node->getParent() == node.getParent())
+            {
+                ScopedSetClosureParams setParams(&node, in1Node, cct);
+                shadergen.emitFunctionCall(*in1Node, context, stage);
+            }
+        }
+        if (in2->getConnection())
+        {
+            // Make sure it's a connection to a sibling and not the graph interface.
+            ShaderNode* in2Node = in2->getConnection()->getNode();
+            if (in2Node->getParent() == node.getParent())
+            {
+                ScopedSetClosureParams setParams(&node, in2Node, cct);
+                shadergen.emitFunctionCall(*in2Node, context, stage);
+            }
+        }
+
+        // Get their results.
+        const string in1Result = shadergen.getUpstreamResult(in1, context);
+        const string in2Result = shadergen.getUpstreamResult(in2, context);
+
+        ShaderOutput* output = node.getOutput();
+        if (output->getType() == Type::BSDF)
+        {
+            emitOutputVariables(node, context, stage);
+            shadergen.emitLine(output->getVariable() + ".response = " + in1Result + ".response + " + in2Result + ".response", stage);
+            shadergen.emitLine(output->getVariable() + ".throughput = " + in1Result + ".throughput * " + in2Result + ".throughput", stage);
+        }
+        else if (output->getType() == Type::EDF)
+        {
+            shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = " + in1Result + " + " + in2Result, stage);
         }
     }
-    if (in2->getConnection())
-    {
-        // Make sure it's a connection to a sibling and not the graph interface.
-        ShaderNode* in2Node = in2->getConnection()->getNode();
-        if (in2Node->getParent() == node.getParent())
-        {
-            ScopedSetClosureParams setParams(&node, in2Node, cct);
-            shadergen.emitFunctionCall(*in2Node, context, stage);
-        }
-    }
-
-    // Get their results.
-    const string in1Result = shadergen.getUpstreamResult(in1, context);
-    const string in2Result = shadergen.getUpstreamResult(in2, context);
-
-    ShaderOutput* output = node.getOutput();
-    if (output->getType() == Type::BSDF)
-    {
-        emitOutputVariables(node, context, stage);
-        shadergen.emitLine(output->getVariable() + ".response = " + in1Result + ".response + " + in2Result + ".response", stage);
-        shadergen.emitLine(output->getVariable() + ".throughput = " + in1Result + ".throughput * " + in2Result + ".throughput", stage);
-    }
-    else if (output->getType() == Type::EDF)
-    {
-        shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = " + in1Result + " + " + in2Result, stage);
-    }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
@@ -23,28 +23,29 @@ void ClosureCompoundNode::addClassification(ShaderNode& node) const
 
 void ClosureCompoundNode::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-
-    // Emit functions for all child nodes
-    shadergen.emitFunctionDefinitions(*_rootGraph, context, stage);
-
-    // Find any closure contexts used by this node
-    // and emit the function for each context.
-    vector<ClosureContext*> ccts;
-    shadergen.getClosureContexts(node, ccts);
-    if (ccts.empty())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        emitFunctionDefinition(nullptr, context, stage);
-    }
-    else
-    {
-        for (ClosureContext* cct : ccts)
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+
+        // Emit functions for all child nodes
+        shadergen.emitFunctionDefinitions(*_rootGraph, context, stage);
+
+        // Find any closure contexts used by this node
+        // and emit the function for each context.
+        vector<ClosureContext*> ccts;
+        shadergen.getClosureContexts(node, ccts);
+        if (ccts.empty())
         {
-            emitFunctionDefinition(cct, context, stage);
+            emitFunctionDefinition(nullptr, context, stage);
+        }
+        else
+        {
+            for (ClosureContext* cct : ccts)
+            {
+                emitFunctionDefinition(cct, context, stage);
+            }
         }
     }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 void ClosureCompoundNode::emitFunctionDefinition(ClosureContext* cct, GenContext& context, ShaderStage& stage) const
@@ -142,78 +143,79 @@ void ClosureCompoundNode::emitFunctionCall(const ShaderNode& node, GenContext& c
 {
     const ShaderGenerator& shadergen = context.getShaderGenerator();
 
-BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
-    // Emit function calls for all child nodes to the vertex shader stage
-    shadergen.emitFunctionCalls(*_rootGraph, context, stage);
-END_SHADER_STAGE(stage, Stage::VERTEX)
-
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-
-    // Emit calls for any closure dependencies upstream from this node.
-    shadergen.emitDependentFunctionCalls(node, context, stage, ShaderNode::Classification::CLOSURE);
-
-    // Declare the output variables
-    emitOutputVariables(node, context, stage);
-
-    shadergen.emitLineBegin(stage);
-    string delim = "";
-
-    // Check if we have a closure context to modify the function call.
-    ClosureContext* cct = context.getClosureContext();
-    if (cct)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
     {
-        // Use the first output for classifying node type for the closure context.
-        // This is only relevent for closures, and they only have a single output.
-        const ShaderGraphOutputSocket* outputSocket = _rootGraph->getOutputSocket();
-        const TypeDesc* closureType = outputSocket->getType();
+        // Emit function calls for all child nodes to the vertex shader stage
+        shadergen.emitFunctionCalls(*_rootGraph, context, stage);
+    }
 
-        // Check if extra parameters has been added for this node.
-        const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
-        if (closureType == Type::BSDF && params)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
+        // Emit calls for any closure dependencies upstream from this node.
+        shadergen.emitDependentFunctionCalls(node, context, stage, ShaderNode::Classification::CLOSURE);
+
+        // Declare the output variables
+        emitOutputVariables(node, context, stage);
+
+        shadergen.emitLineBegin(stage);
+        string delim = "";
+
+        // Check if we have a closure context to modify the function call.
+        ClosureContext* cct = context.getClosureContext();
+        if (cct)
         {
-            // Assign the parameters to the BSDF.
-            for (auto it : *params)
+            // Use the first output for classifying node type for the closure context.
+            // This is only relevent for closures, and they only have a single output.
+            const ShaderGraphOutputSocket* outputSocket = _rootGraph->getOutputSocket();
+            const TypeDesc* closureType = outputSocket->getType();
+
+            // Check if extra parameters has been added for this node.
+            const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
+            if (closureType == Type::BSDF && params)
             {
-                shadergen.emitLine(outputSocket->getVariable() + "." + it.first + " = " + shadergen.getUpstreamResult(it.second, context), stage);
+                // Assign the parameters to the BSDF.
+                for (auto it : *params)
+                {
+                    shadergen.emitLine(outputSocket->getVariable() + "." + it.first + " = " + shadergen.getUpstreamResult(it.second, context), stage);
+                }
+            }
+
+            // Emit function name.
+            shadergen.emitString(_functionName + cct->getSuffix(closureType) + "(", stage);
+
+            // Emit extra argument.
+            for (const ClosureContext::Argument& arg : cct->getArguments(closureType))
+            {
+                shadergen.emitString(delim + arg.second, stage);
+                delim = ", ";
             }
         }
-
-        // Emit function name.
-        shadergen.emitString(_functionName + cct->getSuffix(closureType) + "(", stage);
-
-        // Emit extra argument.
-        for (const ClosureContext::Argument& arg : cct->getArguments(closureType))
+        else
         {
-            shadergen.emitString(delim + arg.second, stage);
+            // Emit function name.
+            shadergen.emitString(_functionName + "(", stage);
+        }
+
+        // Emit all inputs.
+        for (ShaderInput* input : node.getInputs())
+        {
+            shadergen.emitString(delim, stage);
+            shadergen.emitInput(input, context, stage);
             delim = ", ";
         }
-    }
-    else
-    {
-        // Emit function name.
-        shadergen.emitString(_functionName + "(", stage);
-    }
 
-    // Emit all inputs.
-    for (ShaderInput* input : node.getInputs())
-    {
-        shadergen.emitString(delim, stage);
-        shadergen.emitInput(input, context, stage);
-        delim = ", ";
-    }
+        // Emit all outputs.
+        for (size_t i = 0; i < node.numOutputs(); ++i)
+        {
+            shadergen.emitString(delim, stage);
+            shadergen.emitOutput(node.getOutput(i), false, false, context, stage);
+            delim = ", ";
+        }
 
-    // Emit all outputs.
-    for (size_t i = 0; i < node.numOutputs(); ++i)
-    {
-        shadergen.emitString(delim, stage);
-        shadergen.emitOutput(node.getOutput(i), false, false, context, stage);
-        delim = ", ";
+        // End function call
+        shadergen.emitString(")", stage);
+        shadergen.emitLineEnd(stage);
     }
-
-    // End function call
-    shadergen.emitString(")", stage);
-    shadergen.emitLineEnd(stage);
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ClosureLayerNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureLayerNode.cpp
@@ -22,90 +22,91 @@ ShaderNodeImplPtr ClosureLayerNode::create()
 
 void ClosureLayerNode::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-    ClosureContext* cct = context.getClosureContext();
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-
-    ShaderInput* topInput = node.getInput(TOP);
-    ShaderInput* baseInput = node.getInput(BASE);
-    ShaderOutput* output = node.getOutput();
-
-    // Make sure the layer is fully connected.
-    if (!(topInput->getConnection() && baseInput->getConnection()))
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Just declare the output variable with default value.
-        emitOutputVariables(node, context, stage);
-        return;
-    }
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        ClosureContext* cct = context.getClosureContext();
 
-    ShaderNode* top = topInput->getConnection()->getNode();
-    ShaderNode* base = baseInput->getConnection()->getNode();
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
 
-    if (top->hasClassification(ShaderNode::Classification::THINFILM))
-    {
-        // This is a layer node with thin-film as top layer.
-        // Call only the base BSDF but with thin-film parameters set.
+        ShaderInput* topInput = node.getInput(TOP);
+        ShaderInput* baseInput = node.getInput(BASE);
+        ShaderOutput* output = node.getOutput();
 
-        // Make sure the connection to base is a sibling node and not the graph interface.
-        if (base->getParent() != node.getParent())
+        // Make sure the layer is fully connected.
+        if (!(topInput->getConnection() && baseInput->getConnection()))
         {
-            throw ExceptionShaderGenError("Thin-film can only be applied to a sibling node, not through a graph interface");
+            // Just declare the output variable with default value.
+            emitOutputVariables(node, context, stage);
+            return;
         }
 
-        // Set the extra parameters for thin-film.
-        ClosureContext::ClosureParams params;
-        params[THICKNESS] = top->getInput(THICKNESS);
-        params[IOR] = top->getInput(IOR);
-        ScopedSetClosureParams setParams(&params, base, cct);
+        ShaderNode* top = topInput->getConnection()->getNode();
+        ShaderNode* base = baseInput->getConnection()->getNode();
 
-        // Store the base result in the layer result variable.
-        ScopedSetVariableName setVariable(output->getVariable(), base->getOutput());
-
-        // Emit the function call.
-        shadergen.emitFunctionCall(*base, context, stage);
-    }
-    else
-    {
-        // Evaluate top and base nodes and combine their result
-        // according to throughput.
-        //
-        // TODO: In the BSDF over BSDF case should we emit code
-        //       to check the top throughput amount before calling
-        //       the base BSDF?
-
-        // Make sure the connections are sibling nodes and not the graph interface.
-        if (top->getParent() == node.getParent())
+        if (top->hasClassification(ShaderNode::Classification::THINFILM))
         {
-            // If this layer node has closure parameters set,
-            // we pass this on to the top component only.
-            ScopedSetClosureParams setParams(&node, top, cct);
-            shadergen.emitFunctionCall(*top, context, stage);
-        }
-        if (base->getParent() == node.getParent())
-        {
+            // This is a layer node with thin-film as top layer.
+            // Call only the base BSDF but with thin-film parameters set.
+
+            // Make sure the connection to base is a sibling node and not the graph interface.
+            if (base->getParent() != node.getParent())
+            {
+                throw ExceptionShaderGenError("Thin-film can only be applied to a sibling node, not through a graph interface");
+            }
+
+            // Set the extra parameters for thin-film.
+            ClosureContext::ClosureParams params;
+            params[THICKNESS] = top->getInput(THICKNESS);
+            params[IOR] = top->getInput(IOR);
+            ScopedSetClosureParams setParams(&params, base, cct);
+
+            // Store the base result in the layer result variable.
+            ScopedSetVariableName setVariable(output->getVariable(), base->getOutput());
+
+            // Emit the function call.
             shadergen.emitFunctionCall(*base, context, stage);
-        }
-
-        // Get the result variables.
-        const string& topResult = topInput->getConnection()->getVariable();
-        const string& baseResult = baseInput->getConnection()->getVariable();
-
-        // Calculate the layering result.
-        emitOutputVariables(node, context, stage);
-        if (base->getOutput()->getType() == Type::VDF)
-        {
-            shadergen.emitLine(output->getVariable() + ".response = " + topResult + ".response * " + baseResult + ".throughput", stage);
-            shadergen.emitLine(output->getVariable() + ".throughput = " + topResult + ".throughput * " + baseResult + ".throughput", stage);
         }
         else
         {
-            shadergen.emitLine(output->getVariable() + ".response = " + topResult + ".response + " + baseResult + ".response * " + topResult + ".throughput", stage);
-            shadergen.emitLine(output->getVariable() + ".throughput = " + topResult + ".throughput * " + baseResult + ".throughput", stage);
+            // Evaluate top and base nodes and combine their result
+            // according to throughput.
+            //
+            // TODO: In the BSDF over BSDF case should we emit code
+            //       to check the top throughput amount before calling
+            //       the base BSDF?
+
+            // Make sure the connections are sibling nodes and not the graph interface.
+            if (top->getParent() == node.getParent())
+            {
+                // If this layer node has closure parameters set,
+                // we pass this on to the top component only.
+                ScopedSetClosureParams setParams(&node, top, cct);
+                shadergen.emitFunctionCall(*top, context, stage);
+            }
+            if (base->getParent() == node.getParent())
+            {
+                shadergen.emitFunctionCall(*base, context, stage);
+            }
+
+            // Get the result variables.
+            const string& topResult = topInput->getConnection()->getVariable();
+            const string& baseResult = baseInput->getConnection()->getVariable();
+
+            // Calculate the layering result.
+            emitOutputVariables(node, context, stage);
+            if (base->getOutput()->getType() == Type::VDF)
+            {
+                shadergen.emitLine(output->getVariable() + ".response = " + topResult + ".response * " + baseResult + ".throughput", stage);
+                shadergen.emitLine(output->getVariable() + ".throughput = " + topResult + ".throughput * " + baseResult + ".throughput", stage);
+            }
+            else
+            {
+                shadergen.emitLine(output->getVariable() + ".response = " + topResult + ".response + " + baseResult + ".response * " + topResult + ".throughput", stage);
+                shadergen.emitLine(output->getVariable() + ".throughput = " + topResult + ".throughput * " + baseResult + ".throughput", stage);
+            }
         }
     }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ClosureMixNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureMixNode.cpp
@@ -21,56 +21,57 @@ ShaderNodeImplPtr ClosureMixNode::create()
 
 void ClosureMixNode::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-    ClosureContext* cct = context.getClosureContext();
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-
-    ShaderInput* fg = node.getInput(FG);
-    ShaderInput* bg = node.getInput(BG);
-    ShaderInput* mix = node.getInput(MIX);
-
-    // If the add node has closure parameters set,
-    // we pass this on to both components.
-
-    if (fg->getConnection())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Make sure it's a connection to a sibling and not the graph interface.
-        ShaderNode* fgNode = fg->getConnection()->getNode();
-        if (fgNode->getParent() == node.getParent())
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        ClosureContext* cct = context.getClosureContext();
+
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
+
+        ShaderInput* fg = node.getInput(FG);
+        ShaderInput* bg = node.getInput(BG);
+        ShaderInput* mix = node.getInput(MIX);
+
+        // If the add node has closure parameters set,
+        // we pass this on to both components.
+
+        if (fg->getConnection())
         {
-            ScopedSetClosureParams setParams(&node, fgNode, cct);
-            shadergen.emitFunctionCall(*fgNode, context, stage);
+            // Make sure it's a connection to a sibling and not the graph interface.
+            ShaderNode* fgNode = fg->getConnection()->getNode();
+            if (fgNode->getParent() == node.getParent())
+            {
+                ScopedSetClosureParams setParams(&node, fgNode, cct);
+                shadergen.emitFunctionCall(*fgNode, context, stage);
+            }
+        }
+        if (bg->getConnection())
+        {
+            // Make sure it's a connection to a sibling and not the graph interface.
+            ShaderNode* bgNode = bg->getConnection()->getNode();
+            if (bgNode->getParent() == node.getParent())
+            {
+                ScopedSetClosureParams setParams(&node, bgNode, cct);
+                shadergen.emitFunctionCall(*bgNode, context, stage);
+            }
+        }
+
+        const string fgResult = shadergen.getUpstreamResult(fg, context);
+        const string bgResult = shadergen.getUpstreamResult(bg, context);
+        const string mixResult = shadergen.getUpstreamResult(mix, context);
+
+        ShaderOutput* output = node.getOutput();
+        if (output->getType() == Type::BSDF)
+        {
+            emitOutputVariables(node, context, stage);
+            shadergen.emitLine(output->getVariable() + ".response = mix(" + bgResult + ".response, " + fgResult + ".response, " + mixResult + ")", stage);
+            shadergen.emitLine(output->getVariable() + ".throughput = mix(" + bgResult + ".throughput, " + fgResult + ".throughput, " + mixResult + ")", stage);
+        }
+        else if (output->getType() == Type::EDF)
+        {
+            shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = mix(" + bgResult + ", " + fgResult + ", " + mixResult + ")", stage);
         }
     }
-    if (bg->getConnection())
-    {
-        // Make sure it's a connection to a sibling and not the graph interface.
-        ShaderNode* bgNode = bg->getConnection()->getNode();
-        if (bgNode->getParent() == node.getParent())
-        {
-            ScopedSetClosureParams setParams(&node, bgNode, cct);
-            shadergen.emitFunctionCall(*bgNode, context, stage);
-        }
-    }
-
-    const string fgResult = shadergen.getUpstreamResult(fg, context);
-    const string bgResult = shadergen.getUpstreamResult(bg, context);
-    const string mixResult = shadergen.getUpstreamResult(mix, context);
-
-    ShaderOutput* output = node.getOutput();
-    if (output->getType() == Type::BSDF)
-    {
-        emitOutputVariables(node, context, stage);
-        shadergen.emitLine(output->getVariable() + ".response = mix(" + bgResult + ".response, " + fgResult + ".response, " + mixResult + ")", stage);
-        shadergen.emitLine(output->getVariable() + ".throughput = mix(" + bgResult + ".throughput, " + fgResult + ".throughput, " + mixResult + ")", stage);
-    }
-    else if (output->getType() == Type::EDF)
-    {
-        shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = mix(" + bgResult + ", " + fgResult + ", " + mixResult + ")", stage);
-    }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.cpp
@@ -20,49 +20,50 @@ ShaderNodeImplPtr ClosureMultiplyNode::create()
 
 void ClosureMultiplyNode::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-    const Syntax& syntax = shadergen.getSyntax();
-    ClosureContext* cct = context.getClosureContext();
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-
-    ShaderInput* in1 = node.getInput(IN1);
-    ShaderInput* in2 = node.getInput(IN2);
-
-    // If the multiply node has closure parameters set,
-    // we pass this on to the in1 closure component.
-
-    if (in1->getConnection())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Make sure it's a connection to a sibling and not the graph interface.
-        ShaderNode* in1Node = in1->getConnection()->getNode();
-        if (in1Node->getParent() == node.getParent())
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        const Syntax& syntax = shadergen.getSyntax();
+        ClosureContext* cct = context.getClosureContext();
+
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
+
+        ShaderInput* in1 = node.getInput(IN1);
+        ShaderInput* in2 = node.getInput(IN2);
+
+        // If the multiply node has closure parameters set,
+        // we pass this on to the in1 closure component.
+
+        if (in1->getConnection())
         {
-            ScopedSetClosureParams setParams(&node, in1Node, cct);
-            shadergen.emitFunctionCall(*in1Node, context, stage);
+            // Make sure it's a connection to a sibling and not the graph interface.
+            ShaderNode* in1Node = in1->getConnection()->getNode();
+            if (in1Node->getParent() == node.getParent())
+            {
+                ScopedSetClosureParams setParams(&node, in1Node, cct);
+                shadergen.emitFunctionCall(*in1Node, context, stage);
+            }
+        }
+
+        // Get their results.
+        const string in1Result = shadergen.getUpstreamResult(in1, context);
+        const string in2Result = shadergen.getUpstreamResult(in2, context);
+
+        ShaderOutput* output = node.getOutput();
+        if (output->getType() == Type::BSDF)
+        {
+            const string in2clamped = output->getVariable() + "_in2_clamped";
+            shadergen.emitLine(syntax.getTypeName(in2->getType()) + " " + in2clamped + " = clamp(" + in2Result + ", 0.0, 1.0)", stage);
+
+            emitOutputVariables(node, context, stage);
+            shadergen.emitLine(output->getVariable() + ".response = " + in1Result + ".response * " + in2clamped, stage);
+            shadergen.emitLine(output->getVariable() + ".throughput = " + in1Result + ".throughput * " + in2clamped, stage);
+        }
+        else if (output->getType() == Type::EDF)
+        {
+            shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = " + in1Result + " * " + in2Result, stage);
         }
     }
-
-    // Get their results.
-    const string in1Result = shadergen.getUpstreamResult(in1, context);
-    const string in2Result = shadergen.getUpstreamResult(in2, context);
-
-    ShaderOutput* output = node.getOutput();
-    if (output->getType() == Type::BSDF)
-    {
-        const string in2clamped = output->getVariable() + "_in2_clamped";
-        shadergen.emitLine(syntax.getTypeName(in2->getType()) + " " + in2clamped + " = clamp(" + in2Result + ", 0.0, 1.0)", stage);
-
-        emitOutputVariables(node, context, stage);
-        shadergen.emitLine(output->getVariable() + ".response = " + in1Result + ".response * " + in2clamped, stage);
-        shadergen.emitLine(output->getVariable() + ".throughput = " + in1Result + ".throughput * " + in2clamped, stage);
-    }
-    else if (output->getType() == Type::EDF)
-    {
-        shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = " + in1Result + " * " + in2Result, stage);
-    }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
@@ -16,73 +16,74 @@ ShaderNodeImplPtr ClosureSourceCodeNode::create()
 
 void ClosureSourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-
-    // Emit calls for any closure dependencies upstream from this node.
-    shadergen.emitDependentFunctionCalls(node, context, stage, ShaderNode::Classification::CLOSURE);
-
-    if (_inlined)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        SourceCodeNode::emitFunctionCall(node, context, stage);
-    }
-    else
-    {
-        const ShaderOutput* output = node.getOutput();
-        string delim = "";
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
 
-        // Declare the output variable.
-        emitOutputVariables(node, context, stage);
+        // Emit calls for any closure dependencies upstream from this node.
+        shadergen.emitDependentFunctionCalls(node, context, stage, ShaderNode::Classification::CLOSURE);
 
-        // Check if we have a closure context to modify the function call.
-        ClosureContext* cct = context.getClosureContext();
-        if (cct)
+        if (_inlined)
         {
-            // Check if extra parameters has been added for this node.
-            const TypeDesc* closureType = output->getType();
-            const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
-            if (closureType == Type::BSDF && params)
-            {
-                // Assign the parameters to the BSDF.
-                for (auto it : *params)
-                {
-                    shadergen.emitLine(output->getVariable() + "." + it.first + " = " + shadergen.getUpstreamResult(it.second, context), stage);
-                }
-            }
-
-            // Emit function name.
-            shadergen.emitLineBegin(stage);
-            shadergen.emitString(_functionName + cct->getSuffix(closureType) + "(", stage);
-
-            // Emit extra argument.
-            for (const ClosureContext::Argument& arg : cct->getArguments(closureType))
-            {
-                shadergen.emitString(delim + arg.second, stage);
-                delim = ", ";
-            }
+            SourceCodeNode::emitFunctionCall(node, context, stage);
         }
         else
         {
-            // Emit function name.
-            shadergen.emitLineBegin(stage);
-            shadergen.emitString(_functionName + "(", stage);
+            const ShaderOutput* output = node.getOutput();
+            string delim = "";
+
+            // Declare the output variable.
+            emitOutputVariables(node, context, stage);
+
+            // Check if we have a closure context to modify the function call.
+            ClosureContext* cct = context.getClosureContext();
+            if (cct)
+            {
+                // Check if extra parameters has been added for this node.
+                const TypeDesc* closureType = output->getType();
+                const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
+                if (closureType == Type::BSDF && params)
+                {
+                    // Assign the parameters to the BSDF.
+                    for (auto it : *params)
+                    {
+                        shadergen.emitLine(output->getVariable() + "." + it.first + " = " + shadergen.getUpstreamResult(it.second, context), stage);
+                    }
+                }
+
+                // Emit function name.
+                shadergen.emitLineBegin(stage);
+                shadergen.emitString(_functionName + cct->getSuffix(closureType) + "(", stage);
+
+                // Emit extra argument.
+                for (const ClosureContext::Argument& arg : cct->getArguments(closureType))
+                {
+                    shadergen.emitString(delim + arg.second, stage);
+                    delim = ", ";
+                }
+            }
+            else
+            {
+                // Emit function name.
+                shadergen.emitLineBegin(stage);
+                shadergen.emitString(_functionName + "(", stage);
+            }
+
+            // Emit all inputs.
+            for (ShaderInput* input : node.getInputs())
+            {
+                shadergen.emitString(delim, stage);
+                shadergen.emitInput(input, context, stage);
+                delim = ", ";
+            }
+
+            // Emit the output.
+            shadergen.emitString(delim + node.getOutput()->getVariable() + ")", stage);
+
+            // End function call
+            shadergen.emitLineEnd(stage);
         }
-
-        // Emit all inputs.
-        for (ShaderInput* input : node.getInputs())
-        {
-            shadergen.emitString(delim, stage);
-            shadergen.emitInput(input, context, stage);
-            delim = ", ";
-        }
-
-        // Emit the output.
-        shadergen.emitString(delim + node.getOutput()->getVariable() + ")", stage);
-
-        // End function call
-        shadergen.emitLineEnd(stage);
     }
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/CombineNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CombineNode.cpp
@@ -18,7 +18,8 @@ ShaderNodeImplPtr CombineNode::create()
 
 void CombineNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderInput* in1 = node.getInput(0);
@@ -136,7 +137,7 @@ void CombineNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + result, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -56,7 +56,8 @@ void CompoundNode::createVariables(const ShaderNode&, GenContext& context, Shade
 
 void CompoundNode::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const Syntax& syntax = shadergen.getSyntax();
 
@@ -65,7 +66,7 @@ void CompoundNode::emitFunctionDefinition(const ShaderNode&, GenContext& context
 
         // Begin function signature.
         shadergen.emitLineBegin(stage);
-        shadergen.emitString("void " + _functionName + + "(", stage);
+        shadergen.emitString("void " + _functionName + +"(", stage);
 
         string delim = "";
 
@@ -100,19 +101,21 @@ void CompoundNode::emitFunctionDefinition(const ShaderNode&, GenContext& context
 
         // End function body.
         shadergen.emitFunctionBodyEnd(*_rootGraph, context, stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 void CompoundNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
     const ShaderGenerator& shadergen = context.getShaderGenerator();
 
-    BEGIN_SHADER_STAGE(stage, Stage::VERTEX)
+    DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
+    {
         // Emit function calls for all child nodes to the vertex shader stage
         shadergen.emitFunctionCalls(*_rootGraph, context, stage);
-    END_SHADER_STAGE(stage, Stage::VERTEX)
+    }
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         // Declare the output variables.
         emitOutputVariables(node, context, stage);
 
@@ -141,7 +144,7 @@ void CompoundNode::emitFunctionCall(const ShaderNode& node, GenContext& context,
         // End function call
         shadergen.emitString(")", stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ConvertNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvertNode.cpp
@@ -71,7 +71,8 @@ void ConvertNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
 
     static const string IN_STRING("in");
 
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderInput* in = node.getInput(IN_STRING);
@@ -134,7 +135,7 @@ void ConvertNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + result, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/IfNode.cpp
+++ b/source/MaterialXGenShader/Nodes/IfNode.cpp
@@ -18,7 +18,8 @@ string IfEqualNode::EQUALITY_STRING = " == ";
 
 void IfNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderGraph& graph = *node.getParent();
@@ -72,7 +73,7 @@ void IfNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Shade
 
             shadergen.emitScopeEnd(stage);
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 ShaderNodeImplPtr IfGreaterNode::create()

--- a/source/MaterialXGenShader/Nodes/MaterialNode.cpp
+++ b/source/MaterialXGenShader/Nodes/MaterialNode.cpp
@@ -29,30 +29,29 @@ void MaterialNode::addClassification(ShaderNode& node) const
 
 void MaterialNode::emitFunctionCall(const ShaderNode& _node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-
-    ShaderNode& node = const_cast<ShaderNode&>(_node);
-    ShaderInput* surfaceshaderInput = node.getInput(ShaderNode::SURFACESHADER);
-
-    if (!surfaceshaderInput->getConnection())
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Just declare the output variable with default value.
-        emitOutputVariables(node, context, stage);
-        return;
+        ShaderNode& node = const_cast<ShaderNode&>(_node);
+        ShaderInput* surfaceshaderInput = node.getInput(ShaderNode::SURFACESHADER);
+
+        if (!surfaceshaderInput->getConnection())
+        {
+            // Just declare the output variable with default value.
+            emitOutputVariables(node, context, stage);
+            return;
+        }
+
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        const Syntax& syntax = shadergen.getSyntax();
+
+        // Emit the function call for upstream surface shader.
+        const ShaderNode* surfaceshaderNode = surfaceshaderInput->getConnection()->getNode();
+        shadergen.emitFunctionCall(*surfaceshaderNode, context, stage);
+
+        // Assing this result to the material output variable.
+        const ShaderOutput* output = node.getOutput();
+        shadergen.emitLine(syntax.getTypeName(output->getType()) + " " + output->getVariable() + " = " + surfaceshaderInput->getConnection()->getVariable(), stage);
     }
-
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-    const Syntax& syntax = shadergen.getSyntax();
-
-    // Emit the function call for upstream surface shader.
-    const ShaderNode* surfaceshaderNode = surfaceshaderInput->getConnection()->getNode();
-    shadergen.emitFunctionCall(*surfaceshaderNode, context, stage);
-
-    // Assing this result to the material output variable.
-    const ShaderOutput* output = node.getOutput();
-    shadergen.emitLine(syntax.getTypeName(output->getType()) + " " + output->getVariable() + " = " + surfaceshaderInput->getConnection()->getVariable(), stage);
-
-END_SHADER_STAGE(stage, Stage::PIXEL)
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -69,7 +69,8 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
 
 void SourceCodeNode::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         // Emit function definition for non-inlined functions
         if (!_functionSource.empty())
         {
@@ -84,12 +85,13 @@ void SourceCodeNode::emitFunctionDefinition(const ShaderNode&, GenContext& conte
                 shadergen.emitLineBreak(stage);
             }
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 void SourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         if (_inlined)
         {
@@ -190,7 +192,7 @@ void SourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext& contex
             shadergen.emitString(")", stage);
             shadergen.emitLineEnd(stage);
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/SwitchNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SwitchNode.cpp
@@ -20,7 +20,8 @@ ShaderNodeImplPtr SwitchNode::create()
 
 void SwitchNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const ShaderGraph& graph = *node.getParent();
 
@@ -49,7 +50,7 @@ void SwitchNode::emitFunctionCall(const ShaderNode& node, GenContext& context, S
             }
             // Convert to float to insure a valid comparison, since the 'which'
             // input may be float, integer or boolean.
-            shadergen.emitString("if (float(", stage); 
+            shadergen.emitString("if (float(", stage);
             shadergen.emitInput(which, context, stage);
             shadergen.emitString(") < float(", stage);
             shadergen.emitValue(float(branch + 1), stage);
@@ -76,7 +77,7 @@ void SwitchNode::emitFunctionCall(const ShaderNode& node, GenContext& context, S
 
             shadergen.emitScopeEnd(stage);
         }
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/SwizzleNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SwizzleNode.cpp
@@ -21,14 +21,15 @@ ShaderNodeImplPtr SwizzleNode::create()
 
 void SwizzleNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
 
         const ShaderInput* in = node.getInput(IN_STRING);
         const ShaderInput* channels = node.getInput(CHANNELS_STRING);
         if (!in || !channels)
         {
-            throw ExceptionShaderGenError("Node '" + node.getName() +"' is not a valid swizzle node");
+            throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid swizzle node");
         }
         if (!in->getConnection() && !in->getValue())
         {
@@ -56,7 +57,7 @@ void SwizzleNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
         shadergen.emitOutput(node.getOutput(), true, false, context, stage);
         shadergen.emitString(" = " + variableName, stage);
         shadergen.emitLineEnd(stage);
-    END_SHADER_STAGE(stage, Stage::PIXEL)
+    }
 }
 
 bool SwizzleNode::isEditable(const ShaderInput& input) const

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -21,10 +21,13 @@
 
 #include <sstream>
 
-// Macro for begin/end of statements to be picked up by a given shader stage.
-// For shaders that are multi-stage all code generation statements adding code 
-// to the shader should be wrapped inside such begin/end stating its target.
-#define BEGIN_SHADER_STAGE(stage, name) if (stage.getName() == name) {
+// Restrict a scoped block of statements to a specific shader stage, as
+// is required for multi-stage shading languages.  Statements within
+// the block will only be emitted when processing the given stage.
+#define DEFINE_SHADER_STAGE(stage, name) if (stage.getName() == name)
+
+// These macros are deprecated, and should be replaced with DEFINE_SHADER_STAGE.
+#define BEGIN_SHADER_STAGE(stage, name) DEFINE_SHADER_STAGE(stage, name) {
 #define END_SHADER_STAGE(stage, name) }
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenShader/UnitSystem.cpp
+++ b/source/MaterialXGenShader/UnitSystem.cpp
@@ -49,54 +49,55 @@ void ScalarUnitNode::initialize(const InterfaceElement& element, GenContext& /*c
 
 void ScalarUnitNode::emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    // Emit the helper funtion mx_<unittype>_unit_ratio that embeds a look up table for unit scale
-    vector<float> unitScales;
-    unitScales.reserve(_scalarUnitConverter->getUnitScale().size());
-    auto unitScaleMap = _scalarUnitConverter->getUnitScale();
-    unitScales.resize(unitScaleMap.size());
-    for (auto unitScale : unitScaleMap)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        int location = _scalarUnitConverter->getUnitAsInteger(unitScale.first);
-        unitScales[location] = unitScale.second;
+        // Emit the helper funtion mx_<unittype>_unit_ratio that embeds a look up table for unit scale
+        vector<float> unitScales;
+        unitScales.reserve(_scalarUnitConverter->getUnitScale().size());
+        auto unitScaleMap = _scalarUnitConverter->getUnitScale();
+        unitScales.resize(unitScaleMap.size());
+        for (auto unitScale : unitScaleMap)
+        {
+            int location = _scalarUnitConverter->getUnitAsInteger(unitScale.first);
+            unitScales[location] = unitScale.second;
+        }
+        // See stdlib/gen*/mx_<unittype>_unit. This helper function is called by these shaders.
+        const string VAR_UNIT_SCALE = "u_" + _scalarUnitConverter->getUnitType() + "_unit_scales";
+        VariableBlock unitLUT("unitLUT", EMPTY_STRING);
+        ScopedFloatFormatting fmt(Value::FloatFormatFixed, 15);
+        unitLUT.add(Type::FLOATARRAY, VAR_UNIT_SCALE, Value::createValue<vector<float>>(unitScales));
+
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
+        shadergen.emitLine("float " + _unitRatioFunctionName + "(int unit_from, int unit_to)", stage, false);
+        shadergen.emitFunctionBodyBegin(node, context, stage);  
+        shadergen.emitVariableDeclarations(unitLUT, shadergen.getSyntax().getConstantQualifier(), ";", context, stage, true);
+        shadergen.emitLine("return ("+ VAR_UNIT_SCALE + "[unit_from] / " + VAR_UNIT_SCALE + "[unit_to])", stage);
+        shadergen.emitFunctionBodyEnd(node, context, stage);
     }
-    // See stdlib/gen*/mx_<unittype>_unit. This helper function is called by these shaders.
-    const string VAR_UNIT_SCALE = "u_" + _scalarUnitConverter->getUnitType() + "_unit_scales";
-    VariableBlock unitLUT("unitLUT", EMPTY_STRING);
-    ScopedFloatFormatting fmt(Value::FloatFormatFixed, 15);
-    unitLUT.add(Type::FLOATARRAY, VAR_UNIT_SCALE, Value::createValue<vector<float>>(unitScales));
-
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
-    shadergen.emitLine("float " + _unitRatioFunctionName + "(int unit_from, int unit_to)", stage, false);
-    shadergen.emitFunctionBodyBegin(node, context, stage);  
-    shadergen.emitVariableDeclarations(unitLUT, shadergen.getSyntax().getConstantQualifier(), ";", context, stage, true);
-    shadergen.emitLine("return ("+ VAR_UNIT_SCALE + "[unit_from] / " + VAR_UNIT_SCALE + "[unit_to])", stage);
-    shadergen.emitFunctionBodyEnd(node, context, stage);
-
-    END_SHADER_STAGE(shader, Stage::PIXEL)
 }
 
 void ScalarUnitNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-BEGIN_SHADER_STAGE(stage, Stage::PIXEL)
-    const ShaderGenerator& shadergen = context.getShaderGenerator();
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    {
+        const ShaderGenerator& shadergen = context.getShaderGenerator();
 
-    const ShaderInput* in = node.getInput(0);
-    const ShaderInput* from = node.getInput(1);
-    const ShaderInput* to = node.getInput(2);
+        const ShaderInput* in = node.getInput(0);
+        const ShaderInput* from = node.getInput(1);
+        const ShaderInput* to = node.getInput(2);
 
-    shadergen.emitLineBegin(stage);
-    shadergen.emitOutput(node.getOutput(), true, false, context, stage);
-    shadergen.emitString(" = ", stage);
-    shadergen.emitInput(in, context, stage);
-    shadergen.emitString(" * ", stage);
-    shadergen.emitString(_unitRatioFunctionName + "(", stage);
-    shadergen.emitInput(from, context, stage);
-    shadergen.emitString(", ", stage);
-    shadergen.emitInput(to, context, stage);
-    shadergen.emitString(")", stage);
-    shadergen.emitLineEnd(stage);
-END_SHADER_STAGE(shader, Stage::PIXEL)
+        shadergen.emitLineBegin(stage);
+        shadergen.emitOutput(node.getOutput(), true, false, context, stage);
+        shadergen.emitString(" = ", stage);
+        shadergen.emitInput(in, context, stage);
+        shadergen.emitString(" * ", stage);
+        shadergen.emitString(_unitRatioFunctionName + "(", stage);
+        shadergen.emitInput(from, context, stage);
+        shadergen.emitString(", ", stage);
+        shadergen.emitInput(to, context, stage);
+        shadergen.emitString(")", stage);
+        shadergen.emitLineEnd(stage);
+    }
 }
 
 //

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -37,12 +37,13 @@ class TangentOsl : public mx::ShaderNodeImpl
     {
         const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
-        BEGIN_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        DEFINE_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        {
             shadergen.emitLineBegin(stage);
             shadergen.emitOutput(node.getOutput(), true, false, context, stage);
             shadergen.emitString(" = normalize(vector(N[2], 0, -N[0]))", stage);
             shadergen.emitLineEnd(stage);
-        END_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        }
     }
 };
 
@@ -58,12 +59,13 @@ class BitangentOsl : public mx::ShaderNodeImpl
     {
         const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
-        BEGIN_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        DEFINE_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        {
             shadergen.emitLineBegin(stage);
             shadergen.emitOutput(node.getOutput(), true, false, context, stage);
             shadergen.emitString(" = normalize(cross(N, vector(N[2], 0, -N[0])))", stage);
             shadergen.emitLineEnd(stage);
-        END_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        }
     }
 };
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -167,7 +167,8 @@ public:
     {
         const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
-        BEGIN_SHADER_STAGE(stage, mx::Stage::VERTEX)
+        DEFINE_SHADER_STAGE(stage, mx::Stage::VERTEX)
+        {
             mx::VariableBlock& vertexData = stage.getOutputBlock(mx::HW::VERTEX_DATA);
             const mx::string prefix = vertexData.getInstance() + ".";
             mx::ShaderPort* position = vertexData[mx::HW::T_POSITION_WORLD];
@@ -176,9 +177,10 @@ public:
                 position->setEmitted();
                 shadergen.emitLine(prefix + position->getVariable() + " = hPositionWorld.xyz", stage);
             }
-        END_SHADER_STAGE(stage, mx::Stage::VERTEX)
+        }
 
-        BEGIN_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        DEFINE_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        {
             mx::VariableBlock& vertexData = stage.getInputBlock(mx::HW::VERTEX_DATA);
             const mx::string prefix = vertexData.getInstance() + ".";
             mx::ShaderPort* position = vertexData[mx::HW::T_POSITION_WORLD];
@@ -186,7 +188,7 @@ public:
             shadergen.emitOutput(node.getOutput(), true, false, context, stage);
             shadergen.emitString(" = normalize(" + prefix + position->getVariable() + " - " + mx::HW::T_VIEW_POSITION + ")", stage);
             shadergen.emitLineEnd(stage);
-        END_SHADER_STAGE(stage, mx::Stage::PIXEL)
+        }
     }
 };
 


### PR DESCRIPTION
This changelist replaces BEGIN_SHADER_STAGE and END_SHADER_STAGE with a single DEFINE_SHADER_STAGE macro.  Scoping brackets have been moved from macros to client code, allowing them to be understood by code formatting systems such as clang-format.

For backwards compatibility, the original macros are still supported, but should be considered deprecated in client code.