### PR TITLE
Add missing volumetric parameters to MDL surfacematerial

### DIFF
--- a/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
@@ -47,7 +47,9 @@ export material mx_surfacematerial(
         cutout_opacity: mxp_surfaceshader.geometry.cutout_opacity,
         displacement : mxp_displacement,
         normal: mxp_surfaceshader.geometry.normal
-    )
+    ),
+    ior: mxp_surfaceshader.ior,
+    volume: mxp_surfaceshader.volume
 );
 
 export material mx_surface_unlit(


### PR DESCRIPTION
This change list adds a missing transfer of volumetric parameters from surfaceshader node to material node in MDL implementation of <surfacematerial>.
