### PR TITLE
Merge RenderView loading methods

### DIFF
--- a/source/MaterialXGraphEditor/RenderView.h
+++ b/source/MaterialXGraphEditor/RenderView.h
@@ -74,12 +74,6 @@ class RenderView
         _modifiers = modifiers;
     }
 
-    // Return true if all inputs should be shown in the property editor.
-    bool getShowAllInputs() const
-    {
-        return _showAllInputs;
-    }
-
     std::vector<mx::MeshPartitionPtr> getGeometryList()
     {
         return _geometryList;
@@ -321,7 +315,6 @@ class RenderView
 
     // Material options
     bool _mergeMaterials;
-    bool _showAllInputs;
     bool _materialCompilation;
 
     // Unit options


### PR DESCRIPTION
This changelist merges shared logic between the RenderView::loadDocument and RenderView::updateMaterials methods, clarifying the role of each.

Additionally, the RenderView::_showAllInputs variable has been removed, as this property is now stored for each UiNode.