### PR TITLE
Apply Clang formatting to MaterialXGenGlsl

### DIFF
--- a/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
@@ -13,8 +13,8 @@ MATERIALX_NAMESPACE_BEGIN
 const string EsslShaderGenerator::TARGET = "essl";
 const string EsslShaderGenerator::VERSION = "300 es"; // Current target is WebGL 2.0
 
-EsslShaderGenerator::EsslShaderGenerator()
-    : GlslShaderGenerator()
+EsslShaderGenerator::EsslShaderGenerator() :
+    GlslShaderGenerator()
 {
     _syntax = EsslSyntax::create();
     // Add in ESSL specific keywords
@@ -98,7 +98,7 @@ string EsslShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
 HwResourceBindingContextPtr EsslShaderGenerator::getResourceBindingContext(GenContext& context) const
 {
     HwResourceBindingContextPtr resoureBindingCtx = GlslShaderGenerator::getResourceBindingContext(context);
-    if (resoureBindingCtx) 
+    if (resoureBindingCtx)
     {
         throw ExceptionShaderGenError("The EsslShaderGenerator does not support resource binding.");
     }

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.h
@@ -15,8 +15,8 @@ MATERIALX_NAMESPACE_BEGIN
 
 using EsslShaderGeneratorPtr = shared_ptr<class EsslShaderGenerator>;
 
-/// @class EsslShaderGenerator 
-/// An ESSL (OpenGL ES Shading Language) shader generator 
+/// @class EsslShaderGenerator
+/// An ESSL (OpenGL ES Shading Language) shader generator
 class MX_GENGLSL_API EsslShaderGenerator : public GlslShaderGenerator
 {
   public:

--- a/source/MaterialXGenGlsl/EsslSyntax.h
+++ b/source/MaterialXGenGlsl/EsslSyntax.h
@@ -16,7 +16,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Syntax class for ESSL (OpenGL ES Shading Language)
 class MX_GENGLSL_API EsslSyntax : public GlslSyntax
 {
-public:
+  public:
     EsslSyntax();
 
     static SyntaxPtr create() { return std::make_shared<EsslSyntax>(); }

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -73,8 +73,8 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     }
     if (hasValueUniforms)
     {
-        generator.emitLine("layout (std140, binding=" + std::to_string(_hwUniformBindLocation++) + ") " + 
-                           syntax.getUniformQualifier() + " " + uniforms.getName() + "_" + stage.getName(), 
+        generator.emitLine("layout (std140, binding=" + std::to_string(_hwUniformBindLocation++) + ") " +
+                               syntax.getUniformQualifier() + " " + uniforms.getName() + "_" + stage.getName(),
                            stage, false);
         generator.emitScopeBegin(stage);
         for (auto uniform : uniforms.getVariableOrder())
@@ -104,7 +104,7 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     generator.emitLineBreak(stage);
 }
 
-void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms, 
+void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms,
                                                                 ShaderStage& stage, const std::string& structInstanceName,
                                                                 const std::string& arraySuffix)
 {
@@ -117,10 +117,15 @@ void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& cont
 
     const size_t baseAlignment = 16;
     std::unordered_map<const TypeDesc*, size_t> alignmentMap({ { Type::FLOAT, baseAlignment / 4 },
-        { Type::INTEGER, baseAlignment / 4 }, { Type::BOOLEAN, baseAlignment / 4 },
-        { Type::COLOR3, baseAlignment }, { Type::COLOR4, baseAlignment },
-        { Type::VECTOR2, baseAlignment }, { Type::VECTOR3, baseAlignment }, { Type::VECTOR4, baseAlignment },
-        { Type::MATRIX33, baseAlignment * 4 }, { Type::MATRIX44, baseAlignment * 4 } });
+                                                               { Type::INTEGER, baseAlignment / 4 },
+                                                               { Type::BOOLEAN, baseAlignment / 4 },
+                                                               { Type::COLOR3, baseAlignment },
+                                                               { Type::COLOR4, baseAlignment },
+                                                               { Type::VECTOR2, baseAlignment },
+                                                               { Type::VECTOR3, baseAlignment },
+                                                               { Type::VECTOR4, baseAlignment },
+                                                               { Type::MATRIX33, baseAlignment * 4 },
+                                                               { Type::MATRIX44, baseAlignment * 4 } });
 
     // Get struct alignment and size
     // alignment, uniform member index
@@ -147,9 +152,10 @@ void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& cont
 
     // Sort order from largest to smallest
     std::sort(memberOrder.begin(), memberOrder.end(),
-        [](const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b) {
-            return a.first > b.first;
-        });
+              [](const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b)
+              {
+                  return a.first > b.first;
+              });
 
     // Emit the struct
     generator.emitLine("struct " + uniforms.getName(), stage, false);
@@ -172,13 +178,11 @@ void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& cont
     }
     generator.emitScopeEnd(stage, true);
 
-
     // Emit binding information
     generator.emitLineBreak(stage);
     generator.emitLine("layout (std140, binding=" + std::to_string(_hwUniformBindLocation++) +
-        ") " + syntax.getUniformQualifier() + " " + uniforms.getName() + "_" +
-        stage.getName(),
-    stage, false);
+                       ") " + syntax.getUniformQualifier() + " " + uniforms.getName() + "_" +
+                       stage.getName(), stage, false);
     generator.emitScopeBegin(stage);
     generator.emitLine(uniforms.getName() + " " + structInstanceName + arraySuffix, stage);
     generator.emitScopeEnd(stage, true);

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -26,7 +26,7 @@ class MX_GENGLSL_API GlslResourceBindingContext : public HwResourceBindingContex
     GlslResourceBindingContext(size_t uniformBindingLocation, size_t samplerBindingLocation);
 
     static GlslResourceBindingContextPtr create(
-        size_t uniformBindingLocation=0, size_t samplerBindingLocation=0)
+        size_t uniformBindingLocation = 0, size_t samplerBindingLocation = 0)
     {
         return std::make_shared<GlslResourceBindingContext>(
             uniformBindingLocation, samplerBindingLocation);

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -63,12 +63,11 @@ GlslShaderGenerator::GlslShaderGenerator() :
     static const string INT_SEPARATOR = "I_";
     static const string BOOL_SEPARATOR = "B_";
     static const StringVec IMPL_PREFIXES = { "IM_ifgreater_", "IM_ifgreatereq_", "IM_ifequal_" };
-    static const vector<CreatorFunction<ShaderNodeImpl>> IMPL_CREATE_FUNCTIONS =
-            { IfGreaterNode::create,  IfGreaterEqNode::create, IfEqualNode::create };
+    static const vector<CreatorFunction<ShaderNodeImpl>> IMPL_CREATE_FUNCTIONS = { IfGreaterNode::create, IfGreaterEqNode::create, IfEqualNode::create };
     static const vector<bool> IMPL_HAS_INTVERSION = { true, true, true };
     static const vector<bool> IMPL_HAS_BOOLVERSION = { false, false, true };
     static const StringVec IMPL_TYPES = { "float", "color3", "color4", "vector2", "vector3", "vector4" };
-    for (size_t i=0; i<IMPL_PREFIXES.size(); i++)
+    for (size_t i = 0; i < IMPL_PREFIXES.size(); i++)
     {
         const string& implPrefix = IMPL_PREFIXES[i];
         for (const string& implType : IMPL_TYPES)
@@ -85,7 +84,7 @@ GlslShaderGenerator::GlslShaderGenerator() :
             }
         }
     }
-    
+
     // <!-- <switch> -->
     // <!-- 'which' type : float -->
     registerImplementation("IM_switch_float_" + GlslShaderGenerator::TARGET, SwitchNode::create);
@@ -426,7 +425,7 @@ void GlslShaderGenerator::emitLightData(GenContext& context, ShaderStage& stage)
 {
     const VariableBlock& lightData = stage.getUniformBlock(HW::LIGHT_DATA);
     const string structArraySuffix = "[" + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + "]";
-    const string structName        = lightData.getInstance();
+    const string structName = lightData.getInstance();
     HwResourceBindingContextPtr resourceBindingCtx = getResourceBindingContext(context);
     if (resourceBindingCtx)
     {
@@ -514,8 +513,8 @@ bool GlslShaderGenerator::requiresLighting(const ShaderGraph& graph) const
 {
     const bool isBsdf = graph.hasClassification(ShaderNode::Classification::BSDF);
     const bool isLitSurfaceShader = graph.hasClassification(ShaderNode::Classification::SHADER) &&
-                              graph.hasClassification(ShaderNode::Classification::SURFACE) &&
-                              !graph.hasClassification(ShaderNode::Classification::UNLIT);
+                                    graph.hasClassification(ShaderNode::Classification::SURFACE) &&
+                                    !graph.hasClassification(ShaderNode::Classification::UNLIT);
     return isBsdf || isLitSurfaceShader;
 }
 
@@ -553,14 +552,14 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
 
     // Determine whether lighting is required
     bool lighting = requiresLighting(graph);
-    
+
     // Define directional albedo approach
     if (lighting || context.getOptions().hwWriteAlbedoTable)
     {
         emitLine("#define DIRECTIONAL_ALBEDO_METHOD " + std::to_string(int(context.getOptions().hwDirectionalAlbedoMethod)), stage, false);
         emitLineBreak(stage);
     }
-    
+
     // Add lighting support
     if (lighting)
     {
@@ -622,11 +621,11 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
     emitLine("void main()", stage, false);
     emitFunctionBodyBegin(graph, context, stage);
 
-    if (graph.hasClassification(ShaderNode::Classification::CLOSURE) && 
+    if (graph.hasClassification(ShaderNode::Classification::CLOSURE) &&
         !graph.hasClassification(ShaderNode::Classification::SHADER))
     {
         // Handle the case where the graph is a direct closure.
-        // We don't support rendering closures without attaching 
+        // We don't support rendering closures without attaching
         // to a surface shader, so just output black.
         emitLine(outputSocket->getVariable() + " = vec4(0.0, 0.0, 0.0, 1.0)", stage);
     }
@@ -657,8 +656,8 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
                 {
                     const ShaderNode* upstream = socket->getConnection()->getNode();
                     if (upstream->getParent() == &graph &&
-                        (upstream->hasClassification(ShaderNode::Classification::CLOSURE) || 
-                            upstream->hasClassification(ShaderNode::Classification::SHADER)))
+                        (upstream->hasClassification(ShaderNode::Classification::CLOSURE) ||
+                         upstream->hasClassification(ShaderNode::Classification::SHADER)))
                     {
                         emitFunctionCall(*upstream, context, stage);
                     }
@@ -710,7 +709,9 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
         }
         else
         {
-            string outputValue = outputSocket->getValue() ? _syntax->getValue(outputSocket->getType(), *outputSocket->getValue()) : _syntax->getDefaultValue(outputSocket->getType());
+            string outputValue = outputSocket->getValue() ?
+                                 _syntax->getValue(outputSocket->getType(), *outputSocket->getValue()) :
+                                 _syntax->getDefaultValue(outputSocket->getType());
             if (!outputSocket->getType()->isFloat4())
             {
                 string finalOutput = outputSocket->getVariable() + "_tmp";
@@ -783,7 +784,7 @@ void GlslShaderGenerator::toVec4(const TypeDesc* type, string& variable)
     }
 }
 
-void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier, 
+void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier,
                                                   GenContext&, ShaderStage& stage,
                                                   bool assignValue) const
 {
@@ -799,7 +800,8 @@ void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, co
         string str = qualifier.empty() ? EMPTY_STRING : qualifier + " ";
         // Varying parameters of type int must be flat qualified on output from vertex stage and
         // input to pixel stage. The only way to get these is with geompropvalue_integer nodes.
-        if (qualifier.empty() && variable->getType() == Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0) {
+        if (qualifier.empty() && variable->getType() == Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0)
+        {
             str += GlslSyntax::FLAT_QUALIFIER + " ";
         }
         str += _syntax->getTypeName(variable->getType()) + " " + variable->getVariable();
@@ -818,8 +820,8 @@ void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, co
         if (assignValue)
         {
             const string valueStr = (variable->getValue() ?
-                _syntax->getValue(variable->getType(), *variable->getValue(), true) :
-                _syntax->getDefaultValue(variable->getType(), true));
+                                    _syntax->getValue(variable->getType(), *variable->getValue(), true) :
+                                    _syntax->getDefaultValue(variable->getType(), true));
             str += valueStr.empty() ? EMPTY_STRING : " = " + valueStr;
         }
 
@@ -898,7 +900,6 @@ ShaderNodeImplPtr GlslShaderGenerator::getImplementation(const NodeDef& nodedef,
     return impl;
 }
 
-
 const string GlslImplementation::SPACE = "space";
 const string GlslImplementation::TO_SPACE = "tospace";
 const string GlslImplementation::FROM_SPACE = "fromspace";
@@ -910,14 +911,16 @@ const string GlslImplementation::GEOMPROP = "geomprop";
 
 namespace
 {
-    // List name of inputs that are not to be editable and
-    // published as shader uniforms in GLSL.
-    const std::set<string> IMMUTABLE_INPUTS = 
-    {
-        // Geometric node inputs are immutable since a shader needs regeneration if they change.
-        "index", "space", "attrname"
-    };
-}
+
+// List name of inputs that are not to be editable and
+// published as shader uniforms in GLSL.
+const std::set<string> IMMUTABLE_INPUTS =
+{
+    // Geometric node inputs are immutable since a shader needs regeneration if they change.
+    "index", "space", "attrname"
+};
+
+} // anonymous namespace
 
 const string& GlslImplementation::getTarget() const
 {

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -44,7 +44,7 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     /// The element must be an Implementation or a NodeGraph acting as implementation.
     ShaderNodeImplPtr getImplementation(const NodeDef& nodedef, GenContext& context) const override;
 
-    /// Determine the prefix of vertex data variables. 
+    /// Determine the prefix of vertex data variables.
     virtual string getVertexDataPrefix(const VariableBlock& vertexData) const;
 
   public:
@@ -64,7 +64,7 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     virtual void emitLightData(GenContext& context, ShaderStage& stage) const;
     virtual void emitInputs(GenContext& context, ShaderStage& stage) const;
     virtual void emitOutputs(GenContext& context, ShaderStage& stage) const;
-    
+
     virtual HwResourceBindingContextPtr getResourceBindingContext(GenContext& context) const;
 
     /// Logic to indicate whether code to support direct lighting should be emitted.
@@ -87,7 +87,6 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     vector<ShaderNodePtr> _lightSamplingNodes;
 };
 
-
 /// Base class for common GLSL node implementations
 class MX_GENGLSL_API GlslImplementation : public ShaderNodeImpl
 {
@@ -97,16 +96,16 @@ class MX_GENGLSL_API GlslImplementation : public ShaderNodeImpl
     bool isEditable(const ShaderInput& input) const override;
 
   protected:
-    GlslImplementation() {}
+    GlslImplementation() { }
 
     // Integer identifiers for coordinate spaces.
     // The order must match the order given for
     // the space enum string in stdlib.
     enum Space
     {
-        MODEL_SPACE  = 0,
+        MODEL_SPACE = 0,
         OBJECT_SPACE = 1,
-        WORLD_SPACE  = 2
+        WORLD_SPACE = 2
     };
 
     /// Internal string constants

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -17,7 +17,8 @@ namespace
 class GlslStringTypeSyntax : public StringTypeSyntax
 {
   public:
-    GlslStringTypeSyntax() : StringTypeSyntax("int", "0", "0") {}
+    GlslStringTypeSyntax() :
+        StringTypeSyntax("int", "0", "0") { }
 
     string getValue(const Value& /*value*/, bool /*uniform*/) const override
     {
@@ -30,7 +31,8 @@ class GlslArrayTypeSyntax : public ScalarTypeSyntax
   public:
     GlslArrayTypeSyntax(const string& name) :
         ScalarTypeSyntax(name, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -50,7 +52,7 @@ class GlslArrayTypeSyntax : public ScalarTypeSyntax
         }
 
         string result = _name + "[" + std::to_string(values.size()) + "](" + values[0];
-        for (size_t i = 1; i<values.size(); ++i)
+        for (size_t i = 1; i < values.size(); ++i)
         {
             result += ", " + values[i];
         }
@@ -68,7 +70,8 @@ class GlslFloatArrayTypeSyntax : public GlslArrayTypeSyntax
   public:
     explicit GlslFloatArrayTypeSyntax(const string& name) :
         GlslArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     size_t getSize(const Value& value) const override
@@ -83,7 +86,8 @@ class GlslIntegerArrayTypeSyntax : public GlslArrayTypeSyntax
   public:
     explicit GlslIntegerArrayTypeSyntax(const string& name) :
         GlslArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     size_t getSize(const Value& value) const override
@@ -113,49 +117,47 @@ GlslSyntax::GlslSyntax()
 {
     // Add in all reserved words and keywords in GLSL
     registerReservedWords(
-    {
-        "centroid", "flat", "smooth", "noperspective", "patch", "sample",
-        "break", "continue", "do", "for", "while", "switch", "case", "default",
-        "if", "else,", "subroutine", "in", "out", "inout",
-        "float", "double", "int", "void", "bool", "true", "false",
-        "invariant", "discard", "return",
-        "mat2", "mat3", "mat4", "dmat2", "dmat3", "dmat4",
-        "mat2x2", "mat2x3", "mat2x4", "dmat2x2", "dmat2x3", "dmat2x4",
-        "mat3x2", "mat3x3", "mat3x4", "dmat3x2", "dmat3x3", "dmat3x4",
-        "mat4x2", "mat4x3", "mat4x4", "dmat4x2", "dmat4x3", "dmat4x4",
-        "vec2", "vec3", "vec4", "ivec2", "ivec3", "ivec4", "bvec2", "bvec3", "bvec4", "dvec2", "dvec3", "dvec4",
-        "uint", "uvec2", "uvec3", "uvec4",
-        "lowp", "mediump", "highp", "precision",
-        "sampler1D", "sampler2D", "sampler3D", "samplerCube",
-        "sampler1DShadow", "sampler2DShadow", "samplerCubeShadow",
-        "sampler1DArray", "sampler2DArray",
-        "sampler1DArrayShadow", "sampler2DArrayShadow",
-        "isampler1D", "isampler2D", "isampler3D", "isamplerCube",
-        "isampler1DArray", "isampler2DArray",
-        "usampler1D", "usampler2D", "usampler3D", "usamplerCube",
-        "usampler1DArray", "usampler2DArray",
-        "sampler2DRect", "sampler2DRectShadow", "isampler2DRect", "usampler2DRect",
-        "samplerBuffer", "isamplerBuffer", "usamplerBuffer",
-        "sampler2DMS", "isampler2DMS", "usampler2DMS",
-        "sampler2DMSArray", "isampler2DMSArray", "usampler2DMSArray",
-        "samplerCubeArray", "samplerCubeArrayShadow", "isamplerCubeArray", "usamplerCubeArray",
-        "common", "partition", "active", "asm",
-        "struct", "class", "union", "enum", "typedef", "template", "this", "packed", "goto",
-        "inline", "noinline", "volatile", "public", "static", "extern", "external", "interface",
-        "long", "short", "half", "fixed", "unsigned", "superp", "input", "output",
-        "hvec2", "hvec3", "hvec4", "fvec2", "fvec3", "fvec4",
-        "sampler3DRect", "filter",
-        "image1D", "image2D", "image3D", "imageCube",
-        "iimage1D", "iimage2D", "iimage3D", "iimageCube",
-        "uimage1D", "uimage2D", "uimage3D", "uimageCube",
-        "image1DArray", "image2DArray",
-        "iimage1DArray", "iimage2DArray", "uimage1DArray", "uimage2DArray",
-        "image1DShadow", "image2DShadow",
-        "image1DArrayShadow", "image2DArrayShadow",
-        "imageBuffer", "iimageBuffer", "uimageBuffer",
-        "sizeof", "cast", "namespace", "using", "row_major",
-        "mix", "sampler"
-    });
+        { "centroid", "flat", "smooth", "noperspective", "patch", "sample",
+          "break", "continue", "do", "for", "while", "switch", "case", "default",
+          "if", "else,", "subroutine", "in", "out", "inout",
+          "float", "double", "int", "void", "bool", "true", "false",
+          "invariant", "discard", "return",
+          "mat2", "mat3", "mat4", "dmat2", "dmat3", "dmat4",
+          "mat2x2", "mat2x3", "mat2x4", "dmat2x2", "dmat2x3", "dmat2x4",
+          "mat3x2", "mat3x3", "mat3x4", "dmat3x2", "dmat3x3", "dmat3x4",
+          "mat4x2", "mat4x3", "mat4x4", "dmat4x2", "dmat4x3", "dmat4x4",
+          "vec2", "vec3", "vec4", "ivec2", "ivec3", "ivec4", "bvec2", "bvec3", "bvec4", "dvec2", "dvec3", "dvec4",
+          "uint", "uvec2", "uvec3", "uvec4",
+          "lowp", "mediump", "highp", "precision",
+          "sampler1D", "sampler2D", "sampler3D", "samplerCube",
+          "sampler1DShadow", "sampler2DShadow", "samplerCubeShadow",
+          "sampler1DArray", "sampler2DArray",
+          "sampler1DArrayShadow", "sampler2DArrayShadow",
+          "isampler1D", "isampler2D", "isampler3D", "isamplerCube",
+          "isampler1DArray", "isampler2DArray",
+          "usampler1D", "usampler2D", "usampler3D", "usamplerCube",
+          "usampler1DArray", "usampler2DArray",
+          "sampler2DRect", "sampler2DRectShadow", "isampler2DRect", "usampler2DRect",
+          "samplerBuffer", "isamplerBuffer", "usamplerBuffer",
+          "sampler2DMS", "isampler2DMS", "usampler2DMS",
+          "sampler2DMSArray", "isampler2DMSArray", "usampler2DMSArray",
+          "samplerCubeArray", "samplerCubeArrayShadow", "isamplerCubeArray", "usamplerCubeArray",
+          "common", "partition", "active", "asm",
+          "struct", "class", "union", "enum", "typedef", "template", "this", "packed", "goto",
+          "inline", "noinline", "volatile", "public", "static", "extern", "external", "interface",
+          "long", "short", "half", "fixed", "unsigned", "superp", "input", "output",
+          "hvec2", "hvec3", "hvec4", "fvec2", "fvec3", "fvec4",
+          "sampler3DRect", "filter",
+          "image1D", "image2D", "image3D", "imageCube",
+          "iimage1D", "iimage2D", "iimage3D", "iimageCube",
+          "uimage1D", "uimage2D", "uimage3D", "uimageCube",
+          "image1DArray", "image2DArray",
+          "iimage1DArray", "iimage2DArray", "uimage1DArray", "uimage2DArray",
+          "image1DShadow", "image2DShadow",
+          "image1DArrayShadow", "image2DArrayShadow",
+          "imageBuffer", "iimageBuffer", "uimageBuffer",
+          "sizeof", "cast", "namespace", "using", "row_major",
+          "mix", "sampler" });
 
     // Register restricted tokens in GLSL
     StringMap tokens;
@@ -169,49 +171,38 @@ GlslSyntax::GlslSyntax()
     // Register syntax handlers for each data type.
     //
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOAT,
         std::make_shared<ScalarTypeSyntax>(
             "float",
             "0.0",
-            "0.0")
-    );
+            "0.0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOATARRAY,
         std::make_shared<GlslFloatArrayTypeSyntax>(
-            "float")
-    );
+            "float"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGER,
         std::make_shared<ScalarTypeSyntax>(
             "int",
             "0",
-            "0")
-    );
+            "0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGERARRAY,
         std::make_shared<GlslIntegerArrayTypeSyntax>(
-            "int")
-    );
+            "int"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BOOLEAN,
         std::make_shared<ScalarTypeSyntax>(
             "bool",
             "false",
-            "false")
-    );
+            "false"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vec3",
@@ -219,11 +210,9 @@ GlslSyntax::GlslSyntax()
             "vec3(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC3_MEMBERS)
-    );
+            VEC3_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR4,
         std::make_shared<AggregateTypeSyntax>(
             "vec4",
@@ -231,11 +220,9 @@ GlslSyntax::GlslSyntax()
             "vec4(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC4_MEMBERS)
-    );
+            VEC4_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR2,
         std::make_shared<AggregateTypeSyntax>(
             "vec2",
@@ -243,11 +230,9 @@ GlslSyntax::GlslSyntax()
             "vec2(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC2_MEMBERS)
-    );
+            VEC2_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vec3",
@@ -255,11 +240,9 @@ GlslSyntax::GlslSyntax()
             "vec3(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC3_MEMBERS)
-    );
+            VEC3_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR4,
         std::make_shared<AggregateTypeSyntax>(
             "vec4",
@@ -267,134 +250,108 @@ GlslSyntax::GlslSyntax()
             "vec4(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC4_MEMBERS)
-    );
+            VEC4_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX33,
         std::make_shared<AggregateTypeSyntax>(
             "mat3",
             "mat3(1.0)",
-            "mat3(1.0)")
-    );
+            "mat3(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX44,
         std::make_shared<AggregateTypeSyntax>(
             "mat4",
             "mat4(1.0)",
-            "mat4(1.0)")
-    );
+            "mat4(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::STRING,
-        std::make_shared<GlslStringTypeSyntax>()
-    );
+        std::make_shared<GlslStringTypeSyntax>());
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FILENAME,
         std::make_shared<ScalarTypeSyntax>(
             "sampler2D",
             EMPTY_STRING,
-            EMPTY_STRING)
-    );
+            EMPTY_STRING));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BSDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF",
             "BSDF(vec3(0.0),vec3(1.0), 0.0, 0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct BSDF { vec3 response; vec3 throughput; float thickness; float ior; };")
-    );
+            "struct BSDF { vec3 response; vec3 throughput; float thickness; float ior; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::EDF,
         std::make_shared<AggregateTypeSyntax>(
             "EDF",
             "EDF(0.0)",
             "EDF(0.0)",
             "vec3",
-            "#define EDF vec3")
-    );
+            "#define EDF vec3"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF",
             "BSDF(vec3(0.0),vec3(1.0), 0.0, 0.0)",
-            EMPTY_STRING)
-    );
+            EMPTY_STRING));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::SURFACESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "surfaceshader",
             "surfaceshader(vec3(0.0),vec3(0.0))",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct surfaceshader { vec3 color; vec3 transparency; };")
-    );
+            "struct surfaceshader { vec3 color; vec3 transparency; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VOLUMESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "volumeshader",
             "volumeshader(vec3(0.0),vec3(0.0))",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct volumeshader { vec3 color; vec3 transparency; };")
-    );
+            "struct volumeshader { vec3 color; vec3 transparency; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::DISPLACEMENTSHADER,
         std::make_shared<AggregateTypeSyntax>(
             "displacementshader",
             "displacementshader(vec3(0.0),1.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct displacementshader { vec3 offset; float scale; };")
-    );
+            "struct displacementshader { vec3 offset; float scale; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::LIGHTSHADER,
         std::make_shared<AggregateTypeSyntax>(
             "lightshader",
             "lightshader(vec3(0.0),vec3(0.0))",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct lightshader { vec3 intensity; vec3 direction; };")
-    );
+            "struct lightshader { vec3 intensity; vec3 direction; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATERIAL,
         std::make_shared<AggregateTypeSyntax>(
             "material",
             "material(vec3(0.0),vec3(0.0))",
             EMPTY_STRING,
             "surfaceshader",
-            "#define material surfaceshader")
-    );
+            "#define material surfaceshader"));
 }
 
 bool GlslSyntax::typeSupported(const TypeDesc* type) const
 {
     return type != Type::STRING;
 }
-
 
 bool GlslSyntax::remapEnumeration(const string& value, const TypeDesc* type, const string& enumNames, std::pair<const TypeDesc*, ValuePtr>& result) const
 {
@@ -421,7 +378,7 @@ bool GlslSyntax::remapEnumeration(const string& value, const TypeDesc* type, con
     if (!value.empty())
     {
         StringVec valueElemEnumsVec = splitString(enumNames, ",");
-        for (size_t i=0; i<valueElemEnumsVec.size(); i++)
+        for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
         {
             valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
         }

--- a/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Bitangent node implementation for GLSL
 class MX_GENGLSL_API BitangentNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Frame node implementation for GLSL
 class MX_GENGLSL_API FrameNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// GeomColor node implementation for GLSL
 class MX_GENGLSL_API GeomColorNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -13,25 +13,27 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    /// Name of filter function to call to compute normals from input samples
-    const string filterFunctionName = "mx_normal_from_samples_sobel";
 
-    /// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
-    /// as input, and return a 2 channel vector as output
-    const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+/// Name of filter function to call to compute normals from input samples
+const string filterFunctionName = "mx_normal_from_samples_sobel";
 
-    const unsigned int sampleCount = 9;
-    const unsigned int filterWidth = 3;
-    const float filterSize = 1.0;
-    const float filterOffset = 0.0;
-}
+/// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
+/// as input, and return a 2 channel vector as output
+const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+
+const unsigned int sampleCount = 9;
+const unsigned int filterWidth = 3;
+const float filterSize = 1.0;
+const float filterOffset = 0.0;
+
+} // anonymous namespace
 
 ShaderNodeImplPtr HeightToNormalNodeGlsl::create()
 {
     return std::make_shared<HeightToNormalNodeGlsl>();
 }
 
-void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                                         unsigned int, StringVec& offsetStrings) const
 {
     // Build a 3x3 grid of samples that are offset by the provided sample size
@@ -39,7 +41,7 @@ void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSize
     {
         for (int col = -1; col <= 1; col++)
         {
-            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString +  "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString + "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
         }
     }
 }
@@ -75,10 +77,10 @@ void HeightToNormalNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext
             throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid heighttonormal node");
         }
 
-        // Create the input "samples". This means to emit the calls to 
+        // Create the input "samples". This means to emit the calls to
         // compute the sames and return a set of strings containaing
         // the variables to assign to the sample grid.
-        //  
+        //
         StringVec sampleStrings;
         emitInputSamplesUV(node, sampleCount, filterWidth,
                            filterSize, filterOffset, sampleSizeFunctionUV,
@@ -108,6 +110,5 @@ const string& HeightToNormalNodeGlsl::getTarget() const
 {
     return GlslShaderGenerator::TARGET;
 }
-
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
@@ -28,7 +28,7 @@ class MX_GENGLSL_API HeightToNormalNodeGlsl : public ConvolutionNode
     bool acceptsInputType(const TypeDesc* type) const override;
 
     /// Compute offset strings for sampling
-    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                     unsigned int filterWidth, StringVec& offsetStrings) const override;
 };
 

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -50,7 +50,7 @@ void LightCompoundNodeGlsl::createVariables(const ShaderNode&, GenContext& conte
     VariableBlock& lightData = ps.getUniformBlock(HW::LIGHT_DATA);
 
     // Create all light uniforms
-    for (size_t i = 0; i<_lightUniforms.size(); ++i)
+    for (size_t i = 0; i < _lightUniforms.size(); ++i)
     {
         ShaderPort* u = const_cast<ShaderPort*>(_lightUniforms[i]);
         lightData.add(u->getSelf());

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h
@@ -19,7 +19,7 @@ class GlslShaderGenerator;
 /// LightCompound node implementation for GLSL
 class MX_GENGLSL_API LightCompoundNodeGlsl : public CompoundNode
 {
-public:
+  public:
     LightCompoundNodeGlsl();
 
     static ShaderNodeImplPtr create();
@@ -34,7 +34,7 @@ public:
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     void emitFunctionDefinition(ClosureContext* cct, GenContext& context, ShaderStage& stage) const;
 
     VariableBlock _lightUniforms;

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -11,14 +11,16 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    const string LIGHT_DIRECTION_CALCULATION =
-        "vec3 L = light.position - position;\n"
-        "float distance = length(L);\n"
-        "L /= distance;\n"
-        "result.direction = L;\n";
-}
 
-LightNodeGlsl::LightNodeGlsl() : 
+const string LIGHT_DIRECTION_CALCULATION =
+    "vec3 L = light.position - position;\n"
+    "float distance = length(L);\n"
+    "L /= distance;\n"
+    "result.direction = L;\n";
+
+} // anonymous namespace
+
+LightNodeGlsl::LightNodeGlsl() :
     _callEmission(HwShaderGenerator::ClosureContextType::EMISSION)
 {
     // Emission context
@@ -39,7 +41,7 @@ void LightNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shad
     VariableBlock& lightUniforms = ps.getUniformBlock(HW::LIGHT_DATA);
     lightUniforms.add(Type::FLOAT, "intensity", Value::createValue<float>(1.0f));
     lightUniforms.add(Type::FLOAT, "exposure", Value::createValue<float>(0.0f));
-    lightUniforms.add(Type::VECTOR3, "direction", Value::createValue<Vector3>(Vector3(0.0f,1.0f,0.0f)));
+    lightUniforms.add(Type::VECTOR3, "direction", Value::createValue<Vector3>(Vector3(0.0f, 1.0f, 0.0f)));
 
     const GlslShaderGenerator& shadergen = static_cast<const GlslShaderGenerator&>(context.getShaderGenerator());
     shadergen.addStageLightingUniforms(context, ps);

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.h
@@ -23,7 +23,7 @@ class MX_GENGLSL_API LightNodeGlsl : public GlslImplementation
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   private:
-      mutable ClosureContext _callEmission;
+    mutable ClosureContext _callEmission;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
@@ -9,8 +9,10 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    const string SAMPLE_LIGHTS_FUNC_SIGNATURE = "void sampleLightSource(LightData light, vec3 position, out lightshader result)";
-}
+
+const string SAMPLE_LIGHTS_FUNC_SIGNATURE = "void sampleLightSource(LightData light, vec3 position, out lightshader result)";
+
+} // anonymous namespace
 
 LightSamplerNodeGlsl::LightSamplerNodeGlsl()
 {

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Utility node for sampling lights for GLSL.
 class MX_GENGLSL_API LightSamplerNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     LightSamplerNodeGlsl();
 
     static ShaderNodeImplPtr create();

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h
@@ -15,7 +15,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Used for all light shaders implemented in source code.
 class MX_GENGLSL_API LightShaderNodeGlsl : public SourceCodeNode
 {
-public:
+  public:
     LightShaderNodeGlsl();
 
     static ShaderNodeImplPtr create();
@@ -28,7 +28,7 @@ public:
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     VariableBlock _lightUniforms;
 };
 

--- a/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Normal node implementation for GLSL
 class MX_GENGLSL_API NormalNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
@@ -11,8 +11,10 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    const string NUM_LIGHTS_FUNC_SIGNATURE = "int numActiveLightSources()";
-}
+
+const string NUM_LIGHTS_FUNC_SIGNATURE = "int numActiveLightSources()";
+
+} // anonymous namespace
 
 NumLightsNodeGlsl::NumLightsNodeGlsl()
 {

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Utility node for getting number of active lights for GLSL.
 class MX_GENGLSL_API NumLightsNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     NumLightsNodeGlsl();
 
     static ShaderNodeImplPtr create();

--- a/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Position node implementation for GLSL
 class MX_GENGLSL_API PositionNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -43,10 +43,10 @@ ShaderNodeImplPtr SurfaceNodeGlsl::create()
 
 void SurfaceNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
-    // TODO: 
-    // The surface shader needs position, normal, view position and light sources. We should solve this by adding some 
+    // TODO:
+    // The surface shader needs position, normal, view position and light sources. We should solve this by adding some
     // dependency mechanism so this implementation can be set to depend on the PositionNodeGlsl, NormalNodeGlsl
-    // ViewDirectionNodeGlsl and LightNodeGlsl nodes instead? This is where the MaterialX attribute "internalgeomprops" 
+    // ViewDirectionNodeGlsl and LightNodeGlsl nodes instead? This is where the MaterialX attribute "internalgeomprops"
     // is needed.
     //
     ShaderStage& vs = shader.getStage(Stage::VERTEX);
@@ -229,7 +229,7 @@ void SurfaceNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& conte
 
 void SurfaceNodeGlsl::emitLightLoop(const ShaderNode& node, GenContext& context, ShaderStage& stage, const string& outColor) const
 {
-    // 
+    //
     // Generate Light loop if requested
     //
     if (context.getOptions().hwMaxActiveLightSources > 0)

--- a/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
@@ -22,10 +22,10 @@ const string& SurfaceShaderNodeGlsl::getTarget() const
 
 void SurfaceShaderNodeGlsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
-    // TODO: 
-    // The surface shader needs position, view position and light sources. We should solve this by adding some 
-    // dependency mechanism so this implementation can be set to depend on the PositionNodeGlsl,  
-    // ViewDirectionNodeGlsl and LightNodeGlsl nodes instead? This is where the MaterialX attribute "internalgeomprops" 
+    // TODO:
+    // The surface shader needs position, view position and light sources. We should solve this by adding some
+    // dependency mechanism so this implementation can be set to depend on the PositionNodeGlsl,
+    // ViewDirectionNodeGlsl and LightNodeGlsl nodes instead? This is where the MaterialX attribute "internalgeomprops"
     // is needed.
     //
     ShaderStage& vs = shader.getStage(Stage::VERTEX);

--- a/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Tangent node implementation for GLSL
 class MX_GENGLSL_API TangentNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// TexCoord node implementation for GLSL
 class MX_GENGLSL_API TexCoordNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Time node implementation for GLSL
 class MX_GENGLSL_API TimeNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h
@@ -13,10 +13,10 @@ MATERIALX_NAMESPACE_BEGIN
 /// TransformNormal node implementation for GLSL
 class MX_GENGLSL_API TransformNormalNodeGlsl : public TransformVectorNodeGlsl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
-protected:
+  protected:
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
     const string& getMatrix(const string& fromSpace, const string& toSpace) const override;

--- a/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h
@@ -13,10 +13,10 @@ MATERIALX_NAMESPACE_BEGIN
 /// TransformPoint node implementation for GLSL
 class MX_GENGLSL_API TransformPointNodeGlsl : public TransformVectorNodeGlsl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
-protected:
+  protected:
     virtual string getHomogeneousCoordinate(const ShaderInput* in, GenContext& context) const override;
 };
 

--- a/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.h
@@ -13,14 +13,14 @@ MATERIALX_NAMESPACE_BEGIN
 /// TransformVector node implementation for GLSL
 class MX_GENGLSL_API TransformVectorNodeGlsl : public GlslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     virtual const string& getMatrix(const string& fromSpace, const string& toSpace) const;
     virtual string getHomogeneousCoordinate(const ShaderInput* in, GenContext& context) const;
 };


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXGenGlsl, providing improvements in coding style consistency.