### PR TITLE
Fix installation issue with OSL legacy closures

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,9 +1,13 @@
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
         DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}" MESSAGE_NEVER
         PATTERN "CMakeLists.txt" EXCLUDE
-        PATTERN "pbrlib_genosl_impl.legacy" EXCLUDE)
+        PATTERN "pbrlib_genosl_impl.*" EXCLUDE)
 
 if (MATERIALX_OSL_LEGACY_CLOSURES)
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/pbrlib/genosl/pbrlib_genosl_impl.legacy"
-        DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}/pbrlib/genosl/" RENAME pbrlib_genosl_impl.mtlx)
+    set(PBRLIB_SUFFIX "legacy")
+else()
+    set(PBRLIB_SUFFIX "mtlx")
 endif()
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/pbrlib/genosl/pbrlib_genosl_impl.${PBRLIB_SUFFIX}"
+        DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}/pbrlib/genosl/" RENAME pbrlib_genosl_impl.mtlx)


### PR DESCRIPTION
When building with MATERIALX_OSL_LEGACY_CLOSURES=ON CMake would install the non-legacy pbrlib_genosl_impl.mtlx first and then it would find that it is already up-to-date and not install the correct legacy on top of it. This commit fixes this by excluding both the legacy and the non-legacy file from the glob install and then installing the correct one explicitly.

Note that if the user changes the value of MATERIALX_OSL_LEGACY_CLOSURES and then installs again the correct file will NOT be installed.