### PR TITLE
Simplifications to editor headers

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -6,8 +6,15 @@
 #include <MaterialXGraphEditor/Graph.h>
 
 #include <MaterialXRenderGlsl/External/Glad/glad.h>
+#include <MaterialXFormat/Util.h>
+
+#include <imgui_stdlib.h>
+#include <imgui_node_editor_internal.h>
+#include <widgets.h>
 
 #include <GLFW/glfw3.h>
+
+#include <iostream>
 
 namespace
 {

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -6,34 +6,18 @@
 #ifndef MATERIALX_GRAPH_H
 #define MATERIALX_GRAPH_H
 
-#if defined(_WIN32)
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-#endif
-
 #include <MaterialXGraphEditor/RenderView.h>
 #include <MaterialXGraphEditor/UiNode.h>
 
-#include <MaterialXRender/Util.h>
 #include <MaterialXFormat/File.h>
-#include <MaterialXFormat/Util.h>
 
-#include <imgui.h>
 #include <imgui_node_editor.h>
-#include <imgui_node_editor_internal.h>
 #include <imfilebrowser.h>
-#include <imgui_stdlib.h>
-#include <iostream>
+
 #include <stack>
-#include <algorithm>
 
 namespace ed = ax::NodeEditor;
 namespace mx = MaterialX;
-class UiNode;
-class Pin;
-using UiNodePtr = std::shared_ptr<UiNode>;
-using RenderViewPtr = std::shared_ptr<RenderView>;
 
 // A link connects two pins and includes a unique id and the ids of the two pins it connects
 // Based off Link struct from ImGui Node Editor blueprints-examples.cpp
@@ -50,45 +34,6 @@ struct Link
     }
 };
 
-// class for edges between uiNodes
-class UiEdge
-{
-    // an edge is made up of two UiNodes and their connecting input
-  public:
-    UiEdge(UiNodePtr uiDown, UiNodePtr uiUp, mx::InputPtr input) :
-        _uiDown(uiDown),
-        _uiUp(uiUp),
-        _input(input)
-    {
-    }
-    mx::InputPtr getInput()
-    {
-        return _input;
-    }
-    UiNodePtr getDown()
-    {
-        return _uiDown;
-    }
-    UiNodePtr getUp()
-    {
-        return _uiUp;
-    }
-    std::string getInputName()
-    {
-        if (_input != nullptr)
-        {
-            return _input->getName();
-        }
-        else
-        {
-            return mx::EMPTY_STRING;
-        }
-    }
-    UiNodePtr _uiDown;
-    UiNodePtr _uiUp;
-    mx::InputPtr _input;
-};
-
 class Graph
 {
   public:
@@ -99,7 +44,6 @@ class Graph
 
     RenderViewPtr getRenderer()
     {
-
         return _renderer;
     }
     void initialize();

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -5,8 +5,8 @@
 
 #include <MaterialXGraphEditor/Graph.h>
 
-#include "imgui_impl_glfw.h"
-#include "imgui_impl_opengl3.h"
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
 
 #include <GLFW/glfw3.h>
 

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -5,9 +5,10 @@
 
 #include <MaterialXGraphEditor/Graph.h>
 
-#include <GLFW/glfw3.h>
-
+#include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
+
+#include <GLFW/glfw3.h>
 
 #include <iostream>
 

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -19,7 +19,7 @@
 
 #include <MaterialXFormat/Util.h>
 
-#include "imgui_impl_glfw.h"
+#include <imgui_impl_glfw.h>
 
 #include <GLFW/glfw3.h>
 

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXGraphEditor/RenderView.h>
 
 #include "MaterialXRenderGlsl/GLTextureHandler.h"
-#include <MaterialXRenderGlsl/GLUtil.h>
 #include <MaterialXRenderGlsl/External/Glad/glad.h>
 
 #include <MaterialXRender/CgltfLoader.h>
@@ -18,12 +17,13 @@
 
 #include <MaterialXGenShader/DefaultColorManagementSystem.h>
 
-#include <MaterialXFormat/Environ.h>
 #include <MaterialXFormat/Util.h>
 
-#include <iostream>
+#include "imgui_impl_glfw.h"
 
 #include <GLFW/glfw3.h>
+
+#include <iostream>
 
 const mx::Vector3 DEFAULT_CAMERA_POSITION(0.0f, 0.0f, 5.0f);
 const float DEFAULT_CAMERA_VIEW_ANGLE = 45.0f;

--- a/source/MaterialXGraphEditor/RenderView.h
+++ b/source/MaterialXGraphEditor/RenderView.h
@@ -9,17 +9,13 @@
 #include <MaterialXRenderGlsl/GLFramebuffer.h>
 #include <MaterialXRenderGlsl/GlslMaterial.h>
 
-#include <MaterialXRender/Camera.h>
 #include <MaterialXRender/GeometryHandler.h>
 #include <MaterialXRender/LightHandler.h>
-#include <MaterialXRender/Timer.h>
-
-#include <MaterialXGenGlsl/GlslShaderGenerator.h>
-#include <MaterialXCore/Unit.h>
-
-#include "imgui_impl_glfw.h"
 
 namespace mx = MaterialX;
+
+class RenderView;
+using RenderViewPtr = std::shared_ptr<RenderView>;
 
 class DocumentModifiers
 {

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -6,23 +6,112 @@
 #ifndef MATERIALX_UINODE_H
 #define MATERIALX_UINODE_H
 
-#include <MaterialXGraphEditor/Graph.h>
-
 #include <MaterialXCore/Unit.h>
 
 #include <imgui_node_editor.h>
-#include <widgets.h>
 
 namespace mx = MaterialX;
 namespace ed = ax::NodeEditor;
 
-class UiEdge;
-class Pin;
+class UiNode;
+using UiNodePtr = std::shared_ptr<UiNode>;
+
+// class for edges between UiNodes
+class UiEdge
+{
+    // an edge is made up of two UiNodes and their connecting input
+  public:
+    UiEdge(UiNodePtr uiDown, UiNodePtr uiUp, mx::InputPtr input) :
+        _uiDown(uiDown),
+        _uiUp(uiUp),
+        _input(input)
+    {
+    }
+    mx::InputPtr getInput()
+    {
+        return _input;
+    }
+    UiNodePtr getDown()
+    {
+        return _uiDown;
+    }
+    UiNodePtr getUp()
+    {
+        return _uiUp;
+    }
+    std::string getInputName()
+    {
+        if (_input != nullptr)
+        {
+            return _input->getName();
+        }
+        else
+        {
+            return mx::EMPTY_STRING;
+        }
+    }
+    UiNodePtr _uiDown;
+    UiNodePtr _uiUp;
+    mx::InputPtr _input;
+};
+
+// Based off Pin struct from ImGui Node Editor blueprints-examples.cpp
+class Pin
+{
+  public:
+    Pin(int id, const char* name, std::string type, std::shared_ptr<UiNode> node, ed::PinKind kind, mx::InputPtr input, mx::OutputPtr output) :
+        _pinId(id),
+        _name(name),
+        _type(type),
+        _pinNode(node),
+        _kind(kind),
+        _input(input),
+        _output(output),
+        _connected(false)
+    {
+    }
+
+    void setConnected(bool connected)
+    {
+        _connected = connected;
+    }
+
+    bool getConnected()
+    {
+        return _connected;
+    }
+
+     void addConnection(const Pin& pin)
+     {
+         for (size_t i = 0; i < _connections.size(); i++)
+         {
+             if (_connections[i]._pinId == pin._pinId)
+             {
+                 return;
+             }
+         }
+         _connections.push_back(pin);
+     }
+
+    const std::vector<Pin>& getConnections()
+    {
+        return _connections;
+    }
+
+  public:
+    ed::PinId _pinId;
+    std::string _name;
+    std::string _type;
+    std::shared_ptr<UiNode> _pinNode;
+    ed::PinKind _kind;
+    mx::InputPtr _input;
+    mx::OutputPtr _output;
+    std::vector<Pin> _connections;
+    bool _connected;
+};
 
 class UiNode
 {
-    using UiNodePtr = std::shared_ptr<UiNode>;
-
   public:
     UiNode();
     UiNode(const std::string& name, int id);
@@ -157,61 +246,6 @@ class UiNode
     std::string _message;
     std::string _type;
     mx::NodeGraphPtr _currNodeGraph;
-};
-
-// Based off Pin struct from ImGui Node Editor blueprints-examples.cpp
-class Pin
-{
-  public:
-    Pin(int id, const char* name, std::string type, std::shared_ptr<UiNode> node, ed::PinKind kind, mx::InputPtr input, mx::OutputPtr output) :
-        _pinId(id),
-        _name(name),
-        _type(type),
-        _pinNode(node),
-        _kind(kind),
-        _input(input),
-        _output(output),
-        _connected(false)
-    {
-    }
-
-    void setConnected(bool connected)
-    {
-        _connected = connected;
-    }
-
-    bool getConnected()
-    {
-        return _connected;
-    }
-
-     void addConnection(const Pin& pin)
-     {
-         for (size_t i = 0; i < _connections.size(); i++)
-         {
-             if (_connections[i]._pinId == pin._pinId)
-             {
-                 return;
-             }
-         }
-         _connections.push_back(pin);
-     }
-
-    const std::vector<Pin>& getConnections()
-    {
-        return _connections;
-    }
-
-  public:
-    ed::PinId _pinId;
-    std::string _name;
-    std::string _type;
-    std::shared_ptr<UiNode> _pinNode;
-    ed::PinKind _kind;
-    mx::InputPtr _input;
-    mx::OutputPtr _output;
-    std::vector<Pin> _connections;
-    bool _connected;
 };
 
 #endif


### PR DESCRIPTION
This changelist simplifies the header files in MaterialXGraphEditor, with no changes to editor logic or behavior.

- Remove a bidirectional dependency between Graph.h and UiNode.h, moving the UiEdge class class from Graph.h to UiNode.h.
- Move include directives from headers to source code where possible.
- Remove unused include directives where possible.