### PR TITLE
Fix a nullptr check in pasteNode handling

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1602,6 +1602,7 @@ void Graph::positionPasteBin(ImVec2 pos)
     offset.y = pos.y - avgPos.y;
     for (auto pasteNode : _copiedNodes)
     {
+        if (pasteNode.first == nullptr || pasteNode.second == nullptr) continue;
         ImVec2 newPos = ImVec2(0, 0);
         newPos.x = ed::GetNodePosition(pasteNode.first->getId()).x + offset.x;
         newPos.y = ed::GetNodePosition(pasteNode.first->getId()).y + offset.y;

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1602,7 +1602,10 @@ void Graph::positionPasteBin(ImVec2 pos)
     offset.y = pos.y - avgPos.y;
     for (auto pasteNode : _copiedNodes)
     {
-        if (pasteNode.first == nullptr || pasteNode.second == nullptr) continue;
+        if (!pasteNode.second)
+        {
+            continue;
+        }
         ImVec2 newPos = ImVec2(0, 0);
         newPos.x = ed::GetNodePosition(pasteNode.first->getId()).x + offset.x;
         newPos.y = ed::GetNodePosition(pasteNode.first->getId()).y + offset.y;


### PR DESCRIPTION
Just a quick fix for another crash scenario that I was hitting while working with the graph. 

If you delete the default surface shader node in the graph (Ctrl+X), and then create another after that, you'll encounter a case where the pointers on the pasteNode are nullptrs.

This is probably obfuscating an issue further down the pipeline of clipboard handling, but it at least fixes the crash for now.