### PR TITLE
Fix missing basis orthogonalizations in GLSL backend

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -13,8 +13,8 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
     // Generate tangent frame.
-    vec3 Y = normalize(cross(N, X));
-    X = cross(Y, N);
+    X = normalize(X - dot(X, N) * N);
+    vec3 Y = cross(N, X);
     mat3 tangentToWorld = mat3(X, Y, N);
 
     // Transform the view vector to tangent space.

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -11,7 +11,8 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
 
     N = mx_forward_facing_normal(N, V);
 
-    vec3 Y = normalize(cross(N, X));
+    X = normalize(X - dot(X, N) * N);
+    vec3 Y = cross(N, X);
     vec3 H = normalize(L + V);
 
     float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -9,7 +9,8 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
 
     N = mx_forward_facing_normal(N, V);
 
-    vec3 Y = normalize(cross(N, X));
+    X = normalize(X - dot(X, N) * N);
+    vec3 Y = cross(N, X);
     vec3 H = normalize(L + V);
 
     float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -9,7 +9,8 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
 
     N = mx_forward_facing_normal(N, V);
 
-    vec3 Y = normalize(cross(N, X));
+    X = normalize(X - dot(X, N) * N);
+    vec3 Y = cross(N, X);
     vec3 H = normalize(L + V);
 
     float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);


### PR DESCRIPTION
I've encountered shading artifacts in normal mapped MaterialX materials, and upon closer inspection I believe that these are caused by the missing basis orthogonalizations @Tellusim brought to attention in PR #1049.

However, instead of using a second `normalize(cross(..))` call, I've applied the Gram-Schmidt algorithm.

Here are some comparisons from the soon-to-be-released test suite for my glTF to USD+MaterialX converter:

Name | Old | New | Diff
---  | --- | --- | ---
NormalTangentTest | ![NormalTangentTest_ref](https://user-images.githubusercontent.com/3663466/209799003-d1f76682-3326-48ae-91e0-649d4edb1a0e.png) | ![NormalTangentTest_test](https://user-images.githubusercontent.com/3663466/209799042-d6a7a4db-6ff2-4f53-926d-34e0fe1d5130.png) | ![NormalTangentTest_diff](https://user-images.githubusercontent.com/3663466/209799068-7c08d96a-0113-4f03-9572-8e3ac3e176c0.png)
DamagedHelmet | ![DamagedHelmet_ref](https://user-images.githubusercontent.com/3663466/209799286-c9d86911-9a9a-4477-9b6e-10c24c17e1f4.png) | ![DamagedHelmet_test](https://user-images.githubusercontent.com/3663466/209799333-8614d15a-07cf-4d85-a0a6-56930a710820.png) | ![DamagedHelmet_diff](https://user-images.githubusercontent.com/3663466/209799377-7da8138d-ea8a-4b27-9e2d-0eb33a258c06.png)
IridescentDishWithOlives | ![IridescentDishWithOlives_ref](https://user-images.githubusercontent.com/3663466/209799501-1e34948a-3d36-49b0-b03a-1a256db8dd18.png) | ![IridescentDishWithOlives_test](https://user-images.githubusercontent.com/3663466/209799526-b30c1517-5184-4665-a3fd-cff79869203a.png) | ![IridescentDishWithOlives_diff](https://user-images.githubusercontent.com/3663466/209799561-668696b8-b46b-40e2-bc04-ff67c560752f.png)
ClearCoatTest | ![ClearCoatTest_ref](https://user-images.githubusercontent.com/3663466/209799648-ad65d898-f92b-417a-a674-c5c2c8a01a78.png) | ![ClearCoatTest_test](https://user-images.githubusercontent.com/3663466/209799686-71b665b6-0be8-4a7c-88eb-b72260c90096.png) | ![ClearCoatTest_diff](https://user-images.githubusercontent.com/3663466/209799721-7939026f-3e9a-4594-9d98-34a18bf0dd67.png)

The changes can be tested using following model: 
[NormalTangentMirrorTest.zip](https://github.com/AcademySoftwareFoundation/MaterialX/files/10313740/NormalTangentMirrorTest.zip)


It requires a recent build of MaterialXView as it makes use of the support for explicit bitangents introduced in PR #1156.
