### PR TITLE
Fix unique names in copyUiNode

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1619,7 +1619,7 @@ void Graph::copyUiNode(UiNodePtr node)
     ++_graphTotalSize;
     if (node->getMxElement())
     {
-        std::string newName = node->getMxElement()->getParent()->createValidChildName(node->getName());
+        std::string newName = _currGraphElem->createValidChildName(node->getName());
         if (node->getNode())
         {
             mx::NodePtr mxNode;


### PR DESCRIPTION
This changelist fixes the handling of unique names in copyUiNode, using the scope of the destination graph element for name validation.