### PR TITLE
Fix opacity edge case in UsdPreviewSurface

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -272,12 +272,12 @@
       <input name="low" type="float" value="0.00001" />
       <input name="high" type="float" value="1.0" />
     </clamp>
-    <ifgreater name="cutout_opacity" type="float">
+    <ifgreatereq name="cutout_opacity" type="float">
       <input name="value1" type="float" nodename="opacity_clamped" />
       <input name="value2" type="float" interfacename="opacityThreshold" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
-    </ifgreater>
+    </ifgreatereq>
     <surface name="surface_constructor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="coat_bsdf" />
       <input name="edf" type="EDF" nodename="emission_edf" />


### PR DESCRIPTION
This changelist fixes an edge case for the opacity computation in UsdPreviewSurface, making surfaces visible when their non-zero opacity is exactly equal to the opacity threshold.

This aligns the MaterialX graph for UsdPreviewSurface with its specification (https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html), which states:

"... when opacityThreshold is greater than zero, the opacity values less than the opacityThreshold will not be rendered, and the opacity values greater than or equal to the opacityThreshold will be fully visible."