### PR TITLE
Apply Clang formatting to MaterialXGenOsl

### DIFF
--- a/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.cpp
@@ -147,7 +147,6 @@ void ClosureLayerNodeOsl::emitFunctionCall(const ShaderNode& _node, GenContext& 
     }
 
 #endif // MATERIALX_OSL_LEGACY_CLOSURES
-
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -44,11 +44,11 @@ OslShaderGenerator::OslShaderGenerator() :
     static const string BOOL_SEPARATOR = "B_";
     static const StringVec IMPL_PREFIXES = { "IM_ifgreater_", "IM_ifgreatereq_", "IM_ifequal_" };
     static const vector<CreatorFunction<ShaderNodeImpl>> IMPL_CREATE_FUNCTIONS =
-            { IfGreaterNode::create,  IfGreaterEqNode::create, IfEqualNode::create };
+        { IfGreaterNode::create, IfGreaterEqNode::create, IfEqualNode::create };
     static const vector<bool> IMPL_HAS_INTVERSION = { true, true, true };
     static const vector<bool> IMPL_HAS_BOOLVERSION = { false, false, true };
     static const StringVec IMPL_TYPES = { "float", "color3", "color4", "vector2", "vector3", "vector4" };
-    for (size_t i = 0; i<IMPL_PREFIXES.size(); i++)
+    for (size_t i = 0; i < IMPL_PREFIXES.size(); i++)
     {
         const string& implPrefix = IMPL_PREFIXES[i];
         for (const string& implType : IMPL_TYPES)
@@ -251,8 +251,9 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     // Always emit node information
     emitScopeBegin(stage, Syntax::DOUBLE_SQUARE_BRACKETS);
     emitLine("string mtlx_category = \"" + element->getCategory() + "\"" + Syntax::COMMA, stage, false);
-    emitLine("string mtlx_name = \"" + element->getQualifiedName(element->getName())+ "\"" + 
-            (haveShaderMetaData ? Syntax::COMMA : EMPTY_STRING), stage, false);
+    emitLine("string mtlx_name = \"" + element->getQualifiedName(element->getName()) + "\"" +
+                 (haveShaderMetaData ? Syntax::COMMA : EMPTY_STRING),
+             stage, false);
 
     // Add any metadata if set on the graph.
     if (haveShaderMetaData)
@@ -335,8 +336,8 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
         {
             const ShaderNode* upstream = socket->getConnection()->getNode();
             if (upstream->getParent() == &graph &&
-                (upstream->hasClassification(ShaderNode::Classification::CLOSURE) || 
-                    upstream->hasClassification(ShaderNode::Classification::SHADER)))
+                (upstream->hasClassification(ShaderNode::Classification::CLOSURE) ||
+                 upstream->hasClassification(ShaderNode::Classification::SHADER)))
             {
                 emitFunctionCall(*upstream, context, stage);
             }
@@ -403,14 +404,14 @@ void OslShaderGenerator::registerShaderMetadata(const DocumentPtr& doc, GenConte
     // Rename the standard metadata names to corresponding OSL metadata names.
     const StringMap nameRemapping =
     {
-        {ValueElement::UI_NAME_ATTRIBUTE, "label"},
-        {ValueElement::UI_FOLDER_ATTRIBUTE, "page"},
-        {ValueElement::UI_MIN_ATTRIBUTE, "min"},
-        {ValueElement::UI_MAX_ATTRIBUTE, "max"},
-        {ValueElement::UI_SOFT_MIN_ATTRIBUTE, "slidermin"},
-        {ValueElement::UI_SOFT_MAX_ATTRIBUTE, "slidermax"},
-        {ValueElement::UI_STEP_ATTRIBUTE, "sensitivity"},
-        {ValueElement::DOC_ATTRIBUTE, "help"}
+        { ValueElement::UI_NAME_ATTRIBUTE, "label" },
+        { ValueElement::UI_FOLDER_ATTRIBUTE, "page" },
+        { ValueElement::UI_MIN_ATTRIBUTE, "min" },
+        { ValueElement::UI_MAX_ATTRIBUTE, "max" },
+        { ValueElement::UI_SOFT_MIN_ATTRIBUTE, "slidermin" },
+        { ValueElement::UI_SOFT_MAX_ATTRIBUTE, "slidermax" },
+        { ValueElement::UI_STEP_ATTRIBUTE, "sensitivity" },
+        { ValueElement::DOC_ATTRIBUTE, "help" }
     };
     for (auto it : nameRemapping)
     {
@@ -465,7 +466,7 @@ void OslShaderGenerator::emitFunctionCalls(const ShaderGraph& graph, GenContext&
     if ((classification & ShaderNode::Classification::CLOSURE) != 0)
     {
         // Emit function calls for closures connected to the outputs.
-        // These will internally emit other closure function calls 
+        // These will internally emit other closure function calls
         // for upstream nodes if needed.
         for (ShaderGraphOutputSocket* outputSocket : graph.getOutputSockets())
         {
@@ -507,7 +508,7 @@ void OslShaderGenerator::emitLibraryIncludes(ShaderStage& stage, GenContext& con
     {
         FilePath path = context.resolveSourceFile(file, FilePath());
 
-        // Force path to use slash since backslash even if escaped 
+        // Force path to use slash since backslash even if escaped
         // gives problems when saving the source code to file.
         string pathStr = path.asString();
         std::replace(pathStr.begin(), pathStr.end(), '\\', '/');
@@ -520,20 +521,22 @@ void OslShaderGenerator::emitLibraryIncludes(ShaderStage& stage, GenContext& con
 
 namespace
 {
-    std::unordered_map<string, string> GEOMPROP_DEFINITIONS =
-    {
-        {"Pobject", "transform(\"object\", P)"},
-        {"Pworld", "P"},
-        {"Nobject", "transform(\"object\", N)"},
-        {"Nworld", "N"},
-        {"Tobject", "transform(\"object\", dPdu)"},
-        {"Tworld", "dPdu"},
-        {"Bobject", "transform(\"object\", dPdv)"},
-        {"Bworld", "dPdv"},
-        {"UV0", "{u,v}"},
-        {"Vworld", "I"}
-    };
-}
+
+std::unordered_map<string, string> GEOMPROP_DEFINITIONS =
+{
+    { "Pobject", "transform(\"object\", P)" },
+    { "Pworld", "P" },
+    { "Nobject", "transform(\"object\", N)" },
+    { "Nworld", "N" },
+    { "Tobject", "transform(\"object\", dPdu)" },
+    { "Tworld", "dPdu" },
+    { "Bobject", "transform(\"object\", dPdv)" },
+    { "Bworld", "dPdv" },
+    { "UV0", "{u,v}" },
+    { "Vworld", "I" }
+};
+
+} // anonymous namespace
 
 void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderStage& stage) const
 {
@@ -542,16 +545,16 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
         { Type::FLOAT, ShaderMetadata("widget", Type::STRING, Value::createValueFromStrings("number", Type::STRING->getName())) },
         { Type::INTEGER, ShaderMetadata("widget", Type::STRING, Value::createValueFromStrings("number", Type::STRING->getName())) },
         { Type::FILENAME, ShaderMetadata("widget", Type::STRING, Value::createValueFromStrings("filename", Type::STRING->getName())) },
-        { Type::BOOLEAN,  ShaderMetadata("widget", Type::STRING, Value::createValueFromStrings("checkBox", Type::STRING->getName())) }
+        { Type::BOOLEAN, ShaderMetadata("widget", Type::STRING, Value::createValueFromStrings("checkBox", Type::STRING->getName())) }
     };
 
     const std::set<const TypeDesc*> METADATA_TYPE_BLACKLIST =
     {
-        Type::VECTOR2, // Custom struct types doesn't support metadata declarations.
-        Type::VECTOR4, //
-        Type::COLOR4,  //
+        Type::VECTOR2,  // Custom struct types doesn't support metadata declarations.
+        Type::VECTOR4,  //
+        Type::COLOR4,   //
         Type::FILENAME, //
-        Type::BSDF     //
+        Type::BSDF      //
     };
 
     for (size_t i = 0; i < inputs.size(); ++i)
@@ -559,7 +562,7 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
         const ShaderPort* input = inputs[i];
 
         const string& type = _syntax->getTypeName(input->getType());
-        string value = _syntax->getValue((ShaderPort*)input, true);
+        string value = _syntax->getValue((ShaderPort*) input, true);
 
         emitLineBegin(stage);
         emitString(type + " " + input->getVariable(), stage);
@@ -647,10 +650,12 @@ void OslShaderGenerator::emitShaderOutputs(const VariableBlock& outputs, ShaderS
 
 namespace OSL
 {
-    // Identifiers for OSL variable blocks
-    const string UNIFORMS = "u";
-    const string INPUTS   = "i";
-    const string OUTPUTS  = "o";
-}
+
+// Identifiers for OSL variable blocks
+const string UNIFORMS = "u";
+const string INPUTS = "i";
+const string OUTPUTS = "o";
+
+} // namespace OSL
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -47,7 +47,7 @@ class MX_GENOSL_API OslShaderGenerator : public ShaderGenerator
     /// Register metadata that should be exported to the generated shaders.
     void registerShaderMetadata(const DocumentPtr& doc, GenContext& context) const override;
 
-protected:
+  protected:
     // Extra file arguments for texture lookup call
     static const string T_FILE_EXTRA_ARGUMENTS;
 
@@ -66,11 +66,13 @@ protected:
 
 namespace OSL
 {
-    /// Identifiers for OSL variable blocks
-    extern MX_GENOSL_API const string UNIFORMS;
-    extern MX_GENOSL_API const string INPUTS;
-    extern MX_GENOSL_API const string OUTPUTS;
-}
+
+/// Identifiers for OSL variable blocks
+extern MX_GENOSL_API const string UNIFORMS;
+extern MX_GENOSL_API const string INPUTS;
+extern MX_GENOSL_API const string OUTPUTS;
+
+} // namespace OSL
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -16,10 +16,11 @@ namespace
 
 class OslBooleanTypeSyntax : public ScalarTypeSyntax
 {
-public:
+  public:
     OslBooleanTypeSyntax() :
         ScalarTypeSyntax("int", "0", "0", EMPTY_STRING, "#define true 1\n#define false 0")
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -37,7 +38,8 @@ class OslArrayTypeSyntax : public ScalarTypeSyntax
   public:
     OslArrayTypeSyntax(const string& name) :
         ScalarTypeSyntax(name, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool uniform) const override
     {
@@ -61,7 +63,7 @@ class OslArrayTypeSyntax : public ScalarTypeSyntax
         }
 
         string result = "{" + values[0];
-        for (size_t i = 1; i<values.size(); ++i)
+        for (size_t i = 1; i < values.size(); ++i)
         {
             result += ", " + values[i];
         }
@@ -79,7 +81,8 @@ class OslFloatArrayTypeSyntax : public OslArrayTypeSyntax
   public:
     explicit OslFloatArrayTypeSyntax(const string& name) :
         OslArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     bool isEmpty(const Value& value) const override
@@ -94,7 +97,8 @@ class OslIntegerArrayTypeSyntax : public OslArrayTypeSyntax
   public:
     explicit OslIntegerArrayTypeSyntax(const string& name) :
         OslArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     bool isEmpty(const Value& value) const override
@@ -113,7 +117,8 @@ class OslStructTypeSyntax : public AggregateTypeSyntax
                         const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
                         const StringVec& members = EMPTY_MEMBERS) :
         AggregateTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition, members)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool uniform) const override
     {
@@ -135,7 +140,7 @@ class OslStructTypeSyntax : public AggregateTypeSyntax
         }
 
         string result = uniform ? "{" : getName() + "(" + values[0];
-        for (size_t i = 1; i<values.size(); ++i)
+        for (size_t i = 1; i < values.size(); ++i)
         {
             result += ", " + values[i];
         }
@@ -157,7 +162,8 @@ class OslColor4TypeSyntax : public OslStructTypeSyntax
   public:
     OslColor4TypeSyntax() :
         OslStructTypeSyntax("color4", "color4(color(0.0), 0.0)", "{color(0.0), 0.0}", EMPTY_STRING, EMPTY_STRING, OslSyntax::COLOR4_MEMBERS)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool uniform) const override
     {
@@ -166,9 +172,8 @@ class OslColor4TypeSyntax : public OslStructTypeSyntax
         // Set float format and precision for the stream
         const Value::FloatFormat fmt = Value::getFloatFormat();
         ss.setf(std::ios_base::fmtflags(
-            (fmt == Value::FloatFormatFixed ? std::ios_base::fixed :
-            (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0))),
-            std::ios_base::floatfield);
+                    (fmt == Value::FloatFormatFixed ? std::ios_base::fixed : (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0))),
+                std::ios_base::floatfield);
         ss.precision(Value::getFloatPrecision());
 
         const Color4 c = value.asA<Color4>();
@@ -210,7 +215,8 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
                          const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
                          const StringVec& members = EMPTY_MEMBERS) :
         AggregateTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition, members)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool uniform) const override
     {
@@ -230,12 +236,13 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
         // using Value::setFloatFormat() and Value::setFloatPrecision()
         StringStream ss;
         ss << getName() << "(";
-        for (size_t i = 0; i<values.size(); i++)
+        for (size_t i = 0; i < values.size(); i++)
         {
             ss << values[i] << ", ";
-            if ((i+1) % 3 == 0)
+            if ((i + 1) % 3 == 0)
             {
-                ss << "0.000" << ", ";
+                ss << "0.000"
+                   << ", ";
             }
         }
         static string ROW_4("0.000, 0.000, 0.000, 1.000");
@@ -249,11 +256,12 @@ class OSLFilenameTypeSyntax : public AggregateTypeSyntax
 {
   public:
     OSLFilenameTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
-                     const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
-                     const StringVec& members = EMPTY_MEMBERS) :
+                          const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
+                          const StringVec& members = EMPTY_MEMBERS) :
         AggregateTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition, members)
-    {}
-    
+    {
+    }
+
     string getValue(const ShaderPort* port, bool uniform) const override
     {
         if (!port)
@@ -287,15 +295,14 @@ class OSLFilenameTypeSyntax : public AggregateTypeSyntax
     }
 };
 
-
 } // anonymous namespace
 
 const string OslSyntax::OUTPUT_QUALIFIER = "output";
 const string OslSyntax::SOURCE_FILE_EXTENSION = ".osl";
-const StringVec OslSyntax::VECTOR_MEMBERS  = { "[0]", "[1]", "[2]" };
+const StringVec OslSyntax::VECTOR_MEMBERS = { "[0]", "[1]", "[2]" };
 const StringVec OslSyntax::VECTOR2_MEMBERS = { ".x", ".y" };
 const StringVec OslSyntax::VECTOR4_MEMBERS = { ".x", ".y", ".z", ".w" };
-const StringVec OslSyntax::COLOR4_MEMBERS  = { ".rgb[0]", ".rgb[1]", ".rgb[2]", ".a" };
+const StringVec OslSyntax::COLOR4_MEMBERS = { ".rgb[0]", ".rgb[1]", ".rgb[2]", ".a" };
 
 //
 // OslSyntax methods
@@ -305,75 +312,62 @@ OslSyntax::OslSyntax()
 {
     // Add in all reserved words and keywords in OSL
     registerReservedWords(
-    {
-        // OSL types and keywords
-        "and", "break", "closure", "color", "continue", "do", "else", "emit", "float", "for", "if", "illuminance",
-        "illuminate", "int", "matrix", "normal", "not", "or", "output", "point", "public", "return", "string",
-        "struct", "vector", "void", "while",
-        "bool", "case", "catch", "char", "class", "const", "delete", "default", "double", "enum", "extern",
-        "false", "friend", "goto", "inline", "long", "new", "operator", "private", "protected", "short",
-        "signed", "sizeof", "static", "switch", "template", "this", "throw", "true", "try", "typedef", "uniform",
-        "union", "unsigned", "varying", "virtual", "volatile",
-        // OSL standard library functions names
-        "degrees", "radians", "cos", "sin", "tan", "acos", "asin", "atan", "atan2", "cosh", "sinh", "tanh",
-        "pow", "log", "log2", "log10", "logb", "sqrt", "inversesqrt", "cbrt", "hypot", "abs", "fabs", "sign",
-        "floor", "ceil", "round", "trunc", "fmod", "mod", "min", "max", "clamp", "mix", "select", "isnan",
-        "isinf", "isfinite", "erf", "erfc", "cross", "dot", "length", "distance", "normalize", "faceforward", 
-        "reflect", "fresnel", "transform", "transformu", "rotate", "luminance", "blackbody", "wavelength_color", 
-        "transformc", "determinant", "transpose", "step", "smoothstep", "linearstep", "smooth_linearstep", "aastep", 
-        "hash", "strlen", "getchar", "startswith", "endswith", "substr", "stof", "stoi", "concat", "textureresource",
-        "backfacing", "raytype", "iscameraray", "isdiffuseray", "isglossyray", "isshadowray", "getmatrix",
-        "emission", "background", "diffuse", "oren_nayer", "translucent", "phong", "ward", "microfacet",
-        "reflection", "transparent", "debug", "holdout", "subsurface", "sheen",
-        "oren_nayar_diffuse_bsdf", "burley_diffuse_bsdf", "dielectric_bsdf", "conductor_bsdf", "generalized_schlick_bsdf", 
-        "translucent_bsdf", "transparent_bsdf","subsurface_bssrdf", "sheen_bsdf", "uniform_edf", "anisotropic_vdf", 
-        "medium_vdf", "layer", "artistic_ior"
-    });
+        { // OSL types and keywords
+          "and", "break", "closure", "color", "continue", "do", "else", "emit", "float", "for", "if", "illuminance",
+          "illuminate", "int", "matrix", "normal", "not", "or", "output", "point", "public", "return", "string",
+          "struct", "vector", "void", "while",
+          "bool", "case", "catch", "char", "class", "const", "delete", "default", "double", "enum", "extern",
+          "false", "friend", "goto", "inline", "long", "new", "operator", "private", "protected", "short",
+          "signed", "sizeof", "static", "switch", "template", "this", "throw", "true", "try", "typedef", "uniform",
+          "union", "unsigned", "varying", "virtual", "volatile",
+          // OSL standard library functions names
+          "degrees", "radians", "cos", "sin", "tan", "acos", "asin", "atan", "atan2", "cosh", "sinh", "tanh",
+          "pow", "log", "log2", "log10", "logb", "sqrt", "inversesqrt", "cbrt", "hypot", "abs", "fabs", "sign",
+          "floor", "ceil", "round", "trunc", "fmod", "mod", "min", "max", "clamp", "mix", "select", "isnan",
+          "isinf", "isfinite", "erf", "erfc", "cross", "dot", "length", "distance", "normalize", "faceforward",
+          "reflect", "fresnel", "transform", "transformu", "rotate", "luminance", "blackbody", "wavelength_color",
+          "transformc", "determinant", "transpose", "step", "smoothstep", "linearstep", "smooth_linearstep", "aastep",
+          "hash", "strlen", "getchar", "startswith", "endswith", "substr", "stof", "stoi", "concat", "textureresource",
+          "backfacing", "raytype", "iscameraray", "isdiffuseray", "isglossyray", "isshadowray", "getmatrix",
+          "emission", "background", "diffuse", "oren_nayer", "translucent", "phong", "ward", "microfacet",
+          "reflection", "transparent", "debug", "holdout", "subsurface", "sheen",
+          "oren_nayar_diffuse_bsdf", "burley_diffuse_bsdf", "dielectric_bsdf", "conductor_bsdf", "generalized_schlick_bsdf",
+          "translucent_bsdf", "transparent_bsdf", "subsurface_bssrdf", "sheen_bsdf", "uniform_edf", "anisotropic_vdf",
+          "medium_vdf", "layer", "artistic_ior" });
 
     //
     // Register type syntax handlers for each data type.
     //
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOAT,
         std::make_shared<ScalarTypeSyntax>(
             "float",
             "0.0",
-            "0.0")
-    );
+            "0.0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOATARRAY,
         std::make_shared<OslFloatArrayTypeSyntax>(
-            "float")
-    );
+            "float"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGER,
         std::make_shared<ScalarTypeSyntax>(
             "int",
             "0",
-            "0")
-    );
+            "0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGERARRAY,
         std::make_shared<OslIntegerArrayTypeSyntax>(
-            "int")
-    );
+            "int"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BOOLEAN,
-        std::make_shared<OslBooleanTypeSyntax>()
-    );
+        std::make_shared<OslBooleanTypeSyntax>());
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         // Note: the color type in OSL is a built in type and
         // should not use the custom OslStructTypeSyntax.
         Type::COLOR3,
@@ -383,17 +377,13 @@ OslSyntax::OslSyntax()
             "color(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR_MEMBERS)
-    );
+            VECTOR_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR4,
-        std::make_shared<OslColor4TypeSyntax>()
-    );
+        std::make_shared<OslColor4TypeSyntax>());
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR2,
         std::make_shared<OslStructTypeSyntax>(
             "vector2",
@@ -401,11 +391,9 @@ OslSyntax::OslSyntax()
             "{0.0, 0.0}",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR2_MEMBERS)
-    );
+            VECTOR2_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         // Note: the vector type in OSL is a built in type and
         // should not use the custom OslStructTypeSyntax.
         Type::VECTOR3,
@@ -415,11 +403,9 @@ OslSyntax::OslSyntax()
             "vector(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR_MEMBERS)
-    );
+            VECTOR_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR4,
         std::make_shared<OslStructTypeSyntax>(
             "vector4",
@@ -427,151 +413,124 @@ OslSyntax::OslSyntax()
             "{0.0, 0.0, 0.0, 0.0}",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR4_MEMBERS)
-    );
+            VECTOR4_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX33,
         std::make_shared<OSLMatrix3TypeSyntax>(
             "matrix",
             "matrix(1.0)",
-            "matrix(1.0)")
-    );
+            "matrix(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX44,
         std::make_shared<AggregateTypeSyntax>(
             "matrix",
             "matrix(1.0)",
-            "matrix(1.0)")
-    );
+            "matrix(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::STRING,
         std::make_shared<StringTypeSyntax>(
             "string",
             "\"\"",
-            "\"\"")
-    );
+            "\"\""));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FILENAME,
         std::make_shared<OSLFilenameTypeSyntax>(
             "textureresource ",
             "textureresource (\"\", \"\")",
             "(\"\", \"\")",
             EMPTY_STRING,
-            "struct textureresource { string filename; string colorspace; };")
-    );
+            "struct textureresource { string filename; string colorspace; };"));
 
 #ifdef MATERIALX_OSL_LEGACY_CLOSURES
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BSDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF",
             "BSDF(null_closure, color(1.0), 0.0, 0.0)",
             "{ 0, color(1.0), 0.0, 0.0 }",
             "closure color",
-            "struct BSDF { closure color response; color throughput; float thickness; float ior; };")
-    );
+            "struct BSDF { closure color response; color throughput; float thickness; float ior; };"));
 
 #else
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BSDF,
         std::make_shared<ScalarTypeSyntax>(
             "BSDF",
             "null_closure",
             "0",
             "closure color",
-            "#define BSDF closure color")
-    );
+            "#define BSDF closure color"));
 
 #endif // MATERIALX_OSL_LEGACY_CLOSURES
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::EDF,
         std::make_shared<ScalarTypeSyntax>(
             "EDF",
             "null_closure",
             "0",
             "closure color",
-            "#define EDF closure color")
-    );
+            "#define EDF closure color"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VDF,
         std::make_shared<ScalarTypeSyntax>(
             "VDF",
             "null_closure",
             "0",
             "closure color",
-            "#define VDF closure color")
-    );
+            "#define VDF closure color"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::SURFACESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "surfaceshader",
             "surfaceshader(null_closure, null_closure, 1.0)",
             "{ 0, 0, 1.0 }",
             "closure color",
-            "struct surfaceshader { closure color bsdf; closure color edf; float opacity; };")
-    );
+            "struct surfaceshader { closure color bsdf; closure color edf; float opacity; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VOLUMESHADER,
         std::make_shared<ScalarTypeSyntax>(
             "volumeshader",
             "null_closure",
             "0",
             "closure color",
-            "#define volumeshader closure color")
-    );
+            "#define volumeshader closure color"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::DISPLACEMENTSHADER,
         std::make_shared<ScalarTypeSyntax>(
             "displacementshader",
             "vector(0.0)",
             "vector(0.0)",
             "vector",
-            "#define displacementshader vector")
-    );
+            "#define displacementshader vector"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::LIGHTSHADER,
         std::make_shared<ScalarTypeSyntax>(
             "lightshader",
             "null_closure",
             "0",
             "closure color",
-            "#define lightshader closure color")
-    );
+            "#define lightshader closure color"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATERIAL,
         std::make_shared<ScalarTypeSyntax>(
             "MATERIAL",
             "null_closure",
             "0",
             "closure color",
-            "#define MATERIAL closure color")
-    );
+            "#define MATERIAL closure color"));
 }
 
 const string& OslSyntax::getOutputQualifier() const

--- a/source/MaterialXGenOsl/OslSyntax.h
+++ b/source/MaterialXGenOsl/OslSyntax.h
@@ -19,7 +19,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Syntax class for OSL (Open Shading Language)
 class MX_GENOSL_API OslSyntax : public Syntax
 {
-public:
+  public:
     OslSyntax();
 
     static SyntaxPtr create() { return std::make_shared<OslSyntax>(); }


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXGenOsl, providing improvements in coding style consistency.