### PR TITLE
Restore original getDefaultSearchPath

### DIFF
--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -61,13 +61,17 @@ template<class T> void parseToken(std::string token, std::string type, T& res)
 mx::FileSearchPath getDefaultSearchPath()
 {
     mx::FilePath modulePath = mx::FilePath::getModulePath();
-    mx::FilePath parentPath = modulePath.getParentPath();
+    mx::FilePath installRootPath = modulePath.getParentPath();
+    mx::FilePath devRootPath = installRootPath.getParentPath().getParentPath();
 
     mx::FileSearchPath searchPath;
-    searchPath.append(modulePath);
-    if ((parentPath / "libraries").exists())
+    if ((devRootPath / "libraries").exists())
     {
-        searchPath.append(parentPath);
+        searchPath.append(devRootPath);
+    }
+    else
+    {
+        searchPath.append(installRootPath);
     }
 
     return searchPath;


### PR DESCRIPTION
This changelist restores the original definition of getDefaultSearchPath in MaterialXView, as the recently-revised version doesn't appear to be as robust across developer environments, occasionally preventing the viewer from finding its data libraries.