### PR TITLE
Refinements to UiNode class

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -478,10 +478,20 @@ ImVec2 Graph::layoutPosition(UiNodePtr layoutNode, ImVec2 startingPos, bool init
             layoutNode->_level = level;
         }
 
-        if (_levelMap.find(layoutNode->_level) != _levelMap.end())
+        auto it = _levelMap.find(layoutNode->_level);
+        if (it != _levelMap.end())
         {
             // key already exists add to it
-            if ((!std::count(_levelMap[layoutNode->_level].begin(), _levelMap[layoutNode->_level].end(), layoutNode)))
+            bool nodeFound = false;
+            for (UiNodePtr node : it->second)
+            {
+                if (node && node->getName() == layoutNode->getName())
+                {
+                    nodeFound = true;
+                    break;
+                }
+            }
+            if (!nodeFound)
             {
                 _levelMap[layoutNode->_level].push_back(layoutNode);
             }
@@ -1530,7 +1540,7 @@ void Graph::createEdge(UiNodePtr upNode, UiNodePtr downNode, mx::InputPtr connec
 
 void Graph::copyUiNode(UiNodePtr node)
 {
-    UiNodePtr copyNode = std::make_shared<UiNode>(int(_graphTotalSize + 1));
+    UiNodePtr copyNode = std::make_shared<UiNode>(mx::EMPTY_STRING, int(_graphTotalSize + 1));
     ++_graphTotalSize;
     if (node->getMxElement())
     {
@@ -2646,7 +2656,7 @@ void Graph::deleteNode(UiNodePtr node)
         }
     }
     // update downNode info
-    std::vector<Pin> outputConnections = node->outputPins.front().getConnection();
+    std::vector<Pin> outputConnections = node->outputPins.front().getConnections();
 
     for (Pin pin : outputConnections)
     {

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -12,16 +12,6 @@ const int INVALID_POS = -10000;
 
 } // anonymous namespace
 
- void Pin::addConnection(Pin pin)
- {
-     for (size_t i = 0; i < _connections.size(); i++)
-     {
-         if (_connections[i]._pinId == pin._pinId)
-             return;
-     }
-     _connections.push_back(pin);
- }
-
 UiNode::UiNode() :
     _level(-1),
     _showAllInputs(false),
@@ -31,21 +21,12 @@ UiNode::UiNode() :
 {
 }
 
-UiNode::UiNode(const std::string name, int id) :
+UiNode::UiNode(const std::string& name, int id) :
     _level(-1),
     _showAllInputs(false),
     _id(id),
     _nodePos(INVALID_POS, INVALID_POS),
     _name(name),
-    _inputNodeNum(0)
-{
-}
-
-UiNode::UiNode(int id) :
-    _level(-1),
-    _showAllInputs(false),
-    _id(id),
-    _nodePos(INVALID_POS, INVALID_POS),
     _inputNodeNum(0)
 {
 }

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -25,9 +25,8 @@ class UiNode
 
   public:
     UiNode();
-    UiNode(const std::string name, const int id);
-    UiNode(const int id);
-    ~UiNode(){};
+    UiNode(const std::string& name, int id);
+    ~UiNode() { };
 
     std::string getName()
     {
@@ -45,7 +44,7 @@ class UiNode
     {
         return _id;
     }
-    std::vector<UiNodePtr> getOutputConnections()
+    const std::vector<UiNodePtr>& getOutputConnections()
     {
         return _outputConnections;
     }
@@ -90,12 +89,13 @@ class UiNode
     {
         _outputConnections.push_back(connections);
     }
+
     void setMessage(const std::string& message)
     {
         _message = message;
     }
 
-    std::string getMessage()
+    const std::string& getMessage()
     {
         return _message;
     }
@@ -105,7 +105,7 @@ class UiNode
         _category = category;
     }
 
-    std::string getCategory()
+    const std::string& getCategory()
     {
         return _category;
     }
@@ -115,10 +115,11 @@ class UiNode
         _type = type;
     }
 
-    std::string getType()
+    const std::string& getType()
     {
         return _type;
     }
+
     mx::NodeGraphPtr getNodeGraph()
     {
         return _currNodeGraph;
@@ -129,17 +130,6 @@ class UiNode
         _currNodeGraph = nodeGraph;
     }
 
-    friend bool operator==(const UiNodePtr& lhs, const UiNodePtr& rhs)
-    {
-        return lhs != nullptr && rhs != nullptr && lhs->getName() == rhs->getName();
-    }
-
-    bool operator()(const UiNodePtr& node1, const UiNodePtr& node2) const
-    {
-        return (node1->_level < node2->_level);
-    }
-
-    // functions
     UiNodePtr getConnectedNode(std::string name);
     float getAverageY();
     float getMinX();
@@ -158,7 +148,6 @@ class UiNode
     std::string _name;
     int _inputNodeNum;
     std::vector<std::pair<int, std::string>> _inputs;
-    // used only for nodegraph nodes
     std::vector<std::pair<int, std::string>> _outputs;
     std::vector<UiNodePtr> _outputConnections;
     mx::NodePtr _currNode;
@@ -175,22 +164,45 @@ class Pin
 {
   public:
     Pin(int id, const char* name, std::string type, std::shared_ptr<UiNode> node, ed::PinKind kind, mx::InputPtr input, mx::OutputPtr output) :
-        _pinId(id), _name(name), _type(type), _pinNode(node), _kind(kind), _input(input), _output(output), _connected(false)
+        _pinId(id),
+        _name(name),
+        _type(type),
+        _pinNode(node),
+        _kind(kind),
+        _input(input),
+        _output(output),
+        _connected(false)
     {
     }
+
     void setConnected(bool connected)
     {
         _connected = connected;
     }
+
     bool getConnected()
     {
         return _connected;
     }
-    void addConnection(Pin pin);
-    std::vector<Pin> getConnection()
+
+     void addConnection(const Pin& pin)
+     {
+         for (size_t i = 0; i < _connections.size(); i++)
+         {
+             if (_connections[i]._pinId == pin._pinId)
+             {
+                 return;
+             }
+         }
+         _connections.push_back(pin);
+     }
+
+    const std::vector<Pin>& getConnections()
     {
         return _connections;
     }
+
+  public:
     ed::PinId _pinId;
     std::string _name;
     std::string _type;


### PR DESCRIPTION
- Replace custom UiNode operators with explicit logic in Graph::layoutPosition, since these custom operators can potentially be invoked by different compilers in unexpected ways.
- Merge two similar UiNode constructors, reducing the number of unique code paths to maintain.
- Pass constant method arguments by const reference.