### PR TITLE
Support DPI scaling in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2769,7 +2769,7 @@ void Graph::addNodeGraphPins()
                 {
                     std::string name = input->getName();
                     auto result = std::find_if(node->inputPins.begin(), node->inputPins.end(), [name](UiPinPtr x)
-                                               {
+                    {
                         return x->_name == name;
                     });
                     if (result == node->inputPins.end())
@@ -2787,7 +2787,7 @@ void Graph::addNodeGraphPins()
                 {
                     std::string name = output->getName();
                     auto result = std::find_if(node->outputPins.begin(), node->outputPins.end(), [name](UiPinPtr x)
-                                               {
+                    {
                         return x->_name == name;
                     });
                     if (result == node->outputPins.end())

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -163,7 +163,7 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
             if (!doc->validate(&message))
             {
                 std::cerr << "*** Validation warnings for " << filename.asString() << " ***" << std::endl;
-                std::cerr << message;
+                std::cerr << message << std::endl;
             }
         }
     }
@@ -2119,7 +2119,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
             {
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f);
+                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-7.0, -8.0),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
@@ -2129,7 +2129,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
                     ImColor(ImColor(55, 55, 55, 255)), 0.f);
                 ImGui::Text("%s", node->getName().c_str());
-                ImGui::SetWindowFontScale(1);
+                ImGui::SetWindowFontScale(_fontScale);
 
                 outputPin(node);
                 for (UiPinPtr pin : node->inputPins)
@@ -2180,7 +2180,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
             {
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f);
+                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-7.0f, -8.0f),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
@@ -2190,7 +2190,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
                     ImColor(ImColor(85, 85, 85, 255)), 0.f);
                 ImGui::Text("%s", node->getName().c_str());
-                ImGui::SetWindowFontScale(1);
+                ImGui::SetWindowFontScale(_fontScale);
 
                 outputType = node->getInput()->getType();
                 outputPin(node);
@@ -2244,7 +2244,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
             {
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f);
+                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-7.0, -8.0),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
@@ -2254,7 +2254,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
                     ImColor(ImColor(35, 35, 35, 255)), 0);
                 ImGui::Text("%s", node->getName().c_str());
-                ImGui::SetWindowFontScale(1.0);
+                ImGui::SetWindowFontScale(_fontScale);
 
                 outputType = node->getOutput()->getType();
                 outputPin(node);
@@ -2313,7 +2313,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
             {
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f);
+                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-7.0, -8.0),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
@@ -2323,7 +2323,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - 9.f, ImGui::GetTextLineHeight() + 2.f),
                     ImColor(ImColor(35, 35, 35, 255)), 0);
                 ImGui::Text("%s", node->getName().c_str());
-                ImGui::SetWindowFontScale(1.0);
+                ImGui::SetWindowFontScale(_fontScale);
                 for (UiPinPtr pin : node->inputPins)
                 {
                     if (node->getConnectedNode(pin->_name) != nullptr)
@@ -2341,7 +2341,7 @@ std::vector<int> Graph::createNodes(bool nodegraph)
             ed::EndNode();
         }
     }
-    ImGui::SetWindowFontScale(1.0);
+    ImGui::SetWindowFontScale(_fontScale);
     return outputNum;
 }
 
@@ -2769,7 +2769,7 @@ void Graph::addNodeGraphPins()
                 {
                     std::string name = input->getName();
                     auto result = std::find_if(node->inputPins.begin(), node->inputPins.end(), [name](UiPinPtr x)
-                    {
+                                               {
                         return x->_name == name;
                     });
                     if (result == node->inputPins.end())
@@ -2787,7 +2787,7 @@ void Graph::addNodeGraphPins()
                 {
                     std::string name = output->getName();
                     auto result = std::find_if(node->outputPins.begin(), node->outputPins.end(), [name](UiPinPtr x)
-                    {
+                                               {
                         return x->_name == name;
                     });
                     if (result == node->outputPins.end())
@@ -3427,10 +3427,7 @@ void Graph::drawGraph(ImVec2 mousePos)
 
     io2.ConfigFlags = ImGuiConfigFlags_IsSRGB | ImGuiConfigFlags_NavEnableKeyboard;
     io2.MouseDoubleClickTime = .5;
-    // increase default font size
-    ImFont* f = ImGui::GetFont();
-    f->FontSize = 14;
-
+ 
     graphButtons();
 
     ed::Begin("My Editor");

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -50,6 +50,11 @@ class Graph
     void drawGraph(ImVec2 mousePos);
     mx::DocumentPtr loadDocument(mx::FilePath filename);
 
+    void setFontScale(float val)
+    {
+        _fontScale = val;
+    }
+
     ~Graph(){};
 
   private:
@@ -213,6 +218,9 @@ class Graph
     int _frameCount;
     // used for filtering pins when connecting links
     std::string _pinFilterType;
+
+    // DPI scaling for fonts
+    float _fontScale = 1.0f;
 };
 
 #endif

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -182,6 +182,22 @@ int main(int argc, char* const argv[])
         graph->getRenderer()->requestExit();
     }
 
+    // Handle DPI scaling
+    // Note that ScaleAllSizes() only handles things like spacing of elements.
+    // Fonts are not handled, so a global font scale factor is set.
+    // There appears to be no multi-monitor solution so use the primary monitor
+    // for now.
+    GLFWmonitor* monitor = glfwGetPrimaryMonitor();
+    if (monitor)
+    {
+        float xscale = 1.0f, yscale = 1.0f;
+        glfwGetMonitorContentScale(monitor, &xscale, &yscale);
+        ImGuiStyle& style = ImGui::GetStyle();
+        float dpiScale = xscale > yscale ? xscale : yscale;
+        style.ScaleAllSizes(dpiScale);
+        graph->setFontScale(dpiScale);
+    }
+
     // Create editor config and context.
     ed::Config config;
     config.SettingsFile = nullptr;


### PR DESCRIPTION
Update #1213

## Fix
* Detect DPI scale for monitor. For now the primary monitor will be used as there is no good solution for multi-monitor support. Sets ImGui global padding / spacing values. Font's must be manually handled but since they are already being scaled just update to use a "DPI scaling factor". 

## Test
* Tested by changing the DPI on monitor with a comparison with editor and other app ImGui app which handles scaling. This is with a scaling of 2.0. The scaling now matches (though the font used differs).
![image](https://user-images.githubusercontent.com/49369885/219171987-7032857b-8106-4f35-af65-e8df9bf2dde8.png)

