### PR TITLE
Set MaterialX Graph Editor config path directory

### DIFF
--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -207,8 +207,8 @@ int main(int argc, char* const argv[])
     ImGuiIO& io = ImGui::GetIO();
     io.Fonts->AddFontDefault();
 
-    auto configPath = getConfigPath();
-    if (!configPath.asString().empty())
+    mx::FilePath configPath = getConfigPath();
+    if (!configPath.isEmpty())
     {
         io.IniFilename = (const char*) configPath.asString().c_str();
     }

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <MaterialXGraphEditor/Graph.h>
+#include <MaterialXFormat/Environ.h>
 
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
@@ -37,6 +38,38 @@ mx::FileSearchPath getDefaultSearchPath()
     }
 
     return searchPath;
+}
+
+std::filesystem::path getConfigPath()
+{
+    std::filesystem::path config_dir;
+    auto xdg_config_home = mx::getEnviron("XDG_CONFIG_HOME");
+    auto home_directory = mx::getEnviron("HOME");
+    if (!xdg_config_home.empty())
+    {
+        config_dir = std::filesystem::path(xdg_config_home) / "MaterialX";
+    }
+    else if (!home_directory.empty())
+    {
+#if defined(__APPLE__)
+        config_dir = std::filesystem::path(home_directory) / "Library" / "Preferences" / "MaterialX";
+#else
+        config_dir = std::filesystem::path(home_directory) / ".config" / "MaterialX";
+#endif
+    }
+    else
+    {
+        return {};
+    }
+
+    std::filesystem::create_directories(config_dir);
+    if (!std::filesystem::exists(config_dir))
+    {
+        std::cerr << "Failed to create MaterialX config directory at " << config_dir << std::endl;
+        return {};
+    }
+
+    return config_dir / "GraphEditor.imgui.ini";
 }
 
 const std::string options =
@@ -167,6 +200,12 @@ int main(int argc, char* const argv[])
     ImGuiIO& io = ImGui::GetIO();
     io.Fonts->AddFontDefault();
 
+    auto configPath = getConfigPath();
+    if (!configPath.empty())
+    {
+        io.IniFilename = (const char*) configPath.c_str();
+    }
+
     // Setup Dear ImGui style
     ImGui::StyleColorsDark();
 
@@ -224,7 +263,7 @@ int main(int argc, char* const argv[])
             break;
         }
 
-        double xpos, ypos;
+        double xpos = 0.0, ypos = 0.0;
         glfwGetCursorPos(window, &xpos, &ypos);
         graph->drawGraph(ImVec2((float) xpos, (float) ypos));
         ImGui::Render();

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char* const argv[])
     mx::FilePath configPath = getConfigPath();
     if (!configPath.isEmpty())
     {
-        io.IniFilename = (const char*) configPath.asString().c_str();
+        io.IniFilename = configPath.asString().c_str();
     }
 
     // Setup Dear ImGui style

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -7,7 +7,6 @@
 #include <MaterialXFormat/Environ.h>
 #include <MaterialXFormat/File.h>
 
-
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
 
@@ -57,7 +56,8 @@ mx::FilePath getConfigPath()
         config_path = mx::FilePath(home_directory) / "Library" / "Preferences";
 #else
         config_path = mx::FilePath(home_directory) / ".config";
-        if (!config_path.exists()) {
+        if (!config_path.exists())
+        {
             config_path.createDirectory();
         }
 #endif
@@ -270,7 +270,8 @@ int main(int argc, char* const argv[])
             break;
         }
 
-        double xpos = 0.0, ypos = 0.0;
+        double xpos = 0.0;
+        double ypos = 0.0;
         glfwGetCursorPos(window, &xpos, &ypos);
         graph->drawGraph(ImVec2((float) xpos, (float) ypos));
         ImGui::Render();

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -43,22 +43,22 @@ mx::FileSearchPath getDefaultSearchPath()
 
 mx::FilePath getConfigPath()
 {
-    mx::FilePath config_path;
-    auto xdg_config_home = mx::getEnviron("XDG_CONFIG_HOME");
-    auto home_directory = mx::getEnviron("HOME");
-    if (!xdg_config_home.empty())
+    mx::FilePath configPath;
+    auto xdgConfigHome = mx::getEnviron("XDG_CONFIG_HOME");
+    auto homeDirectory = mx::getEnviron("HOME");
+    if (!xdgConfigHome.empty())
     {
-        config_path = mx::FilePath(xdg_config_home);
+        configPath = mx::FilePath(xdgConfigHome);
     }
-    else if (!home_directory.empty())
+    else if (!homeDirectory.empty())
     {
 #if defined(__APPLE__)
-        config_path = mx::FilePath(home_directory) / "Library" / "Preferences";
+        configPath = mx::FilePath(homeDirectory) / "Library" / "Preferences";
 #else
-        config_path = mx::FilePath(home_directory) / ".config";
-        if (!config_path.exists())
+        configPath = mx::FilePath(homeDirectory) / ".config";
+        if (!configPath.exists())
         {
-            config_path.createDirectory();
+            configPath.createDirectory();
         }
 #endif
     }
@@ -67,16 +67,16 @@ mx::FilePath getConfigPath()
         return {};
     }
 
-    config_path = config_path / "MaterialX";
-    config_path.createDirectory();
+    configPath = configPath / "MaterialX";
+    configPath.createDirectory();
 
-    if (!config_path.exists())
+    if (!configPath.exists())
     {
-        std::cerr << "Failed to create MaterialX config directory at " << config_path.asString() << std::endl;
+        std::cerr << "Failed to create MaterialX config directory at " << configPath.asString() << std::endl;
         return {};
     }
 
-    return config_path / "GraphEditor.imgui.ini";
+    return configPath / "GraphEditor.imgui.ini";
 }
 
 const std::string options =


### PR DESCRIPTION
The Imgui library used by the MaterialXGraphEditor will leave an `imgui.ini` file in the current working directory.
This causes a lot of files littered around the place , unless the user always launches with the same cwd.

This PR changes that so it will store the config in a specified directory.

I've opted to only put this in the GraphEditor library for now, since it's the only thing that would need to use it.
However, if other parts of MaterialX need to use a config directory, it's an easy enough function to just hoist out at a later time.

The logic for finding a config directory is as follows:

1. Start with respecting the users `XDG_CONFIG_HOME` variable if set. This is Linux convention but applies to most Posix based systems
2. If it's not set, it'll default to the fallback values for `XDG_CONFIG_HOME` which is `~/Library/Preferences` on macOS and `~/.config` on Linux.
3. If either of the above conditions fail, it just fallsback to the current behaviour of using the current working directory.

I do not have a windows machine to test adding windows specific behaviour here.