### PR TITLE
Use marble as default in editor

### DIFF
--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* const argv[])
         tokens.emplace_back(argv[i]);
     }
 
-    std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx";
+    std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx";
     std::string meshFilename = "resources/Geometry/shaderball.glb";
     mx::FileSearchPath searchPath = getDefaultSearchPath();
     mx::FilePathVec libraryFolders;


### PR DESCRIPTION
This changelist assigns standard_surface_marble_solid.mtlx as the default material in the graph editor.