### PR TITLE
Fix node linking issue in editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -143,7 +143,8 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
             }
             catch (mx::Exception& e)
             {
-                std::cerr << "Failed to read include file: " << filename.asString() << ". " << std::string(e.what()) << std::endl;
+                std::cerr << "Failed to read include file: " << filename.asString() << ". " << 
+                    std::string(e.what()) << std::endl;
             }
         }
         else
@@ -168,7 +169,8 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
     }
     catch (mx::Exception& e)
     {
-        std::cerr << "Failed to read file: " << filename.asString() << ": \"" << std::string(e.what()) << "\"" << std::endl;
+        std::cerr << "Failed to read file: " << filename.asString() << ": \"" << 
+            std::string(e.what()) << "\"" << std::endl;
     }
     _graphStack = std::stack<std::vector<UiNodePtr>>();
     _pinStack = std::stack<std::vector<UiPinPtr>>();
@@ -2769,7 +2771,7 @@ void Graph::addNodeGraphPins()
                 {
                     std::string name = input->getName();
                     auto result = std::find_if(node->inputPins.begin(), node->inputPins.end(), [name](UiPinPtr x)
-                                               {
+                    {
                         return x->_name == name;
                     });
                     if (result == node->inputPins.end())
@@ -2787,7 +2789,7 @@ void Graph::addNodeGraphPins()
                 {
                     std::string name = output->getName();
                     auto result = std::find_if(node->outputPins.begin(), node->outputPins.end(), [name](UiPinPtr x)
-                                               {
+                    {
                         return x->_name == name;
                     });
                     if (result == node->outputPins.end())
@@ -3425,7 +3427,6 @@ void Graph::drawGraph(ImVec2 mousePos)
 
     io2.ConfigFlags = ImGuiConfigFlags_IsSRGB | ImGuiConfigFlags_NavEnableKeyboard;
     io2.MouseDoubleClickTime = .5;
-
     graphButtons();
 
     ed::Begin("My Editor");

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -143,7 +143,7 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
             }
             catch (mx::Exception& e)
             {
-                std::cerr << "Failed to read include file: " << filename.asString() << ". " << 
+                std::cerr << "Failed to read include file: " << filename.asString() << ". " <<
                     std::string(e.what()) << std::endl;
             }
         }
@@ -169,7 +169,7 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
     }
     catch (mx::Exception& e)
     {
-        std::cerr << "Failed to read file: " << filename.asString() << ": \"" << 
+        std::cerr << "Failed to read file: " << filename.asString() << ": \"" <<
             std::string(e.what()) << "\"" << std::endl;
     }
     _graphStack = std::stack<std::vector<UiNodePtr>>();

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -104,6 +104,7 @@ class Graph
     // UiEdge functions
     bool edgeExists(UiEdge edge);
     void createEdge(UiNodePtr upNode, UiNodePtr downNode, mx::InputPtr connectingInput);
+    void removeEdge(int downNode, int upNode, UiPinPtr pin);
 
     void writeText(std::string filename, mx::FilePath filePath);
     void savePosition();

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -89,12 +89,12 @@ float UiNode::getMinX()
     return small;
 }
 
-int UiNode::getEdgeIndex(int id)
+int UiNode::getEdgeIndex(int id, UiPinPtr pin)
 {
     int count = 0;
     for (UiEdge edge : edges)
     {
-        if (edge.getUp()->getId() == id || edge.getDown()->getId() == id)
+        if ((edge.getUp()->getId() == id && pin->_input == edge._input) || (edge.getDown()->getId() == id && pin->_input == edge._input))
         {
             return count;
         }

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -225,7 +225,7 @@ class UiNode
     UiNodePtr getConnectedNode(std::string name);
     float getAverageY();
     float getMinX();
-    int getEdgeIndex(int id);
+    int getEdgeIndex(int id, UiPinPtr pin);
     std::vector<UiEdge> edges;
     std::vector<UiPinPtr> inputPins;
     std::vector<UiPinPtr> outputPins;


### PR DESCRIPTION
This pull request addresses and issue where edges were not being properly deleted when a node was connected to the same node through multiple different input pins. The remove edge function now relies on both the upstream node id as well as the downstream node pin in order to identify and remove the edge. 