### PR TITLE
Add UiNode null checks

### DIFF
--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -131,7 +131,7 @@ class UiNode
 
     friend bool operator==(const UiNodePtr& lhs, const UiNodePtr& rhs)
     {
-        return lhs->getName() == rhs->getName();
+        return lhs != nullptr && rhs != nullptr && lhs->getName() == rhs->getName();
     }
 
     bool operator()(const UiNodePtr& node1, const UiNodePtr& node2) const


### PR DESCRIPTION
This pull request is attempting the solve the issue with the Graph Editor where it fails when a node is clicked on MacOs