### PR TITLE
NodeEditor: Update Material Handling

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3673,6 +3673,12 @@ void Graph::drawGraph(ImVec2 mousePos)
             _isCut = false;
         }
 
+        // start the session with content centered
+        if (ImGui::GetFrameCount() == 2)
+        {
+            ed::NavigateToContent(0.0f);
+        }
+
         // hotkey to frame selected node(s)
         if (ImGui::IsKeyReleased(GLFW_KEY_F) && !_fileDialogSave.IsOpened())
         {

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -62,32 +62,44 @@ Graph::Graph(const std::string& materialFilename,
     loadStandardLibraries();
     setPinColor();
 
-    // Generate node UI from nodedefs.
-    std::vector<mx::NodeDefPtr> nodeDefs = _stdLib->getNodeDefs();
-    for (size_t i = 0; i < nodeDefs.size(); i++)
+    _graphDoc = loadDocument(materialFilename);
+    _graphDoc->importLibrary(_stdLib);
+
+    _initial = true;
+    createNodeUIList(_stdLib);
+
+    if (_graphDoc)
     {
-        // nodeDef is the key for the map
-        std::string group = nodeDefs[i]->getNodeGroup();
-        if (group == "")
-        {
-            group = "extra";
-        }
-        std::unordered_map<std::string, std::vector<mx::NodeDefPtr>>::iterator it = _nodesToAdd.find(group);
-        if (it == _nodesToAdd.end())
-        {
-            std::vector<mx::NodeDefPtr> nodes;
-            _nodesToAdd[group] = nodes;
-        }
-        _nodesToAdd[group].push_back(nodeDefs[i]);
+        buildUiBaseGraph(_graphDoc);
+        _currGraphElem = _graphDoc;
+        _prevUiNode = nullptr;
     }
 
+    // Create a renderer using the initial startup document.
+    // Note that this document may have no nodes in it
+    // if the material file name does not exist.
     mx::FilePath captureFilename = "resources/Materials/Examples/example.png";
     std::string envRadianceFilename = "resources/Lights/san_giuseppe_bridge_split.hdr";
-    mx::Color3 screenColor(1.0f, 0.3f, 0.32f);
-
-    _renderer = std::make_shared<RenderView>(materialFilename, meshFilename, envRadianceFilename,
-                                             _searchPath, _libraryFolders, 256, 256);
+    _renderer = std::make_shared<RenderView>(_graphDoc, meshFilename, envRadianceFilename,
+                                             _searchPath, 256, 256);
     _renderer->initialize();
+    _renderer->updateMaterials(nullptr);
+    for (const std::string& incl : _renderer->getXincludeFiles())
+    {
+        _xincludeFiles.insert(incl);
+    }
+}
+
+mx::ElementPredicate Graph::getElementPredicate() const
+{
+    return [this](mx::ConstElementPtr elem)
+    {
+        if (elem->hasSourceUri())
+        {
+            return (_xincludeFiles.count(elem->getSourceUri()) == 0);
+        }
+        return true;
+    };
 }
 
 void Graph::loadStandardLibraries()
@@ -111,7 +123,6 @@ void Graph::loadStandardLibraries()
 
 mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
 {
-    std::string materialFilename = filename;
     mx::FilePathVec libraryFolders = { "libraries" };
     _libraryFolders = libraryFolders;
     mx::XmlReadOptions readOptions;
@@ -140,12 +151,21 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
     mx::DocumentPtr doc = mx::createDocument();
     try
     {
-        mx::readFromXmlFile(doc, materialFilename, _searchPath, &readOptions);
+        if (!filename.isEmpty())
+        {
+            mx::readFromXmlFile(doc, filename, _searchPath, &readOptions);
+            std::string message;
+            if (!doc->validate(&message))
+            {
+                std::cerr << "*** Validation warnings for " << filename.asString() << " ***" << std::endl;
+                std::cerr << message;
+            }
+        }
     }
     catch (mx::Exception& e)
     {
-        std::cerr << "Failed to read file: " << materialFilename << ". " <<
-            std::string(e.what()) << std::endl;
+        std::cerr << "Failed to read file: " << filename.asString() << ": \"" <<
+            std::string(e.what()) << "\"" << std::endl;
     }
     _graphStack = std::stack<std::vector<UiNodePtr>>();
     _pinStack = std::stack<std::vector<Pin>>();
@@ -155,6 +175,8 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
 // populate nodes to add with input output group and nodegraph nodes which are not found in the stdlib
 void Graph::addExtraNodes()
 {
+    _extraNodes.clear();
+
     std::vector<std::string> groups{ "Input Nodes", "Output Nodes", "Group Nodes", "Node Graph" };
     std::vector<std::string> types{
         "float", "integer", "vector2", "vector3", "vector4", "color3", "color4", "string", "filename", "bool"
@@ -712,16 +734,10 @@ void Graph::setRenderMaterial(UiNodePtr node)
 
 void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
 {
-
-    std::string renderablePaths;
+    std::string renderablePath;
     std::vector<mx::TypedElementPtr> elems;
-    std::vector<mx::NodePtr> materialNodes;
     mx::TypedElementPtr renderableElem;
     mx::findRenderableElements(_graphDoc, elems);
-    if (elems.size() > 0 && _renderer->getMaterials().size() == 0)
-    {
-        _renderer->updateMaterials(_graphDoc, nullptr);
-    }
 
     size_t num = 0;
     int num2 = 0;
@@ -735,21 +751,18 @@ void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
             {
                 if (node->getName() == _currRenderNode->getName())
                 {
-                    materialNodes.push_back(node->getType() == mx::MATERIAL_TYPE_STRING ? node : nullptr);
-                    renderablePaths = renderableElem->getNamePath();
+                    renderablePath = renderableElem->getNamePath();
                     break;
                 }
             }
             else
             {
-                materialNodes.push_back(node->getType() == mx::MATERIAL_TYPE_STRING ? node : nullptr);
-                renderablePaths = renderableElem->getNamePath();
+                renderablePath = renderableElem->getNamePath();
             }
         }
         else
         {
-            materialNodes.push_back(nullptr);
-            renderablePaths = renderableElem->getNamePath();
+            renderablePath = renderableElem->getNamePath();
             if (num2 == 2)
             {
                 break;
@@ -757,18 +770,23 @@ void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
             num2++;
         }
     }
-    if (input == nullptr)
+
+    if (renderablePath.empty())
     {
-        if (renderablePaths != "")
-        {
-            mx::ElementPtr elem = _graphDoc->getDescendant(renderablePaths);
-            mx::TypedElementPtr typedElem = elem ? elem->asA<mx::TypedElement>() : nullptr;
-            _renderer->updateMaterials(_graphDoc, typedElem);
-        }
+        _renderer->updateMaterials(nullptr);
     }
     else
     {
-        if (renderablePaths != "")
+        if (!input)
+        {
+            mx::ElementPtr elem = nullptr;
+            {
+                elem = _graphDoc->getDescendant(renderablePath);
+            }
+            mx::TypedElementPtr typedElem = elem ? elem->asA<mx::TypedElement>() : nullptr;
+            _renderer->updateMaterials(typedElem);
+        }
+        else
         {
             std::string name = input->getNamePath();
             // need to use exact interface name in order for input
@@ -777,6 +795,9 @@ void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
             {
                 name = interfaceInput->getNamePath();
             }
+            // Note that if there is a topogical change due to
+            // this value change or a transparency change, then
+            // this is not currently caught here.
             _renderer->getMaterials()[num]->modifyUniform(name, value);
         }
     }
@@ -962,6 +983,13 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input)
             {
                 _fileDialogConstant.SetTitle("Node Input Dialog");
                 _fileDialogConstant.Open();
+                mx::StringSet supportedExtensions = _renderer ? _renderer->getImageHandler()->supportedExtensions() : mx::StringSet();
+                std::vector<std::string> filters;
+                for (const std::string& supportedExtension : supportedExtensions)
+                {
+                    filters.push_back("." + supportedExtension);
+                }
+                _fileDialogConstant.SetTypeFilters(filters);
             }
             ImGui::SameLine();
             ImGui::PushItemWidth(labelWidth);
@@ -979,6 +1007,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input)
                 // need to set the file prefix for the input to "" so that it can find the new file
                 input->setAttribute(input->FILE_PREFIX_ATTRIBUTE, "");
                 _fileDialogConstant.ClearSelected();
+                _fileDialogConstant.SetTypeFilters(std::vector<std::string>());
             }
 
             // set input value  and update materials if different from previous value
@@ -1096,9 +1125,40 @@ void Graph::setUiNodeInfo(UiNodePtr node, std::string type, std::string category
 
     _graphNodes.push_back(std::move(node));
 }
-// build the UiNode node graph based off of loading a document
-void Graph::buildUiBaseGraph(const std::vector<mx::NodeGraphPtr>& nodeGraphs, const std::vector<mx::NodePtr>& docNodes, const std::vector<mx::InputPtr>& inputNodes, const std::vector<mx::OutputPtr>& outputNodes)
+
+// Generate node UI from nodedefs.
+void Graph::createNodeUIList(mx::DocumentPtr doc)
 {
+    _nodesToAdd.clear();
+    const std::string EXTRA_GROUP_NAME = "extra";
+    for (mx::NodeDefPtr nodeDef : doc->getNodeDefs())
+    {
+        // nodeDef is the key for the map
+        std::string group = nodeDef->getNodeGroup();
+        if (group.empty())
+        {
+            group = EXTRA_GROUP_NAME;
+        }
+        if (_nodesToAdd.find(group) == _nodesToAdd.end())
+        {
+            _nodesToAdd[group] = std::vector<mx::NodeDefPtr>();
+        }
+        _nodesToAdd[group].push_back(nodeDef);
+    }
+
+    addExtraNodes();
+}
+
+// build the UiNode node graph based off of loading a document
+void Graph::buildUiBaseGraph(mx::DocumentPtr doc)
+{
+    std::vector<mx::NodeGraphPtr> nodeGraphs = doc->getNodeGraphs();
+    std::vector<mx::InputPtr> inputNodes = doc->getActiveInputs();
+    std::vector<mx::OutputPtr> outputNodes = doc->getOutputs();
+    std::vector<mx::NodePtr> docNodes = doc->getNodes();
+
+    mx::ElementPredicate includeElement = getElementPredicate();
+
     _graphNodes.clear();
     _currLinks.clear();
     _currEdge.clear();
@@ -1108,6 +1168,8 @@ void Graph::buildUiBaseGraph(const std::vector<mx::NodeGraphPtr>& nodeGraphs, co
     // creating uiNodes for nodes that belong to the document so they are not in a nodegraph
     for (mx::NodePtr node : docNodes)
     {
+        if (!includeElement(node))
+            continue;
         std::string name = node->getName();
         auto currNode = std::make_shared<UiNode>(name, _graphTotalSize);
         currNode->setNode(node);
@@ -1116,6 +1178,8 @@ void Graph::buildUiBaseGraph(const std::vector<mx::NodeGraphPtr>& nodeGraphs, co
     // creating uiNodes for the nodegraph
     for (mx::NodeGraphPtr nodeGraph : nodeGraphs)
     {
+        if (!includeElement(nodeGraph))
+            continue;
         std::string name = nodeGraph->getName();
         auto currNode = std::make_shared<UiNode>(name, _graphTotalSize);
         currNode->setNodeGraph(nodeGraph);
@@ -1123,12 +1187,16 @@ void Graph::buildUiBaseGraph(const std::vector<mx::NodeGraphPtr>& nodeGraphs, co
     }
     for (mx::InputPtr input : inputNodes)
     {
+        if (!includeElement(input))
+            continue;
         auto currNode = std::make_shared<UiNode>(input->getName(), _graphTotalSize);
         currNode->setInput(input);
         setUiNodeInfo(currNode, input->getType(), input->getCategory());
     }
     for (mx::OutputPtr output : outputNodes)
     {
+        if (!includeElement(output))
+            continue;
         auto currNode = std::make_shared<UiNode>(output->getName(), _graphTotalSize);
         currNode->setOutput(output);
         setUiNodeInfo(currNode, output->getType(), output->getCategory());
@@ -2794,7 +2862,10 @@ void Graph::graphButtons()
         _currEdge.clear();
         _newLinks.clear();
         _currPins.clear();
-        _graphDoc = nullptr;
+        _graphDoc = mx::createDocument();
+        _graphDoc->importLibrary(_stdLib);
+        _currGraphElem = _graphDoc;
+
         if (_currUiNode != nullptr)
         {
             ed::DeselectNode(_currUiNode->getId());
@@ -2804,6 +2875,9 @@ void Graph::graphButtons()
         _currRenderNode = nullptr;
         _isNodeGraph = false;
         _currGraphName.clear();
+
+        _renderer->setDocument(_graphDoc);
+        _renderer->updateMaterials(nullptr);
     }
     ImGui::SameLine();
     if (ImGui::Button("Load Material"))
@@ -3130,18 +3204,6 @@ void Graph::addNodePopup(bool cursor)
     }
     if (ImGui::BeginPopup("add node"))
     {
-
-        // check if there is a document
-        if (_graphDoc == nullptr)
-        {
-            // when creating files from scratch
-            mx::DocumentPtr doc = mx::createDocument();
-            doc->importLibrary(_stdLib);
-            _graphDoc = doc;
-            _currGraphElem = _graphDoc;
-            addExtraNodes();
-        }
-
         ImGui::Text("Add Node");
         ImGui::Separator();
         static char input[16]{ "" };
@@ -3771,37 +3833,17 @@ void Graph::drawGraph(ImVec2 mousePos)
         _currGraphName.clear();
         std::string graphName = fileName.getBaseName();
         _currGraphName.push_back(graphName.substr(0, graphName.length() - 5));
-        mx::DocumentPtr doc = loadDocument(fileName);
-        _graphDoc = doc;
-        _initial = true;
-        std::vector<mx::NodeGraphPtr> nodeGraphs = _graphDoc->getNodeGraphs();
-        std::vector<mx::InputPtr> inputNodes = _graphDoc->getActiveInputs();
-        std::vector<mx::OutputPtr> outputNodes = _graphDoc->getOutputs();
-        std::vector<mx::NodePtr> docNodes = _graphDoc->getNodes();
-
+        _graphDoc = loadDocument(fileName);
         _graphDoc->importLibrary(_stdLib);
-        buildUiBaseGraph(nodeGraphs, docNodes, inputNodes, outputNodes);
-        _renderer->loadDocument(fileName, _stdLib);
-        if (_nodesToAdd.size() == 0)
-        {
-            std::vector<mx::NodeDefPtr> nodeDefs = _stdLib->getNodeDefs();
-            for (size_t i = 0; i < nodeDefs.size(); i++)
-            {
-                // nodeDef group is the key for the map
-                std::string group = nodeDefs[i]->getNodeGroup();
-                std::unordered_map<std::string, std::vector<mx::NodeDefPtr>>::iterator it = _nodesToAdd.find(group);
-                if (it == _nodesToAdd.end())
-                {
-                    std::vector<mx::NodeDefPtr> nodes;
-                    _nodesToAdd[group] = nodes;
-                }
-                _nodesToAdd[group].push_back(nodeDefs[i]);
-            }
-        }
-        addExtraNodes();
+        
+        _initial = true;
+        buildUiBaseGraph(_graphDoc);
         _currGraphElem = _graphDoc;
         _prevUiNode = nullptr;
         _fileDialog.ClearSelected();
+
+        _renderer->setDocument(_graphDoc);
+        _renderer->updateMaterials(nullptr);
     }
 
     _fileDialogConstant.Display();
@@ -3923,6 +3965,6 @@ void Graph::writeText(std::string fileName, mx::FilePath filePath)
     }
 
     mx::XmlWriteOptions writeOptions;
-    writeOptions.elementPredicate = _renderer->getElementPredicate();
+    writeOptions.elementPredicate = getElementPredicate();
     mx::writeToXmlFile(_graphDoc, filePath, &writeOptions);
 }

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -109,8 +109,10 @@ class Graph
     ~Graph(){};
 
   private:
+    mx::ElementPredicate getElementPredicate() const;
     void loadStandardLibraries();
-    void buildUiBaseGraph(const std::vector<mx::NodeGraphPtr>& nodeGraphs, const std::vector<mx::NodePtr>& docNodes, const std::vector<mx::InputPtr>& inputNodes, const std::vector<mx::OutputPtr>& outputNodes);
+    void createNodeUIList(mx::DocumentPtr doc);
+    void buildUiBaseGraph(mx::DocumentPtr doc);
     void buildUiNodeGraph(const mx::NodeGraphPtr& nodeGraphs);
     void buildGroupNode(UiNodePtr node);
 
@@ -193,7 +195,7 @@ class Graph
     void selectMaterial(UiNodePtr node);
     void handleRenderViewInputs(ImVec2 minValue, float width, float height);
     void setRenderMaterial(UiNodePtr node);
-
+    
     RenderViewPtr _renderer;
 
     // document and intializing information

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -202,20 +202,16 @@ int main(int argc, char* const argv[])
         if (g_FirstFrame)
         {
             ed::Config config;
-            config.SettingsFile = "BasicInteraction.json";
+            config.SettingsFile = nullptr;
             g_Context = ed::CreateEditor(&config);
             const float ZOOM_LEVELS[] = { 0.1f, 0.15f, 0.20f, 0.25f, 0.33f, 0.5f, 0.75f, 1.0f };
             for (auto& level : ZOOM_LEVELS)
             {
                 config.CustomZoomLevels.push_back(level);
             }
+            g_FirstFrame = false;
         }
         ed::SetCurrentEditor(g_Context);
-        if (g_FirstFrame)
-        {
-            ed::NavigateToContent(0.0f);
-        }
-        g_FirstFrame = false;
 
         graph->getRenderer()->drawContents();
         if (!captureFilename.empty())

--- a/source/MaterialXGraphEditor/RenderView.h
+++ b/source/MaterialXGraphEditor/RenderView.h
@@ -32,11 +32,10 @@ class DocumentModifiers
 class RenderView
 {
   public:
-    RenderView(const std::string& materialFilename,
+    RenderView(mx::DocumentPtr doc,
                const std::string& meshFilename,
                const std::string& envRadianceFilename,
                const mx::FileSearchPath& searchPath,
-               const mx::FilePathVec& libraryFolders,
                unsigned int screenWidth,
                unsigned int screenHeight);
     ~RenderView() { }
@@ -135,6 +134,10 @@ class RenderView
         return _viewCamera;
     }
 
+    const mx::StringSet& getXincludeFiles() const
+    {
+        return _xincludeFiles;
+    }
     mx::ElementPredicate getElementPredicate();
 
     // Request a capture of the current frame, writing it to the given filename.
@@ -184,9 +187,9 @@ class RenderView
     unsigned int _screenWidth;
     unsigned int _screenHeight;
     mx::GLFramebufferPtr _renderFrame;
-    void loadDocument(const mx::FilePath& filename, mx::DocumentPtr libraries);
+    void setDocument(mx::DocumentPtr document);
     void assignMaterial(mx::MeshPartitionPtr geometry, mx::GlslMaterialPtr material);
-    void updateMaterials(mx::DocumentPtr doc, mx::TypedElementPtr typedElem);
+    void updateMaterials(mx::TypedElementPtr typedElem);
     void setMouseButtonEvent(int button, bool down, mx::Vector2 pos);
     void setMouseMotionEvent(mx::Vector2 pos);
     void setKeyEvent(int key);
@@ -198,7 +201,6 @@ class RenderView
     void loadMesh(const mx::FilePath& filename);
     void loadEnvironmentLight();
     void applyDirectLights(mx::DocumentPtr doc);
-    void loadStandardLibraries();
 
     // Mark the given material as currently selected in the viewer.
     void setSelectedMaterial(mx::GlslMaterialPtr material)
@@ -212,9 +214,6 @@ class RenderView
             }
         }
     }
-
-    // Generate a base output filepath for data derived from the current material.
-    mx::FilePath getBaseOutputPath();
 
     // Return an element predicate for documents written from the viewer.
 
@@ -233,13 +232,11 @@ class RenderView
     void renderScreenSpaceQuad(mx::GlslMaterialPtr material);
 
   private:
-    mx::FilePath _materialFilename;
     mx::FileSearchPath _materialSearchPath;
     mx::FilePath _meshFilename;
     mx::FilePath _envRadianceFilename;
 
     mx::FileSearchPath _searchPath;
-    mx::FilePathVec _libraryFolders;
 
     mx::Vector3 _meshTranslation;
     mx::Vector3 _meshRotation;
@@ -260,7 +257,7 @@ class RenderView
     mx::Vector2 _userTranslationPixel;
 
     // Document management
-    mx::DocumentPtr _stdLib;
+    mx::DocumentPtr _document;
     DocumentModifiers _modifiers;
     mx::StringSet _xincludeFiles;
 


### PR DESCRIPTION
## Fixes for

- Making default document show up in graph view as well as renderer.
- Load with invalid file, or file with no materials. Renderer was crashing.
- Load with file with look will only show the first material assigned to all geometry instead of trying to perform any assignment matching.
- Material modified to not be "renderable", or deleted: Was always rendering last material all the time, even if it did not exist.
- "New Material": Was not clearing last material.
- Generation context was not updating fully for new documents.
- Generation context option was not creating all uniforms and as such some uniforms in graphs would not be found and thus not update.

## Cleanup
- Set up local element predicate on `Graph` appropriately so it's not call order dependent and will filter out all includes
from `Graph` or `RenderView`.
- Small refactoring to pull out reusable functions for UI building.

## New
- Small addition to filter image files names in file dialog based on `ImageHandler` file extensions. Not directly related.

## Testing:
- Command line:
  - Start with file which cannot be found.
  - Start with valid file still renders and captures okay.
- "New Material" clears `RenderView`
- Startup displays graph for initial document. Renderer will render empty if no materials found.
- "Save Material" has no change
- Updates inside of some node graphs with constants updates properly now.
- File extension filtering on image browser.