### PR TITLE
Fix binding of geomprops to functional graphs in GLSL

### DIFF
--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -251,6 +251,48 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     ShaderGraphPtr graph = ShaderGraph::create(nullptr, name, element, context);
     ShaderPtr shader = std::make_shared<Shader>(name, graph);
 
+    // If the given element is a functional nodegraph we may have inputs with 
+    // default geomprops assigned. In order to bind the corresponding geometric 
+    // data to these inputs we can insert geomprop nodes in the graph.
+    ElementPtr parent = element->getParent();
+    if (parent && parent->isA<NodeGraph>())
+    {
+        NodeDefPtr nodedef = parent->asA<NodeGraph>()->getNodeDef();
+        if (nodedef)
+        {
+            // It's a functional nodegraph so check all inputs for geomprop assignments.
+            bool nodeAdded = false;
+            for (ShaderGraphInputSocket* socket : graph->getInputSockets())
+            {
+                if (!socket->getGeomProp().empty())
+                {
+                    InputPtr input = nodedef->getActiveInput(socket->getName());
+                    GeomPropDefPtr geomprop = input ? input->getDefaultGeomProp() : nullptr;
+                    if (geomprop)
+                    {
+                        // A default geomprop was assigned to this graph input.
+                        // For all internal connections to this input, break the connection 
+                        // and assing a geomprop node that generates this data.
+                        // Note: If a geomprop node exists already it is reused, 
+                        // so only a single node per geometry type is created.
+                        ShaderInputVec connections = socket->getConnections();
+                        for (auto connection : connections)
+                        {
+                            connection->breakConnection();
+                            graph->addDefaultGeomNode(connection, *geomprop, context);
+                            nodeAdded = true;
+                        }
+                    }
+                }
+            }
+            // If nodes where added we need to re-sort the nodes in topological order.
+            if (nodeAdded)
+            {
+                graph->topologicalSort();
+            }
+        }
+    }
+
     // Create vertex stage.
     ShaderStagePtr vs = createStage(Stage::VERTEX, *shader);
     vs->createInputBlock(HW::VERTEX_INPUTS, "i_vs");

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -257,6 +257,13 @@ void ShaderGraph::addDefaultGeomNode(ShaderInput* input, const GeomPropDef& geom
         }
 
         node = geomNode.get();
+
+        // Assign a unique variable name for the node output.
+        const Syntax& syntax = context.getShaderGenerator().getSyntax();
+        ShaderOutput* output = node->getOutput();
+        string variable = output->getFullName();
+        variable = syntax.getVariableName(variable, output->getType(), _identifiers);
+        output->setVariable(variable);
     }
 
     input->makeConnection(node->getOutput());

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -99,6 +99,13 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     ShaderGraphInputSocket* addInputSocket(const string& name, const TypeDesc* type);
     ShaderGraphOutputSocket* addOutputSocket(const string& name, const TypeDesc* type);
 
+    /// Add a default geometric node and connect to the given input.
+    void addDefaultGeomNode(ShaderInput* input, const GeomPropDef& geomprop, GenContext& context);
+
+    /// Sort the nodes in topological order.
+    /// @throws ExceptionFoundCycle if a cycle is encountered.
+    void topologicalSort();
+
     /// Return an iterator for traversal upstream from the given output
     static ShaderGraphEdgeIterator traverseUpstream(ShaderOutput* output);
 
@@ -137,9 +144,6 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     /// bind input elements in the traversal.
     void addUpstreamDependencies(const Element& root, GenContext& context);
 
-    /// Add a default geometric node and connect to the given input.
-    void addDefaultGeomNode(ShaderInput* input, const GeomPropDef& geomprop, GenContext& context);
-
     /// Add a color transform node and connect to the given input.
     void addColorTransformNode(ShaderInput* input, const ColorSpaceTransform& transform, GenContext& context);
 
@@ -162,10 +166,6 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     /// effectively connecting the input's upstream connection
     /// with the output's downstream connections.
     void bypass(GenContext& context, ShaderNode* node, size_t inputIndex, size_t outputIndex = 0);
-
-    /// Sort the nodes in topological order.
-    /// @throws ExceptionFoundCycle if a cycle is encountered.
-    void topologicalSort();
 
     /// Calculate scopes for all nodes in the graph
     void calculateScopes();


### PR DESCRIPTION
This change list adds binding of geomprop data to functional graphs that has inputs with `defaultgeomprop` set. 

As a result we can now render such functional graphs directly in the MaterialX Viewer and Graph Editor. Examples includes the implementation graph for Standard Surface, UsdPreviewSurface, etc. Previously they would render black if visualized directly, since data like normals and tangents were not bound to the shader.

This changes applies to HW targets only. It's already supported in OSL and MDL where this data is assigned directly as default values on the shader inputs.
