### PR TITLE
Apply Clang formatting to MaterialXGenMdl

### DIFF
--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -30,37 +30,40 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    std::unordered_map<string, string> GEOMPROP_DEFINITIONS =
-    {
-        {"Pobject", "base::transform_point(base::coordinate_internal, base::coordinate_object, state::position())"},
-        {"Pworld", "base::transform_point(base::coordinate_internal, base::coordinate_world, state::position())"},
-        {"Nobject", "base::transform_normal(base::coordinate_internal, base::coordinate_object, state::normal())"},
-        {"Nworld", "base::transform_normal(base::coordinate_internal, base::coordinate_world, state::normal())"},
-        {"Tobject", "base::transform_vector(base::coordinate_internal, base::coordinate_object, state::texture_tangent_u(0))"},
-        {"Tworld", "base::transform_vector(base::coordinate_internal, base::coordinate_world, state::texture_tangent_u(0))"},
-        {"Bobject", "base::transform_vector(base::coordinate_internal, base::coordinate_object, state::texture_tangent_v(0))"},
-        {"Bworld", "base::transform_vector(base::coordinate_internal, base::coordinate_world, state::texture_tangent_v(0))"},
-        {"UV0", "float2(state::texture_coordinate(0).x, state::texture_coordinate(0).y)"},
-        {"Vworld", "state::direction()"}
-    };
 
-    const string MDL_VERSION = "1.6";
+std::unordered_map<string, string> GEOMPROP_DEFINITIONS =
+{
+    { "Pobject", "base::transform_point(base::coordinate_internal, base::coordinate_object, state::position())" },
+    { "Pworld", "base::transform_point(base::coordinate_internal, base::coordinate_world, state::position())" },
+    { "Nobject", "base::transform_normal(base::coordinate_internal, base::coordinate_object, state::normal())" },
+    { "Nworld", "base::transform_normal(base::coordinate_internal, base::coordinate_world, state::normal())" },
+    { "Tobject", "base::transform_vector(base::coordinate_internal, base::coordinate_object, state::texture_tangent_u(0))" },
+    { "Tworld", "base::transform_vector(base::coordinate_internal, base::coordinate_world, state::texture_tangent_u(0))" },
+    { "Bobject", "base::transform_vector(base::coordinate_internal, base::coordinate_object, state::texture_tangent_v(0))" },
+    { "Bworld", "base::transform_vector(base::coordinate_internal, base::coordinate_world, state::texture_tangent_v(0))" },
+    { "UV0", "float2(state::texture_coordinate(0).x, state::texture_coordinate(0).y)" },
+    { "Vworld", "state::direction()" }
+};
 
-    const vector<string> DEFAULT_IMPORTS = {
-        "import ::df::*",
-        "import ::base::*",
-        "import ::math::*",
-        "import ::state::*",
-        "import ::anno::*",
-        "import ::tex::*",
-        "import ::mx::swizzle::*",
-        "import ::mx::cm::*",
-        "using ::mx::core import *",
-        "using ::mx::stdlib import *",
-        "using ::mx::pbrlib import *",
-        "using ::mx::sampling import *",
-    };
-}
+const string MDL_VERSION = "1.6";
+
+const vector<string> DEFAULT_IMPORTS =
+{
+    "import ::df::*",
+    "import ::base::*",
+    "import ::math::*",
+    "import ::state::*",
+    "import ::anno::*",
+    "import ::tex::*",
+    "import ::mx::swizzle::*",
+    "import ::mx::cm::*",
+    "using ::mx::core import *",
+    "using ::mx::stdlib import *",
+    "using ::mx::pbrlib import *",
+    "using ::mx::sampling import *",
+};
+
+} // anonymous namespace
 
 const string MdlShaderGenerator::TARGET = "genmdl";
 
@@ -251,8 +254,8 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
         {
             const ShaderNode* upstream = socket->getConnection()->getNode();
             if (upstream->getParent() == &graph &&
-                (upstream->hasClassification(ShaderNode::Classification::CLOSURE) || 
-                    upstream->hasClassification(ShaderNode::Classification::SHADER)))
+                (upstream->hasClassification(ShaderNode::Classification::CLOSURE) ||
+                 upstream->hasClassification(ShaderNode::Classification::SHADER)))
             {
                 emitFunctionCall(*upstream, context, stage);
             }
@@ -284,7 +287,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
     }
     else
     {
-        emitLine(_syntax->getTypeSyntax(outputSocket->getType()).getName() +  " finalOutput__ = " + result, stage);
+        emitLine(_syntax->getTypeSyntax(outputSocket->getType()).getName() + " finalOutput__ = " + result, stage);
 
         // End shader body
         emitScopeEnd(stage);
@@ -298,7 +301,6 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
 
     return shader;
 }
-
 
 ShaderNodeImplPtr MdlShaderGenerator::getImplementation(const NodeDef& nodedef, GenContext& context) const
 {
@@ -403,136 +405,137 @@ string MdlShaderGenerator::getUpstreamResult(const ShaderInput* input, GenContex
     return variable;
 }
 
-
 namespace
 {
-    // [TODO]
-    // Here we assume this bit of the port flags is unused.
-    // Change this to a more general and safe solution.
-    class ShaderPortFlagMdl
-    {
-      public:
-        static const uint32_t TRANSMISSION_IOR_DEPENDENCY = 1u << 31;
-    };
 
-    // Check if a graph has inputs with dependencies on transmission IOR on the inside.
-    // Track all subgraphs found that has such a dependency, as well as subgraphs that are 
-    // found to have a varying connection to transmission IOR.
-    // Returns true if uniform ior dependencies are found.
-    bool checkTransmissionIorDependencies(ShaderGraph* g, std::set<ShaderGraph*>& graphsWithIorDependency, std::set<ShaderGraph*>& graphsWithIorVarying)
+// [TODO]
+// Here we assume this bit of the port flags is unused.
+// Change this to a more general and safe solution.
+class ShaderPortFlagMdl
+{
+  public:
+    static const uint32_t TRANSMISSION_IOR_DEPENDENCY = 1u << 31;
+};
+
+// Check if a graph has inputs with dependencies on transmission IOR on the inside.
+// Track all subgraphs found that has such a dependency, as well as subgraphs that are
+// found to have a varying connection to transmission IOR.
+// Returns true if uniform ior dependencies are found.
+bool checkTransmissionIorDependencies(ShaderGraph* g, std::set<ShaderGraph*>& graphsWithIorDependency, std::set<ShaderGraph*>& graphsWithIorVarying)
+{
+    bool result = false;
+    for (ShaderNode* node : g->getNodes())
     {
-        bool result = false;
-        for (ShaderNode* node : g->getNodes())
+        ShaderGraph* subgraph = node->getImplementation().getGraph();
+        if (subgraph)
         {
-            ShaderGraph* subgraph = node->getImplementation().getGraph();
-            if (subgraph)
+            // Check recursively if this subgraph has IOR dependencies.
+            if (checkTransmissionIorDependencies(subgraph, graphsWithIorDependency, graphsWithIorVarying))
             {
-                // Check recursively if this subgraph has IOR dependencies.
-                if (checkTransmissionIorDependencies(subgraph, graphsWithIorDependency, graphsWithIorVarying))
+                for (ShaderOutput* socket : subgraph->getInputSockets())
                 {
-                    for (ShaderOutput* socket : subgraph->getInputSockets())
+                    if (socket->getFlag(ShaderPortFlagMdl::TRANSMISSION_IOR_DEPENDENCY))
                     {
-                        if (socket->getFlag(ShaderPortFlagMdl::TRANSMISSION_IOR_DEPENDENCY))
+                        ShaderInput* input = node->getInput(socket->getName());
+                        ShaderOutput* source = input ? input->getConnection() : nullptr;
+                        if (source)
                         {
-                            ShaderInput* input = node->getInput(socket->getName());
-                            ShaderOutput* source = input ? input->getConnection() : nullptr;
-                            if (source)
+                            // Check if this is a graph interface connection.
+                            if (source->getNode() == g)
                             {
-                                // Check if this is a graph interface connection.
-                                if (source->getNode() == g)
-                                {
-                                    graphsWithIorDependency.insert(g);
-                                    source->setFlag(ShaderPortFlagMdl::TRANSMISSION_IOR_DEPENDENCY, true);
-                                    result = true;
-                                }
-                                else if (source->getNode()->hasClassification(ShaderNode::Classification::CONSTANT))
-                                {
-                                    // If the connection is to a constant node we can
-                                    // handled that here since it's just a uniform value.
-                                    ShaderInput* value = source->getNode()->getInput(ValueElement::VALUE_ATTRIBUTE);
-                                    if (value && value->getValue())
-                                    {
-                                        input->setValue(value->getValue());
-                                    }
-                                    input->breakConnection();
-                                }
-                                else
-                                {
-                                    // If we get here we have to assume this is a varying connection.
-                                    // Save the graph as a varying graph so we later can break its 
-                                    // internal connections to transmission IOR.
-                                    graphsWithIorVarying.insert(subgraph);
-                                    return false; // no need to continue with this subgraph
-                                }
+                                graphsWithIorDependency.insert(g);
+                                source->setFlag(ShaderPortFlagMdl::TRANSMISSION_IOR_DEPENDENCY, true);
+                                result = true;
                             }
-                        }
-                    }
-                }
-            }
-            else
-            {
-                // Check for transmission BSDF node.
-                if (node->hasClassification(ShaderNode::Classification::BSDF_T))
-                {
-                    // Check if IOR is connected.
-                    ShaderInput* ior = node->getInput("ior");
-                    ShaderOutput* source = ior ? ior->getConnection() : nullptr;
-                    if (source)
-                    {
-                        // Check if this is a graph interface connection.
-                        if (source->getNode() == g)
-                        {
-                            graphsWithIorDependency.insert(g);
-                            source->setFlag(ShaderPortFlagMdl::TRANSMISSION_IOR_DEPENDENCY, true);
-                            result = true;
-                        }
-                        else if (source->getNode()->hasClassification(ShaderNode::Classification::CONSTANT))
-                        {
-                            // If the connection is to a constant node we can
-                            // handled that here since it's just a uniform value.
-                            ShaderInput* value = source->getNode()->getInput(ValueElement::VALUE_ATTRIBUTE);
-                            if (value && value->getValue())
+                            else if (source->getNode()->hasClassification(ShaderNode::Classification::CONSTANT))
                             {
-                                ior->setValue(value->getValue());
+                                // If the connection is to a constant node we can
+                                // handled that here since it's just a uniform value.
+                                ShaderInput* value = source->getNode()->getInput(ValueElement::VALUE_ATTRIBUTE);
+                                if (value && value->getValue())
+                                {
+                                    input->setValue(value->getValue());
+                                }
+                                input->breakConnection();
                             }
-                            ior->breakConnection();
-                        }
-                        else
-                        {
-                            // If we get here we have to assume this is a varying connection
-                            // and we can break it immediately here.
-                            ior->breakConnection();
+                            else
+                            {
+                                // If we get here we have to assume this is a varying connection.
+                                // Save the graph as a varying graph so we later can break its
+                                // internal connections to transmission IOR.
+                                graphsWithIorVarying.insert(subgraph);
+                                return false; // no need to continue with this subgraph
+                            }
                         }
                     }
                 }
             }
         }
-        return result;
-    }
-
-    // Disconnect any incomming connections to transmission IOR
-    // inside a graph.
-    void disconnectTransmissionIor(ShaderGraph* g)
-    {
-        for (ShaderNode* node : g->getNodes())
+        else
         {
-            ShaderGraph* subgraph = node->getImplementation().getGraph();
-            if (subgraph && (subgraph->hasClassification(ShaderNode::Classification::SHADER) ||
-                             subgraph->hasClassification(ShaderNode::Classification::CLOSURE)))
+            // Check for transmission BSDF node.
+            if (node->hasClassification(ShaderNode::Classification::BSDF_T))
             {
-                disconnectTransmissionIor(subgraph);
-            }
-            else if (node->hasClassification(ShaderNode::Classification::BSDF_T))
-            {
+                // Check if IOR is connected.
                 ShaderInput* ior = node->getInput("ior");
-                if (ior)
+                ShaderOutput* source = ior ? ior->getConnection() : nullptr;
+                if (source)
                 {
-                    ior->breakConnection();
+                    // Check if this is a graph interface connection.
+                    if (source->getNode() == g)
+                    {
+                        graphsWithIorDependency.insert(g);
+                        source->setFlag(ShaderPortFlagMdl::TRANSMISSION_IOR_DEPENDENCY, true);
+                        result = true;
+                    }
+                    else if (source->getNode()->hasClassification(ShaderNode::Classification::CONSTANT))
+                    {
+                        // If the connection is to a constant node we can
+                        // handled that here since it's just a uniform value.
+                        ShaderInput* value = source->getNode()->getInput(ValueElement::VALUE_ATTRIBUTE);
+                        if (value && value->getValue())
+                        {
+                            ior->setValue(value->getValue());
+                        }
+                        ior->breakConnection();
+                    }
+                    else
+                    {
+                        // If we get here we have to assume this is a varying connection
+                        // and we can break it immediately here.
+                        ior->breakConnection();
+                    }
                 }
+            }
+        }
+    }
+    return result;
+}
+
+// Disconnect any incomming connections to transmission IOR
+// inside a graph.
+void disconnectTransmissionIor(ShaderGraph* g)
+{
+    for (ShaderNode* node : g->getNodes())
+    {
+        ShaderGraph* subgraph = node->getImplementation().getGraph();
+        if (subgraph && (subgraph->hasClassification(ShaderNode::Classification::SHADER) ||
+                         subgraph->hasClassification(ShaderNode::Classification::CLOSURE)))
+        {
+            disconnectTransmissionIor(subgraph);
+        }
+        else if (node->hasClassification(ShaderNode::Classification::BSDF_T))
+        {
+            ShaderInput* ior = node->getInput("ior");
+            if (ior)
+            {
+                ior->breakConnection();
             }
         }
     }
 }
+
+} // anonymous namespace
 
 ShaderPtr MdlShaderGenerator::createShader(const string& name, ElementPtr element, GenContext& context) const
 {
@@ -571,11 +574,11 @@ ShaderPtr MdlShaderGenerator::createShader(const string& name, ElementPtr elemen
     // we break that connection and revert to using default value on that
     // instance of IOR, so that other uses of the same varying input still
     // works in other places.
-    // As a result if a varying connections is set on transmission IOR 
+    // As a result if a varying connections is set on transmission IOR
     // it just reverts to default value. Varying data on transmission IOR
     // is very rare so this is normally not a problem in practice.
     // One use-case where this fix is important is for shading models with
-    // a single IOR input, that gets connected to both reflection and 
+    // a single IOR input, that gets connected to both reflection and
     // transmission IOR inside the shading model graph. For such cases
     // this fix will disconnect the transmission IOR on the inside, but
     // still support the connection to reflection IOR.
@@ -621,7 +624,7 @@ void MdlShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
     {
         const ShaderPort* input = inputs[i];
 
-        const string& qualifier = input->isUniform() || input->getType()==Type::FILENAME ? uniformPrefix : EMPTY_STRING;
+        const string& qualifier = input->isUniform() || input->getType() == Type::FILENAME ? uniformPrefix : EMPTY_STRING;
         const string& type = _syntax->getTypeName(input->getType());
 
         string value = input->getValue() ? _syntax->getValue(input->getType(), *input->getValue(), true) : EMPTY_STRING;
@@ -653,9 +656,9 @@ void MdlShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
 
 namespace MDL
 {
-    // Identifiers for MDL variable blocks
-    const string INPUTS   = "i";
-    const string OUTPUTS  = "o";
-}
+// Identifiers for MDL variable blocks
+const string INPUTS = "i";
+const string OUTPUTS = "o";
+} // namespace MDL
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/MdlShaderGenerator.h
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.h
@@ -54,10 +54,12 @@ class MX_GENMDL_API MdlShaderGenerator : public ShaderGenerator
 
 namespace MDL
 {
-    // Identifiers for MDL variable blocks
-    extern MX_GENMDL_API const string INPUTS;
-    extern MX_GENMDL_API const string OUTPUTS;
-}
+
+// Identifiers for MDL variable blocks
+extern MX_GENMDL_API const string INPUTS;
+extern MX_GENMDL_API const string OUTPUTS;
+
+} // namespace MDL
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -16,13 +16,15 @@ MATERIALX_NAMESPACE_BEGIN
 // Custom types to handle enumeration output
 namespace Type
 {
-    const TypeDesc* MDL_COORDINATESPACE = TypeDesc::registerType("coordinatespace", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0 );
-    const TypeDesc* MDL_ADDRESSMODE = TypeDesc::registerType("addressmode", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
-    const TypeDesc* MDL_FILTERLOOKUPMODE = TypeDesc::registerType("filterlookup", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
-    const TypeDesc* MDL_FILTERTYPE = TypeDesc::registerType("filtertype", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
-    const TypeDesc* MDL_DISTRIBUTION = TypeDesc::registerType("distributiontype", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
-    const TypeDesc* MDL_SCATTER_MODE = TypeDesc::registerType("scatter_mode", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
-}
+
+const TypeDesc* MDL_COORDINATESPACE = TypeDesc::registerType("coordinatespace", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
+const TypeDesc* MDL_ADDRESSMODE = TypeDesc::registerType("addressmode", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
+const TypeDesc* MDL_FILTERLOOKUPMODE = TypeDesc::registerType("filterlookup", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
+const TypeDesc* MDL_FILTERTYPE = TypeDesc::registerType("filtertype", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
+const TypeDesc* MDL_DISTRIBUTION = TypeDesc::registerType("distributiontype", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
+const TypeDesc* MDL_SCATTER_MODE = TypeDesc::registerType("scatter_mode", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_ENUM, 0);
+
+} // namespace Type
 
 namespace
 {
@@ -32,7 +34,8 @@ class MdlFilenameTypeSyntax : public ScalarTypeSyntax
   public:
     MdlFilenameTypeSyntax() :
         ScalarTypeSyntax("texture_2d", "texture_2d()", "texture_2d()")
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -57,7 +60,8 @@ class MdlArrayTypeSyntax : public ScalarTypeSyntax
   public:
     MdlArrayTypeSyntax(const string& name) :
         ScalarTypeSyntax(name, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -76,7 +80,7 @@ class MdlArrayTypeSyntax : public ScalarTypeSyntax
         }
 
         string result = getName() + "[](" + values[0];
-        for (size_t i = 1; i<values.size(); ++i)
+        for (size_t i = 1; i < values.size(); ++i)
         {
             result += ", " + values[i];
         }
@@ -94,7 +98,8 @@ class MdlFloatArrayTypeSyntax : public MdlArrayTypeSyntax
   public:
     explicit MdlFloatArrayTypeSyntax(const string& name) :
         MdlArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     bool isEmpty(const Value& value) const override
@@ -109,7 +114,8 @@ class MdlIntegerArrayTypeSyntax : public MdlArrayTypeSyntax
   public:
     explicit MdlIntegerArrayTypeSyntax(const string& name) :
         MdlArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     bool isEmpty(const Value& value) const override
@@ -130,9 +136,10 @@ class MdlColor4TypeSyntax : public AggregateTypeSyntax
 {
   public:
     MdlColor4TypeSyntax() :
-        AggregateTypeSyntax("color4", "mk_color4(0.0)", "mk_color4(0.0)", 
-            EMPTY_STRING, EMPTY_STRING, MdlSyntax::COLOR4_MEMBERS)
-    {}
+        AggregateTypeSyntax("color4", "mk_color4(0.0)", "mk_color4(0.0)",
+                            EMPTY_STRING, EMPTY_STRING, MdlSyntax::COLOR4_MEMBERS)
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -141,9 +148,8 @@ class MdlColor4TypeSyntax : public AggregateTypeSyntax
         // Set float format and precision for the stream
         const Value::FloatFormat fmt = Value::getFloatFormat();
         ss.setf(std::ios_base::fmtflags(
-            (fmt == Value::FloatFormatFixed ? std::ios_base::fixed :
-            (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0))),
-            std::ios_base::floatfield);
+                    (fmt == Value::FloatFormatFixed ? std::ios_base::fixed : (fmt == Value::FloatFormatScientific ? std::ios_base::scientific : 0))),
+                std::ios_base::floatfield);
         ss.precision(Value::getFloatPrecision());
 
         const Color4 c = value.asA<Color4>();
@@ -157,11 +163,11 @@ class MdlColor4TypeSyntax : public AggregateTypeSyntax
         size_t valueCount = values.size();
         if (valueCount == 4)
         {
-            return "mk_color4(" + values[0] + ", " + values[1] + ", " + values[2] + ", " + values[3] + ")";        
+            return "mk_color4(" + values[0] + ", " + values[1] + ", " + values[2] + ", " + values[3] + ")";
         }
         else if (valueCount == 2)
         {
-            return "mk_color4(" + values[0]  + ", " + values[1] + ")";
+            return "mk_color4(" + values[0] + ", " + values[1] + ")";
         }
         throw ExceptionShaderGenError("Incorrect number of values to construct a color4 value:" + std::to_string(valueCount));
     }
@@ -172,7 +178,8 @@ class MdlEnumSyntax : public AggregateTypeSyntax
   public:
     MdlEnumSyntax(const string& name, const string& defaultValue, const string& defaultUniformValue, const StringVec& members) :
         AggregateTypeSyntax(name, defaultValue, defaultUniformValue, EMPTY_STRING, EMPTY_STRING, members)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -206,23 +213,21 @@ MdlSyntax::MdlSyntax()
 {
     // Add in all reserved words and keywords in MDL
     registerReservedWords(
-    {
-        // Reserved words
-        "annotation", "bool", "bool2", "bool3", "bool4", "break", "bsdf", "bsdf_measurement", "case", "cast", "color", "const",
-        "continue", "default", "do", "double", "double2", "double2x2", "double2x3", "double3", "double3x2", "double3x3", "double3x4",
-        "double4", "double4x3", "double4x4", "double4x2", "double2x4", "edf", "else", "enum", "export", "false", "float", "float2",
-        "float2x2", "float2x3", "float3", "float3x2", "float3x3", "float3x4", "float4", "float4x3", "float4x4", "float4x2", "float2x4",
-        "for", "hair_bsdf", "if", "import", "in", "int", "int2", "int3", "int4", "intensity_mode", "intensity_power", "intensity_radiant_exitance",
-        "let", "light_profile", "material", "material_emission", "material_geometry", "material_surface", "material_volume", "mdl", "module",
-        "package", "return", "string", "struct", "switch", "texture_2d", "texture_3d", "texture_cube", "texture_ptex", "true", "typedef", "uniform",
-        "using", "varying", "vdf", "while", 
-        // Reserved for future use
-        "auto", "catch", "char", "class", "const_cast", "delete", "dynamic_cast", "explicit", "extern", "external", "foreach", "friend", "goto",
-        "graph", "half", "half2", "half2x2", "half2x3", "half3", "half3x2", "half3x3", "half3x4", "half4", "half4x3", "half4x4", "half4x2", "half2x4",
-        "inline", "inout", "lambda", "long", "mutable", "namespace", "native", "new", "operator", "out", "phenomenon", "private", "protected", "public",
-        "reinterpret_cast", "sampler", "shader", "short", "signed", "sizeof", "static", "static_cast", "technique", "template", "this", "throw", "try",
-        "typeid", "typename", "union", "unsigned", "virtual", "void", "volatile", "wchar_t"
-    });
+        { // Reserved words
+          "annotation", "bool", "bool2", "bool3", "bool4", "break", "bsdf", "bsdf_measurement", "case", "cast", "color", "const",
+          "continue", "default", "do", "double", "double2", "double2x2", "double2x3", "double3", "double3x2", "double3x3", "double3x4",
+          "double4", "double4x3", "double4x4", "double4x2", "double2x4", "edf", "else", "enum", "export", "false", "float", "float2",
+          "float2x2", "float2x3", "float3", "float3x2", "float3x3", "float3x4", "float4", "float4x3", "float4x4", "float4x2", "float2x4",
+          "for", "hair_bsdf", "if", "import", "in", "int", "int2", "int3", "int4", "intensity_mode", "intensity_power", "intensity_radiant_exitance",
+          "let", "light_profile", "material", "material_emission", "material_geometry", "material_surface", "material_volume", "mdl", "module",
+          "package", "return", "string", "struct", "switch", "texture_2d", "texture_3d", "texture_cube", "texture_ptex", "true", "typedef", "uniform",
+          "using", "varying", "vdf", "while",
+          // Reserved for future use
+          "auto", "catch", "char", "class", "const_cast", "delete", "dynamic_cast", "explicit", "extern", "external", "foreach", "friend", "goto",
+          "graph", "half", "half2", "half2x2", "half2x3", "half3", "half3x2", "half3x3", "half3x4", "half4", "half4x3", "half4x4", "half4x2", "half2x4",
+          "inline", "inout", "lambda", "long", "mutable", "namespace", "native", "new", "operator", "out", "phenomenon", "private", "protected", "public",
+          "reinterpret_cast", "sampler", "shader", "short", "signed", "sizeof", "static", "static_cast", "technique", "template", "this", "throw", "try",
+          "typeid", "typename", "union", "unsigned", "virtual", "void", "volatile", "wchar_t" });
 
     // Register restricted tokens in MDL
     StringMap tokens;
@@ -233,49 +238,38 @@ MdlSyntax::MdlSyntax()
     // Register type syntax handlers for each data type.
     //
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOAT,
         std::make_shared<ScalarTypeSyntax>(
             "float",
             "0.0",
-            "0.0")
-    );
+            "0.0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOATARRAY,
         std::make_shared<MdlFloatArrayTypeSyntax>(
-            "float")
-    );
+            "float"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGER,
         std::make_shared<ScalarTypeSyntax>(
             "int",
             "0",
-            "0")
-    );
+            "0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGERARRAY,
         std::make_shared<MdlIntegerArrayTypeSyntax>(
-            "int")
-    );
+            "int"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BOOLEAN,
         std::make_shared<ScalarTypeSyntax>(
             "bool",
             "false",
-            "false")
-    );
+            "false"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR3,
         std::make_shared<AggregateTypeSyntax>(
             "color",
@@ -283,17 +277,13 @@ MdlSyntax::MdlSyntax()
             "color(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            COLOR3_MEMBERS)
-    );
+            COLOR3_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR4,
-        std::make_shared<MdlColor4TypeSyntax>()
-    );
+        std::make_shared<MdlColor4TypeSyntax>());
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR2,
         std::make_shared<AggregateTypeSyntax>(
             "float2",
@@ -301,11 +291,9 @@ MdlSyntax::MdlSyntax()
             "float2(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR2_MEMBERS)
-    );
+            VECTOR2_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR3,
         std::make_shared<AggregateTypeSyntax>(
             "float3",
@@ -313,11 +301,9 @@ MdlSyntax::MdlSyntax()
             "float3(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR3_MEMBERS)
-    );
+            VECTOR3_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR4,
         std::make_shared<AggregateTypeSyntax>(
             "float4",
@@ -325,173 +311,136 @@ MdlSyntax::MdlSyntax()
             "float4(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VECTOR4_MEMBERS)
-    );
+            VECTOR4_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX33,
         std::make_shared<AggregateTypeSyntax>(
             "float3x3",
             "float3x3(1.0)",
-            "float3x3(1.0)")
-    );
+            "float3x3(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX44,
         std::make_shared<AggregateTypeSyntax>(
             "float4x4",
             "float4x4(1.0)",
-            "float4x4(1.0)")
-    );
+            "float4x4(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::STRING,
         std::make_shared<StringTypeSyntax>(
             "string",
             "\"\"",
-            "\"\"")
-    );
+            "\"\""));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FILENAME,
-        std::make_shared<MdlFilenameTypeSyntax>()
-    );
+        std::make_shared<MdlFilenameTypeSyntax>());
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BSDF,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::EDF,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VDF,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::SURFACESHADER,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VOLUMESHADER,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::DISPLACEMENTSHADER,
         std::make_shared<ScalarTypeSyntax>(
             "float3",
             "float3(0.0)",
-            "float3(0.0)")
-    );
+            "float3(0.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::LIGHTSHADER,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATERIAL,
         std::make_shared<ScalarTypeSyntax>(
             "material",
             "material()",
-            "material()")
-    );
+            "material()"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MDL_ADDRESSMODE,
         std::make_shared<MdlEnumSyntax>(
             "mx_addressmode_type",
             "mx_addressmode_type_periodic",
             "mx_addressmode_type_periodic",
-            ADDRESSMODE_MEMBERS)
-    );
+            ADDRESSMODE_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MDL_COORDINATESPACE,
         std::make_shared<MdlEnumSyntax>(
             "mx_coordinatespace_type",
             "mx_coordinatespace_type_model",
             "mx_coordinatespace_type_model",
-            COORDINATESPACE_MEMBERS)
-    );
+            COORDINATESPACE_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MDL_FILTERLOOKUPMODE,
         std::make_shared<MdlEnumSyntax>(
             "mx_filterlookup_type",
             "mx_filterlookup_type_linear",
             "mx_filterlookup_type_linear",
-            FILTERLOOKUPMODE_MEMBERS)
-    );
+            FILTERLOOKUPMODE_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MDL_FILTERTYPE,
         std::make_shared<MdlEnumSyntax>(
             "mx_filter_type",
             "mx_filter_type_gaussian",
             "mx_filter_type_gaussian",
-            FILTERTYPE_MEMBERS)
-    );
+            FILTERTYPE_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MDL_DISTRIBUTION,
         std::make_shared<MdlEnumSyntax>(
             "mx_distribution_type",
             "mx_distribution_type_ggx",
             "mx_distribution_type_ggx",
-            DISTRIBUTIONTYPE_MEMBERS)
-    );
+            DISTRIBUTIONTYPE_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MDL_SCATTER_MODE,
         std::make_shared<MdlEnumSyntax>(
             "mx_scatter_mode",
             "mx_scatter_mode_R",
             "mx_scatter_mode_R",
-            SCATTER_MODE_MEMBERS)
-    );
+            SCATTER_MODE_MEMBERS));
 }
 
 const TypeDesc* MdlSyntax::getEnumeratedType(const string& value) const

--- a/source/MaterialXGenMdl/MdlSyntax.h
+++ b/source/MaterialXGenMdl/MdlSyntax.h
@@ -69,12 +69,14 @@ class MX_GENMDL_API MdlSyntax : public Syntax
 
 namespace Type
 {
-    extern MX_GENMDL_API const TypeDesc* MDL_ADDRESSMODE;
-    extern MX_GENMDL_API const TypeDesc* MDL_COORDINATESPACE;
-    extern MX_GENMDL_API const TypeDesc* MDL_FILTERLOOKUPMODE;
-    extern MX_GENMDL_API const TypeDesc* MDL_FILTERTYPE;
-    extern MX_GENMDL_API const TypeDesc* MDL_DISTRIBUTIONTYPE;
-}
+
+extern MX_GENMDL_API const TypeDesc* MDL_ADDRESSMODE;
+extern MX_GENMDL_API const TypeDesc* MDL_COORDINATESPACE;
+extern MX_GENMDL_API const TypeDesc* MDL_FILTERLOOKUPMODE;
+extern MX_GENMDL_API const TypeDesc* MDL_FILTERTYPE;
+extern MX_GENMDL_API const TypeDesc* MDL_DISTRIBUTIONTYPE;
+
+} // namespace Type
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
@@ -17,8 +17,8 @@ ShaderNodeImplPtr BlurNodeMdl::create()
     return std::make_shared<BlurNodeMdl>();
 }
 
-void BlurNodeMdl::outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& stage, const TypeDesc* inputType, 
-                                 const string& sampleName, const StringVec& sampleStrings) const
+void BlurNodeMdl::outputSampleArray(const ShaderGenerator& shadergen, ShaderStage& stage, const TypeDesc* inputType,
+                                    const string& sampleName, const StringVec& sampleStrings) const
 {
     const Syntax& syntax = shadergen.getSyntax();
     const string& inputTypeString = syntax.getTypeName(inputType);
@@ -72,7 +72,8 @@ void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, 
 
         // Get input type name string
         const string& inputTypeString = inInput && acceptsInputType(inInput->getType()) ?
-            syntax.getTypeName(inInput->getType()) : EMPTY_STRING;
+                                                   syntax.getTypeName(inInput->getType()) :
+                                                   EMPTY_STRING;
 
         const ShaderInput* filterTypeInput = node.getInput(FILTER_TYPE_STRING);
         if (!filterTypeInput || inputTypeString.empty())
@@ -111,14 +112,14 @@ void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, 
         const unsigned int sampleCount = filterWidth * filterWidth;
 
         // Emit samples
-        // Note: The maximum sample count MX_MAX_SAMPLE_COUNT is defined in the shader code and 
-        // is assumed to be 49 (7x7 kernel). If this changes the filter size logic here 
+        // Note: The maximum sample count MX_MAX_SAMPLE_COUNT is defined in the shader code and
+        // is assumed to be 49 (7x7 kernel). If this changes the filter size logic here
         // needs to be adjusted.
         //
         StringVec sampleStrings;
         emitInputSamplesUV(node, sampleCount, filterWidth,
-            _filterSize, _filterOffset, _sampleSizeFunctionUV,
-            context, stage, sampleStrings);
+                           _filterSize, _filterOffset, _sampleSizeFunctionUV,
+                           context, stage, sampleStrings);
 
         // There should always be at least 1 sample
         if (sampleStrings.empty())
@@ -137,7 +138,7 @@ void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, 
             string sampleName(output->getVariable() + SAMPLES_POSTFIX_STRING);
             outputSampleArray(shadergen, stage, inInput->getType(), sampleName, sampleStrings);
 
-            // Emit code to evaluate using input sample and weight arrays. 
+            // Emit code to evaluate using input sample and weight arrays.
             // The function to call depends on input type.
             //
             shadergen.emitLineBegin(stage);
@@ -158,19 +159,21 @@ void BlurNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, 
             {
                 string filterFunctionName = MX_CONVOLUTION_PREFIX_STRING + inputTypeString;
                 shadergen.emitString(filterFunctionName + "(" + sampleName + ", " +
-                    GAUSSIAN_WEIGHTS_VARIABLE + ", " +
-                    std::to_string(arrayOffset) + ", " +
-                    std::to_string(sampleCount) +
-                    ")", stage);
+                                         GAUSSIAN_WEIGHTS_VARIABLE + ", " +
+                                         std::to_string(arrayOffset) + ", " +
+                                         std::to_string(sampleCount) +
+                                         ")",
+                                     stage);
             }
             shadergen.emitString(" : ", stage);
             {
                 string filterFunctionName = MX_CONVOLUTION_PREFIX_STRING + inputTypeString;
                 shadergen.emitString(filterFunctionName + "(" + sampleName + ", " +
-                    BOX_WEIGHTS_VARIABLE + ", " +
-                    std::to_string(arrayOffset) + ", " +
-                    std::to_string(sampleCount) +
-                    ")", stage);
+                                         BOX_WEIGHTS_VARIABLE + ", " +
+                                         std::to_string(arrayOffset) + ", " +
+                                         std::to_string(sampleCount) +
+                                         ")",
+                                     stage);
             }
             shadergen.emitLineEnd(stage);
         }

--- a/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
@@ -31,10 +31,8 @@ void ClosureCompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContex
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const Syntax& syntax = shadergen.getSyntax();
 
-        const bool isMaterialExpr = (
-            _rootGraph->hasClassification(ShaderNode::Classification::CLOSURE) ||
-            _rootGraph->hasClassification(ShaderNode::Classification::SHADER)
-        );
+        const bool isMaterialExpr = (_rootGraph->hasClassification(ShaderNode::Classification::CLOSURE) ||
+                                     _rootGraph->hasClassification(ShaderNode::Classification::SHADER));
 
         // Emit functions for all child nodes
         shadergen.emitFunctionDefinitions(*_rootGraph, context, stage);
@@ -73,8 +71,8 @@ void ClosureCompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContex
             const string& qualifier = input->isUniform() || input->getType() == Type::FILENAME ? uniformPrefix : EMPTY_STRING;
             const string& type = syntax.getTypeName(input->getType());
             const string value = (input->getValue() ?
-                syntax.getValue(input->getType(), *input->getValue()) :
-                syntax.getDefaultValue(input->getType()));
+                                  syntax.getValue(input->getType(), *input->getValue()) :
+                                  syntax.getDefaultValue(input->getType()));
 
             const string& delim = --count > 0 ? Syntax::COMMA : EMPTY_STRING;
             shadergen.emitLine(qualifier + type + " " + input->getVariable() + " = " + value + delim, stage, false);

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
@@ -68,8 +68,9 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
         const string b = shadergen.getUpstreamResult(baseInput, context);
 
         // Join the BSDF and VDF into a single material.
-        shadergen.emitLine("material " + output->getVariable() 
-            + " = material(surface: " + t + ".surface, backface: " + t + ".backface, ior: " + t + ".ior, volume: " + b + ".volume)", stage);
+        shadergen.emitLine("material " + output->getVariable() +
+                           " = material(surface: " + t + ".surface, backface: " + t +
+                           ".backface, ior: " + t + ".ior, volume: " + b + ".volume)", stage);
 
         return;
     }
@@ -100,7 +101,7 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
     // Only a subset of the MaterialX BSDF nodes can be layered vertically in MDL.
     // This is because MDL only supports layering through BSDF nesting with a base
     // input, and it's only possible to do this workaround on a subset of the BSDFs.
-    // So if the top BSDF doesn't have a base input, we can only emit the top BSDF 
+    // So if the top BSDF doesn't have a base input, we can only emit the top BSDF
     // without any base layering.
     //
     ShaderInput* topNodeBaseInput = top->getInput(BASE);
@@ -108,7 +109,7 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
     {
         shadergen.emitComment("Warning: MDL has no support for layering BSDF nodes without a base input. Only the top BSDF will used.", stage);
 
-        // Change the state so we emit the top BSDF function 
+        // Change the state so we emit the top BSDF function
         // with output variable name from the layer node itself.
         ScopedSetVariableName setVariable(output->getVariable(), top->getOutput());
 
@@ -137,7 +138,6 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
     // Restore state.
     topNodeBaseInput->breakConnection();
 }
-
 
 ShaderNodeImplPtr LayerableNodeMdl::create()
 {

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h
@@ -27,11 +27,10 @@ class MX_GENMDL_API ClosureLayerNodeMdl : public ShaderNodeImpl
     static const string BASE;
 };
 
-
 /// Layerable BSDF node.
 class MX_GENMDL_API LayerableNodeMdl : public SourceCodeNodeMdl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void addInputs(ShaderNode& node, GenContext&) const override;

--- a/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.h
@@ -12,7 +12,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 class MX_GENMDL_API ClosureSourceCodeNodeMdl : public SourceCodeNodeMdl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;

--- a/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
@@ -21,7 +21,7 @@ void CombineNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& contex
 {
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        // Custom handling for color3 type input, all other types 
+        // Custom handling for color3 type input, all other types
         // can are handled by our parent class below.
         // Custom handling is needed since in MDL color must be converted
         // to float3 before accessing its sub-component.

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
@@ -36,10 +36,8 @@ void CompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContext& cont
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const Syntax& syntax = shadergen.getSyntax();
 
-        const bool isMaterialExpr = (
-            _rootGraph->hasClassification(ShaderNode::Classification::CLOSURE) ||
-            _rootGraph->hasClassification(ShaderNode::Classification::SHADER)
-        );
+        const bool isMaterialExpr = (_rootGraph->hasClassification(ShaderNode::Classification::CLOSURE) ||
+                                     _rootGraph->hasClassification(ShaderNode::Classification::SHADER));
 
         // Emit functions for all child nodes
         shadergen.emitFunctionDefinitions(*_rootGraph, context, stage);
@@ -78,8 +76,8 @@ void CompoundNodeMdl::emitFunctionDefinition(const ShaderNode&, GenContext& cont
             const string& qualifier = input->isUniform() || input->getType() == Type::FILENAME ? uniformPrefix : EMPTY_STRING;
             const string& type = syntax.getTypeName(input->getType());
             const string value = (input->getValue() ?
-                syntax.getValue(input->getType(), *input->getValue()) :
-                syntax.getDefaultValue(input->getType()));
+                                  syntax.getValue(input->getType(), *input->getValue()) :
+                                  syntax.getDefaultValue(input->getType()));
 
             const string& delim = --count > 0 ? Syntax::COMMA : EMPTY_STRING;
             shadergen.emitLine(qualifier + type + " " + input->getVariable() + " = " + value + delim, stage, false);

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.h
@@ -22,7 +22,7 @@ class MX_GENMDL_API CompoundNodeMdl : public CompoundNode
     void emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     string _returnStruct;
 };
 

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -14,33 +14,35 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    /// Name of filter function to call to compute normals from input samples
-    const string filterFunctionName = "mx_normal_from_samples_sobel";
 
-    /// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
-    /// as input, and return a 2 channel vector as output
-    const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+/// Name of filter function to call to compute normals from input samples
+const string filterFunctionName = "mx_normal_from_samples_sobel";
 
-    const unsigned int sampleCount = 9;
-    const unsigned int filterWidth = 3;
-    const float filterSize = 1.0;
-    const float filterOffset = 0.0;
-}
+/// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
+/// as input, and return a 2 channel vector as output
+const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+
+const unsigned int sampleCount = 9;
+const unsigned int filterWidth = 3;
+const float filterSize = 1.0;
+const float filterOffset = 0.0;
+
+} // anonymous namespace
 
 ShaderNodeImplPtr HeightToNormalNodeMdl::create()
 {
     return std::make_shared<HeightToNormalNodeMdl>();
 }
 
-void HeightToNormalNodeMdl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
-                                                        unsigned int, StringVec& offsetStrings) const
+void HeightToNormalNodeMdl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
+                                                       unsigned int, StringVec& offsetStrings) const
 {
     // Build a 3x3 grid of samples that are offset by the provided sample size
     for (int row = -1; row <= 1; row++)
     {
         for (int col = -1; col <= 1; col++)
         {
-            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString +  "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString + "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
         }
     }
 }
@@ -65,10 +67,10 @@ void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext&
             throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid heighttonormal node");
         }
 
-        // Create the input "samples". This means to emit the calls to 
+        // Create the input "samples". This means to emit the calls to
         // compute the sames and return a set of strings containaing
         // the variables to assign to the sample grid.
-        //  
+        //
         StringVec sampleStrings;
         emitInputSamplesUV(node, sampleCount, filterWidth,
                            filterSize, filterOffset, sampleSizeFunctionUV,

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
@@ -27,7 +27,7 @@ class MX_GENMDL_API HeightToNormalNodeMdl : public ConvolutionNode
     bool acceptsInputType(const TypeDesc* type) const override;
 
     /// Compute offset strings for sampling
-    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                     unsigned int filterWidth, StringVec& offsetStrings) const override;
 };
 

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -78,7 +78,7 @@ void SourceCodeNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& con
                 if (!input)
                 {
                     throw ExceptionShaderGenError("Could not find an input named '" + variable +
-                        "' on node '" + node.getName() + "'");
+                                                  "' on node '" + node.getName() + "'");
                 }
 
                 code.push_back(shadergen.getUpstreamResult(input, context));

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h
@@ -13,18 +13,18 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Node implementation using data-driven static source code.
-/// This is the default implementation used for all nodes that 
+/// This is the default implementation used for all nodes that
 /// do not have a custom ShaderNodeImpl class.
 class MX_GENMDL_API SourceCodeNodeMdl : public SourceCodeNode
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void initialize(const InterfaceElement& element, GenContext& context) override;
     void emitFunctionDefinition(const ShaderNode&, GenContext&, ShaderStage&) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     string _returnStruct;
 };
 

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
@@ -16,7 +16,6 @@ ShaderNodeImplPtr SurfaceNodeMdl::create()
     return std::make_shared<SurfaceNodeMdl>();
 }
 
-
 const ShaderInput* findTransmissionIOR(const ShaderNode& node)
 {
     if (node.hasClassification(ShaderNode::Classification::BSDF_T))


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXGenMdl, providing improvements in coding style consistency.