### PR TITLE
Update copyright notices to ASWF standards

### DIFF
--- a/cmake/modules/MaterialXConfig.cmake.in
+++ b/cmake/modules/MaterialXConfig.cmake.in
@@ -1,6 +1,6 @@
 #
-# TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-# All rights reserved.  See LICENSE.txt for license.
+# Copyright Contributors to the MaterialX Project
+# SPDX-License-Identifier: Apache-2.0
 #
 # MaterialX CMake configuration file. Mostly auto-generated.
 #

--- a/javascript/MaterialXView/source/helper.js
+++ b/javascript/MaterialXView/source/helper.js
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 import * as THREE from 'three';

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 import * as THREE from 'three';

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 import * as THREE from 'three';

--- a/libraries/lights/lights_defs.mtlx
+++ b/libraries/lights/lights_defs.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Declarations of common light nodes, used in code generation for hardware
     shading languages that require explicit light loops.

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Declarations of standard data types and nodes included in the MaterialX specification.
   -->

--- a/libraries/pbrlib/pbrlib_ng.mtlx
+++ b/libraries/pbrlib/pbrlib_ng.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Graph definitions of standard nodes included in the MaterialX specification.
   -->

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Declarations for glsl implementations of standard nodes included in the MaterialX specification.
   -->

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Declarations for MDL implementations of standard nodes included in the MaterialX specification.
   -->

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Declarations for OSL implementations of standard nodes included in the MaterialX specification.
   -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Declarations of standard data types and nodes included in the MaterialX specification.
   -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <materialx version="1.38">
   <!--
-    TM & (c) 2018 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-    All rights reserved.  See LICENSE.txt for license.
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
 
     Nodegraph implementations for Supplemental Nodes included in the MaterialX specification.
   -->

--- a/libraries/targets/essl.mtlx
+++ b/libraries/targets/essl.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-  All rights reserved.  See LICENSE.txt for license.
+  Copyright Contributors to the MaterialX Project
+  SPDX-License-Identifier: Apache-2.0
 -->
 
 <materialx version="1.38">

--- a/libraries/targets/genglsl.mtlx
+++ b/libraries/targets/genglsl.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-  All rights reserved.  See LICENSE.txt for license.
+  Copyright Contributors to the MaterialX Project
+  SPDX-License-Identifier: Apache-2.0
 -->
 
 <materialx version="1.38">

--- a/libraries/targets/genmdl.mtlx
+++ b/libraries/targets/genmdl.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-  All rights reserved.  See LICENSE.txt for license.
+  Copyright Contributors to the MaterialX Project
+  SPDX-License-Identifier: Apache-2.0
 -->
 
 <materialx version="1.38">

--- a/libraries/targets/genosl.mtlx
+++ b/libraries/targets/genosl.mtlx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-  All rights reserved.  See LICENSE.txt for license.
+  Copyright Contributors to the MaterialX Project
+  SPDX-License-Identifier: Apache-2.0
 -->
 
 <materialx version="1.38">

--- a/source/JsMaterialX/Helpers.h
+++ b/source/JsMaterialX/Helpers.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef JSMATERIALX_HELPERS_H

--- a/source/JsMaterialX/JsMaterialXCore/JsDefinition.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsDefinition.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsDocument.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsDocument.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsElement.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsElement.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsExceptions.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsExceptions.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <emscripten/bind.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsGeom.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsGeom.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsInterface.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsInterface.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsLook.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsLook.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsMaterial.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsMaterial.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsNode.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsProperty.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsProperty.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsTraversal.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsTraversal.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsTypes.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsTypes.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsUnit.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsUnit.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsUtil.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsValue.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsValue.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXCore/JsVariant.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsVariant.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/VectorHelper.h>

--- a/source/JsMaterialX/JsMaterialXFormat/JsEnviron.cpp
+++ b/source/JsMaterialX/JsMaterialXFormat/JsEnviron.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXFormat/Environ.h>

--- a/source/JsMaterialX/JsMaterialXFormat/JsXmlIo.cpp
+++ b/source/JsMaterialX/JsMaterialXFormat/JsXmlIo.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/Helpers.h>

--- a/source/JsMaterialX/JsMaterialXFormat/StrContainerTypeRegistration.h
+++ b/source/JsMaterialX/JsMaterialXFormat/StrContainerTypeRegistration.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved. See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXFormat/File.h>

--- a/source/JsMaterialX/JsMaterialXFormat/post.js
+++ b/source/JsMaterialX/JsMaterialXFormat/post.js
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved. See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 // Wrapping code in an anonymous function to prevent clashes with the main module and other pre / post JS.

--- a/source/JsMaterialX/JsMaterialXGenEssl/JsEsslShaderGenerator.cpp
+++ b/source/JsMaterialX/JsMaterialXGenEssl/JsEsslShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/EsslShaderGenerator.h>

--- a/source/JsMaterialX/JsMaterialXGenShader/JsGenContext.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsGenContext.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include "../Helpers.h"

--- a/source/JsMaterialX/JsMaterialXGenShader/JsGenOptions.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsGenOptions.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/GenOptions.h>

--- a/source/JsMaterialX/JsMaterialXGenShader/JsHwShaderGenerator.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsHwShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/HwShaderGenerator.h>

--- a/source/JsMaterialX/JsMaterialXGenShader/JsShader.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsShader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/Helpers.h>

--- a/source/JsMaterialX/JsMaterialXGenShader/JsShaderGenerator.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/GenContext.h>

--- a/source/JsMaterialX/JsMaterialXGenShader/JsShaderNode.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsShaderNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include "../MapHelper.h"

--- a/source/JsMaterialX/JsMaterialXGenShader/JsShaderStage.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsShaderStage.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include "../MapHelper.h"

--- a/source/JsMaterialX/JsMaterialXGenShader/JsTypeDesc.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsTypeDesc.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/TypeDesc.h>

--- a/source/JsMaterialX/JsMaterialXGenShader/JsUtil.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <JsMaterialX/Helpers.h>

--- a/source/JsMaterialX/MapHelper.h
+++ b/source/JsMaterialX/MapHelper.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 /**

--- a/source/JsMaterialX/MaterialXLib.cpp
+++ b/source/JsMaterialX/MaterialXLib.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 // This file is used as the executable in the CMakeLists.txt file.

--- a/source/JsMaterialX/VectorHelper.h
+++ b/source/JsMaterialX/VectorHelper.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 /**

--- a/source/JsMaterialX/post.js
+++ b/source/JsMaterialX/post.js
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 var postRegistrations = [];
 

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Definition.h>

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_DEFINITION_H

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Document.h>

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_DOCUMENT

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Element.h>

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_ELEMENT_H

--- a/source/MaterialXCore/Exception.h
+++ b/source/MaterialXCore/Exception.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_EXCEPTION_H

--- a/source/MaterialXCore/Export.h
+++ b/source/MaterialXCore/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CORE_EXPORT_H

--- a/source/MaterialXCore/Generated.h.in
+++ b/source/MaterialXCore/Generated.h.in
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENERATED_H

--- a/source/MaterialXCore/Geom.cpp
+++ b/source/MaterialXCore/Geom.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Geom.h>

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GEOM_H

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Interface.h>

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_INTERFACE_H

--- a/source/MaterialXCore/Library.h
+++ b/source/MaterialXCore/Library.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LIBRARY_H

--- a/source/MaterialXCore/Look.cpp
+++ b/source/MaterialXCore/Look.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Look.h>

--- a/source/MaterialXCore/Look.h
+++ b/source/MaterialXCore/Look.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LOOK_H

--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Material.h>

--- a/source/MaterialXCore/Material.h
+++ b/source/MaterialXCore/Material.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MATERIAL_H

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Node.h>

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_NODE_H

--- a/source/MaterialXCore/Property.cpp
+++ b/source/MaterialXCore/Property.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Property.h>

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_PROPERTY_H

--- a/source/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXCore/Traversal.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Traversal.h>

--- a/source/MaterialXCore/Traversal.h
+++ b/source/MaterialXCore/Traversal.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TRAVERSAL_H

--- a/source/MaterialXCore/Types.cpp
+++ b/source/MaterialXCore/Types.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Types.h>

--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TYPES_H

--- a/source/MaterialXCore/Unit.cpp
+++ b/source/MaterialXCore/Unit.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Unit.h>

--- a/source/MaterialXCore/Unit.h
+++ b/source/MaterialXCore/Unit.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_UNIT_H_

--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Types.h>

--- a/source/MaterialXCore/Util.h
+++ b/source/MaterialXCore/Util.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_UTIL

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Value.h>

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_VALUE_H

--- a/source/MaterialXCore/Variant.cpp
+++ b/source/MaterialXCore/Variant.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXCore/Variant.h>

--- a/source/MaterialXCore/Variant.h
+++ b/source/MaterialXCore/Variant.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_VARIANT_H

--- a/source/MaterialXFormat/Environ.cpp
+++ b/source/MaterialXFormat/Environ.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXFormat/Environ.h>

--- a/source/MaterialXFormat/Environ.h
+++ b/source/MaterialXFormat/Environ.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_ENVIRON_H

--- a/source/MaterialXFormat/Export.h
+++ b/source/MaterialXFormat/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_FORMAT_EXPORT_H

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXFormat/File.h>

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_FILE_H

--- a/source/MaterialXFormat/Util.cpp
+++ b/source/MaterialXFormat/Util.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXFormat/Util.h>

--- a/source/MaterialXFormat/Util.h
+++ b/source/MaterialXFormat/Util.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_FORMAT_UTIL_H

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXFormat/XmlIo.h>

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_XMLIO_H

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/EsslShaderGenerator.h>

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_ESSLSHADERGENERATOR_H

--- a/source/MaterialXGenGlsl/EsslSyntax.cpp
+++ b/source/MaterialXGenGlsl/EsslSyntax.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/EsslSyntax.h>

--- a/source/MaterialXGenGlsl/EsslSyntax.h
+++ b/source/MaterialXGenGlsl/EsslSyntax.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_ESSLSYNTAX_H

--- a/source/MaterialXGenGlsl/Export.h
+++ b/source/MaterialXGenGlsl/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENGLSL_EXPORT_H

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/GlslResourceBindingContext.h>

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLSLRESOURCEBINDING_H

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLSLSHADERGENERATOR_H

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/GlslSyntax.h>

--- a/source/MaterialXGenGlsl/GlslSyntax.h
+++ b/source/MaterialXGenGlsl/GlslSyntax.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLSL_SYNTAX_H

--- a/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/BitangentNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/BitangentNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_BITANGENTNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/BlurNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/BlurNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_BLURNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/FrameNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/FrameNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_FRAMENODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GEOMCOLORNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/GeomPropValueNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GEOMPROPVALUENODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_HEIGHTTONORMALNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LIGHTCOMPOUNDNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/LightNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LIGHTNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LIGHTSAMPLERNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LIGHTSHADERNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/NormalNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/NormalNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_NORMALNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_NUMLIGHTSNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/PositionNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/PositionNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_POSITIONNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SURFACENODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceShaderNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SURFACESHADERNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/TangentNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TangentNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TANGENTNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TexCoordNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TEXCOORDNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/TimeNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TimeNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TIMENODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformNormalNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TRANSFORMNORMALNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformPointNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TRANSFORMPOINTNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/TransformVectorNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TRANSFORMVECTORNODEGLSL_H

--- a/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.h>

--- a/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/UnlitSurfaceNodeGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_UNLITSURFACENODEGLSL_H

--- a/source/MaterialXGenGlsl/VkResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/VkResourceBindingContext.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/VkResourceBindingContext.h>

--- a/source/MaterialXGenGlsl/VkResourceBindingContext.h
+++ b/source/MaterialXGenGlsl/VkResourceBindingContext.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_VKRESOURCEBINDING_H

--- a/source/MaterialXGenGlsl/VkShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/VkShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/VkShaderGenerator.h>

--- a/source/MaterialXGenGlsl/VkShaderGenerator.h
+++ b/source/MaterialXGenGlsl/VkShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_VKSHADERGENERATOR_H

--- a/source/MaterialXGenGlsl/VkSyntax.cpp
+++ b/source/MaterialXGenGlsl/VkSyntax.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenGlsl/VkSyntax.h>

--- a/source/MaterialXGenGlsl/VkSyntax.h
+++ b/source/MaterialXGenGlsl/VkSyntax.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_VKSYNTAX_H

--- a/source/MaterialXGenMdl/Export.h
+++ b/source/MaterialXGenMdl/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENMDL_EXPORT_H

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/MdlShaderGenerator.h>

--- a/source/MaterialXGenMdl/MdlShaderGenerator.h
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MDLSHADERGENERATOR_H

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/MdlSyntax.h>

--- a/source/MaterialXGenMdl/MdlSyntax.h
+++ b/source/MaterialXGenMdl/MdlSyntax.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MDLSYNTAX_H

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/GenContext.h>

--- a/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/BlurNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_BLURNODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURECOMPOUNDNODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURELAYERNODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/ClosureSourceCodeNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURESOURCECODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/CombineNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/CombineNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/CombineNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_COMBINENODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/CompoundNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_COMPOUNDNODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_HEIGHTTONORMALNODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/MaterialNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MATERIALNODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SOURCECODEMDL_H

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenMdl/Nodes/SurfaceNodeMdl.h>

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SURFACENODEMDL_H

--- a/source/MaterialXGenMdl/mdl/materialx/cm.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/cm.mdl
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 // Default color management transforms for MDL
 //

--- a/source/MaterialXGenMdl/mdl/materialx/noise.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/noise.mdl
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 /********************************************************************************

--- a/source/MaterialXGenMdl/mdl/materialx/sampling.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/sampling.mdl
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 mdl 1.6;

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 // MDL implementation of all Standard Source Nodes of
 //     MaterialX: An Open Standard for Network-Based CG Object Looks

--- a/source/MaterialXGenOsl/Export.h
+++ b/source/MaterialXGenOsl/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENOSL_EXPORT_H

--- a/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/BlurNodeOsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenOsl/Nodes/BlurNodeOsl.h>

--- a/source/MaterialXGenOsl/Nodes/BlurNodeOsl.h
+++ b/source/MaterialXGenOsl/Nodes/BlurNodeOsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_BLURNODEOSL_H

--- a/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.h>

--- a/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.h
+++ b/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURELAYERNODEOSL_H

--- a/source/MaterialXGenOsl/Nodes/MaterialNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/MaterialNodeOsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenOsl/Nodes/MaterialNodeOsl.h>

--- a/source/MaterialXGenOsl/Nodes/MaterialNodeOsl.h
+++ b/source/MaterialXGenOsl/Nodes/MaterialNodeOsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MATERIALNODEOSL_H

--- a/source/MaterialXGenOsl/Nodes/SurfaceNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/SurfaceNodeOsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenOsl/Nodes/SurfaceNodeOsl.h>

--- a/source/MaterialXGenOsl/Nodes/SurfaceNodeOsl.h
+++ b/source/MaterialXGenOsl/Nodes/SurfaceNodeOsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SURFACENODEOSL_H

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenOsl/OslShaderGenerator.h>

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_OSLSHADERGENERATOR_H

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenOsl/OslSyntax.h>

--- a/source/MaterialXGenOsl/OslSyntax.h
+++ b/source/MaterialXGenOsl/OslSyntax.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_OSLSYNTAX_H

--- a/source/MaterialXGenShader/ColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/ColorManagementSystem.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ColorManagementSystem.h>

--- a/source/MaterialXGenShader/ColorManagementSystem.h
+++ b/source/MaterialXGenShader/ColorManagementSystem.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_COLOR_MANAGEMENT_SYSTEM_H

--- a/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/DefaultColorManagementSystem.h>

--- a/source/MaterialXGenShader/DefaultColorManagementSystem.h
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_DEFAULT_COLOR_MANAGEMENT_SYSTEM_H

--- a/source/MaterialXGenShader/Export.h
+++ b/source/MaterialXGenShader/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENSHADER_EXPORT_H

--- a/source/MaterialXGenShader/Factory.h
+++ b/source/MaterialXGenShader/Factory.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_FACTORY_H

--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/GenContext.h>

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENCONTEXT_H

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENOPTIONS_H

--- a/source/MaterialXGenShader/GenUserData.h
+++ b/source/MaterialXGenShader/GenUserData.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENUSERDATA_H

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/HwShaderGenerator.h>

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_HWSHADERGENERATOR_H

--- a/source/MaterialXGenShader/Library.h
+++ b/source/MaterialXGenShader/Library.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GENSHADERLIBRARY_H

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/BlurNode.h>

--- a/source/MaterialXGenShader/Nodes/BlurNode.h
+++ b/source/MaterialXGenShader/Nodes/BlurNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_BLURNODE_H

--- a/source/MaterialXGenShader/Nodes/ClosureAddNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureAddNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ClosureAddNode.h>

--- a/source/MaterialXGenShader/Nodes/ClosureAddNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureAddNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSUREADDNODE_H

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ClosureCompoundNode.h>

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURECOMPOUNDNODE_H

--- a/source/MaterialXGenShader/Nodes/ClosureLayerNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureLayerNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ClosureLayerNode.h>

--- a/source/MaterialXGenShader/Nodes/ClosureLayerNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureLayerNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURELAYERNODE_H

--- a/source/MaterialXGenShader/Nodes/ClosureMixNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureMixNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ClosureMixNode.h>

--- a/source/MaterialXGenShader/Nodes/ClosureMixNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureMixNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSUREMIXNODE_H

--- a/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ClosureMultiplyNode.h>

--- a/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSUREMULTIPLYNODE_H

--- a/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ClosureSourceCodeNode.h>

--- a/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.h
+++ b/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CLOSURESOURCECODENODE_H

--- a/source/MaterialXGenShader/Nodes/CombineNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CombineNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/CombineNode.h>

--- a/source/MaterialXGenShader/Nodes/CombineNode.h
+++ b/source/MaterialXGenShader/Nodes/CombineNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_COMBINENODE_H

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/CompoundNode.h>

--- a/source/MaterialXGenShader/Nodes/CompoundNode.h
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_COMPOUNDNODE_H

--- a/source/MaterialXGenShader/Nodes/ConvertNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvertNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ConvertNode.h>

--- a/source/MaterialXGenShader/Nodes/ConvertNode.h
+++ b/source/MaterialXGenShader/Nodes/ConvertNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CONVERTNODE_H

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/ConvolutionNode.h>

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.h
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CONVOLUTIONNODE_H

--- a/source/MaterialXGenShader/Nodes/HwImageNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/HwImageNode.h>

--- a/source/MaterialXGenShader/Nodes/HwImageNode.h
+++ b/source/MaterialXGenShader/Nodes/HwImageNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_HWIMAGECODENODE_H

--- a/source/MaterialXGenShader/Nodes/MaterialNode.cpp
+++ b/source/MaterialXGenShader/Nodes/MaterialNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/MaterialNode.h>

--- a/source/MaterialXGenShader/Nodes/MaterialNode.h
+++ b/source/MaterialXGenShader/Nodes/MaterialNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MATERIALNODE_H

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.h
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SOURCECODENODE_H

--- a/source/MaterialXGenShader/Nodes/SwitchNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SwitchNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/SwitchNode.h>

--- a/source/MaterialXGenShader/Nodes/SwitchNode.h
+++ b/source/MaterialXGenShader/Nodes/SwitchNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SWITCHNODE_H

--- a/source/MaterialXGenShader/Nodes/SwizzleNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SwizzleNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Nodes/SwizzleNode.h>

--- a/source/MaterialXGenShader/Nodes/SwizzleNode.h
+++ b/source/MaterialXGenShader/Nodes/SwizzleNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SWIZZLENODE_H

--- a/source/MaterialXGenShader/Shader.cpp
+++ b/source/MaterialXGenShader/Shader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Shader.h>

--- a/source/MaterialXGenShader/Shader.h
+++ b/source/MaterialXGenShader/Shader.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADER_H

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ShaderGenerator.h>

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERGENERATOR_H

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ShaderGraph.h>

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERGRAPH_H

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ShaderNode.h>

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERNODE_H

--- a/source/MaterialXGenShader/ShaderNodeImpl.cpp
+++ b/source/MaterialXGenShader/ShaderNodeImpl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ShaderNodeImpl.h>

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERNODEIMPL_H

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ShaderStage.h>

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERSTAGE_H

--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/ShaderTranslator.h>

--- a/source/MaterialXGenShader/ShaderTranslator.h
+++ b/source/MaterialXGenShader/ShaderTranslator.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERTRANSLATOR_H

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Syntax.h>

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SYNTAX_H

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/TypeDesc.h>

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TYPEDESC_H

--- a/source/MaterialXGenShader/UnitSystem.cpp
+++ b/source/MaterialXGenShader/UnitSystem.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/UnitSystem.h>

--- a/source/MaterialXGenShader/UnitSystem.h
+++ b/source/MaterialXGenShader/UnitSystem.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_UNITSYSTEM_H

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXGenShader/Util.h>

--- a/source/MaterialXGenShader/Util.h
+++ b/source/MaterialXGenShader/Util.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERGEN_UTIL_H

--- a/source/MaterialXRender/Camera.cpp
+++ b/source/MaterialXRender/Camera.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Camera.h>

--- a/source/MaterialXRender/Camera.h
+++ b/source/MaterialXRender/Camera.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CAMERA_H

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/CgltfLoader.h>

--- a/source/MaterialXRender/CgltfLoader.h
+++ b/source/MaterialXRender/CgltfLoader.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_CGLTFLOADER_H

--- a/source/MaterialXRender/Export.h
+++ b/source/MaterialXRender/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_RENDER_EXPORT_H

--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/GeometryHandler.h>

--- a/source/MaterialXRender/GeometryHandler.h
+++ b/source/MaterialXRender/GeometryHandler.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GEOMETRYHANDLER_H

--- a/source/MaterialXRender/Harmonics.cpp
+++ b/source/MaterialXRender/Harmonics.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Harmonics.h>

--- a/source/MaterialXRender/Harmonics.h
+++ b/source/MaterialXRender/Harmonics.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_HARMONICS_H

--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Image.h>

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_IMAGE_H

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/ImageHandler.h>

--- a/source/MaterialXRender/ImageHandler.h
+++ b/source/MaterialXRender/ImageHandler.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_IMAGEHANDLER_H

--- a/source/MaterialXRender/LightHandler.cpp
+++ b/source/MaterialXRender/LightHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/LightHandler.h>

--- a/source/MaterialXRender/LightHandler.h
+++ b/source/MaterialXRender/LightHandler.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_LIGHTHANDLER_H

--- a/source/MaterialXRender/Mesh.cpp
+++ b/source/MaterialXRender/Mesh.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Mesh.h>

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_MESH_H

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/OiioImageLoader.h>

--- a/source/MaterialXRender/OiioImageLoader.h
+++ b/source/MaterialXRender/OiioImageLoader.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_OIIOIMAGELOADER_H

--- a/source/MaterialXRender/ShaderRenderer.cpp
+++ b/source/MaterialXRender/ShaderRenderer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/ShaderRenderer.h>

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SHADERRENDERER_H

--- a/source/MaterialXRender/StbImageLoader.cpp
+++ b/source/MaterialXRender/StbImageLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/StbImageLoader.h>

--- a/source/MaterialXRender/StbImageLoader.h
+++ b/source/MaterialXRender/StbImageLoader.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_STBIMAGELOADER_H

--- a/source/MaterialXRender/Timer.cpp
+++ b/source/MaterialXRender/Timer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Timer.h>

--- a/source/MaterialXRender/Timer.h
+++ b/source/MaterialXRender/Timer.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TIMER_H

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/TinyObjLoader.h>

--- a/source/MaterialXRender/TinyObjLoader.h
+++ b/source/MaterialXRender/TinyObjLoader.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TINYOBJLOADER_H

--- a/source/MaterialXRender/Types.cpp
+++ b/source/MaterialXRender/Types.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Types.h>

--- a/source/MaterialXRender/Types.h
+++ b/source/MaterialXRender/Types.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_RENDER_TYPES_H

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRender/Util.h>

--- a/source/MaterialXRender/Util.h
+++ b/source/MaterialXRender/Util.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_RENDER_UTIL_H

--- a/source/MaterialXRenderGlsl/Export.h
+++ b/source/MaterialXRenderGlsl/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_RENDERGLSL_EXPORT_H

--- a/source/MaterialXRenderGlsl/GLCocoaWrappers.h
+++ b/source/MaterialXRenderGlsl/GLCocoaWrappers.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLCOCOAWRAPPERS_H

--- a/source/MaterialXRenderGlsl/GLCocoaWrappers.m
+++ b/source/MaterialXRenderGlsl/GLCocoaWrappers.m
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #if defined (__APPLE__)

--- a/source/MaterialXRenderGlsl/GLContext.cpp
+++ b/source/MaterialXRenderGlsl/GLContext.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #if defined(_WIN32)

--- a/source/MaterialXRenderGlsl/GLContext.h
+++ b/source/MaterialXRenderGlsl/GLContext.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLCONTEXT_H

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderGlsl/GLFramebuffer.h>

--- a/source/MaterialXRenderGlsl/GLFramebuffer.h
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLFRAMEBUFFER_H

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderGlsl/GLTextureHandler.h>

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLTEXTUREHANDLER_H

--- a/source/MaterialXRenderGlsl/GLUtil.cpp
+++ b/source/MaterialXRenderGlsl/GLUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderGlsl/External/Glad/glad.h>

--- a/source/MaterialXRenderGlsl/GLUtil.h
+++ b/source/MaterialXRenderGlsl/GLUtil.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLUTIL_H

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderGlsl/External/Glad/glad.h>

--- a/source/MaterialXRenderGlsl/GlslProgram.h
+++ b/source/MaterialXRenderGlsl/GlslProgram.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLSLPROGRAM_H

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderGlsl/GlslRenderer.h>

--- a/source/MaterialXRenderGlsl/GlslRenderer.h
+++ b/source/MaterialXRenderGlsl/GlslRenderer.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_GLSLRENDERER_H

--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderGlsl/TextureBaker.h>

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_TEXTUREBAKER

--- a/source/MaterialXRenderHw/Export.h
+++ b/source/MaterialXRenderHw/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_RENDERHW_EXPORT_H

--- a/source/MaterialXRenderHw/SimpleWindow.h
+++ b/source/MaterialXRenderHw/SimpleWindow.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_SIMPLEWINDOW_H

--- a/source/MaterialXRenderHw/SimpleWindowLinux.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowLinux.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #if defined(__linux__) || defined(__FreeBSD__)

--- a/source/MaterialXRenderHw/SimpleWindowMac.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowMac.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #if defined(__APPLE__)

--- a/source/MaterialXRenderHw/SimpleWindowWindows.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowWindows.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #if defined(_WIN32)

--- a/source/MaterialXRenderHw/WindowCocoaWrappers.h
+++ b/source/MaterialXRenderHw/WindowCocoaWrappers.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_WINDOWCOCOAWRAPPERS_H

--- a/source/MaterialXRenderHw/WindowCocoaWrappers.m
+++ b/source/MaterialXRenderHw/WindowCocoaWrappers.m
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #if defined (__APPLE__)

--- a/source/MaterialXRenderHw/WindowWrapper.cpp
+++ b/source/MaterialXRenderHw/WindowWrapper.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderHw/WindowWrapper.h>

--- a/source/MaterialXRenderHw/WindowWrapper.h
+++ b/source/MaterialXRenderHw/WindowWrapper.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_WINDOWWRAPPER_H

--- a/source/MaterialXRenderOsl/Export.h
+++ b/source/MaterialXRenderOsl/Export.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_RENDEROSL_EXPORT_H

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXRenderOsl/OslRenderer.h>

--- a/source/MaterialXRenderOsl/OslRenderer.h
+++ b/source/MaterialXRenderOsl/OslRenderer.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_OSLRENDERER_H

--- a/source/MaterialXTest/Main.cpp
+++ b/source/MaterialXTest/Main.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #define CATCH_CONFIG_RUNNER

--- a/source/MaterialXTest/MaterialXCore/CoreUtil.cpp
+++ b/source/MaterialXTest/MaterialXCore/CoreUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Element.cpp
+++ b/source/MaterialXTest/MaterialXCore/Element.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Geom.cpp
+++ b/source/MaterialXTest/MaterialXCore/Geom.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Look.cpp
+++ b/source/MaterialXTest/MaterialXCore/Look.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXTest/MaterialXCore/Traversal.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Types.cpp
+++ b/source/MaterialXTest/MaterialXCore/Types.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Unit.cpp
+++ b/source/MaterialXTest/MaterialXCore/Unit.cpp
@@ -1,6 +1,6 @@
 ﻿//
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXCore/Value.cpp
+++ b/source/MaterialXTest/MaterialXCore/Value.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXFormat/File.cpp
+++ b/source/MaterialXTest/MaterialXFormat/File.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef GENGLSL_H

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef GENMDL_H

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef GENOSL_H

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef GENSHADER_UTIL_H

--- a/source/MaterialXTest/MaterialXRender/Render.cpp
+++ b/source/MaterialXTest/MaterialXRender/Render.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef RENDER_UTIL_H

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #include <MaterialXView/Editor.h>
 
 #include <MaterialXView/Viewer.h>

--- a/source/MaterialXView/Editor.h
+++ b/source/MaterialXView/Editor.h
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #ifndef MATERIALXVIEW_EDITOR_H
 #define MATERIALXVIEW_EDITOR_H
 

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #include <MaterialXView/Viewer.h>
 
 #include <MaterialXRender/Util.h>

--- a/source/MaterialXView/Material.cpp
+++ b/source/MaterialXView/Material.cpp
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #include <MaterialXView/Material.h>
 
 #include <MaterialXRenderGlsl/External/Glad/glad.h>

--- a/source/MaterialXView/Material.h
+++ b/source/MaterialXView/Material.h
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #ifndef MATERIALXVIEW_MATERIAL_H
 #define MATERIALXVIEW_MATERIAL_H
 

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #include <MaterialXView/Viewer.h>
 
 #include <MaterialXRenderGlsl/GLUtil.h>

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -1,3 +1,8 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
 #ifndef MATERIALXVIEW_VIEWER_H
 #define MATERIALXVIEW_VIEWER_H
 

--- a/source/PyMaterialX/PyMaterialX.h
+++ b/source/PyMaterialX/PyMaterialX.h
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #ifndef MATERIALX_PYMATERIALX_H

--- a/source/PyMaterialX/PyMaterialXCore/PyDefinition.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDefinition.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDocument.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyException.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyException.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyGeom.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyLook.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyMaterial.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyNode.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyProperty.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyProperty.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyTraversal.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyTraversal.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyTypes.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyTypes.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyUnitConverter.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUnitConverter.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyValue.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyValue.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyVariant.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyVariant.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXFormat/PyFile.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyFile.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenMdl/PyMdlShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMdl/PyMdlShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenMdl/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMdl/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenOsl/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXGenOsl/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenOsl/PyOslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenOsl/PyOslShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyColorManagement.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyColorManagement.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyGenContext.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyGenContext.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyGenOptions.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyGenOptions.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShader.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderGenerator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderPort.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderPort.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderStage.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderStage.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyShaderTranslator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyShaderTranslator.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2020 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyTypeDesc.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyTypeDesc.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyUnitSystem.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyUnitSystem.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyUtil.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2017 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyCamera.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyCamera.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2021 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImage.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyImageHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyLightHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyLightHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyMesh.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyMesh.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyOiioImageLoader.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyOiioImageLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyShaderRenderer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyStbImageLoader.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyStbImageLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRender/PyTinyObjLoader.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyTinyObjLoader.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGLTextureHandler.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslProgram.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslProgram.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyGlslRenderer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderOsl/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderOsl/PyModule.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>

--- a/source/PyMaterialX/PyMaterialXRenderOsl/PyOslRenderer.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderOsl/PyOslRenderer.cpp
@@ -1,6 +1,6 @@
 //
-// TM & (c) 2019 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
-// All rights reserved.  See LICENSE.txt for license.
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
 //
 
 #include <PyMaterialX/PyMaterialX.h>


### PR DESCRIPTION
This changelist updates the copyright notices in MaterialX source and data files, aligning them with the standards of the Academy Software Foundation.