### PR TITLE
Fix metallic F90 in UsdPreviewSurface

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -209,7 +209,7 @@
     <generalized_schlick_bsdf name="specular_bsdf2" type="BSDF">
       <input name="weight" type="float" value="1" />
       <input name="color0" type="color3" nodename="F0" />
-      <input name="color90" type="color3" interfacename="specularColor" />
+      <input name="color90" type="color3" nodename="specular_color_metallic" />
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
     </generalized_schlick_bsdf>


### PR DESCRIPTION
This changelist fixes the computation of F90 in the metallic workflow of UsdPreviewSurface.

This aligns the MaterialX graph for UsdPreviewSurface with its specification (https://graphics.pixar.com/usd/release/spec_usdpreviewsurface.html), which states:

"If metallic is 1, then both F0 (reflectivity at 0 degree incidence) and edge F90 reflectivity will simply be the Albedo. If metallic is 0, then Albedo is ignored in the calculation of F0 and F90; F0 is derived from ior via ((1-ior)/(1+ior))^2 and F90 is white. In between, we interpolate."