### PR TITLE
Add editor support for multioutput nodes

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -210,6 +210,7 @@ ed::PinId Graph::getOutputPin(UiNodePtr node, UiNodePtr upNode, Pin input)
     else
     {
         // every other node can just get the first output pin since there is only one
+        // This needs to be fixed !
         return (upNode->outputPins[0]._pinId);
     }
 }
@@ -1021,7 +1022,21 @@ void Graph::setUiNodeInfo(UiNodePtr node, std::string type, std::string category
                     Pin inPin = Pin(_graphTotalSize, &*input->getName().begin(), input->getType(), node, ax::NodeEditor::PinKind::Input, input, nullptr);
                     node->inputPins.push_back(inPin);
                     _currPins.push_back(inPin);
-                    ++_graphTotalSize;
+                    ++_graphTotalSize;                    
+                }
+
+                for (mx::OutputPtr output : nodeDef->getActiveOutputs())
+                {
+                    std::cerr << "Add output:" << output->getName() << std::endl;
+                    if (node->getNode()->getOutput(output->getName()))
+                    {
+                        output = node->getNode()->getOutput(output->getName());
+                    }
+                    Pin outPin = Pin(_graphTotalSize, &*output->getName().begin(), 
+                    output->getType(), node, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
+                    node->outputPins.push_back(outPin);
+                    _currPins.push_back(outPin);
+                    ++_graphTotalSize;                    
                 }
             }
         }
@@ -1039,10 +1054,13 @@ void Graph::setUiNodeInfo(UiNodePtr node, std::string type, std::string category
             _currPins.push_back(inPin);
             ++_graphTotalSize;
         }
+        //std::cerr << "Add single output pin: " << type << std::endl;
+        /*
         Pin outPin = Pin(_graphTotalSize, &*("output"), type, node, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
         ++_graphTotalSize;
         node->outputPins.push_back(outPin);
         _currPins.push_back(outPin);
+        */
     }
 
     _graphNodes.push_back(std::move(node));
@@ -1763,11 +1781,19 @@ void Graph::addNode(std::string category, std::string name, std::string type)
             _currPins.push_back(inPin);
             ++_graphTotalSize;
         }
+        std::vector<mx::OutputPtr> defOutputs = matchingNodeDefs[num]->getActiveOutputs();
+        for (mx::OutputPtr output : defOutputs)
+        {
+            Pin outPin = Pin(_graphTotalSize, &*output->getName().begin(), output->getType(), newNode, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
+            newNode->outputPins.push_back(outPin);
+            _currPins.push_back(outPin);
+            ++_graphTotalSize;
+        }
         // output pin
-        Pin outPin = Pin(_graphTotalSize, &*("ouput"), newNode->getType(), newNode, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
-        ++_graphTotalSize;
-        newNode->outputPins.push_back(outPin);
-        _currPins.push_back(outPin);
+        //Pin outPin = Pin(_graphTotalSize, &*("ouput"), newNode->getType(), newNode, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
+        //++_graphTotalSize;
+        //newNode->outputPins.push_back(outPin);
+        //_currPins.push_back(outPin);
 
         _graphNodes.push_back(std::move(newNode));
         updateMaterials();

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1593,7 +1593,6 @@ void Graph::copyInputs()
         UiNodePtr copyNode = iter->second;
         for (Pin pin : origNode->inputPins)
         {
-            
             if (origNode->getConnectedNode(pin._name) && !_ctrlClick)
             {
                 // if original node is connected check if connect node is in copied nodes

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1821,11 +1821,6 @@ void Graph::addNode(std::string category, std::string name, std::string type)
             _currPins.push_back(outPin);
             ++_graphTotalSize;
         }
-        // output pin
-        //Pin outPin = Pin(_graphTotalSize, &*("ouput"), newNode->getType(), newNode, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
-        //++_graphTotalSize;
-        //newNode->outputPins.push_back(outPin);
-        //_currPins.push_back(outPin);
 
         _graphNodes.push_back(std::move(newNode));
         updateMaterials();
@@ -2108,9 +2103,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                                     }
                                 }
                             }
-
-                            //std::cerr << "1. Try add connection to: " << pin._name << " from " <<
-                            //    upUiNode->outputPins[pinIndex]._name << std::endl;
 
                             upUiNode->outputPins[pinIndex].addConnection(pin);
                         }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1057,7 +1057,6 @@ void Graph::setUiNodeInfo(UiNodePtr node, std::string type, std::string category
 
                 for (mx::OutputPtr output : nodeDef->getActiveOutputs())
                 {
-                    std::cerr << "Add output:" << output->getName() << std::endl;
                     if (node->getNode()->getOutput(output->getName()))
                     {
                         output = node->getNode()->getOutput(output->getName());
@@ -1088,7 +1087,6 @@ void Graph::setUiNodeInfo(UiNodePtr node, std::string type, std::string category
 
         if (node->getInput() || node->getOutput())
         {
-            std::cerr << "Add single output pin: " << type << std::endl;
             Pin outPin = Pin(_graphTotalSize, &*("output"), type, node, ax::NodeEditor::PinKind::Output, nullptr, nullptr);
             ++_graphTotalSize;
             node->outputPins.push_back(outPin);

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -208,35 +208,37 @@ ed::PinId Graph::getOutputPin(UiNodePtr node, UiNodePtr upNode, Pin input)
         return ed::PinId();
     }
 
-    // For node need to get the correct ouput pin based on the input's output attribute
-    else if (upNode->getNode())
-    {
-        const std::string outputName = input._input ? input._input->getOutputString() : mx::EMPTY_STRING;
-        if (!outputName.empty())
-        {
-            for (Pin outputs : upNode->outputPins)
-            {
-                if (outputs._name == outputName)
-                {
-                    return outputs._pinId;
-                }
-            }
-        }
-        if (!upNode->outputPins.empty())
-        {
-            return (upNode->outputPins[0]._pinId);
-        }
-        return ed::PinId();
-    }
+    // For node need to get the correct ouput pin based on the appropriate 'output' attribute
     else
     {
-        // every other node can just get the first output pin since there is only one
         if (!upNode->outputPins.empty())
         {
-            return (upNode->outputPins[0]._pinId);
+            std::string outputName = mx::EMPTY_STRING;
+            if (input._input)
+            {
+                outputName = input._input->getOutputString();
+            }
+            else if (input._output)
+            {
+                outputName = input._output->getOutputString();
+            }
+
+            size_t pinIndex = 0;
+            if (!outputName.empty())
+            {
+                for (size_t i = 0; i < upNode->outputPins.size(); i++)
+                {
+                    if (upNode->outputPins[i]._name == outputName)
+                    {
+                        pinIndex = i;
+                        break;
+                    }
+                }
+            }
+            return (upNode->outputPins[pinIndex]._pinId);
         }
         return ed::PinId();
-    }
+    } 
 }
 
 // connect links via connected nodes in UiNodePtr
@@ -1592,7 +1594,7 @@ void Graph::copyInputs()
         UiNodePtr copyNode = iter->second;
         for (Pin pin : origNode->inputPins)
         {
-
+            
             if (origNode->getConnectedNode(pin._name) && !_ctrlClick)
             {
                 // if original node is connected check if connect node is in copied nodes
@@ -2151,7 +2153,20 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     {
                         if (upUiNode->outputPins.size())
                         {
-                            upUiNode->outputPins[0].addConnection(pin);
+                            std::string outString = pin._output ? pin._output->getOutputString() : mx::EMPTY_STRING;
+                            size_t pinIndex = 0;
+                            if (!outString.empty())  
+                            {
+                                for (size_t i=0; i<upUiNode->outputPins.size(); i++)
+                                {
+                                    if (upUiNode->outputPins[i]._name == outString)
+                                    {
+                                        pinIndex = i;
+                                        break;
+                                    }
+                                }
+                            }
+                            upUiNode->outputPins[pinIndex].addConnection(pin);
                         }
                         pin.setConnected(true);
                     }
@@ -2204,7 +2219,20 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     {
                         if (upUiNode->outputPins.size())
                         {
-                            upUiNode->outputPins[0].addConnection(pin);
+                            std::string outString = pin._output ? pin._output->getOutputString() : mx::EMPTY_STRING;
+                            size_t pinIndex = 0;
+                            if (!outString.empty())  
+                            {
+                                for (size_t i=0; i<upUiNode->outputPins.size(); i++)
+                                {
+                                    if (upUiNode->outputPins[i]._name == outString)
+                                    {
+                                        pinIndex = i;
+                                        break;
+                                    }
+                                }
+                            }
+                            upUiNode->outputPins[pinIndex].addConnection(pin);
                         }
                     }
 

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1315,7 +1315,8 @@ void Graph::buildUiNodeGraph(const mx::NodeGraphPtr& nodeGraphs)
                     }
                     int upNode = findNode(upName, upstreamType);
                     int downNode = findNode(downName, downstreamType);
-                    if (_graphNodes[downNode]->getOutput() != nullptr)
+                    if (downNode > 0 && upNode > 0 && 
+                        _graphNodes[downNode]->getOutput() != nullptr)
                     {
                         // creating edges for the output nodes
                         UiEdge newEdge = UiEdge(_graphNodes[upNode], _graphNodes[downNode], nullptr);

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2155,7 +2155,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                             size_t pinIndex = 0;
                             if (!outString.empty())  
                             {
-                                for (size_t i=0; i<upUiNode->outputPins.size(); i++)
+                                for (size_t i = 0; i<upUiNode->outputPins.size(); i++)
                                 {
                                     if (upUiNode->outputPins[i]._name == outString)
                                     {
@@ -2221,7 +2221,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                             size_t pinIndex = 0;
                             if (!outString.empty())  
                             {
-                                for (size_t i=0; i<upUiNode->outputPins.size(); i++)
+                                for (size_t i = 0; i<upUiNode->outputPins.size(); i++)
                                 {
                                     if (upUiNode->outputPins[i]._name == outString)
                                     {

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -190,9 +190,9 @@ void Graph::addExtraNodes()
 // return output pin needed to link the inputs and outputs
 ed::PinId Graph::getOutputPin(UiNodePtr node, UiNodePtr upNode, Pin input)
 {
-    // For nodegraph need to get the correct ouput pin accorinding to the names of the output nodes
     if (upNode->getNodeGraph() != nullptr)
     {
+        // For nodegraph need to get the correct ouput pin accorinding to the names of the output nodes
         mx::OutputPtr output = input._pinNode->getNode()->getConnectedOutput(input._name);
         if (output)
         {
@@ -207,10 +207,9 @@ ed::PinId Graph::getOutputPin(UiNodePtr node, UiNodePtr upNode, Pin input)
         }
         return ed::PinId();
     }
-
-    // For node need to get the correct ouput pin based on the appropriate 'output' attribute
     else
     {
+        // For node need to get the correct ouput pin based on the output attribute
         if (!upNode->outputPins.empty())
         {
             std::string outputName = mx::EMPTY_STRING;

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1077,7 +1077,6 @@ void Graph::setUiNodeInfo(UiNodePtr node, std::string type, std::string category
             node->inputPins.push_back(inPin);
             _currPins.push_back(inPin);
             ++_graphTotalSize;
-
         }
         else if (node->getOutput())
         {

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -12,6 +12,17 @@ const int INVALID_POS = -10000;
 
 } // anonymous namespace
 
+ void Pin::addConnection(Pin pin)
+ {
+     for (size_t i = 0; i < _connections.size(); i++)
+     {
+         if (_connections[i]._pinId == pin._pinId)
+             return;
+     }
+     std::cerr << "add connection from: " << _name << " to " << pin._name << std::endl;
+     _connections.push_back(pin);
+ }
+
 UiNode::UiNode() :
     _level(-1),
     _showAllInputs(false),

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -19,7 +19,6 @@ const int INVALID_POS = -10000;
          if (_connections[i]._pinId == pin._pinId)
              return;
      }
-     std::cerr << "add connection from: " << _name << " to " << pin._name << std::endl;
      _connections.push_back(pin);
  }
 

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -186,10 +186,7 @@ class Pin
     {
         return _connected;
     }
-    void addConnection(Pin pin)
-    {
-        _connections.push_back(pin);
-    }
+    void addConnection(Pin pin);
     std::vector<Pin> getConnection()
     {
         return _connections;


### PR DESCRIPTION
Update #1220

## Changes

* Add in all output pins on creation of nodes
* Get the correct output pin for input pins for making connections
* Small firewall checks.

## Results:

Nodes like `separate`, `UsdUvTexture`, shader translation and `gltf` image should load and connect properly now.

* UsdUVTexture Unit test:
![image](https://user-images.githubusercontent.com/49369885/216454256-1630bec6-37b7-48d5-8275-2042479ff598.png)

* glTF boombox material:
![image](https://user-images.githubusercontent.com/49369885/216454060-22f2c0e7-ddf7-4da4-8c8e-f44eb35341a3.png)

* color correct functional graph:
![image](https://user-images.githubusercontent.com/49369885/216455703-e3965780-f06e-40c2-97de-8edc4dfdbf64.png)

Sample test graph also tried (created, saved, and reloaded)
```xml
<?xml version="1.0"?>
<materialx version="1.38">
  <separate2 name="separate2_vector2" type="multioutput" xpos="1.456522" ypos="-1.008621" />
  <UsdUVTexture name="UsdUVTexture_23" type="multioutput" xpos="1.398551" ypos="0.586207" />
  <multiply name="multiply_float" type="float" xpos="2.992754" ypos="0.120690">
    <input name="in1" type="float" nodename="separate2_vector2" />
    <input name="in2" type="float" nodename="UsdUVTexture_23" />
  </multiply>
  <nodegraph name="nodegraph1">
    <input name="inputfilename" type="filename" value="brass_color.jpg" fileprefix="" xpos="2.362319" ypos="1.620690" />
    <input name="inputvector2" type="vector2" xpos="2.463768" ypos="2.724138" nodename="constant_vector2" />
    <gltf_colorimage name="gltf_colorimage" type="multioutput" xpos="3.753623" ypos="1.482759">
      <input name="file" type="filename" interfacename="inputfilename" />
      <input name="scale" type="vector2" interfacename="inputvector2" />
    </gltf_colorimage>
    <output name="outputfloat2" type="float" nodename="gltf_colorimage" output="outa" xpos="5.942029" ypos="2.586207" />
    <output name="outputcolor3" type="color3" nodename="gltf_colorimage" output="outcolor" xpos="5.840580" ypos="1.310345" />
  </nodegraph>
  <multiply name="multiply_float2" type="float" xpos="7.514493" ypos="0.956897">
    <input name="in1" type="float" nodename="separate2_vector3" />
    <input name="in2" type="float" nodename="UsdUVTexture_24" />
  </multiply>
  <UsdUVTexture name="UsdUVTexture_24" type="multioutput" xpos="4.594203" ypos="1.034483" />
  <separate2 name="separate2_vector3" type="multioutput" xpos="4.818841" ypos="0.068966" />
  <constant name="constant_vector2" type="vector2" xpos="3.630435" ypos="-1.172414">
    <input name="value" type="vector2" value="2, 2" />
  </constant>
  <multiply name="multiply_float3" type="float" xpos="9.253623" ypos="-1.146552">
    <input name="in1" type="float" output="outputfloat2" nodegraph="nodegraph1" />
    <input name="in2" type="float" nodename="multiply_float2" />
  </multiply>
  <standard_surface_to_UsdPreviewSurface name="standard_surface_to_UsdPreviewSurface" type="multioutput" xpos="-2.326087" ypos="-1.250000">
    <input name="metalness" type="float" value="0" />
  </standard_surface_to_UsdPreviewSurface>
  <gltf_colorimage name="gltf_colorimage" type="multioutput" xpos="0.398551" ypos="-2.663793" />
  <combine3 name="combine3_color3" type="color3" xpos="3.108696" ypos="-2.870690">
    <input name="in1" type="float" nodename="gltf_colorimage" />
    <input name="in2" type="float" nodename="standard_surface_to_UsdPreviewSurface" />
  </combine3>
</materialx>
```
Top level:
![image](https://user-images.githubusercontent.com/49369885/216643452-e0f7415e-39e5-4c3b-af40-dc22277b4e82.png)
Inside nodegraph:
![image](https://user-images.githubusercontent.com/49369885/216643618-d51b95d9-42b3-43ec-b4ba-5b5f6815b9aa.png)

