### PR TITLE
Add nullptr check in getTypeSyntax

### DIFF
--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -69,6 +69,10 @@ void Syntax::registerInvalidTokens(const StringMap& tokens)
 /// Throws an exception if a type syntax is not defined for the given type.
 const TypeSyntax& Syntax::getTypeSyntax(const TypeDesc* type) const
 {
+    if (type == nullptr)
+    {
+        throw ExceptionShaderGenError("Cannot lookup type syntax for a nullptr");
+    }
     auto it = _typeSyntaxByType.find(type);
     if (it == _typeSyntaxByType.end())
     {

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -69,14 +69,11 @@ void Syntax::registerInvalidTokens(const StringMap& tokens)
 /// Throws an exception if a type syntax is not defined for the given type.
 const TypeSyntax& Syntax::getTypeSyntax(const TypeDesc* type) const
 {
-    if (type == nullptr)
-    {
-        throw ExceptionShaderGenError("Cannot lookup type syntax for a nullptr");
-    }
     auto it = _typeSyntaxByType.find(type);
     if (it == _typeSyntaxByType.end())
     {
-        throw ExceptionShaderGenError("No syntax is defined for the given type '" + type->getName() + "'.");
+        string typeName = type ? type->getName() : "nullptr";
+        throw ExceptionShaderGenError("No syntax is defined for the given type '" + typeName + "'.");
     }
     return *_typeSyntaxes[it->second];
 }


### PR DESCRIPTION
I hit a segfault when I accidentally created a malformed shader, and found this raw pointer that needed a nullptr check.
Ultimately the function will still crash the program since it throws an exception either way, but this way it's not hitting a sigabrt when trying to construct the exception message.