### PR TITLE
Apply Clang formatting to MaterialXGenShader

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,5 @@
 AllowShortBlocksOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: false
 AlwaysBreakTemplateDeclarations: No
 BreakBeforeBraces: Allman

--- a/source/MaterialXGenShader/ColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/ColorManagementSystem.cpp
@@ -26,7 +26,6 @@ ColorSpaceTransform::ColorSpaceTransform(const string& ss, const string& ts, con
     }
 }
 
-
 ColorManagementSystem::ColorManagementSystem()
 {
 }
@@ -46,7 +45,7 @@ bool ColorManagementSystem::supportsTransform(const ColorSpaceTransform& transfo
     return impl != nullptr;
 }
 
-ShaderNodePtr ColorManagementSystem::createNode(const ShaderGraph* parent, const ColorSpaceTransform& transform, const string& name, 
+ShaderNodePtr ColorManagementSystem::createNode(const ShaderGraph* parent, const ColorSpaceTransform& transform, const string& name,
                                                 GenContext& context) const
 {
     ImplementationPtr impl = getImplementation(transform);

--- a/source/MaterialXGenShader/ColorManagementSystem.h
+++ b/source/MaterialXGenShader/ColorManagementSystem.h
@@ -35,7 +35,7 @@ struct MX_GENSHADER_API ColorSpaceTransform
     const TypeDesc* type;
 
     /// Comparison operator
-    bool operator==(const ColorSpaceTransform &other) const
+    bool operator==(const ColorSpaceTransform& other) const
     {
         return sourceSpace == other.sourceSpace &&
                targetSpace == other.targetSpace &&
@@ -67,7 +67,7 @@ class MX_GENSHADER_API ColorManagementSystem
   protected:
     /// Protected constructor
     ColorManagementSystem();
-      
+
     /// Returns an implementation for a given transform
     virtual ImplementationPtr getImplementation(const ColorSpaceTransform& transform) const = 0;
 

--- a/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
@@ -9,7 +9,8 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-namespace {
+namespace
+{
 
 const string CMS_NAME = "default_cms";
 

--- a/source/MaterialXGenShader/Factory.h
+++ b/source/MaterialXGenShader/Factory.h
@@ -15,11 +15,11 @@ MATERIALX_NAMESPACE_BEGIN
 
 /// @class Factory
 /// Factory class for creating instances of classes given their type name.
-template<class T> class Factory
+template <class T> class Factory
 {
   public:
     using Ptr = shared_ptr<T>;
-    using CreatorFunction = Ptr(*)();
+    using CreatorFunction = Ptr (*)();
     using CreatorMap = std::unordered_map<string, CreatorFunction>;
 
     /// Register a new class given a unique type name

--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -109,7 +109,6 @@ void GenContext::getOutputSuffix(const ShaderOutput* output, string& suffix) con
     }
 }
 
-
 ScopedSetClosureParams::ScopedSetClosureParams(const ClosureContext::ClosureParams* params, const ShaderNode* node, ClosureContext* cct) :
     _cct(cct),
     _node(node),
@@ -147,7 +146,6 @@ ScopedSetClosureParams::~ScopedSetClosureParams()
         _cct->setClosureParams(_node, _oldParams);
     }
 }
-
 
 ScopedSetVariableName::ScopedSetVariableName(const string& name, ShaderPort* port) :
     _port(port),

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -24,7 +24,7 @@ class ClosureContext;
 /// A standard function to allow for handling of application variables for a given node
 using ApplicationVariableHandler = std::function<void(ShaderNode*, GenContext&)>;
 
-/// @class GenContext 
+/// @class GenContext
 /// A context class for shader generation.
 /// Used for thread local storage of data needed during shader generation.
 class MX_GENSHADER_API GenContext
@@ -155,7 +155,7 @@ class MX_GENSHADER_API GenContext
 
     /// Return user data with given name,
     /// or nullptr if no data is found.
-    template<class T>
+    template <class T>
     std::shared_ptr<T> getUserData(const string& name)
     {
         auto it = _userData.find(name);
@@ -190,13 +190,13 @@ class MX_GENSHADER_API GenContext
     /// @param suffix Suffix string returned. Is empty if not found.
     void getOutputSuffix(const ShaderOutput* output, string& suffix) const;
 
-    /// Set handler for application variables 
+    /// Set handler for application variables
     void setApplicationVariableHandler(ApplicationVariableHandler handler)
     {
         _applicationVariableHandler = handler;
     }
 
-    /// Get handler for application variables 
+    /// Get handler for application variables
     ApplicationVariableHandler getApplicationVariableHandler() const
     {
         return _applicationVariableHandler;
@@ -220,7 +220,6 @@ class MX_GENSHADER_API GenContext
     ApplicationVariableHandler _applicationVariableHandler;
 };
 
-
 /// @class ClosureContext
 /// Class representing a context for closure evaluation.
 /// On hardware BSDF closures are evaluated differently in reflection, transmission
@@ -228,7 +227,7 @@ class MX_GENSHADER_API GenContext
 /// and if extra arguments and function decorators are needed for that context.
 class MX_GENSHADER_API ClosureContext
 {
-public:
+  public:
     /// An extra argument for closure functions.
     /// An argument is a pair of strings holding the
     /// 'type' and 'name' of the argument.
@@ -240,7 +239,8 @@ public:
     using ClosureParams = std::unordered_map<string, const ShaderInput*>;
 
     /// Constructor
-    ClosureContext(int type = 0) : _type(type) {}
+    ClosureContext(int type = 0) :
+        _type(type) { }
 
     /// Return the identifier for this context.
     int getType() const { return _type; }
@@ -292,7 +292,7 @@ public:
         return it != _params.end() ? it->second : nullptr;
     }
 
-protected:
+  protected:
     const int _type;
     std::unordered_map<const TypeDesc*, Arguments> _arguments;
     std::unordered_map<const TypeDesc*, string> _suffix;
@@ -305,7 +305,7 @@ protected:
 /// stored in the closure context.
 class MX_GENSHADER_API ScopedSetClosureParams
 {
-public:
+  public:
     /// Constructor for setting explicit parameters for a closure node.
     ScopedSetClosureParams(const ClosureContext::ClosureParams* params, const ShaderNode* node, ClosureContext* cct);
 
@@ -315,7 +315,7 @@ public:
     /// Destructor restoring the closure parameter state.
     ~ScopedSetClosureParams();
 
-private:
+  private:
     ClosureContext* _cct;
     const ShaderNode* _node;
     const ClosureContext::ClosureParams* _oldParams;
@@ -324,14 +324,14 @@ private:
 /// A RAII class for overriding port variable names.
 class MX_GENSHADER_API ScopedSetVariableName
 {
-public:
+  public:
     /// Constructor for setting a new variable name for a port.
     ScopedSetVariableName(const string& name, ShaderPort* port);
 
     /// Destructor restoring the original variable name.
     ~ScopedSetVariableName();
 
-private:
+  private:
     ShaderPort* _port;
     string _oldName;
 };

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -70,7 +70,7 @@ enum HwTransmissionRenderMethod
     TRANSMISSION_OPACITY,
 };
 
-/// @class GenOptions 
+/// @class GenOptions
 /// Class holding options to configure shader generation.
 class MX_GENSHADER_API GenOptions
 {
@@ -118,8 +118,8 @@ class MX_GENSHADER_API GenOptions
     /// Shader fragments will be generated to transform
     /// input distance values to the given unit.
     string targetDistanceUnit;
-    
-    /// Sets whether to include upstream dependencies 
+
+    /// Sets whether to include upstream dependencies
     /// for the element to generate a shader for.
     bool addUpstreamDependencies;
 
@@ -178,7 +178,7 @@ class MX_GENSHADER_API GenOptions
     /// inside the <bitangent> node.
     bool hwImplicitBitangents;
 
-    /// Enable emitting colorspace transform code if a color management 
+    /// Enable emitting colorspace transform code if a color management
     /// system is defined.
     /// Defaults to true.
     bool emitColorTransforms;

--- a/source/MaterialXGenShader/GenUserData.h
+++ b/source/MaterialXGenShader/GenUserData.h
@@ -21,13 +21,13 @@ using GenUserDataPtr = std::shared_ptr<GenUserData>;
 /// Shared pointer to a constant GenUserData
 using ConstGenUserDataPtr = std::shared_ptr<const GenUserData>;
 
-/// @class GenUserData 
+/// @class GenUserData
 /// Base class for custom user data needed during shader generation.
 class MX_GENSHADER_API GenUserData : public std::enable_shared_from_this<GenUserData>
 {
   public:
     virtual ~GenUserData() { }
-    
+
     /// Return a shared pointer for this object.
     GenUserDataPtr getSelf()
     {
@@ -41,13 +41,13 @@ class MX_GENSHADER_API GenUserData : public std::enable_shared_from_this<GenUser
     }
 
     /// Return this object cast to a templated type.
-    template<class T> shared_ptr<T> asA()
+    template <class T> shared_ptr<T> asA()
     {
         return std::dynamic_pointer_cast<T>(getSelf());
     }
 
     /// Return this object cast to a templated type.
-    template<class T> shared_ptr<const T> asA() const
+    template <class T> shared_ptr<const T> asA() const
     {
         return std::dynamic_pointer_cast<const T>(getSelf());
     }

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -14,138 +14,142 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace HW
 {
-    const string T_IN_POSITION                    = "$inPosition";
-    const string T_IN_NORMAL                      = "$inNormal";
-    const string T_IN_TANGENT                     = "$inTangent";
-    const string T_IN_BITANGENT                   = "$inBitangent";
-    const string T_IN_TEXCOORD                    = "$inTexcoord";
-    const string T_IN_GEOMPROP                    = "$inGeomprop";
-    const string T_IN_COLOR                       = "$inColor";
-    const string T_POSITION_WORLD                 = "$positionWorld";
-    const string T_NORMAL_WORLD                   = "$normalWorld";
-    const string T_TANGENT_WORLD                  = "$tangentWorld";
-    const string T_BITANGENT_WORLD                = "$bitangentWorld";
-    const string T_POSITION_OBJECT                = "$positionObject";
-    const string T_NORMAL_OBJECT                  = "$normalObject";
-    const string T_TANGENT_OBJECT                 = "$tangentObject";
-    const string T_BITANGENT_OBJECT               = "$bitangentObject";
-    const string T_TEXCOORD                       = "$texcoord";
-    const string T_COLOR                          = "$color";
-    const string T_WORLD_MATRIX                   = "$worldMatrix";
-    const string T_WORLD_INVERSE_MATRIX           = "$worldInverseMatrix";
-    const string T_WORLD_TRANSPOSE_MATRIX         = "$worldTransposeMatrix";
-    const string T_WORLD_INVERSE_TRANSPOSE_MATRIX = "$worldInverseTransposeMatrix";
-    const string T_VIEW_MATRIX                    = "$viewMatrix";
-    const string T_VIEW_INVERSE_MATRIX            = "$viewInverseMatrix";
-    const string T_VIEW_TRANSPOSE_MATRIX          = "$viewTransposeMatrix";
-    const string T_VIEW_INVERSE_TRANSPOSE_MATRIX  = "$viewInverseTransposeMatrix";
-    const string T_PROJ_MATRIX                    = "$projectionMatrix";
-    const string T_PROJ_INVERSE_MATRIX            = "$projectionInverseMatrix";
-    const string T_PROJ_TRANSPOSE_MATRIX          = "$projectionTransposeMatrix";
-    const string T_PROJ_INVERSE_TRANSPOSE_MATRIX  = "$projectionInverseTransposeMatrix";
-    const string T_WORLD_VIEW_MATRIX              = "$worldViewMatrix";
-    const string T_VIEW_PROJECTION_MATRIX         = "$viewProjectionMatrix";
-    const string T_WORLD_VIEW_PROJECTION_MATRIX   = "$worldViewProjectionMatrix";
-    const string T_VIEW_POSITION                  = "$viewPosition";
-    const string T_VIEW_DIRECTION                 = "$viewDirection";
-    const string T_FRAME                          = "$frame";
-    const string T_TIME                           = "$time";
-    const string T_GEOMPROP                       = "$geomprop";
-    const string T_ALPHA_THRESHOLD                = "$alphaThreshold";
-    const string T_NUM_ACTIVE_LIGHT_SOURCES       = "$numActiveLightSources";
-    const string T_ENV_MATRIX                     = "$envMatrix";
-    const string T_ENV_RADIANCE                   = "$envRadiance";
-    const string T_ENV_RADIANCE_MIPS              = "$envRadianceMips";
-    const string T_ENV_RADIANCE_SAMPLES           = "$envRadianceSamples";
-    const string T_ENV_IRRADIANCE                 = "$envIrradiance";
-    const string T_REFRACTION_ENV                 = "$refractionEnv";
-    const string T_REFRACTION_COLOR               = "$refractionColor";
-    const string T_ALBEDO_TABLE                   = "$albedoTable";
-    const string T_ALBEDO_TABLE_SIZE              = "$albedoTableSize";
-    const string T_AMB_OCC_MAP                    = "$ambOccMap";
-    const string T_AMB_OCC_GAIN                   = "$ambOccGain";
-    const string T_SHADOW_MAP                     = "$shadowMap";
-    const string T_SHADOW_MATRIX                  = "$shadowMatrix";
-    const string T_VERTEX_DATA_INSTANCE           = "$vd";
-    const string T_LIGHT_DATA_INSTANCE            = "$lightData";
 
-    const string IN_POSITION                      = "i_position";
-    const string IN_NORMAL                        = "i_normal";
-    const string IN_TANGENT                       = "i_tangent";
-    const string IN_BITANGENT                     = "i_bitangent";
-    const string IN_TEXCOORD                      = "i_texcoord";
-    const string IN_GEOMPROP                      = "i_geomprop";
-    const string IN_COLOR                         = "i_color";
-    const string POSITION_WORLD                   = "positionWorld";
-    const string NORMAL_WORLD                     = "normalWorld";
-    const string TANGENT_WORLD                    = "tangentWorld";
-    const string BITANGENT_WORLD                  = "bitangentWorld";
-    const string POSITION_OBJECT                  = "positionObject";
-    const string NORMAL_OBJECT                    = "normalObject";
-    const string TANGENT_OBJECT                   = "tangentObject";
-    const string BITANGENT_OBJECT                 = "bitangentObject";
-    const string TEXCOORD                         = "texcoord";
-    const string COLOR                            = "color";
-    const string WORLD_MATRIX                     = "u_worldMatrix";
-    const string WORLD_INVERSE_MATRIX             = "u_worldInverseMatrix";
-    const string WORLD_TRANSPOSE_MATRIX           = "u_worldTransposeMatrix";
-    const string WORLD_INVERSE_TRANSPOSE_MATRIX   = "u_worldInverseTransposeMatrix";
-    const string VIEW_MATRIX                      = "u_viewMatrix";
-    const string VIEW_INVERSE_MATRIX              = "u_viewInverseMatrix";
-    const string VIEW_TRANSPOSE_MATRIX            = "u_viewTransposeMatrix";
-    const string VIEW_INVERSE_TRANSPOSE_MATRIX    = "u_viewInverseTransposeMatrix";
-    const string PROJ_MATRIX                      = "u_projectionMatrix";
-    const string PROJ_INVERSE_MATRIX              = "u_projectionInverseMatrix";
-    const string PROJ_TRANSPOSE_MATRIX            = "u_projectionTransposeMatrix";
-    const string PROJ_INVERSE_TRANSPOSE_MATRIX    = "u_projectionInverseTransposeMatrix";
-    const string WORLD_VIEW_MATRIX                = "u_worldViewMatrix";
-    const string VIEW_PROJECTION_MATRIX           = "u_viewProjectionMatrix";
-    const string WORLD_VIEW_PROJECTION_MATRIX     = "u_worldViewProjectionMatrix";
-    const string VIEW_POSITION                    = "u_viewPosition";
-    const string VIEW_DIRECTION                   = "u_viewDirection";
-    const string FRAME                            = "u_frame";
-    const string TIME                             = "u_time";
-    const string GEOMPROP                         = "u_geomprop";
-    const string ALPHA_THRESHOLD                  = "u_alphaThreshold";
-    const string NUM_ACTIVE_LIGHT_SOURCES         = "u_numActiveLightSources";
-    const string ENV_MATRIX                       = "u_envMatrix";
-    const string ENV_RADIANCE                     = "u_envRadiance";
-    const string ENV_RADIANCE_MIPS                = "u_envRadianceMips";
-    const string ENV_RADIANCE_SAMPLES             = "u_envRadianceSamples";
-    const string ENV_IRRADIANCE                   = "u_envIrradiance";
-    const string REFRACTION_ENV                   = "u_refractionEnv";
-    const string REFRACTION_COLOR                 = "u_refractionColor";
-    const string ALBEDO_TABLE                     = "u_albedoTable";
-    const string ALBEDO_TABLE_SIZE                = "u_albedoTableSize";
-    const string AMB_OCC_MAP                      = "u_ambOccMap";
-    const string AMB_OCC_GAIN                     = "u_ambOccGain";
-    const string SHADOW_MAP                       = "u_shadowMap";
-    const string SHADOW_MATRIX                    = "u_shadowMatrix";
-    const string VERTEX_DATA_INSTANCE             = "vd";
-    const string LIGHT_DATA_INSTANCE              = "u_lightData";
-    const string LIGHT_DATA_MAX_LIGHT_SOURCES     = "MAX_LIGHT_SOURCES";
+const string T_IN_POSITION                    = "$inPosition";
+const string T_IN_NORMAL                      = "$inNormal";
+const string T_IN_TANGENT                     = "$inTangent";
+const string T_IN_BITANGENT                   = "$inBitangent";
+const string T_IN_TEXCOORD                    = "$inTexcoord";
+const string T_IN_GEOMPROP                    = "$inGeomprop";
+const string T_IN_COLOR                       = "$inColor";
+const string T_POSITION_WORLD                 = "$positionWorld";
+const string T_NORMAL_WORLD                   = "$normalWorld";
+const string T_TANGENT_WORLD                  = "$tangentWorld";
+const string T_BITANGENT_WORLD                = "$bitangentWorld";
+const string T_POSITION_OBJECT                = "$positionObject";
+const string T_NORMAL_OBJECT                  = "$normalObject";
+const string T_TANGENT_OBJECT                 = "$tangentObject";
+const string T_BITANGENT_OBJECT               = "$bitangentObject";
+const string T_TEXCOORD                       = "$texcoord";
+const string T_COLOR                          = "$color";
+const string T_WORLD_MATRIX                   = "$worldMatrix";
+const string T_WORLD_INVERSE_MATRIX           = "$worldInverseMatrix";
+const string T_WORLD_TRANSPOSE_MATRIX         = "$worldTransposeMatrix";
+const string T_WORLD_INVERSE_TRANSPOSE_MATRIX = "$worldInverseTransposeMatrix";
+const string T_VIEW_MATRIX                    = "$viewMatrix";
+const string T_VIEW_INVERSE_MATRIX            = "$viewInverseMatrix";
+const string T_VIEW_TRANSPOSE_MATRIX          = "$viewTransposeMatrix";
+const string T_VIEW_INVERSE_TRANSPOSE_MATRIX  = "$viewInverseTransposeMatrix";
+const string T_PROJ_MATRIX                    = "$projectionMatrix";
+const string T_PROJ_INVERSE_MATRIX            = "$projectionInverseMatrix";
+const string T_PROJ_TRANSPOSE_MATRIX          = "$projectionTransposeMatrix";
+const string T_PROJ_INVERSE_TRANSPOSE_MATRIX  = "$projectionInverseTransposeMatrix";
+const string T_WORLD_VIEW_MATRIX              = "$worldViewMatrix";
+const string T_VIEW_PROJECTION_MATRIX         = "$viewProjectionMatrix";
+const string T_WORLD_VIEW_PROJECTION_MATRIX   = "$worldViewProjectionMatrix";
+const string T_VIEW_POSITION                  = "$viewPosition";
+const string T_VIEW_DIRECTION                 = "$viewDirection";
+const string T_FRAME                          = "$frame";
+const string T_TIME                           = "$time";
+const string T_GEOMPROP                       = "$geomprop";
+const string T_ALPHA_THRESHOLD                = "$alphaThreshold";
+const string T_NUM_ACTIVE_LIGHT_SOURCES       = "$numActiveLightSources";
+const string T_ENV_MATRIX                     = "$envMatrix";
+const string T_ENV_RADIANCE                   = "$envRadiance";
+const string T_ENV_RADIANCE_MIPS              = "$envRadianceMips";
+const string T_ENV_RADIANCE_SAMPLES           = "$envRadianceSamples";
+const string T_ENV_IRRADIANCE                 = "$envIrradiance";
+const string T_REFRACTION_ENV                 = "$refractionEnv";
+const string T_REFRACTION_COLOR               = "$refractionColor";
+const string T_ALBEDO_TABLE                   = "$albedoTable";
+const string T_ALBEDO_TABLE_SIZE              = "$albedoTableSize";
+const string T_AMB_OCC_MAP                    = "$ambOccMap";
+const string T_AMB_OCC_GAIN                   = "$ambOccGain";
+const string T_SHADOW_MAP                     = "$shadowMap";
+const string T_SHADOW_MATRIX                  = "$shadowMatrix";
+const string T_VERTEX_DATA_INSTANCE           = "$vd";
+const string T_LIGHT_DATA_INSTANCE            = "$lightData";
 
-    const string VERTEX_INPUTS                    = "VertexInputs";
-    const string VERTEX_DATA                      = "VertexData";
-    const string PRIVATE_UNIFORMS                 = "PrivateUniforms";
-    const string PUBLIC_UNIFORMS                  = "PublicUniforms";
-    const string LIGHT_DATA                       = "LightData";
-    const string PIXEL_OUTPUTS                    = "PixelOutputs";
-    const string DIR_N                            = "N";
-    const string DIR_L                            = "L";
-    const string DIR_V                            = "V";
-    const string WORLD_POSITION                   = "P";
-    const string OCCLUSION                        = "occlusion";
-    const string ATTR_TRANSPARENT                 = "transparent";
-    const string USER_DATA_CLOSURE_CONTEXT        = "udcc";
-    const string USER_DATA_LIGHT_SHADERS          = "udls";
-    const string USER_DATA_BINDING_CONTEXT        = "udbinding";
-}
+const string IN_POSITION                      = "i_position";
+const string IN_NORMAL                        = "i_normal";
+const string IN_TANGENT                       = "i_tangent";
+const string IN_BITANGENT                     = "i_bitangent";
+const string IN_TEXCOORD                      = "i_texcoord";
+const string IN_GEOMPROP                      = "i_geomprop";
+const string IN_COLOR                         = "i_color";
+const string POSITION_WORLD                   = "positionWorld";
+const string NORMAL_WORLD                     = "normalWorld";
+const string TANGENT_WORLD                    = "tangentWorld";
+const string BITANGENT_WORLD                  = "bitangentWorld";
+const string POSITION_OBJECT                  = "positionObject";
+const string NORMAL_OBJECT                    = "normalObject";
+const string TANGENT_OBJECT                   = "tangentObject";
+const string BITANGENT_OBJECT                 = "bitangentObject";
+const string TEXCOORD                         = "texcoord";
+const string COLOR                            = "color";
+const string WORLD_MATRIX                     = "u_worldMatrix";
+const string WORLD_INVERSE_MATRIX             = "u_worldInverseMatrix";
+const string WORLD_TRANSPOSE_MATRIX           = "u_worldTransposeMatrix";
+const string WORLD_INVERSE_TRANSPOSE_MATRIX   = "u_worldInverseTransposeMatrix";
+const string VIEW_MATRIX                      = "u_viewMatrix";
+const string VIEW_INVERSE_MATRIX              = "u_viewInverseMatrix";
+const string VIEW_TRANSPOSE_MATRIX            = "u_viewTransposeMatrix";
+const string VIEW_INVERSE_TRANSPOSE_MATRIX    = "u_viewInverseTransposeMatrix";
+const string PROJ_MATRIX                      = "u_projectionMatrix";
+const string PROJ_INVERSE_MATRIX              = "u_projectionInverseMatrix";
+const string PROJ_TRANSPOSE_MATRIX            = "u_projectionTransposeMatrix";
+const string PROJ_INVERSE_TRANSPOSE_MATRIX    = "u_projectionInverseTransposeMatrix";
+const string WORLD_VIEW_MATRIX                = "u_worldViewMatrix";
+const string VIEW_PROJECTION_MATRIX           = "u_viewProjectionMatrix";
+const string WORLD_VIEW_PROJECTION_MATRIX     = "u_worldViewProjectionMatrix";
+const string VIEW_POSITION                    = "u_viewPosition";
+const string VIEW_DIRECTION                   = "u_viewDirection";
+const string FRAME                            = "u_frame";
+const string TIME                             = "u_time";
+const string GEOMPROP                         = "u_geomprop";
+const string ALPHA_THRESHOLD                  = "u_alphaThreshold";
+const string NUM_ACTIVE_LIGHT_SOURCES         = "u_numActiveLightSources";
+const string ENV_MATRIX                       = "u_envMatrix";
+const string ENV_RADIANCE                     = "u_envRadiance";
+const string ENV_RADIANCE_MIPS                = "u_envRadianceMips";
+const string ENV_RADIANCE_SAMPLES             = "u_envRadianceSamples";
+const string ENV_IRRADIANCE                   = "u_envIrradiance";
+const string REFRACTION_ENV                   = "u_refractionEnv";
+const string REFRACTION_COLOR                 = "u_refractionColor";
+const string ALBEDO_TABLE                     = "u_albedoTable";
+const string ALBEDO_TABLE_SIZE                = "u_albedoTableSize";
+const string AMB_OCC_MAP                      = "u_ambOccMap";
+const string AMB_OCC_GAIN                     = "u_ambOccGain";
+const string SHADOW_MAP                       = "u_shadowMap";
+const string SHADOW_MATRIX                    = "u_shadowMatrix";
+const string VERTEX_DATA_INSTANCE             = "vd";
+const string LIGHT_DATA_INSTANCE              = "u_lightData";
+const string LIGHT_DATA_MAX_LIGHT_SOURCES     = "MAX_LIGHT_SOURCES";
+
+const string VERTEX_INPUTS                    = "VertexInputs";
+const string VERTEX_DATA                      = "VertexData";
+const string PRIVATE_UNIFORMS                 = "PrivateUniforms";
+const string PUBLIC_UNIFORMS                  = "PublicUniforms";
+const string LIGHT_DATA                       = "LightData";
+const string PIXEL_OUTPUTS                    = "PixelOutputs";
+const string DIR_N                            = "N";
+const string DIR_L                            = "L";
+const string DIR_V                            = "V";
+const string WORLD_POSITION                   = "P";
+const string OCCLUSION                        = "occlusion";
+const string ATTR_TRANSPARENT                 = "transparent";
+const string USER_DATA_CLOSURE_CONTEXT        = "udcc";
+const string USER_DATA_LIGHT_SHADERS          = "udls";
+const string USER_DATA_BINDING_CONTEXT        = "udbinding";
+
+} // namespace HW
 
 namespace Stage
 {
-    const string VERTEX = "vertex";
-}
+
+const string VERTEX = "vertex";
+
+} // namespace Stage
 
 const ClosureContext::Arguments ClosureContext::EMPTY_ARGUMENTS;
 
@@ -364,7 +368,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
 
     //
     // For image textures we need to convert filenames into uniforms (texture samplers).
-    // Any unconnected filename input on file texture nodes needs to have a corresponding 
+    // Any unconnected filename input on file texture nodes needs to have a corresponding
     // uniform.
     //
 
@@ -436,8 +440,9 @@ void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& con
     // Omit node if it's only used inside a conditional branch
     if (checkScope && node.referencedConditionally())
     {
-        emitComment("Omitted node '" + node.getName() + "'. Only used in conditional node '" + 
-                    node.getScopeInfo().conditionalNode->getName() + "'", stage);
+        emitComment("Omitted node '" + node.getName() + "'. Only used in conditional node '" +
+                        node.getScopeInfo().conditionalNode->getName() + "'",
+                    stage);
         return;
     }
 
@@ -452,13 +457,13 @@ void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& con
             match =
                 // For reflection and environment we support reflective closures.
                 ((cct->getType() == ClosureContextType::REFLECTION || cct->getType() == ClosureContextType::INDIRECT) &&
-                    node.hasClassification(ShaderNode::Classification::BSDF_R)) ||
+                 node.hasClassification(ShaderNode::Classification::BSDF_R)) ||
                 // For transmissive we support transmissive closures.
                 ((cct->getType() == ClosureContextType::TRANSMISSION) &&
-                    (node.hasClassification(ShaderNode::Classification::BSDF_T) || node.hasClassification(ShaderNode::Classification::VDF))) ||
+                 (node.hasClassification(ShaderNode::Classification::BSDF_T) || node.hasClassification(ShaderNode::Classification::VDF))) ||
                 // For emission we only support emission closures.
                 ((cct->getType() == ClosureContextType::EMISSION) &&
-                    (node.hasClassification(ShaderNode::Classification::EDF)));
+                 (node.hasClassification(ShaderNode::Classification::EDF)));
         }
     }
 
@@ -496,7 +501,7 @@ void HwShaderGenerator::bindLightShader(const NodeDef& nodeDef, unsigned int lig
     if (lightShaders->get(lightTypeId))
     {
         throw ExceptionShaderGenError("Error binding light shader. Light type id '" + std::to_string(lightTypeId) +
-            "' has already been bound");
+                                      "' has already been bound");
     }
 
     ShaderNodePtr shader = ShaderNode::create(nullptr, nodeDef.getNodeString(), nodeDef, context);

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -81,148 +81,148 @@ Uniform variables :
 /// HW specific identifiers.
 namespace HW
 {
-    /// Token identifiers
-    extern MX_GENSHADER_API const string T_IN_POSITION;
-    extern MX_GENSHADER_API const string T_IN_NORMAL;
-    extern MX_GENSHADER_API const string T_IN_TANGENT;
-    extern MX_GENSHADER_API const string T_IN_BITANGENT;
-    extern MX_GENSHADER_API const string T_IN_TEXCOORD;
-    extern MX_GENSHADER_API const string T_IN_GEOMPROP;
-    extern MX_GENSHADER_API const string T_IN_COLOR;
-    extern MX_GENSHADER_API const string T_POSITION_WORLD;
-    extern MX_GENSHADER_API const string T_NORMAL_WORLD;
-    extern MX_GENSHADER_API const string T_TANGENT_WORLD;
-    extern MX_GENSHADER_API const string T_BITANGENT_WORLD;
-    extern MX_GENSHADER_API const string T_POSITION_OBJECT;
-    extern MX_GENSHADER_API const string T_NORMAL_OBJECT;
-    extern MX_GENSHADER_API const string T_TANGENT_OBJECT;
-    extern MX_GENSHADER_API const string T_BITANGENT_OBJECT;
-    extern MX_GENSHADER_API const string T_TEXCOORD;
-    extern MX_GENSHADER_API const string T_COLOR;
-    extern MX_GENSHADER_API const string T_WORLD_MATRIX;
-    extern MX_GENSHADER_API const string T_WORLD_INVERSE_MATRIX;
-    extern MX_GENSHADER_API const string T_WORLD_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string T_WORLD_INVERSE_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string T_VIEW_MATRIX;
-    extern MX_GENSHADER_API const string T_VIEW_INVERSE_MATRIX;
-    extern MX_GENSHADER_API const string T_VIEW_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string T_VIEW_INVERSE_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string T_PROJ_MATRIX;
-    extern MX_GENSHADER_API const string T_PROJ_INVERSE_MATRIX;
-    extern MX_GENSHADER_API const string T_PROJ_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string T_PROJ_INVERSE_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string T_WORLD_VIEW_MATRIX;
-    extern MX_GENSHADER_API const string T_VIEW_PROJECTION_MATRIX;
-    extern MX_GENSHADER_API const string T_WORLD_VIEW_PROJECTION_MATRIX;
-    extern MX_GENSHADER_API const string T_VIEW_POSITION;
-    extern MX_GENSHADER_API const string T_VIEW_DIRECTION;
-    extern MX_GENSHADER_API const string T_FRAME;
-    extern MX_GENSHADER_API const string T_TIME;
-    extern MX_GENSHADER_API const string T_GEOMPROP;
-    extern MX_GENSHADER_API const string T_ALPHA_THRESHOLD;
-    extern MX_GENSHADER_API const string T_NUM_ACTIVE_LIGHT_SOURCES;
-    extern MX_GENSHADER_API const string T_ENV_MATRIX;
-    extern MX_GENSHADER_API const string T_ENV_RADIANCE;
-    extern MX_GENSHADER_API const string T_ENV_RADIANCE_MIPS;
-    extern MX_GENSHADER_API const string T_ENV_RADIANCE_SAMPLES;
-    extern MX_GENSHADER_API const string T_ENV_IRRADIANCE;
-    extern MX_GENSHADER_API const string T_REFRACTION_ENV;
-    extern MX_GENSHADER_API const string T_REFRACTION_COLOR;
-    extern MX_GENSHADER_API const string T_ALBEDO_TABLE;
-    extern MX_GENSHADER_API const string T_ALBEDO_TABLE_SIZE;
-    extern MX_GENSHADER_API const string T_AMB_OCC_MAP;
-    extern MX_GENSHADER_API const string T_AMB_OCC_GAIN;
-    extern MX_GENSHADER_API const string T_SHADOW_MAP;
-    extern MX_GENSHADER_API const string T_SHADOW_MATRIX;
-    extern MX_GENSHADER_API const string T_VERTEX_DATA_INSTANCE;
-    extern MX_GENSHADER_API const string T_LIGHT_DATA_INSTANCE;
+/// Token identifiers
+extern MX_GENSHADER_API const string T_IN_POSITION;
+extern MX_GENSHADER_API const string T_IN_NORMAL;
+extern MX_GENSHADER_API const string T_IN_TANGENT;
+extern MX_GENSHADER_API const string T_IN_BITANGENT;
+extern MX_GENSHADER_API const string T_IN_TEXCOORD;
+extern MX_GENSHADER_API const string T_IN_GEOMPROP;
+extern MX_GENSHADER_API const string T_IN_COLOR;
+extern MX_GENSHADER_API const string T_POSITION_WORLD;
+extern MX_GENSHADER_API const string T_NORMAL_WORLD;
+extern MX_GENSHADER_API const string T_TANGENT_WORLD;
+extern MX_GENSHADER_API const string T_BITANGENT_WORLD;
+extern MX_GENSHADER_API const string T_POSITION_OBJECT;
+extern MX_GENSHADER_API const string T_NORMAL_OBJECT;
+extern MX_GENSHADER_API const string T_TANGENT_OBJECT;
+extern MX_GENSHADER_API const string T_BITANGENT_OBJECT;
+extern MX_GENSHADER_API const string T_TEXCOORD;
+extern MX_GENSHADER_API const string T_COLOR;
+extern MX_GENSHADER_API const string T_WORLD_MATRIX;
+extern MX_GENSHADER_API const string T_WORLD_INVERSE_MATRIX;
+extern MX_GENSHADER_API const string T_WORLD_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string T_WORLD_INVERSE_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string T_VIEW_MATRIX;
+extern MX_GENSHADER_API const string T_VIEW_INVERSE_MATRIX;
+extern MX_GENSHADER_API const string T_VIEW_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string T_VIEW_INVERSE_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string T_PROJ_MATRIX;
+extern MX_GENSHADER_API const string T_PROJ_INVERSE_MATRIX;
+extern MX_GENSHADER_API const string T_PROJ_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string T_PROJ_INVERSE_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string T_WORLD_VIEW_MATRIX;
+extern MX_GENSHADER_API const string T_VIEW_PROJECTION_MATRIX;
+extern MX_GENSHADER_API const string T_WORLD_VIEW_PROJECTION_MATRIX;
+extern MX_GENSHADER_API const string T_VIEW_POSITION;
+extern MX_GENSHADER_API const string T_VIEW_DIRECTION;
+extern MX_GENSHADER_API const string T_FRAME;
+extern MX_GENSHADER_API const string T_TIME;
+extern MX_GENSHADER_API const string T_GEOMPROP;
+extern MX_GENSHADER_API const string T_ALPHA_THRESHOLD;
+extern MX_GENSHADER_API const string T_NUM_ACTIVE_LIGHT_SOURCES;
+extern MX_GENSHADER_API const string T_ENV_MATRIX;
+extern MX_GENSHADER_API const string T_ENV_RADIANCE;
+extern MX_GENSHADER_API const string T_ENV_RADIANCE_MIPS;
+extern MX_GENSHADER_API const string T_ENV_RADIANCE_SAMPLES;
+extern MX_GENSHADER_API const string T_ENV_IRRADIANCE;
+extern MX_GENSHADER_API const string T_REFRACTION_ENV;
+extern MX_GENSHADER_API const string T_REFRACTION_COLOR;
+extern MX_GENSHADER_API const string T_ALBEDO_TABLE;
+extern MX_GENSHADER_API const string T_ALBEDO_TABLE_SIZE;
+extern MX_GENSHADER_API const string T_AMB_OCC_MAP;
+extern MX_GENSHADER_API const string T_AMB_OCC_GAIN;
+extern MX_GENSHADER_API const string T_SHADOW_MAP;
+extern MX_GENSHADER_API const string T_SHADOW_MATRIX;
+extern MX_GENSHADER_API const string T_VERTEX_DATA_INSTANCE;
+extern MX_GENSHADER_API const string T_LIGHT_DATA_INSTANCE;
 
-    /// Default names for identifiers.
-    /// Replacing above tokens in final code.
-    extern MX_GENSHADER_API const string IN_POSITION;
-    extern MX_GENSHADER_API const string IN_NORMAL;
-    extern MX_GENSHADER_API const string IN_TANGENT;
-    extern MX_GENSHADER_API const string IN_BITANGENT;
-    extern MX_GENSHADER_API const string IN_TEXCOORD;
-    extern MX_GENSHADER_API const string IN_GEOMPROP;
-    extern MX_GENSHADER_API const string IN_COLOR;
-    extern MX_GENSHADER_API const string POSITION_WORLD;
-    extern MX_GENSHADER_API const string NORMAL_WORLD;
-    extern MX_GENSHADER_API const string TANGENT_WORLD;
-    extern MX_GENSHADER_API const string BITANGENT_WORLD;
-    extern MX_GENSHADER_API const string POSITION_OBJECT;
-    extern MX_GENSHADER_API const string NORMAL_OBJECT;
-    extern MX_GENSHADER_API const string TANGENT_OBJECT;
-    extern MX_GENSHADER_API const string BITANGENT_OBJECT;
-    extern MX_GENSHADER_API const string TEXCOORD;
-    extern MX_GENSHADER_API const string COLOR;
-    extern MX_GENSHADER_API const string WORLD_MATRIX;
-    extern MX_GENSHADER_API const string WORLD_INVERSE_MATRIX;
-    extern MX_GENSHADER_API const string WORLD_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string WORLD_INVERSE_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string VIEW_MATRIX;
-    extern MX_GENSHADER_API const string VIEW_INVERSE_MATRIX;
-    extern MX_GENSHADER_API const string VIEW_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string VIEW_INVERSE_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string PROJ_MATRIX;
-    extern MX_GENSHADER_API const string PROJ_INVERSE_MATRIX;
-    extern MX_GENSHADER_API const string PROJ_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string PROJ_INVERSE_TRANSPOSE_MATRIX;
-    extern MX_GENSHADER_API const string WORLD_VIEW_MATRIX;
-    extern MX_GENSHADER_API const string VIEW_PROJECTION_MATRIX;
-    extern MX_GENSHADER_API const string WORLD_VIEW_PROJECTION_MATRIX;
-    extern MX_GENSHADER_API const string VIEW_POSITION;
-    extern MX_GENSHADER_API const string VIEW_DIRECTION;
-    extern MX_GENSHADER_API const string FRAME;
-    extern MX_GENSHADER_API const string TIME;
-    extern MX_GENSHADER_API const string GEOMPROP;
-    extern MX_GENSHADER_API const string ALPHA_THRESHOLD;
-    extern MX_GENSHADER_API const string NUM_ACTIVE_LIGHT_SOURCES;
-    extern MX_GENSHADER_API const string ENV_MATRIX;
-    extern MX_GENSHADER_API const string ENV_RADIANCE;
-    extern MX_GENSHADER_API const string ENV_RADIANCE_MIPS;
-    extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLES;
-    extern MX_GENSHADER_API const string ENV_IRRADIANCE;
-    extern MX_GENSHADER_API const string REFRACTION_ENV;
-    extern MX_GENSHADER_API const string REFRACTION_COLOR;
-    extern MX_GENSHADER_API const string ALBEDO_TABLE;
-    extern MX_GENSHADER_API const string ALBEDO_TABLE_SIZE;
-    extern MX_GENSHADER_API const string AMB_OCC_MAP;
-    extern MX_GENSHADER_API const string AMB_OCC_GAIN;
-    extern MX_GENSHADER_API const string SHADOW_MAP;
-    extern MX_GENSHADER_API const string SHADOW_MATRIX;
-    extern MX_GENSHADER_API const string VERTEX_DATA_INSTANCE;
-    extern MX_GENSHADER_API const string LIGHT_DATA_INSTANCE;
-    extern MX_GENSHADER_API const string LIGHT_DATA_MAX_LIGHT_SOURCES;
+/// Default names for identifiers.
+/// Replacing above tokens in final code.
+extern MX_GENSHADER_API const string IN_POSITION;
+extern MX_GENSHADER_API const string IN_NORMAL;
+extern MX_GENSHADER_API const string IN_TANGENT;
+extern MX_GENSHADER_API const string IN_BITANGENT;
+extern MX_GENSHADER_API const string IN_TEXCOORD;
+extern MX_GENSHADER_API const string IN_GEOMPROP;
+extern MX_GENSHADER_API const string IN_COLOR;
+extern MX_GENSHADER_API const string POSITION_WORLD;
+extern MX_GENSHADER_API const string NORMAL_WORLD;
+extern MX_GENSHADER_API const string TANGENT_WORLD;
+extern MX_GENSHADER_API const string BITANGENT_WORLD;
+extern MX_GENSHADER_API const string POSITION_OBJECT;
+extern MX_GENSHADER_API const string NORMAL_OBJECT;
+extern MX_GENSHADER_API const string TANGENT_OBJECT;
+extern MX_GENSHADER_API const string BITANGENT_OBJECT;
+extern MX_GENSHADER_API const string TEXCOORD;
+extern MX_GENSHADER_API const string COLOR;
+extern MX_GENSHADER_API const string WORLD_MATRIX;
+extern MX_GENSHADER_API const string WORLD_INVERSE_MATRIX;
+extern MX_GENSHADER_API const string WORLD_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string WORLD_INVERSE_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string VIEW_MATRIX;
+extern MX_GENSHADER_API const string VIEW_INVERSE_MATRIX;
+extern MX_GENSHADER_API const string VIEW_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string VIEW_INVERSE_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string PROJ_MATRIX;
+extern MX_GENSHADER_API const string PROJ_INVERSE_MATRIX;
+extern MX_GENSHADER_API const string PROJ_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string PROJ_INVERSE_TRANSPOSE_MATRIX;
+extern MX_GENSHADER_API const string WORLD_VIEW_MATRIX;
+extern MX_GENSHADER_API const string VIEW_PROJECTION_MATRIX;
+extern MX_GENSHADER_API const string WORLD_VIEW_PROJECTION_MATRIX;
+extern MX_GENSHADER_API const string VIEW_POSITION;
+extern MX_GENSHADER_API const string VIEW_DIRECTION;
+extern MX_GENSHADER_API const string FRAME;
+extern MX_GENSHADER_API const string TIME;
+extern MX_GENSHADER_API const string GEOMPROP;
+extern MX_GENSHADER_API const string ALPHA_THRESHOLD;
+extern MX_GENSHADER_API const string NUM_ACTIVE_LIGHT_SOURCES;
+extern MX_GENSHADER_API const string ENV_MATRIX;
+extern MX_GENSHADER_API const string ENV_RADIANCE;
+extern MX_GENSHADER_API const string ENV_RADIANCE_MIPS;
+extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLES;
+extern MX_GENSHADER_API const string ENV_IRRADIANCE;
+extern MX_GENSHADER_API const string REFRACTION_ENV;
+extern MX_GENSHADER_API const string REFRACTION_COLOR;
+extern MX_GENSHADER_API const string ALBEDO_TABLE;
+extern MX_GENSHADER_API const string ALBEDO_TABLE_SIZE;
+extern MX_GENSHADER_API const string AMB_OCC_MAP;
+extern MX_GENSHADER_API const string AMB_OCC_GAIN;
+extern MX_GENSHADER_API const string SHADOW_MAP;
+extern MX_GENSHADER_API const string SHADOW_MATRIX;
+extern MX_GENSHADER_API const string VERTEX_DATA_INSTANCE;
+extern MX_GENSHADER_API const string LIGHT_DATA_INSTANCE;
+extern MX_GENSHADER_API const string LIGHT_DATA_MAX_LIGHT_SOURCES;
 
-    /// Variable blocks names.
-    extern MX_GENSHADER_API const string VERTEX_INPUTS;    // Geometric inputs for vertex stage.
-    extern MX_GENSHADER_API const string VERTEX_DATA;      // Connector block for data transfer from vertex stage to pixel stage.
-    extern MX_GENSHADER_API const string PRIVATE_UNIFORMS; // Uniform inputs set privately by application.
-    extern MX_GENSHADER_API const string PUBLIC_UNIFORMS;  // Uniform inputs visible in UI and set by user.
-    extern MX_GENSHADER_API const string LIGHT_DATA;       // Uniform inputs for light sources.
-    extern MX_GENSHADER_API const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
+/// Variable blocks names.
+extern MX_GENSHADER_API const string VERTEX_INPUTS;    // Geometric inputs for vertex stage.
+extern MX_GENSHADER_API const string VERTEX_DATA;      // Connector block for data transfer from vertex stage to pixel stage.
+extern MX_GENSHADER_API const string PRIVATE_UNIFORMS; // Uniform inputs set privately by application.
+extern MX_GENSHADER_API const string PUBLIC_UNIFORMS;  // Uniform inputs visible in UI and set by user.
+extern MX_GENSHADER_API const string LIGHT_DATA;       // Uniform inputs for light sources.
+extern MX_GENSHADER_API const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
 
-    /// Variable names for lighting parameters.
-    extern MX_GENSHADER_API const string DIR_N;
-    extern MX_GENSHADER_API const string DIR_L;
-    extern MX_GENSHADER_API const string DIR_V;
-    extern MX_GENSHADER_API const string WORLD_POSITION;
-    extern MX_GENSHADER_API const string OCCLUSION;
+/// Variable names for lighting parameters.
+extern MX_GENSHADER_API const string DIR_N;
+extern MX_GENSHADER_API const string DIR_L;
+extern MX_GENSHADER_API const string DIR_V;
+extern MX_GENSHADER_API const string WORLD_POSITION;
+extern MX_GENSHADER_API const string OCCLUSION;
 
-    /// Attribute names.
-    extern MX_GENSHADER_API const string ATTR_TRANSPARENT;
+/// Attribute names.
+extern MX_GENSHADER_API const string ATTR_TRANSPARENT;
 
-    /// User data names.
-    extern MX_GENSHADER_API const string USER_DATA_LIGHT_SHADERS;
-    extern MX_GENSHADER_API const string USER_DATA_BINDING_CONTEXT;
-}
+/// User data names.
+extern MX_GENSHADER_API const string USER_DATA_LIGHT_SHADERS;
+extern MX_GENSHADER_API const string USER_DATA_BINDING_CONTEXT;
+} // namespace HW
 
 namespace Stage
 {
-    /// Identifier for vertex stage.
-    extern MX_GENSHADER_API const string VERTEX;
-}
+/// Identifier for vertex stage.
+extern MX_GENSHADER_API const string VERTEX;
+} // namespace Stage
 
 class HwLightShaders;
 class HwShaderGenerator;
@@ -235,7 +235,7 @@ using HwShaderGeneratorPtr = shared_ptr<class HwShaderGenerator>;
 /// Shared pointer to a HwResourceBindingContext
 using HwResourceBindingContextPtr = shared_ptr<class HwResourceBindingContext>;
 
-/// @class HwLightShaders 
+/// @class HwLightShaders
 /// Hardware light shader user data
 class MX_GENSHADER_API HwLightShaders : public GenUserData
 {
@@ -288,7 +288,7 @@ class MX_GENSHADER_API HwShaderGenerator : public ShaderGenerator
 {
   public:
     /// Add the function call for a single node.
-    void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage, 
+    void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage,
                           bool checkScope = true) const override;
 
     /// Emit code for active light count definitions and uniforms
@@ -297,9 +297,9 @@ class MX_GENSHADER_API HwShaderGenerator : public ShaderGenerator
     /// Return the closure contexts defined for the given node.
     void getClosureContexts(const ShaderNode& node, vector<ClosureContext*>& cct) const override;
 
-    /// Bind a light shader to a light type id, for usage in surface shaders created 
-    /// by the generator. The lightTypeId should be a unique identifier for the light 
-    /// type (node definition) and the same id should be used when setting light parameters on a 
+    /// Bind a light shader to a light type id, for usage in surface shaders created
+    /// by the generator. The lightTypeId should be a unique identifier for the light
+    /// type (node definition) and the same id should be used when setting light parameters on a
     /// generated surface shader.
     static void bindLightShader(const NodeDef& nodeDef, unsigned int lightTypeId, GenContext& context);
 
@@ -343,12 +343,12 @@ class MX_GENSHADER_API HwShaderGenerator : public ShaderGenerator
 class MX_GENSHADER_API HwResourceBindingContext : public GenUserData
 {
   public:
-    virtual ~HwResourceBindingContext() {}
+    virtual ~HwResourceBindingContext() { }
 
     // Initialize the context before generation starts.
     virtual void initialize() = 0;
 
-    // Emit directives required for binding support 
+    // Emit directives required for binding support
     virtual void emitDirectives(GenContext& context, ShaderStage& stage) = 0;
 
     // Emit uniforms with binding information
@@ -356,9 +356,8 @@ class MX_GENSHADER_API HwResourceBindingContext : public GenUserData
 
     // Emit struct uniforms with binding information
     virtual void emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms,
-        ShaderStage& stage, const std::string& structInstanceName,
-        const std::string& arraySuffix = EMPTY_STRING) = 0;
-
+                                                ShaderStage& stage, const std::string& structInstanceName,
+                                                const std::string& arraySuffix = EMPTY_STRING) = 0;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Library.h
+++ b/source/MaterialXGenShader/Library.h
@@ -41,7 +41,7 @@ using ShaderNodeImplPtr = shared_ptr<ShaderNodeImpl>;
 /// Shared pointer to a GenContext
 using GenContextPtr = shared_ptr<GenContext>;
 
-template<class T> using CreatorFunction = shared_ptr<T>(*)();
+template <class T> using CreatorFunction = shared_ptr<T> (*)();
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -50,7 +50,7 @@ bool BlurNode::acceptsInputType(const TypeDesc* type) const
 {
     // Float 1-4 is acceptable as input
     return ((type == Type::FLOAT && type->isScalar()) ||
-        type->isFloat2() || type->isFloat3() || type->isFloat4());
+            type->isFloat2() || type->isFloat3() || type->isFloat4());
 }
 
 void BlurNode::outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& stage, const TypeDesc* inputType,
@@ -86,8 +86,7 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
         const Syntax& syntax = shadergen.getSyntax();
 
         // Get input type name string
-        const string& inputTypeString = inInput && acceptsInputType(inInput->getType()) ?
-            syntax.getTypeName(inInput->getType()) : EMPTY_STRING;
+        const string& inputTypeString = inInput && acceptsInputType(inInput->getType()) ? syntax.getTypeName(inInput->getType()) : EMPTY_STRING;
 
         const ShaderInput* filterTypeInput = node.getInput(FILTER_TYPE_STRING);
         if (!filterTypeInput || inputTypeString.empty())
@@ -126,14 +125,14 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
         const unsigned int sampleCount = filterWidth * filterWidth;
 
         // Emit samples
-        // Note: The maximum sample count MX_MAX_SAMPLE_COUNT is defined in the shader code and 
-        // is assumed to be 49 (7x7 kernel). If this changes the filter size logic here 
+        // Note: The maximum sample count MX_MAX_SAMPLE_COUNT is defined in the shader code and
+        // is assumed to be 49 (7x7 kernel). If this changes the filter size logic here
         // needs to be adjusted.
         //
         StringVec sampleStrings;
         emitInputSamplesUV(node, sampleCount, filterWidth,
-            _filterSize, _filterOffset, _sampleSizeFunctionUV,
-            context, stage, sampleStrings);
+                           _filterSize, _filterOffset, _sampleSizeFunctionUV,
+                           context, stage, sampleStrings);
 
         // There should always be at least 1 sample
         if (sampleStrings.empty())
@@ -152,7 +151,7 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
             string sampleName(output->getVariable() + SAMPLES_POSTFIX_STRING);
             outputSampleArray(shadergen, stage, inInput->getType(), sampleName, sampleStrings);
 
-            // Emit code to evaluate using input sample and weight arrays. 
+            // Emit code to evaluate using input sample and weight arrays.
             // The function to call depends on input type.
             //
             shadergen.emitLineBegin(stage);
@@ -181,10 +180,11 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
                 shadergen.emitString(output->getVariable(), stage);
                 shadergen.emitString(" = " + filterFunctionName, stage);
                 shadergen.emitString("(" + sampleName + ", " +
-                    GAUSSIAN_WEIGHTS_VARIABLE + ", " +
-                    std::to_string(arrayOffset) + ", " +
-                    std::to_string(sampleCount) +
-                    ")", stage);
+                                         GAUSSIAN_WEIGHTS_VARIABLE + ", " +
+                                         std::to_string(arrayOffset) + ", " +
+                                         std::to_string(sampleCount) +
+                                         ")",
+                                     stage);
                 shadergen.emitLineEnd(stage);
             }
             shadergen.emitScopeEnd(stage);
@@ -196,10 +196,11 @@ void BlurNode::emitFunctionCall(const ShaderNode& node, GenContext& context, Sha
                 shadergen.emitString(output->getVariable(), stage);
                 shadergen.emitString(" = " + filterFunctionName, stage);
                 shadergen.emitString("(" + sampleName + ", " +
-                    BOX_WEIGHTS_VARIABLE + ", " +
-                    std::to_string(arrayOffset) + ", " +
-                    std::to_string(sampleCount) +
-                    ")", stage);
+                                         BOX_WEIGHTS_VARIABLE + ", " +
+                                         std::to_string(arrayOffset) + ", " +
+                                         std::to_string(sampleCount) +
+                                         ")",
+                                     stage);
                 shadergen.emitLineEnd(stage);
             }
             shadergen.emitScopeEnd(stage);

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
@@ -116,7 +116,7 @@ void ClosureCompoundNode::emitFunctionDefinition(ClosureContext* cct, GenContext
         {
             const ShaderNode* upstream = outputSocket->getConnection()->getNode();
             if (upstream->getParent() == _rootGraph.get() &&
-               (upstream->hasClassification(ShaderNode::Classification::CLOSURE) || upstream->hasClassification(ShaderNode::Classification::SHADER)))
+                (upstream->hasClassification(ShaderNode::Classification::CLOSURE) || upstream->hasClassification(ShaderNode::Classification::SHADER)))
             {
                 shadergen.emitFunctionCall(*upstream, context, stage);
             }

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.h
@@ -14,7 +14,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Extending the CompoundNode with requirements for closures.
 class MX_GENSHADER_API ClosureCompoundNode : public CompoundNode
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void addClassification(ShaderNode& node) const override;
@@ -23,7 +23,7 @@ public:
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     void emitFunctionDefinition(ClosureContext* cct, GenContext& context, ShaderStage& stage) const;
 };
 

--- a/source/MaterialXGenShader/Nodes/ConvertNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvertNode.cpp
@@ -19,55 +19,29 @@ ShaderNodeImplPtr ConvertNode::create()
 
 void ConvertNode::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-    using ConvertTable = std::unordered_map<const TypeDesc*, std::unordered_map<const TypeDesc*, string> >;
+    using ConvertTable = std::unordered_map<const TypeDesc*, std::unordered_map<const TypeDesc*, string>>;
 
-    static const ConvertTable CONVERT_TABLE({
-        {
-            Type::COLOR3,
-            {
-                { Type::VECTOR3, string("rgb") },
-                { Type::COLOR4, string("rgb1") }
-            }
-        },
-        {
-            Type::COLOR4,
-            {
-                { Type::VECTOR4, string("rgba") },
-                { Type::COLOR3, string("rgb") }
-            }
-        },
-        {
-            Type::VECTOR2,
-            {
-                { Type::VECTOR3, string("xy0") }
-            }
-        },
-        {
-            Type::VECTOR3,
-            {
-                { Type::COLOR3, string("xyz") },
-                { Type::VECTOR4, string("xyz1") },
-                { Type::VECTOR2, string("xy") }
-            }
-        },
-        {
-            Type::VECTOR4,
-            {
-                { Type::COLOR4, string("xyzw") },
-                { Type::VECTOR3, string("xyz") }
-            }
-        },
-        {
-            Type::FLOAT,
-            {
-                { Type::COLOR3, string("rrr") },
-                { Type::COLOR4, string("rrrr") },
-                { Type::VECTOR2, string("rr") },
-                { Type::VECTOR3, string("rrr") },
-                { Type::VECTOR4, string("rrrr") }
-            }
-        }
-    });
+    static const ConvertTable CONVERT_TABLE({ { Type::COLOR3,
+                                                { { Type::VECTOR3, string("rgb") },
+                                                  { Type::COLOR4, string("rgb1") } } },
+                                              { Type::COLOR4,
+                                                { { Type::VECTOR4, string("rgba") },
+                                                  { Type::COLOR3, string("rgb") } } },
+                                              { Type::VECTOR2,
+                                                { { Type::VECTOR3, string("xy0") } } },
+                                              { Type::VECTOR3,
+                                                { { Type::COLOR3, string("xyz") },
+                                                  { Type::VECTOR4, string("xyz1") },
+                                                  { Type::VECTOR2, string("xy") } } },
+                                              { Type::VECTOR4,
+                                                { { Type::COLOR4, string("xyzw") },
+                                                  { Type::VECTOR3, string("xyz") } } },
+                                              { Type::FLOAT,
+                                                { { Type::COLOR3, string("rrr") },
+                                                  { Type::COLOR4, string("rrrr") },
+                                                  { Type::VECTOR2, string("rr") },
+                                                  { Type::VECTOR3, string("rrr") },
+                                                  { Type::VECTOR4, string("rrrr") } } } });
 
     static const string IN_STRING("in");
 

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -12,23 +12,21 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-namespace {
+namespace
+{
 
 const string SAMPLE2D_INPUT = "texcoord";
 const string SAMPLE3D_INPUT = "position";
 
 } // anonymous namespace
 
-const std::array<float, 3> GAUSSIAN_KERNEL_3 =
-{
+const std::array<float, 3> GAUSSIAN_KERNEL_3 = {
     0.27901f, 0.44198f, 0.27901f // Sigma 1
 };
-const std::array<float, 5> GAUSSIAN_KERNEL_5 =
-{
+const std::array<float, 5> GAUSSIAN_KERNEL_5 = {
     0.06136f, 0.24477f, 0.38774f, 0.24477f, 0.06136f // Sigma 1
 };
-const std::array<float, 7> GAUSSIAN_KERNEL_7 =
-{
+const std::array<float, 7> GAUSSIAN_KERNEL_7 = {
     0.00598f, 0.060626f, 0.241843f, 0.383103f, 0.241843f, 0.060626f, 0.00598f // Sigma 1
 };
 
@@ -106,11 +104,11 @@ const ShaderInput* ConvolutionNode::getSamplingInput(const ShaderNode& node) con
     return nullptr;
 }
 
-void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node, 
-                                         unsigned int sampleCount, unsigned int filterWidth, 
+void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node,
+                                         unsigned int sampleCount, unsigned int filterWidth,
                                          float filterSize, float filterOffset,
-                                         const string& sampleSizeFunctionUV, 
-                                         GenContext& context, ShaderStage& stage, 
+                                         const string& sampleSizeFunctionUV,
+                                         GenContext& context, ShaderStage& stage,
                                          StringVec& sampleStrings) const
 {
     sampleStrings.clear();
@@ -168,13 +166,13 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node,
                     if (sampleCount > 1)
                     {
                         computeSampleOffsetStrings(sampleSizeName, vec2TypeString,
-                            filterWidth, inputVec2Suffix);
+                                                   filterWidth, inputVec2Suffix);
                     }
 
-                    // Emit outputs for sample input 
+                    // Emit outputs for sample input
                     for (unsigned int i = 0; i < sampleCount; i++)
                     {
-                        // Add an input name suffix. 
+                        // Add an input name suffix.
                         context.addInputSuffix(samplingInput, inputVec2Suffix[i]);
 
                         // Add a output name suffix for the emit call
@@ -222,6 +220,6 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node,
             sampleStrings.push_back(inValueString);
         }
     }
-} 
+}
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.h
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.h
@@ -21,7 +21,7 @@ extern MX_GENSHADER_API const std::array<float, 7> GAUSSIAN_KERNEL_7;
 class MX_GENSHADER_API ConvolutionNode : public ShaderNodeImpl
 {
   public:
-     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;
+    void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;
 
   protected:
     /// Constructor
@@ -32,14 +32,14 @@ class MX_GENSHADER_API ConvolutionNode : public ShaderNodeImpl
 
     // Derived classes are responsible for computing offset strings relative to the center sample
     // The sample size and offset type are passed in as arguments.
-    virtual void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+    virtual void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                             unsigned int filterWidth, StringVec& offsetStrings) const = 0;
 
     /// Get input which is used for sampling. If there is none
     /// then a null pointer is returned.
     virtual const ShaderInput* getSamplingInput(const ShaderNode& node) const;
 
-    /// Generate upstream / input sampling code in uv space and cache the output variable names which 
+    /// Generate upstream / input sampling code in uv space and cache the output variable names which
     /// will hold the sample values after execution.
     void emitInputSamplesUV(const ShaderNode& node,
                             unsigned int sampleCount, unsigned int filterWidth,

--- a/source/MaterialXGenShader/Nodes/HwImageNode.h
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Extending the SourceCodeNode with requirements for image nodes.
 class MX_GENSHADER_API HwImageNode : public SourceCodeNode
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void addInputs(ShaderNode& node, GenContext& context) const override;

--- a/source/MaterialXGenShader/Nodes/IfNode.cpp
+++ b/source/MaterialXGenShader/Nodes/IfNode.cpp
@@ -91,5 +91,4 @@ ShaderNodeImplPtr IfEqualNode::create()
     return std::make_shared<IfEqualNode>();
 }
 
-
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Nodes/IfNode.h
+++ b/source/MaterialXGenShader/Nodes/IfNode.h
@@ -30,6 +30,7 @@ class MX_GENSHADER_API IfGreaterNode : public IfNode
 {
   public:
     static ShaderNodeImplPtr create();
+
   private:
     const string& equalityString() const override
     {
@@ -38,12 +39,13 @@ class MX_GENSHADER_API IfGreaterNode : public IfNode
     static string EQUALITY_STRING;
 };
 
-/// @class IfGreaterEqNode 
+/// @class IfGreaterEqNode
 /// "ifgreatereq" node implementation
 class MX_GENSHADER_API IfGreaterEqNode : public IfNode
 {
   public:
     static ShaderNodeImplPtr create();
+
   private:
     const string& equalityString() const override
     {
@@ -52,12 +54,13 @@ class MX_GENSHADER_API IfGreaterEqNode : public IfNode
     static string EQUALITY_STRING;
 };
 
-/// @class IfEqualNode 
+/// @class IfEqualNode
 /// "ifequal" node implementation
 class MX_GENSHADER_API IfEqualNode : public IfNode
 {
   public:
     static ShaderNodeImplPtr create();
+
   private:
     const string& equalityString() const override
     {

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -54,7 +54,7 @@ void SourceCodeNode::initialize(const InterfaceElement& element, GenContext& con
         if (_functionName != validFunctionName)
         {
             throw ExceptionShaderGenError("Function name '" + _functionName +
-                "' used by implementation '" + impl.getName() + "' is not a valid identifier.");
+                                          "' used by implementation '" + impl.getName() + "' is not a valid identifier.");
         }
     }
     else
@@ -118,7 +118,7 @@ void SourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext& contex
                 if (!input)
                 {
                     throw ExceptionShaderGenError("Could not find an input named '" + variable +
-                        "' on node '" + node.getName() + "'");
+                                                  "' on node '" + node.getName() + "'");
                 }
 
                 if (input->getConnection())

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.h
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.h
@@ -14,7 +14,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 /// @class SourceCodeNode
 /// Implemention for a node using data-driven static source code.
-/// This is the default implementation used for all nodes that 
+/// This is the default implementation used for all nodes that
 /// do not have a custom ShaderNodeImpl class.
 class MX_GENSHADER_API SourceCodeNode : public ShaderNodeImpl
 {

--- a/source/MaterialXGenShader/Nodes/SwitchNode.h
+++ b/source/MaterialXGenShader/Nodes/SwitchNode.h
@@ -13,12 +13,12 @@ MATERIALX_NAMESPACE_BEGIN
 /// Switch node implementation
 class MX_GENSHADER_API SwitchNode : public ShaderNodeImpl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-public:
+  public:
     static const StringVec INPUT_NAMES;
 };
 

--- a/source/MaterialXGenShader/Shader.cpp
+++ b/source/MaterialXGenShader/Shader.cpp
@@ -41,7 +41,6 @@ bool Shader::hasStage(const string& name)
     return (it != _stagesMap.end());
 }
 
-
 ShaderStage& Shader::getStage(const string& name)
 {
     auto it = _stagesMap.find(name);

--- a/source/MaterialXGenShader/Shader.h
+++ b/source/MaterialXGenShader/Shader.h
@@ -26,7 +26,7 @@ class Shader;
 /// emitted by shader generators.
 ///
 /// The class contains a default implementation using a single shader stage.
-/// Derived shaders can override this, as well as overriding all methods 
+/// Derived shaders can override this, as well as overriding all methods
 /// that add code to the shader.
 ///
 class MX_GENSHADER_API Shader

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -30,7 +30,7 @@ const string ShaderGenerator::T_FILE_TRANSFORM_UV = "$fileTransformUv";
 //
 
 ShaderGenerator::ShaderGenerator(SyntaxPtr syntax) :
-     _syntax(syntax)
+    _syntax(syntax)
 {
 }
 
@@ -102,7 +102,7 @@ void ShaderGenerator::emitFunctionDefinitions(const ShaderGraph& graph, GenConte
 }
 
 void ShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage,
-    bool checkScope) const
+                                       bool checkScope) const
 {
     // Check if it's emitted already.
     if (stage.isEmitted(node, context))
@@ -114,7 +114,8 @@ void ShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& conte
     if (checkScope && node.referencedConditionally())
     {
         emitComment("Omitted node '" + node.getName() + "'. Only used in conditional node '" +
-            node.getScopeInfo().conditionalNode->getName() + "'", stage);
+                        node.getScopeInfo().conditionalNode->getName() + "'",
+                    stage);
         return;
     }
     stage.addFunctionCall(node, context);
@@ -167,19 +168,19 @@ void ShaderGenerator::emitTypeDefinitions(GenContext&, ShaderStage& stage) const
     stage.newLine();
 }
 
-void ShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier, 
+void ShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier,
                                               GenContext&, ShaderStage& stage,
                                               bool assignValue) const
 {
     string str = qualifier.empty() ? EMPTY_STRING : qualifier + " ";
     str += _syntax->getTypeName(variable->getType());
-    
+
     bool haveArray = variable->getType()->isArray() && variable->getValue();
     if (haveArray)
     {
         str += _syntax->getArrayTypeSuffix(variable->getType(), *variable->getValue());
     }
-    
+
     str += " " + variable->getVariable();
 
     // If an array we need an array qualifier (suffix) for the variable name
@@ -191,19 +192,19 @@ void ShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const 
     if (assignValue)
     {
         const string valueStr = (variable->getValue() ?
-            _syntax->getValue(variable->getType(), *variable->getValue(), true) :
-            _syntax->getDefaultValue(variable->getType(), true));
+                                 _syntax->getValue(variable->getType(), *variable->getValue(), true) :
+                                 _syntax->getDefaultValue(variable->getType(), true));
         str += valueStr.empty() ? EMPTY_STRING : " = " + valueStr;
     }
 
     stage.addString(str);
 }
 
-void ShaderGenerator::emitVariableDeclarations(const VariableBlock& block, const string& qualifier, const string& separator, 
+void ShaderGenerator::emitVariableDeclarations(const VariableBlock& block, const string& qualifier, const string& separator,
                                                GenContext& context, ShaderStage& stage,
                                                bool assignValue) const
 {
-    for (size_t i=0; i<block.size(); ++i)
+    for (size_t i = 0; i < block.size(); ++i)
     {
         emitLineBegin(stage);
         emitVariableDeclaration(block[i], qualifier, context, stage, assignValue);
@@ -346,16 +347,18 @@ ShaderNodeImplPtr ShaderGenerator::getImplementation(const NodeDef& nodedef, Gen
 
 namespace
 {
-    void replace(const StringMap& substitutions, ShaderPort* port)
-    {
-        string name = port->getName();
-        tokenSubstitution(substitutions, name);
-        port->setName(name);
-        string variable = port->getVariable();
-        tokenSubstitution(substitutions, variable);
-        port->setVariable(variable);
-    }
+
+void replace(const StringMap& substitutions, ShaderPort* port)
+{
+    string name = port->getName();
+    tokenSubstitution(substitutions, name);
+    port->setName(name);
+    string variable = port->getVariable();
+    tokenSubstitution(substitutions, variable);
+    port->setVariable(variable);
 }
+
+} // anonymous namespace
 
 void ShaderGenerator::registerShaderMetadata(const DocumentPtr& doc, GenContext& context) const
 {
@@ -367,8 +370,7 @@ void ShaderGenerator::registerShaderMetadata(const DocumentPtr& doc, GenContext&
     }
 
     // Add default entries.
-    ShaderMetadataVec defaultMetadata =
-    {
+    ShaderMetadataVec defaultMetadata = {
         ShaderMetadata(ValueElement::UI_NAME_ATTRIBUTE, Type::STRING),
         ShaderMetadata(ValueElement::UI_FOLDER_ATTRIBUTE, Type::STRING),
         ShaderMetadata(ValueElement::UI_MIN_ATTRIBUTE, nullptr),
@@ -451,7 +453,7 @@ void ShaderGenerator::createVariables(ShaderGraphPtr graph, GenContext& context,
         if (handler)
         {
             handler(node, context);
-        }  
+        }
         node->getImplementation().createVariables(*node, context, shader);
     }
 }

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -79,7 +79,7 @@ class MX_GENSHADER_API ShaderGenerator
     virtual void emitLibraryInclude(const FilePath& filename, GenContext& context, ShaderStage& stage) const;
 
     /// Add a value.
-    template<typename T>
+    template <typename T>
     void emitValue(const T& value, ShaderStage& stage) const
     {
         stage.addValue<T>(value);
@@ -188,10 +188,10 @@ class MX_GENSHADER_API ShaderGenerator
     }
 
     /// Register metadata that should be exported to the generated shaders.
-    /// Supported metadata includes standard UI attributes like "uiname", "uifolder", 
-    /// "uimin", "uimax", etc. 
+    /// Supported metadata includes standard UI attributes like "uiname", "uifolder",
+    /// "uimin", "uimax", etc.
     /// But it is also extendable by defining custom attributes using AttributeDefs.
-    /// Any AttributeDef in the given document with exportable="true" will be 
+    /// Any AttributeDef in the given document with exportable="true" will be
     /// exported as shader metadata when found on nodes during shader generation.
     /// Derived shader generators may override this method to change the registration.
     /// Applications must explicitly call this method before shader generation to enable

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -81,8 +81,8 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
     NodePtr upstreamNode = upstreamElement->asA<Node>();
     if (!upstreamNode)
     {
-        throw ExceptionShaderGenError("Upstream element to connect is not a node '" 
-            + upstreamElement->getName() + "'");
+        throw ExceptionShaderGenError("Upstream element to connect is not a node '" +
+                                      upstreamElement->getName() + "'");
     }
     const string& newNodeName = upstreamNode->getName();
     ShaderNode* newNode = getNode(newNodeName);
@@ -109,7 +109,7 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
     if (!output)
     {
         throw ExceptionShaderGenError("Could not find an output named '" + (nodeDefOutput ? nodeDefOutput->getName() : string("out")) +
-            "' on upstream node '" + upstreamNode->getName() + "'");
+                                      "' on upstream node '" + upstreamNode->getName() + "'");
     }
 
     // Check if it was a node downstream
@@ -124,7 +124,7 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
             if (!input)
             {
                 throw ExceptionShaderGenError("Could not find an input named '" + connectingElement->getName() +
-                    "' on downstream node '" + downstream->getName() + "'");
+                                              "' on downstream node '" + downstream->getName() + "'");
             }
             input->makeConnection(output);
         }
@@ -201,7 +201,7 @@ void ShaderGraph::addDefaultGeomNode(ShaderInput* input, const GeomPropDef& geom
         if (!geomNodeDef)
         {
             throw ExceptionShaderGenError("Could not find a nodedef named '" + geomNodeDefName +
-                "' for defaultgeomprop on input '" + input->getFullName() + "'");
+                                          "' for defaultgeomprop on input '" + input->getFullName() + "'");
         }
 
         ShaderNodePtr geomNode = ShaderNode::create(this, geomNodeName, *geomNodeDef, context);
@@ -469,7 +469,8 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
 
     ColorManagementSystemPtr colorManagementSystem = context.getShaderGenerator().getColorManagementSystem();
     string targetColorSpace = context.getOptions().targetColorSpaceOverride.empty() ?
-            node->getDocument()->getColorSpace() : context.getOptions().targetColorSpaceOverride;
+                              node->getDocument()->getColorSpace() :
+                              context.getOptions().targetColorSpaceOverride;
 
     const string& targetDistanceUnit = context.getOptions().targetDistanceUnit;
     UnitSystemPtr unitSystem = context.getShaderGenerator().getUnitSystem();
@@ -559,7 +560,7 @@ ShaderGraphPtr ShaderGraph::createSurfaceShader(
         if (input)
         {
             if (input->getPath().empty())
-            { 
+            {
                 input->setPath(path);
             }
             if (input->getUnit().empty() && !unit.empty())
@@ -836,7 +837,8 @@ ShaderNode* ShaderGraph::createNode(const Node& node, GenContext& context)
 
     ColorManagementSystemPtr colorManagementSystem = context.getShaderGenerator().getColorManagementSystem();
     string targetColorSpace = context.getOptions().targetColorSpaceOverride.empty() ?
-        _document->getActiveColorSpace() : context.getOptions().targetColorSpaceOverride;
+                              _document->getActiveColorSpace() :
+                              context.getOptions().targetColorSpaceOverride;
 
     for (InputPtr input : node.getInputs())
     {
@@ -915,7 +917,7 @@ void ShaderGraph::finalize(GenContext& context)
 
     // Insert color transformation nodes where needed
     if (context.getOptions().emitColorTransforms)
-    { 
+    {
         for (const auto& it : _inputColorTransformMap)
         {
             addColorTransformNode(it.first, it.second, context);
@@ -948,7 +950,7 @@ void ShaderGraph::finalize(GenContext& context)
 
     // Calculate scopes for all nodes in the graph.
     //
-    // TODO: Enable calculateScopes() again when support for 
+    // TODO: Enable calculateScopes() again when support for
     // conditional nodes are improved.
     //
     // calculateScopes();
@@ -1015,7 +1017,7 @@ void ShaderGraph::optimize(GenContext& context)
     {
         if (node->hasClassification(ShaderNode::Classification::CONSTANT))
         {
-            // Constant nodes can be removed by moving their value 
+            // Constant nodes can be removed by moving their value
             // or connection downstream.
             bypass(context, node, 0);
             ++numEdits;
@@ -1046,8 +1048,7 @@ void ShaderGraph::optimize(GenContext& context)
             {
                 // Find which branch should be taken
                 ValuePtr value = which->getValue();
-                const int branch = int(value==nullptr ? 0 :
-                    (which->getType() == Type::FLOAT ? value->asA<float>() : value->asA<int>()));
+                const int branch = int(value == nullptr ? 0 : (which->getType() == Type::FLOAT ? value->asA<float>() : value->asA<int>()));
 
                 // Bypass the conditional using the taken branch
                 bypass(context, node, branch);
@@ -1140,9 +1141,9 @@ void ShaderGraph::bypass(GenContext& context, ShaderNode* node, size_t inputInde
             if (!channels.empty())
             {
                 downstream->setValue(context.getShaderGenerator().getSyntax().getSwizzledValue(input->getValue(),
-                                                                                          input->getType(), 
-                                                                                          channels,
-                                                                                          downstream->getType()));
+                                                                                               input->getType(),
+                                                                                               channels,
+                                                                                               downstream->getType()));
                 downstream->setType(downstream->getType());
                 downstream->setChannels(EMPTY_STRING);
             }
@@ -1317,7 +1318,7 @@ void ShaderGraph::setVariableNames(GenContext& context)
     }
 }
 
-string ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManagementSystem, ShaderPort* shaderPort, 
+string ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManagementSystem, ShaderPort* shaderPort,
                                               ValueElementPtr input, const string& targetColorSpace, bool asInput)
 {
     if (targetColorSpace.empty())
@@ -1336,7 +1337,7 @@ string ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorMana
                 // Cache colorspace on shader port
                 shaderPort->setColorSpace(sourceColorSpace);
                 if (colorManagementSystem)
-                { 
+                {
                     ColorSpaceTransform transform(sourceColorSpace, targetColorSpace, shaderPort->getType());
                     if (colorManagementSystem->supportsTransform(transform))
                     {
@@ -1352,7 +1353,7 @@ string ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorMana
                     else
                     {
                         std::cerr << "Unsupported color space transform from " <<
-                            sourceColorSpace << " to " << targetColorSpace << std::endl;
+                                     sourceColorSpace << " to " << targetColorSpace << std::endl;
                     }
                 }
             }
@@ -1398,9 +1399,9 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
     // Only support convertion for float and vectors. arrays, matrices are not supported.
     // TODO: This should be provided by the UnitSystem.
     bool supportedType = (shaderPort->getType() == Type::FLOAT ||
-                        shaderPort->getType() == Type::VECTOR2 ||
-                        shaderPort->getType() == Type::VECTOR3 ||
-                        shaderPort->getType() == Type::VECTOR4);
+                          shaderPort->getType() == Type::VECTOR2 ||
+                          shaderPort->getType() == Type::VECTOR3 ||
+                          shaderPort->getType() == Type::VECTOR4);
     if (supportedType)
     {
         UnitTransform transform(sourceUnitSpace, targetUnitSpace, shaderPort->getType(), unitType);
@@ -1421,7 +1422,7 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
 
 namespace
 {
-    static const ShaderGraphEdgeIterator NULL_EDGE_ITERATOR(nullptr);
+static const ShaderGraphEdgeIterator NULL_EDGE_ITERATOR(nullptr);
 }
 
 //

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -51,7 +51,7 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
 
     /// Create a new shader graph from an element.
     /// Supported elements are outputs and shader nodes.
-    static ShaderGraphPtr create(const ShaderGraph* parent, const string& name, ElementPtr element, 
+    static ShaderGraphPtr create(const ShaderGraph* parent, const string& name, ElementPtr element,
                                  GenContext& context);
 
     /// Create a new shader graph from a nodegraph.
@@ -148,7 +148,7 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
 
     /// Add a unit transform node and connect to the given input.
     void addUnitTransformNode(ShaderInput* input, const UnitTransform& transform, GenContext& context);
-    
+
     /// Add a unit transform node and connect to the given output.
     void addUnitTransformNode(ShaderOutput* output, const UnitTransform& transform, GenContext& context);
 
@@ -210,7 +210,8 @@ class MX_GENSHADER_API ShaderGraphEdge
     ShaderGraphEdge(ShaderOutput* up, ShaderInput* down) :
         upstream(up),
         downstream(down)
-    {}
+    {
+    }
     ShaderOutput* upstream;
     ShaderInput* downstream;
 };
@@ -226,8 +227,8 @@ class MX_GENSHADER_API ShaderGraphEdgeIterator
     bool operator==(const ShaderGraphEdgeIterator& rhs) const
     {
         return _upstream == rhs._upstream &&
-            _downstream == rhs._downstream &&
-            _stack == rhs._stack;
+               _downstream == rhs._downstream &&
+               _stack == rhs._stack;
     }
     bool operator!=(const ShaderGraphEdgeIterator& rhs) const
     {

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -27,9 +27,9 @@ ShaderPort::ShaderPort(ShaderNode* node, const TypeDesc* type, const string& nam
 {
 }
 
-string ShaderPort::getFullName() const 
-{ 
-    return (_node->getName() + "_" + _name); 
+string ShaderPort::getFullName() const
+{
+    return (_node->getName() + "_" + _name);
 }
 
 //
@@ -83,7 +83,6 @@ ShaderNode* ShaderInput::getConnectedSibling() const
     return nullptr;
 }
 
-
 //
 // ShaderOutput methods
 //
@@ -103,10 +102,9 @@ void ShaderOutput::breakConnection(ShaderInput* dst)
     if (std::find(_connections.begin(), _connections.end(), dst) == _connections.end())
     {
         throw ExceptionShaderGenError(
-            "Cannot break non-existent connection from output: " + getFullName()
-            + " to input: " + dst->getFullName());
+            "Cannot break non-existent connection from output: " + getFullName() + " to input: " + dst->getFullName());
     }
-    dst->breakConnection(); 
+    dst->breakConnection();
 }
 
 void ShaderOutput::breakConnections()
@@ -120,17 +118,17 @@ void ShaderOutput::breakConnections()
     if (!_connections.empty())
     {
         throw ExceptionShaderGenError("Number of output connections not broken properly'" + std::to_string(_connections.size()) +
-            " for output: " + getFullName());
+                                      " for output: " + getFullName());
     }
 }
 
 namespace
 {
-    ShaderNodePtr createEmptyNode()
-    {
-        return std::make_shared<ShaderNode>(nullptr, "");
-    }
+ShaderNodePtr createEmptyNode()
+{
+    return std::make_shared<ShaderNode>(nullptr, "");
 }
+} // namespace
 
 const ShaderNodePtr ShaderNode::NONE = createEmptyNode();
 
@@ -194,7 +192,7 @@ void ShaderNode::ScopeInfo::adjustAtConditionalInput(ShaderNode* condNode, int b
     }
 }
 
-void ShaderNode::ScopeInfo::merge(const ScopeInfo &fromScope)
+void ShaderNode::ScopeInfo::merge(const ScopeInfo& fromScope)
 {
     if (type == ScopeInfo::UNKNOWN || fromScope.type == ScopeInfo::GLOBAL)
     {
@@ -202,7 +200,6 @@ void ShaderNode::ScopeInfo::merge(const ScopeInfo &fromScope)
     }
     else if (type == ScopeInfo::GLOBAL)
     {
-
     }
     else if (type == ScopeInfo::SINGLE && fromScope.type == ScopeInfo::SINGLE && conditionalNode == fromScope.conditionalNode)
     {
@@ -234,7 +231,7 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
     if (!newNode->_impl)
     {
         throw ExceptionShaderGenError("Could not find a matching implementation for node '" + nodeDef.getNodeString() +
-            "' matching target '" + shadergen.getTarget() + "'");
+                                      "' matching target '" + shadergen.getTarget() + "'");
     }
 
     // Create interface from nodedef

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -36,7 +36,6 @@ using ShaderNodePtr = shared_ptr<class ShaderNode>;
 /// A vector of ShaderInput pointers
 using ShaderInputVec = vector<ShaderInput*>;
 
-
 /// Metadata to be exported to generated shader.
 struct MX_GENSHADER_API ShaderMetadata
 {
@@ -47,12 +46,13 @@ struct MX_GENSHADER_API ShaderMetadata
         name(n),
         type(t),
         value(v)
-    {}
+    {
+    }
 };
 using ShaderMetadataVec = vector<ShaderMetadata>;
 using ShaderMetadataVecPtr = shared_ptr<ShaderMetadataVec>;
 
-/// @class ShaderMetadataRegistry 
+/// @class ShaderMetadataRegistry
 /// A registry for metadata that will be exported to the generated shader
 /// if found on nodes and inputs during shader generation.
 class MX_GENSHADER_API ShaderMetadataRegistry : public GenUserData
@@ -107,7 +107,6 @@ class MX_GENSHADER_API ShaderMetadataRegistry : public GenUserData
 };
 
 using ShaderMetadataRegistryPtr = shared_ptr<ShaderMetadataRegistry>;
-
 
 /// Flags set on shader ports.
 class MX_GENSHADER_API ShaderPortFlag
@@ -328,7 +327,7 @@ class MX_GENSHADER_API ShaderNode
     /// Flags for classifying nodes into different categories.
     class Classification
     {
-    public:
+      public:
         // Node classes
         static const uint32_t TEXTURE       = 1 << 0;  /// Any node that outputs floats, colors, vectors, etc.
         static const uint32_t CLOSURE       = 1 << 1;  /// Any node that represents light integration
@@ -375,7 +374,8 @@ class MX_GENSHADER_API ShaderNode
             MULTIPLE
         };
 
-        ScopeInfo() : type(UNKNOWN), conditionalNode(nullptr), conditionBitmask(0), fullConditionMask(0) {}
+        ScopeInfo() :
+            type(UNKNOWN), conditionalNode(nullptr), conditionBitmask(0), fullConditionMask(0) { }
 
         void merge(const ScopeInfo& fromScope);
         void adjustAtConditionalInput(ShaderNode* condNode, int branch, uint32_t fullMask);
@@ -411,7 +411,7 @@ class MX_GENSHADER_API ShaderNode
     ShaderNode(const ShaderGraph* parent, const string& name);
 
     /// Create a new node from a nodedef.
-    static ShaderNodePtr create(const ShaderGraph* parent, const string& name, const NodeDef& nodeDef, 
+    static ShaderNodePtr create(const ShaderGraph* parent, const string& name, const NodeDef& nodeDef,
                                 GenContext& context);
 
     /// Create a new node from a node implementation.

--- a/source/MaterialXGenShader/ShaderNodeImpl.cpp
+++ b/source/MaterialXGenShader/ShaderNodeImpl.cpp
@@ -16,8 +16,8 @@ MATERIALX_NAMESPACE_BEGIN
 // ShaderNodeImpl methods
 //
 
-ShaderNodeImpl::ShaderNodeImpl() : 
-    _name(EMPTY_STRING), 
+ShaderNodeImpl::ShaderNodeImpl() :
+    _name(EMPTY_STRING),
     _hash(0)
 {
 }
@@ -75,7 +75,6 @@ ShaderGraph* ShaderNodeImpl::getGraph() const
 {
     return nullptr;
 }
-
 
 ShaderNodeImplPtr NopNode::create()
 {

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -25,7 +25,7 @@ using ShaderNodeImplPtr = shared_ptr<class ShaderNodeImpl>;
 
 /// @class ShaderNodeImpl
 /// Class handling the shader generation implementation for a node.
-/// Responsible for emitting the function definition and function call 
+/// Responsible for emitting the function definition and function call
 /// that is the node implementation.
 class MX_GENSHADER_API ShaderNodeImpl
 {
@@ -114,7 +114,7 @@ class MX_GENSHADER_API ShaderNodeImpl
 /// A no operation node, to be used for organizational nodes that has no code to execute.
 class MX_GENSHADER_API NopNode : public ShaderNodeImpl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 };
 

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -18,8 +18,10 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace Stage
 {
-    const string PIXEL = "pixel";
-}
+
+const string PIXEL = "pixel";
+
+} // namespace Stage
 
 //
 // VariableBlock methods
@@ -192,23 +194,24 @@ const VariableBlock& ShaderStage::getConstantBlock() const
 
 void ShaderStage::beginScope(Syntax::Punctuation punc)
 {
-    switch (punc) {
-    case Syntax::CURLY_BRACKETS:
-        beginLine();
-        _code += "{" + _syntax->getNewline();
-        break;
-    case Syntax::PARENTHESES:
-        beginLine();
-        _code += "(" + _syntax->getNewline();
-        break;
-    case Syntax::SQUARE_BRACKETS:
-        beginLine();
-        _code += "[" + _syntax->getNewline();
-        break;
-    case Syntax::DOUBLE_SQUARE_BRACKETS:
-        beginLine();
-        _code += "[[" + _syntax->getNewline();
-        break;
+    switch (punc)
+    {
+        case Syntax::CURLY_BRACKETS:
+            beginLine();
+            _code += "{" + _syntax->getNewline();
+            break;
+        case Syntax::PARENTHESES:
+            beginLine();
+            _code += "(" + _syntax->getNewline();
+            break;
+        case Syntax::SQUARE_BRACKETS:
+            beginLine();
+            _code += "[" + _syntax->getNewline();
+            break;
+        case Syntax::DOUBLE_SQUARE_BRACKETS:
+            beginLine();
+            _code += "[[" + _syntax->getNewline();
+            break;
     }
 
     ++_indentations;
@@ -226,23 +229,24 @@ void ShaderStage::endScope(bool semicolon, bool newline)
     _scopes.pop_back();
     --_indentations;
 
-    switch (punc) {
-    case Syntax::CURLY_BRACKETS:
-        beginLine();
-        _code += "}";
-        break;
-    case Syntax::PARENTHESES:
-        beginLine();
-        _code += ")";
-        break;
-    case Syntax::SQUARE_BRACKETS:
-        beginLine();
-        _code += "]";
-        break;
-    case Syntax::DOUBLE_SQUARE_BRACKETS:
-        beginLine();
-        _code += "]]";
-        break;
+    switch (punc)
+    {
+        case Syntax::CURLY_BRACKETS:
+            beginLine();
+            _code += "}";
+            break;
+        case Syntax::PARENTHESES:
+            beginLine();
+            _code += ")";
+            break;
+        case Syntax::SQUARE_BRACKETS:
+            beginLine();
+            _code += "]";
+            break;
+        case Syntax::DOUBLE_SQUARE_BRACKETS:
+            beginLine();
+            _code += "]]";
+            break;
     }
     if (semicolon)
         _code += ";";
@@ -298,7 +302,7 @@ void ShaderStage::addBlock(const string& str, const FilePath& sourceFilename, Ge
 
     // Add each line in the block seperately to get correct indentation.
     StringStream stream(str);
-    for (string line; std::getline(stream, line); )
+    for (string line; std::getline(stream, line);)
     {
         size_t pos = line.find(INCLUDE);
         if (pos != string::npos)

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -27,21 +27,25 @@
 #define DEFINE_SHADER_STAGE(stage, name) if (stage.getName() == name)
 
 // These macros are deprecated, and should be replaced with DEFINE_SHADER_STAGE.
-#define BEGIN_SHADER_STAGE(stage, name) DEFINE_SHADER_STAGE(stage, name) {
+#define BEGIN_SHADER_STAGE(stage, name) \
+    if (stage.getName() == name)        \
+    {
 #define END_SHADER_STAGE(stage, name) }
 
 MATERIALX_NAMESPACE_BEGIN
 
 namespace Stage
 {
-    /// Identifier for pixel stage.
-    /// This is the main stage used by all shader targets.
-    /// For single stage shader targets this is the one
-    /// and only stage.
-    /// Shader targets with multiple stages can add additional
-    /// stage identifiers to the Stage namespace.
-    extern MX_GENSHADER_API const string PIXEL;
-}
+
+/// Identifier for pixel stage.
+/// This is the main stage used by all shader targets.
+/// For single stage shader targets this is the one
+/// and only stage.
+/// Shader targets with multiple stages can add additional
+/// stage identifiers to the Stage namespace.
+extern MX_GENSHADER_API const string PIXEL;
+
+} // namespace Stage
 
 class VariableBlock;
 /// Shared pointer to a VariableBlock
@@ -59,7 +63,8 @@ class MX_GENSHADER_API VariableBlock
     VariableBlock(const string& name, const string& instance) :
         _name(name),
         _instance(instance)
-    {}
+    {
+    }
 
     /// Get the name of this block.
     const string& getName() const { return _name; }
@@ -120,19 +125,19 @@ class MX_GENSHADER_API VariableBlock
     vector<ShaderPort*> _variableOrder;
 };
 
-
 /// @class ShaderStage
-/// A shader stage, containing the state and 
+/// A shader stage, containing the state and
 /// resulting source code for the stage.
 class MX_GENSHADER_API ShaderStage
 {
-public:
+  public:
     using FunctionCallId = std::pair<const ShaderNode*, int>;
     struct Scope
     {
         Syntax::Punctuation punctuation;
         std::set<FunctionCallId> functions;
-        Scope(Syntax::Punctuation p) : punctuation(p) {}
+        Scope(Syntax::Punctuation p) :
+            punctuation(p) { }
     };
 
   public:
@@ -213,7 +218,7 @@ public:
     {
         return _sourceDependencies;
     }
- 
+
     /// Start a new scope using the given bracket type.
     void beginScope(Syntax::Punctuation punc = Syntax::CURLY_BRACKETS);
 
@@ -248,7 +253,7 @@ public:
     void addSourceDependency(const FilePath& file);
 
     /// Add a value.
-    template<typename T>
+    template <typename T>
     void addValue(const T& value)
     {
         StringStream str;
@@ -266,8 +271,8 @@ public:
     bool isEmitted(const ShaderNode& node, GenContext& context) const;
 
     /// Set stage function name.
-    void setFunctionName(const string& functionName) 
-    { 
+    void setFunctionName(const string& functionName)
+    {
         _functionName = functionName;
     }
 
@@ -318,8 +323,8 @@ public:
 using ShaderStagePtr = std::shared_ptr<ShaderStage>;
 
 /// Utility function for adding a new shader port to a uniform block.
-inline ShaderPort* addStageUniform(const string& block, 
-                                   const TypeDesc* type, 
+inline ShaderPort* addStageUniform(const string& block,
+                                   const TypeDesc* type,
                                    const string& name,
                                    ShaderStage& stage)
 {
@@ -328,7 +333,7 @@ inline ShaderPort* addStageUniform(const string& block,
 }
 
 /// Utility function for adding a new shader port to an input block.
-inline ShaderPort* addStageInput(const string& block, 
+inline ShaderPort* addStageInput(const string& block,
                                  const TypeDesc* type,
                                  const string& name,
                                  ShaderStage& stage)
@@ -339,7 +344,7 @@ inline ShaderPort* addStageInput(const string& block,
 
 /// Utility function for adding a new shader port to an output block.
 inline ShaderPort* addStageOutput(const string& block,
-                                  const TypeDesc* type, 
+                                  const TypeDesc* type,
                                   const string& name,
                                   ShaderStage& stage)
 {
@@ -348,9 +353,9 @@ inline ShaderPort* addStageOutput(const string& block,
 }
 
 /// Utility function for adding a connector block between stages.
-inline void addStageConnectorBlock(const string& block, 
+inline void addStageConnectorBlock(const string& block,
                                    const string& instance,
-                                   ShaderStage& from, 
+                                   ShaderStage& from,
                                    ShaderStage& to)
 {
     from.createOutputBlock(block, instance);
@@ -358,8 +363,8 @@ inline void addStageConnectorBlock(const string& block,
 }
 
 /// Utility function for adding a variable to a stage connector block.
-inline void addStageConnector(const string& block, 
-                              const TypeDesc* type, 
+inline void addStageConnector(const string& block,
+                              const TypeDesc* type,
                               const string& name,
                               ShaderStage& from,
                               ShaderStage& to)

--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -44,7 +44,7 @@ void ShaderTranslator::connectTranslationInputs(NodePtr shader, NodeDefPtr trans
                 origOutputs.insert(connectedOutput);
             }
             else if (shaderInput->hasValueString())
-            { 
+            {
                 input->setValueString(shaderInput->getValueString());
             }
             else

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -152,7 +152,7 @@ string Syntax::getSwizzledVariable(const string& srcName, const TypeDesc* srcTyp
         const char ch = channels[i];
         if (ch == '0' || ch == '1')
         {
-            membersSwizzled.push_back(string(1,ch));
+            membersSwizzled.push_back(string(1, ch));
             continue;
         }
 
@@ -171,7 +171,7 @@ string Syntax::getSwizzledVariable(const string& srcName, const TypeDesc* srcTyp
             int channelIndex = srcType->getChannelIndex(ch);
             if (channelIndex < 0 || channelIndex >= static_cast<int>(srcMembers.size()))
             {
-                throw ExceptionShaderGenError("Given channel index: '" + string(1,ch) + "' in channels pattern is incorrect for type '" + srcType->getName() + "'.");
+                throw ExceptionShaderGenError("Given channel index: '" + string(1, ch) + "' in channels pattern is incorrect for type '" + srcType->getName() + "'.");
             }
             membersSwizzled.push_back(srcName + srcMembers[channelIndex]);
         }
@@ -310,7 +310,8 @@ void Syntax::makeIdentifier(string& name, IdentifierMap& identifiers) const
         // Name is not unique so append the counter and keep
         // incrementing until a unique name is found.
         string name2;
-        do {
+        do
+        {
             name2 = name + std::to_string(it->second++);
         } while (identifiers.count(name2));
 
@@ -323,7 +324,7 @@ void Syntax::makeIdentifier(string& name, IdentifierMap& identifiers) const
 
 string Syntax::getVariableName(const string& name, const TypeDesc* /*type*/, IdentifierMap& identifiers) const
 {
-    // Default implementation just makes an identifier, but derived 
+    // Default implementation just makes an identifier, but derived
     // classes can override this for custom variable naming.
     string variable = name;
     makeIdentifier(variable, identifiers);
@@ -348,14 +349,14 @@ TypeSyntax::TypeSyntax(const string& name, const string& defaultValue, const str
 {
 }
 
- string TypeSyntax::getValue(const ShaderPort* port, bool uniform) const
- {
-     if (!port || !port->getValue())
-     {
-         return getDefaultValue(uniform);
-     }
-     return getValue(*port->getValue(), uniform);
- }
+string TypeSyntax::getValue(const ShaderPort* port, bool uniform) const
+{
+    if (!port || !port->getValue())
+    {
+        return getDefaultValue(uniform);
+    }
+    return getValue(*port->getValue(), uniform);
+}
 
 ScalarTypeSyntax::ScalarTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                                    const string& typeAlias, const string& typeDefinition) :
@@ -381,7 +382,6 @@ string ScalarTypeSyntax::getValue(const StringVec& values, bool /*uniform*/) con
     return ss.str();
 }
 
-
 StringTypeSyntax::StringTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                                    const string& typeAlias, const string& typeDefinition) :
     ScalarTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition)
@@ -392,7 +392,6 @@ string StringTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
 {
     return "\"" + value.getValueString() + "\"";
 }
-
 
 AggregateTypeSyntax::AggregateTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                                          const string& typeAlias, const string& typeDefinition, const StringVec& members) :
@@ -417,7 +416,7 @@ string AggregateTypeSyntax::getValue(const StringVec& values, bool /*uniform*/) 
     // using Value::setFloatFormat() and Value::setFloatPrecision()
     StringStream ss;
     ss << getName() << "(" << values[0];
-    for (size_t i=1; i<values.size(); ++i)
+    for (size_t i = 1; i < values.size(); ++i)
     {
         ss << ", " << values[i];
     }

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -56,12 +56,12 @@ class MX_GENSHADER_API Syntax
     void registerTypeSyntax(const TypeDesc* type, TypeSyntaxPtr syntax);
 
     /// Register names that are reserved words not to be used by a code generator when naming
-    /// variables and functions. Keywords, types, built-in functions etc. should be 
+    /// variables and functions. Keywords, types, built-in functions etc. should be
     /// added to this set. Multiple calls will add to the internal set of names.
     void registerReservedWords(const StringSet& names);
 
-    /// Register a set string replacements for disallowed tokens 
-    /// for a code generator when naming variables and functions. 
+    /// Register a set string replacements for disallowed tokens
+    /// for a code generator when naming variables and functions.
     /// Multiple calls will add to the internal set of tokens.
     void registerInvalidTokens(const StringMap& tokens);
 
@@ -122,7 +122,7 @@ class MX_GENSHADER_API Syntax
     virtual const string& getOutputQualifier() const { return EMPTY_STRING; };
 
     /// Get the qualifier used when declaring constant variables.
-    /// Derived classes must define this method. 
+    /// Derived classes must define this method.
     virtual const string& getConstantQualifier() const = 0;
 
     /// Get the qualifier used when declaring uniform variables.
@@ -174,7 +174,7 @@ class MX_GENSHADER_API Syntax
     /// Create a unique identifier for the given variable name and type.
     /// The method is used for naming variables (inputs and outputs) in generated code.
     /// Derived classes can override this method to have a custom naming strategy.
-    /// Default implementation adds a number suffix, or increases an existing number suffix, 
+    /// Default implementation adds a number suffix, or increases an existing number suffix,
     /// on the name string if there is a name collision.
     virtual string getVariableName(const string& name, const TypeDesc* type, IdentifierMap& identifiers) const;
 
@@ -232,7 +232,7 @@ class MX_GENSHADER_API TypeSyntax
     /// Returns the default value for this type.
     const string& getDefaultValue(bool uniform) const { return uniform ? _uniformDefaultValue : _defaultValue; }
 
-    /// Returns the syntax for accessing type members if the type 
+    /// Returns the syntax for accessing type members if the type
     /// can be swizzled.
     const StringVec& getMembers() const { return _members; }
 
@@ -251,7 +251,7 @@ class MX_GENSHADER_API TypeSyntax
 
   protected:
     /// Protected constructor
-    TypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, 
+    TypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                const string& typeAlias, const string& typeDefinition, const StringVec& members);
 
     string _name;                // type name
@@ -268,7 +268,7 @@ class MX_GENSHADER_API TypeSyntax
 class MX_GENSHADER_API ScalarTypeSyntax : public TypeSyntax
 {
   public:
-    ScalarTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue, 
+    ScalarTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                      const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING);
 
     string getValue(const Value& value, bool uniform) const override;
@@ -290,7 +290,7 @@ class MX_GENSHADER_API AggregateTypeSyntax : public TypeSyntax
 {
   public:
     AggregateTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
-                        const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING, 
+                        const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
                         const StringVec& members = EMPTY_MEMBERS);
 
     string getValue(const Value& value, bool uniform) const override;

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -11,15 +11,17 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    using TypeDescPtr = std::unique_ptr<TypeDesc>;
-    using TypeDescMap = std::unordered_map<string, TypeDescPtr>;
 
-    // Internal storage of the type descriptor pointers
-    TypeDescMap& typeMap()
-    {
-        static TypeDescMap map;
-        return map;
-    }
+using TypeDescPtr = std::unique_ptr<TypeDesc>;
+using TypeDescMap = std::unordered_map<string, TypeDescPtr>;
+
+// Internal storage of the type descriptor pointers
+TypeDescMap& typeMap()
+{
+    static TypeDescMap map;
+    return map;
+}
+
 } // anonymous namespace
 
 //
@@ -54,7 +56,7 @@ const TypeDesc* TypeDesc::registerType(const string& name, unsigned char basetyp
 
 int TypeDesc::getChannelIndex(char channel) const
 {
-    auto it =_channelMapping.find(channel);
+    auto it = _channelMapping.find(channel);
     return it != _channelMapping.end() ? it->second : -1;
 }
 
@@ -67,32 +69,34 @@ const TypeDesc* TypeDesc::get(const string& name)
 
 namespace Type
 {
-    // Register all standard types and save their pointers
-    // for quick access and type comparisons later.
-    const TypeDesc* NONE               = TypeDesc::registerType("none", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_NONE, 1, false);
-    const TypeDesc* MULTIOUTPUT        = TypeDesc::registerType("multioutput", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_NONE, 1, false);
-    const TypeDesc* BOOLEAN            = TypeDesc::registerType("boolean", TypeDesc::BASETYPE_BOOLEAN);
-    const TypeDesc* INTEGER            = TypeDesc::registerType("integer", TypeDesc::BASETYPE_INTEGER);
-    const TypeDesc* INTEGERARRAY       = TypeDesc::registerType("integerarray", TypeDesc::BASETYPE_INTEGER, TypeDesc::SEMANTIC_NONE, 0);
-    const TypeDesc* FLOAT              = TypeDesc::registerType("float", TypeDesc::BASETYPE_FLOAT);
-    const TypeDesc* FLOATARRAY         = TypeDesc::registerType("floatarray", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_NONE, 0);
-    const TypeDesc* VECTOR2            = TypeDesc::registerType("vector2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_VECTOR, 2, true, {{'x', 0}, {'y', 1}});
-    const TypeDesc* VECTOR3            = TypeDesc::registerType("vector3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_VECTOR, 3, true, {{'x', 0}, {'y', 1}, {'z', 2}});
-    const TypeDesc* VECTOR4            = TypeDesc::registerType("vector4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_VECTOR, 4, true, {{'x', 0}, {'y', 1}, {'z', 2}, {'w', 3}});
-    const TypeDesc* COLOR3             = TypeDesc::registerType("color3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_COLOR, 3, true, {{'r', 0}, {'g', 1}, {'b', 2}});
-    const TypeDesc* COLOR4             = TypeDesc::registerType("color4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_COLOR, 4, true, {{'r', 0}, {'g', 1}, {'b', 2}, {'a', 3}});
-    const TypeDesc* MATRIX33           = TypeDesc::registerType("matrix33", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_MATRIX, 9);
-    const TypeDesc* MATRIX44           = TypeDesc::registerType("matrix44", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_MATRIX, 16);
-    const TypeDesc* STRING             = TypeDesc::registerType("string", TypeDesc::BASETYPE_STRING);
-    const TypeDesc* FILENAME           = TypeDesc::registerType("filename", TypeDesc::BASETYPE_STRING, TypeDesc::SEMANTIC_FILENAME);
-    const TypeDesc* BSDF               = TypeDesc::registerType("BSDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
-    const TypeDesc* EDF                = TypeDesc::registerType("EDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
-    const TypeDesc* VDF                = TypeDesc::registerType("VDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
-    const TypeDesc* SURFACESHADER      = TypeDesc::registerType("surfaceshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
-    const TypeDesc* VOLUMESHADER       = TypeDesc::registerType("volumeshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
-    const TypeDesc* DISPLACEMENTSHADER = TypeDesc::registerType("displacementshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
-    const TypeDesc* LIGHTSHADER        = TypeDesc::registerType("lightshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
-    const TypeDesc* MATERIAL           = TypeDesc::registerType("material", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_MATERIAL, 1, false);
-}
+
+// Register all standard types and save their pointers
+// for quick access and type comparisons later.
+const TypeDesc* NONE                = TypeDesc::registerType("none", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_NONE, 1, false);
+const TypeDesc* MULTIOUTPUT         = TypeDesc::registerType("multioutput", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_NONE, 1, false);
+const TypeDesc* BOOLEAN             = TypeDesc::registerType("boolean", TypeDesc::BASETYPE_BOOLEAN);
+const TypeDesc* INTEGER             = TypeDesc::registerType("integer", TypeDesc::BASETYPE_INTEGER);
+const TypeDesc* INTEGERARRAY        = TypeDesc::registerType("integerarray", TypeDesc::BASETYPE_INTEGER, TypeDesc::SEMANTIC_NONE, 0);
+const TypeDesc* FLOAT               = TypeDesc::registerType("float", TypeDesc::BASETYPE_FLOAT);
+const TypeDesc* FLOATARRAY          = TypeDesc::registerType("floatarray", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_NONE, 0);
+const TypeDesc* VECTOR2             = TypeDesc::registerType("vector2", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_VECTOR, 2, true, {{'x', 0}, {'y', 1}});
+const TypeDesc* VECTOR3             = TypeDesc::registerType("vector3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_VECTOR, 3, true, {{'x', 0}, {'y', 1}, {'z', 2}});
+const TypeDesc* VECTOR4             = TypeDesc::registerType("vector4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_VECTOR, 4, true, {{'x', 0}, {'y', 1}, {'z', 2}, {'w', 3}});
+const TypeDesc* COLOR3              = TypeDesc::registerType("color3", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_COLOR, 3, true, {{'r', 0}, {'g', 1}, {'b', 2}});
+const TypeDesc* COLOR4              = TypeDesc::registerType("color4", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_COLOR, 4, true, {{'r', 0}, {'g', 1}, {'b', 2}, {'a', 3}});
+const TypeDesc* MATRIX33            = TypeDesc::registerType("matrix33", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_MATRIX, 9);
+const TypeDesc* MATRIX44            = TypeDesc::registerType("matrix44", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_MATRIX, 16);
+const TypeDesc* STRING              = TypeDesc::registerType("string", TypeDesc::BASETYPE_STRING);
+const TypeDesc* FILENAME            = TypeDesc::registerType("filename", TypeDesc::BASETYPE_STRING, TypeDesc::SEMANTIC_FILENAME);
+const TypeDesc* BSDF                = TypeDesc::registerType("BSDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
+const TypeDesc* EDF                 = TypeDesc::registerType("EDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
+const TypeDesc* VDF                 = TypeDesc::registerType("VDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
+const TypeDesc* SURFACESHADER       = TypeDesc::registerType("surfaceshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
+const TypeDesc* VOLUMESHADER        = TypeDesc::registerType("volumeshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
+const TypeDesc* DISPLACEMENTSHADER  = TypeDesc::registerType("displacementshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
+const TypeDesc* LIGHTSHADER         = TypeDesc::registerType("lightshader", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_SHADER, 1, false);
+const TypeDesc* MATERIAL            = TypeDesc::registerType("material", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_MATERIAL, 1, false);
+
+} // namespace Type
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -120,34 +120,36 @@ class MX_GENSHADER_API TypeDesc
 
 namespace Type
 {
-    /// Type descriptors for all standard types.
-    /// These are always registered by default.
-    ///
-    /// TODO: Add support for the standard array types.
-    ///
-    extern MX_GENSHADER_API const TypeDesc* NONE;
-    extern MX_GENSHADER_API const TypeDesc* BOOLEAN;
-    extern MX_GENSHADER_API const TypeDesc* INTEGER;
-    extern MX_GENSHADER_API const TypeDesc* INTEGERARRAY;
-    extern MX_GENSHADER_API const TypeDesc* FLOAT;
-    extern MX_GENSHADER_API const TypeDesc* FLOATARRAY;
-    extern MX_GENSHADER_API const TypeDesc* VECTOR2;
-    extern MX_GENSHADER_API const TypeDesc* VECTOR3;
-    extern MX_GENSHADER_API const TypeDesc* VECTOR4;
-    extern MX_GENSHADER_API const TypeDesc* COLOR3;
-    extern MX_GENSHADER_API const TypeDesc* COLOR4;
-    extern MX_GENSHADER_API const TypeDesc* MATRIX33;
-    extern MX_GENSHADER_API const TypeDesc* MATRIX44;
-    extern MX_GENSHADER_API const TypeDesc* STRING;
-    extern MX_GENSHADER_API const TypeDesc* FILENAME;
-    extern MX_GENSHADER_API const TypeDesc* BSDF;
-    extern MX_GENSHADER_API const TypeDesc* EDF;
-    extern MX_GENSHADER_API const TypeDesc* VDF;
-    extern MX_GENSHADER_API const TypeDesc* SURFACESHADER;
-    extern MX_GENSHADER_API const TypeDesc* VOLUMESHADER;
-    extern MX_GENSHADER_API const TypeDesc* DISPLACEMENTSHADER;
-    extern MX_GENSHADER_API const TypeDesc* LIGHTSHADER;
-    extern MX_GENSHADER_API const TypeDesc* MATERIAL;
+
+/// Type descriptors for all standard types.
+/// These are always registered by default.
+///
+/// TODO: Add support for the standard array types.
+///
+extern MX_GENSHADER_API const TypeDesc* NONE;
+extern MX_GENSHADER_API const TypeDesc* BOOLEAN;
+extern MX_GENSHADER_API const TypeDesc* INTEGER;
+extern MX_GENSHADER_API const TypeDesc* INTEGERARRAY;
+extern MX_GENSHADER_API const TypeDesc* FLOAT;
+extern MX_GENSHADER_API const TypeDesc* FLOATARRAY;
+extern MX_GENSHADER_API const TypeDesc* VECTOR2;
+extern MX_GENSHADER_API const TypeDesc* VECTOR3;
+extern MX_GENSHADER_API const TypeDesc* VECTOR4;
+extern MX_GENSHADER_API const TypeDesc* COLOR3;
+extern MX_GENSHADER_API const TypeDesc* COLOR4;
+extern MX_GENSHADER_API const TypeDesc* MATRIX33;
+extern MX_GENSHADER_API const TypeDesc* MATRIX44;
+extern MX_GENSHADER_API const TypeDesc* STRING;
+extern MX_GENSHADER_API const TypeDesc* FILENAME;
+extern MX_GENSHADER_API const TypeDesc* BSDF;
+extern MX_GENSHADER_API const TypeDesc* EDF;
+extern MX_GENSHADER_API const TypeDesc* VDF;
+extern MX_GENSHADER_API const TypeDesc* SURFACESHADER;
+extern MX_GENSHADER_API const TypeDesc* VOLUMESHADER;
+extern MX_GENSHADER_API const TypeDesc* DISPLACEMENTSHADER;
+extern MX_GENSHADER_API const TypeDesc* LIGHTSHADER;
+extern MX_GENSHADER_API const TypeDesc* MATERIAL;
+
 } // namespace Type
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/UnitSystem.cpp
+++ b/source/MaterialXGenShader/UnitSystem.cpp
@@ -69,9 +69,9 @@ void ScalarUnitNode::emitFunctionDefinition(const ShaderNode& node, GenContext& 
 
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         shadergen.emitLine("float " + _unitRatioFunctionName + "(int unit_from, int unit_to)", stage, false);
-        shadergen.emitFunctionBodyBegin(node, context, stage);  
+        shadergen.emitFunctionBodyBegin(node, context, stage);
         shadergen.emitVariableDeclarations(unitLUT, shadergen.getSyntax().getConstantQualifier(), ";", context, stage, true);
-        shadergen.emitLine("return ("+ VAR_UNIT_SCALE + "[unit_from] / " + VAR_UNIT_SCALE + "[unit_to])", stage);
+        shadergen.emitLine("return (" + VAR_UNIT_SCALE + "[unit_from] / " + VAR_UNIT_SCALE + "[unit_to])", stage);
         shadergen.emitFunctionBodyEnd(node, context, stage);
     }
 }
@@ -105,10 +105,10 @@ void ScalarUnitNode::emitFunctionCall(const ShaderNode& node, GenContext& contex
 //
 
 UnitTransform::UnitTransform(const string& ss, const string& ts, const TypeDesc* t, const string& unittype) :
-                             sourceUnit(ss),
-                             targetUnit(ts),
-                             type(t),
-                             unitType(unittype)
+    sourceUnit(ss),
+    targetUnit(ts),
+    type(t),
+    unitType(unittype)
 {
     if (type != Type::FLOAT && type != Type::VECTOR2 && type != Type::VECTOR3 && type != Type::VECTOR4)
     {

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -49,9 +49,9 @@ MX_GENSHADER_API bool elementRequiresShading(ConstTypedElementPtr element);
 /// @param doc Document to examine
 /// @param elements List of renderable elements (returned)
 /// @param includeReferencedGraphs Whether to check for outputs on referenced graphs
-/// @param processedSources List of elements examined. 
+/// @param processedSources List of elements examined.
 MX_GENSHADER_API void findRenderableMaterialNodes(ConstDocumentPtr doc,
-                                                  vector<TypedElementPtr>& elements, 
+                                                  vector<TypedElementPtr>& elements,
                                                   bool includeReferencedGraphs,
                                                   std::unordered_set<ElementPtr>& processedSources);
 
@@ -88,7 +88,7 @@ MX_GENSHADER_API NodePtr connectsToWorldSpaceNode(OutputPtr output);
 
 /// Returns true if there is are any value elements with a given set of attributes either on the
 /// starting node or any graph upsstream of that node.
-/// @param output Starting node 
+/// @param output Starting node
 /// @param attributes Attributes to test for
 MX_GENSHADER_API bool hasElementAttributes(OutputPtr output, const StringVec& attributes);
 


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXGenShader, providing improvements in coding style consistency.

Additionally, a clang-format setting has been added, allowing the formatting of inline and empty functions on a single line.