### PR TITLE
Graph I/O Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,8 +197,9 @@ jobs:
         python MaterialXTest/genshader.py
         python Scripts/mxupdate.py ../resources/Materials/TestSuite/stdlib/upgrade --yes
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --verbose
-        python Scripts/mxdoc.py --docType md ../libraries/pbrlib/pbrlib_defs.mtlx
-        python Scripts/mxdoc.py --docType html ../libraries/bxdf/standard_surface.mtlx
+        python Scripts/mxdoc.py --docType md --nodegraph --printIndex ../libraries > node_library.md
+        python Scripts/mxdoc.py --docType html --nodegraph --printIndex ../libraries > node_library.html
+        python Scripts/mxgraph.py --libraryPath ../libraries ../resources/Materials/Examples/StandardSurface/standard_surface_chess_set.mtlx
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface --path .. --target glsl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface --path .. --target osl
         python Scripts/generateshader.py ../resources/Materials/Examples/StandardSurface --path .. --target mdl

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -62,7 +62,7 @@ By default, the MaterialX viewer loads and saves image files using `stb_image`, 
 - `O`: Save the current OSL shader source to file.
 - `M`: Save the current MDL shader source to file.
 - `L`: Load GLSL shader source from file.  Editing the source files before loading provides a way to debug and experiment with shader source code.
-- `D`: Save each node graph in the current material as a DOT file.  See www.graphviz.org for more details on this format.
+- `D`: Save the node graph for the current material as a diagram file. This can be either a `mermaid` or `dot` file foramt. See and https://mermaid.js.org/ and https://www.graphviz.org for more details on the each format. See `Advanced Settings` for additional controls.
 - `F`: Capture the current frame and save to file.
 - `W`: Create a wedge rendering and save to file.  See `Advanced Settings` for additional controls.
 - `T`: Translate the current material to a different shading model.  See `Advanced Settings` for additional controls.

--- a/python/Scripts/mxdoc.py
+++ b/python/Scripts/mxdoc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 '''
-Print markdown documentation for each nodedef in the given document.
+Print markdown documentation for each nodedef in the given document or documents in a folder
 '''
 
 import sys, os, argparse
@@ -11,30 +11,96 @@ HEADERS = ('Name', 'Type', 'Default Value',
 
 ATTR_NAMES = ('uiname', 'uimin', 'uimax', 'uisoftmin', 'uisoftmax', 'uistep', 'uifolder', 'uiadvanced', 'doc', 'uniform' )
 
-def main():
-    parser = argparse.ArgumentParser(description="Print documentation for each nodedef in the given document.")
-    parser.add_argument(dest="inputFilename", help="Filename of the input MaterialX document.")
-    parser.add_argument('--docType', dest='documentType', default='md', help='Document type. Default is "md" (Markdown). Specify "html" for HTML output')
-    parser.add_argument('--showInherited', default=False, action='store_true', help='Show inherited inputs. Default is False')
-    opts = parser.parse_args()
+# Find all MaterialX files
+def getFiles(rootPath):
+    filelist = []
+    for subdir, dirs, files in os.walk(rootPath):
+        for file in files:
+            if file.endswith('mtlx'):
+                filelist.append(os.path.join(subdir, file)) 
+    return filelist
 
-    doc = mx.createDocument()
-    try:
-        mx.readFromXmlFile(doc, opts.inputFilename)
-    except mx.ExceptionFileMissing as err:
-        print(err)
-        sys.exit(0)
+# Create a dictionary with node group as the primary key for a list of associated
+# node types
+def getNodeDictionary(doc):
+    nodegroups = { "" } 
+    nodetypes = { "" }
+    nodegroupdict = {}
+    for nd in doc.getNodeDefs():
+        nodestring = nd.getNodeString() 
+        nodetypes.add( nodestring )
+        nodegroup = nd.getNodeGroup()
+        if not nodegroup:
+            nodegroup = "no group"
+        nodegroups.add( nodegroup )
+        if not nodegroup in nodegroupdict.keys():
+            nodegroupdict[nodegroup] = { nodestring }
+        else:
+            nodegroupdict[nodegroup].add(nodestring)
+
+    return nodegroupdict
+
+# Print out dictionary in Markdown format
+def printNodeDictionary(nodegroupdict, opts):
+    for ng in nodegroupdict:
+        if opts.documentType == "html":
+            print('<h3>Node Group: ' + ng + '</h3>')
+        elif opts.documentType == 'md':
+            print('### Node Group: ' + ng)
+        else:
+            print('/// @defgroup ' + ng + " Group: " + ng)
+            print('///@{')
+
+        groupString = ""
+        if opts.documentType == "html":
+            for n in nodegroupdict[ng]:
+                groupString += '<a href="#%s">%s</a> ' % (n, n)
+            print('<ul>')
+            print('<li>' + groupString)
+            print('</ul>')
+        elif opts.documentType == 'md':
+            for n in nodegroupdict[ng]:
+                groupString += '[' + n + '](#' + n + ') '
+            print('* ' + groupString)
+        else:
+            for n in nodegroupdict[ng]:
+                print('/// @brief class ' + n + ' in ' + ng)
+            print('///@}')
+
+    if opts.documentType == "html":
+        print('<hr>')
+    elif opts.documentType == 'md':
+        print('---------')
+    else:
+        print(' ')
+
+# Print the document for node definitions in a file
+def printNodeDefs(doc, opts):
+
+    currentNodeString = ""
+
+    # Crete grapher. Note that we don't need additional subgraphs groupings as the 
+    # implemention is a subgraph.
+    graphio = mx.MermaidGraphIo.create()
+    graphOptions = mx.GraphIoGenOptions()
+    graphOptions.setWriteSubgraphs(False)
+    graphOptions.setOrientation(mx.GraphOrientation.LEFT_RIGHT)
+    graphio.setGenOptions(graphOptions)
 
     for nd in doc.getNodeDefs():
+
         # HTML output
-        if opts.documentType == "html":
-            print('<head><style>')
-            print('table, th, td {')
-            print('   border-bottom: 1px solid; border-collapse: collapse; padding: 10px;')
-            print('}')
-            print('</style></head>')
+        if opts.documentType == 'html':
+            nodeString = nd.getNodeString()
+            if currentNodeString != nodeString:
+                print('<h3><a id="%s">' % nodeString)
+                print('Node: %s' % nodeString)
+                print('</a></h3>')
+                currentNodeString = nodeString  
+            print('<details><summary>%s</summary>' % nd.getName())
+            print('<p>')
             print('<ul>')
-            print('<li> <em>Nodedef</em>: %s' % nd.getName())
+            print('<li> <em>NodeDef</em>: %s' % nd.getName())
             print('<li> <em>Type</em>: %s' % nd.getType())
             if len(nd.getNodeGroup()) > 0:
                 print('<li> <em>Node Group</em>: %s' % nd.getNodeGroup())
@@ -43,7 +109,27 @@ def main():
             if len(nd.getInheritString()) > 0:
                 print('<li> <em>Inherits From</em>: %s' % nd.getInheritString())
             print('<li> <em>Doc</em>: %s\n' % nd.getAttribute('doc'))
+            if opts.nodegraph:
+                mdoutput = ''
+                ng = nd.getImplementation()
+                if ng and ng.isA(mx.NodeGraph):
+                    outputList = []
+                    for output in ng.getOutputs():
+                        outputList.append(output.getNamePath())                         
+                    mdoutput = graphio.write(ng, outputList)
+                    print('<li> <em>Nodegraph</em>: %s' % ng.getName())
+                    if mdoutput:
+                        print('<pre><code class="language-mermaid"><div class="mermaid">')
+                        print(mdoutput)
+                        print('\n')
+                        print('</div></code></pre>\n')   
+                    else:
+                        print('None')
+                else:
+                    print('<li> <em>Implementation</em>: Non-graph')
+
             print('</ul>')
+            
             print('<table><tr>')
             for h in HEADERS:
                 print('<th>' + h + '</th>')
@@ -63,7 +149,7 @@ def main():
                     infos.append('<b>'+ port.getName() + '</b>')
                 infos.append(port.getType())
                 val = port.getValue()
-                if port.getType() == "float":
+                if val and port.getType() == "float":
                     val = round(val, 6)
                 infos.append(str(val))
                 for attrname in ATTR_NAMES:
@@ -72,18 +158,49 @@ def main():
                     print('<td>' + info + '</td>')
                 print('</tr>')
             print('</table>')
+            print('</p></details>')
 
         # Markdown output
-        else:
-            print('- *Nodedef*: %s' % nd.getName())
-            print('- *Type*: %s' % nd.getType())
+        elif opts.documentType == 'md':
+            nodeString = nd.getNodeString()
+            if currentNodeString != nodeString:
+                print('### Node: *%s*' % nodeString)
+                currentNodeString = nodeString
+            print('<details><summary>%s</summary>' % nd.getName())
+            print('<p>')
+            print(' ')
+            print('* *Nodedef*: %s' % nd.getName())
+            print('* *Type*: %s' % nd.getType())
             if len(nd.getNodeGroup()) > 0:
-                print('- *Node Group*: %s' % nd.getNodeGroup())
+                print('* *Node Group*: %s' % nd.getNodeGroup())
             if len(nd.getVersionString()) > 0:
-                print('- *Version*: %s. Is default: %s' % (nd.getVersionString(), nd.getDefaultVersion()))
+                print('* *Version*: %s. Is default: %s' % (nd.getVersionString(), nd.getDefaultVersion()))
             if len(nd.getInheritString()) > 0:
                 print('- *Inherits From*: %s' % nd.getInheritString())
-            print('- *Doc*: %s\n' % nd.getAttribute('doc'))
+            docstring = nd.getAttribute('doc')
+            if not docstring:
+                docstring = "UNDOCUMENTED"
+            print('* *Doc*: %s' % docstring)
+            if opts.nodegraph:
+                mdoutput = ''
+                ng = nd.getImplementation()
+                if ng and ng.isA(mx.NodeGraph):
+                    outputList = []                    
+                    for output in ng.getOutputs():
+                        outputList.append(output.getNamePath())                         
+                    mdoutput = graphio.write(ng, outputList)
+                    print('* *Nodegraph*: %s' % ng.getName())
+                    if mdoutput:
+                        print('\n')
+                        print('```mermaid')
+                        print(mdoutput)
+                        print('```')
+                    else:
+                        print('None')
+                else:
+                    print('* *Implementation*: Non-graph')
+            
+            print(' \n')
             print('| ' + ' | '.join(HEADERS) + ' |')
             print('|' + ' ---- |' * len(HEADERS) + '')
             inputList = nd.getActiveInputs() if opts.showInherited  else nd.getInputs()
@@ -100,12 +217,82 @@ def main():
                     infos.append('**'+ port.getName() + '**')
                 infos.append(port.getType())
                 val = port.getValue()
-                if port.getType() == "float":
+                if val and port.getType() == "float":
                     val = round(val, 6)
                 infos.append(str(val))
                 for attrname in ATTR_NAMES:
                     infos.append(port.getAttribute(attrname))
                 print('| ' + " | ".join(infos) + ' |')
+
+            print('</p></details>')
+            print(' ')
+
+# Read in a single document or documents in a folder
+# Return false if any document cannot be read
+def readDocuments(rootPath, doc):
+
+    readDoc = True
+
+    if os.path.isdir(rootPath): 
+        filelist = getFiles(rootPath)
+        for inputFilename in filelist:
+            try:
+                mx.readFromXmlFile(doc, inputFilename)
+            except mx.ExceptionFileMissing as err:
+                print(err)
+    else:
+        try:
+            mx.readFromXmlFile(doc, rootPath)
+        except mx.ExceptionFileMissing as err:
+            print(err)
+            readDoc = False
+
+    return readDoc
+
+
+def printHeader(opts):
+    if opts.documentType == "html":
+        print('<html>')
+        # Add in mermaid support
+        if opts.nodegraph:
+            print('<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>')
+            print('<script>')
+            print('mermaid.initialize({ startOnLoad: true, theme: document.body.classList.contains("vscode-dark") || document.body.classList.contains("vscode-high-contrast") ? "dark" : "default" });')
+            print('</script>')        
+        print('<head><style>')
+        print('table, th, td {')
+        print('   border-bottom: 1px solid; border-collapse: collapse; padding: 10px;')
+        print('}')
+        print('</style></head>')
+        print('<body>')
+
+def printFooter(opts):
+    if opts.documentType == "html":
+        print('</body>')
+        print('</html>')
+
+def main():
+    parser = argparse.ArgumentParser(description="Print documentation for each nodedef in the given document.")
+    parser.add_argument(dest="inputFilename", help="Path of the input MaterialX document or folder.")
+    parser.add_argument('--docType', dest='documentType', default='md', help='Document type. Default is "md" (Markdown). Specify "html" for HTML output')
+    parser.add_argument('--showInherited', default=False, action='store_true', help='Show inherited inputs. Default is False')
+    parser.add_argument('--nodegraph', default=False, action='store_true', help='Show nodegraph implementation if any. Default is False')
+    parser.add_argument('--printIndex', default=False, action='store_true', help="Print nodedef index. Default is False")
+
+    opts = parser.parse_args()
+
+    printHeader(opts)
+
+    rootPath = opts.inputFilename;
+    doc = mx.createDocument()
+    readDocuments(rootPath, doc)    
+
+    nodedict = getNodeDictionary(doc)
+    printNodeDictionary(nodedict, opts)
+            
+    printNodeDefs(doc, opts) 
+
+    printFooter(opts) 
 
 if __name__ == '__main__':
     main()

--- a/python/Scripts/mxgraph.py
+++ b/python/Scripts/mxgraph.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+'''
+Utility to generate diagrams for node graphs in a MaterialX document. By default
+all renderable elements are scanned within the document to produce a single output file.
+The current output options are 'Mermard' and GraphViz 'dot' format. The default format is Mermaid
+which is appropriate for Markdown consumption.
+'''
+
+import sys, os, argparse, shutil, io
+import MaterialX as mx
+import MaterialX.PyMaterialXGenShader as mx_gen_shader
+import MaterialX.PyMaterialXGenGlsl as mx_gen_glsl
+import MaterialX.PyMaterialXGenOsl as mx_gen_osl
+import MaterialX.PyMaterialXGenMdl as mx_gen_mdl
+
+def getFiles(rootPath):
+    "Find all MaterialX files"
+    filelist = []
+    for subdir, dirs, files in os.walk(rootPath):
+        for file in files:
+            if file.endswith('mtlx'):
+                filelist.append(os.path.join(subdir, file)) 
+    return filelist
+
+def readLibraries(rootPath, doc):
+    "Setup and read in libraries"
+
+    readDoc = True
+    readOptions = mx.XmlReadOptions()
+
+    if os.path.isdir(rootPath): 
+        filelist = getFiles(rootPath)
+        for inputFilename in filelist:
+            try:  
+                libDoc = mx.createDocument()              
+                mx.readFromXmlFile(libDoc, inputFilename, mx.FileSearchPath(), readOptions)
+                doc.importLibrary(libDoc)
+            except mx.ExceptionFileMissing as err:
+                print(err)
+    else:
+        try:
+            libDoc = mx.createDocument()              
+            mx.readFromXmlFile(libDoc, rootPath, mx.FileSearchPath(), readOptions)
+            doc.importLibrary(libDoc)
+        except mx.ExceptionFileMissing as err:
+            print(err)
+            readDoc = False
+
+    return readDoc
+
+def generateGraph(opts, root, outputList, writeHeader):
+    "Generate the graph for a set of outputs within a <nodegraph>"
+
+    graphOutput = ''
+
+    # By default we don't want the per graph headers and will add them
+    # in as a wrapper outside this function.
+    graphOptions = mx.GraphIoGenOptions()
+    graphOptions.setWriteGraphHeader(writeHeader)
+    graphOptions.setWriteCategories(False)
+    graphOptions.setWriteSubgraphs(True)
+    graphOptions.setOrientation(mx.GraphOrientation.LEFT_RIGHT)
+
+    if opts.graphFormat == 'dot':
+        # Write dot
+        graphio = mx.DotGraphIo.create()
+    else:
+        # Write mermaid
+        graphio = mx.MermaidGraphIo.create()
+
+    graphio.setGenOptions(graphOptions)
+    graphOutput = graphio.write(root, outputList)
+
+    return graphOutput
+
+def main():
+    parser = argparse.ArgumentParser(description="Print documentation for each nodedef in the given document.")
+    parser.add_argument(dest="inputFilename", help="Path of the input MaterialX document or folder.")
+    parser.add_argument("--libraryPath", default="libraries", help="Path for MaterialX libraries.")
+    parser.add_argument('--graphFormat', dest='graphFormat', default='mermaid', help='Graph format. Default is "mermaid" (Mermaid). Specify "dot" for GraphViz dot output')
+    parser.add_argument('--outputFile', default="graph_output.md", help="Name of output file. Default name is 'graph.md")
+
+    opts = parser.parse_args()
+
+    rootPath = opts.inputFilename;
+    doc = mx.createDocument()
+    readLibraries(opts.libraryPath, doc)
+
+    mx.readFromXmlFile(doc, opts.inputFilename, mx.FileSearchPath())
+
+    # Try to find renderable elements in the document
+    nodes = mx_gen_shader.findRenderableElements(doc, False)
+    if not nodes:
+        nodes = doc.getMaterialNodes()
+        if not nodes:
+            nodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
+
+
+    # Set up header and foot for the graph
+    header = "```mermaid\n" 
+    footer = "```"
+    if opts.graphFormat == 'dot':
+        header = "digraph {\n"
+        footer = "}"
+
+    graphOutput = header
+
+    # Create the graph for each element found.
+    writeHeader = True
+    for elem in nodes:
+        graphNode = elem.getDocument()
+        roots = []
+
+        # Check outputs
+        if elem.isA(mx.Output):
+
+            roots.append(elem.getNamePath())
+            parent = elem.getParent()
+            if parent.isA(mx.NodeGraph):
+                graphNode = parent
+            else:
+                graphNode = elem.getDocument()
+
+        # Check nodes
+        elif elem.isA(mx.InterfaceElement):
+            for out in elem.getActiveOutputs():
+                roots.append(out.getNamePath())
+            if not roots:
+                roots.append(elem.getNamePath())
+        
+        # Generate graph for the set of outputs found
+        if graphNode:
+            for root in roots:
+                print('Generate graph for root: ', root)
+            graphOutput += generateGraph(opts, graphNode, roots, writeHeader)
+            # Only write header once
+            writeHeader = False
+        
+
+    graphOutput += footer
+    
+    # Write output to disk
+    filename = opts.outputFile
+    f = open(filename, 'w')
+    f.write(graphOutput)
+    f.close()
+    print('Wrote file: ' + filename) 
+
+if __name__ == '__main__':
+    main()

--- a/source/MaterialXFormat/GraphIo.cpp
+++ b/source/MaterialXFormat/GraphIo.cpp
@@ -1,0 +1,527 @@
+//
+// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXFormat/GraphIo.h>
+
+#include <iostream>
+
+MATERIALX_NAMESPACE_BEGIN
+
+static string GRAPH_INDENT = "    ";
+static string GRAPH_QUOTE = "\"";
+
+// Base class methods
+
+string GraphIo::addNodeToSubgraph(std::unordered_map<string, StringSet>& subGraphs, 
+                                  const ElementPtr node, const string& label) const
+{   
+    if (!node)
+    {
+        return EMPTY_STRING;
+    }
+
+    string subgraphNodeName = label;
+    if (!_restrictedMap.empty())
+    {
+        subgraphNodeName = replaceSubstrings(subgraphNodeName, _restrictedMap);
+    }
+    const ElementPtr subgraph = node->getParent();
+    if (!subgraph)
+    {
+        return subgraphNodeName;
+    }
+
+    // Use full path to identify sub-graphs
+    // A Document has no path so even though it is a GraphElement it will not be added here
+    string graphId = createValidName(subgraph->getNamePath());
+    if (!graphId.empty())
+    {
+        subgraphNodeName = graphId + "_" + subgraphNodeName;
+        if (subGraphs.count(graphId))
+        {
+            subGraphs[graphId].insert(subgraphNodeName);
+        }
+        else
+        {
+            StringSet newSet;
+            newSet.insert(subgraphNodeName);
+            subGraphs[graphId] = newSet;
+        }
+    }
+
+    return subgraphNodeName;
+}
+
+void GraphIo::emitGraph(GraphElementPtr graph, const StringVec& rootPaths)
+{
+    DocumentPtr doc = graph->getDocument();
+
+    _graphResult.clear();
+
+    // Write out all connections.
+    std::set<Edge> processedEdges;
+    StringSet processedInterfaces;
+    std::unordered_map<string, StringSet> subGraphs;
+
+    std::vector<ElementPtr> roots;
+    if (!rootPaths.empty())
+    {
+        for (const string& rootPath : rootPaths)
+        {
+            ElementPtr root = doc->getDescendant(rootPath);
+            if (root)
+            {
+                roots.push_back(root);
+            }
+        }
+    }
+    else
+    {
+        // Add in any outputs or materials found
+        for (OutputPtr out : graph->getOutputs())
+        {
+            roots.push_back(out);
+        }
+        for (NodePtr material : graph->getMaterialNodes())
+        {
+            roots.push_back(material);
+        }
+    }
+
+    bool writeCategoryNames = _genOptions.getWriteCategories();
+    for (ElementPtr root : roots)
+    {
+        bool processedAny = false;
+        for (Edge edge : root->traverseGraph())
+        {
+            if (!processedEdges.count(edge))
+            {
+                processedEdges.insert(edge);
+
+                ElementPtr upstreamElem = edge.getUpstreamElement();
+                ElementPtr downstreamElem = edge.getDownstreamElement();
+                ElementPtr connectingElem = edge.getConnectingElement();
+
+                processedAny = true;
+
+                // Add upstream nodes. 
+                // - Add list of unique nodes to parent subgraph if it exists
+                // - Output upstream node + label (id or category)
+                string upstreamId = addNodeToSubgraph(subGraphs, upstreamElem, upstreamElem->getName());
+                NodeIO nodeIO;                
+                NodePtr upstreamNode = upstreamElem->asA<Node>();
+                nodeIO.group = EMPTY_STRING;
+                if (upstreamNode)
+                {
+                    NodeDefPtr upstreamNodeDef = upstreamNode->getNodeDef();                    
+                    nodeIO.group = upstreamNodeDef ? upstreamNodeDef->getNodeGroup() : EMPTY_STRING;
+                }
+                nodeIO.identifier = upstreamId;
+                nodeIO.uilabel = writeCategoryNames ? upstreamElem->getCategory() : upstreamId;
+                nodeIO.category = upstreamElem->getCategory();
+                nodeIO.uishape = NodeIO::NodeShape::BOX;
+                emitUpstreamNode(nodeIO);
+
+                // Add connecting edges
+                //
+                string outputPort;
+                string outputLabel;
+                string inputName;
+                string channelName;
+                if (connectingElem)
+                {
+                    inputName = connectingElem->getName();
+                    // Check for channel
+                    channelName = connectingElem->getAttribute(PortElement::CHANNELS_ATTRIBUTE);
+
+                    // Check for an explicit output name
+                    outputLabel = connectingElem->getAttribute(PortElement::OUTPUT_ATTRIBUTE);
+                    if (!outputLabel.empty())
+                    {
+                        // Add the output to parent subgraph if any
+                        // Upstream to Output connection
+                        outputPort = addNodeToSubgraph(subGraphs, upstreamElem, upstreamId + outputLabel);                        
+                    }
+                }
+                emitConnection(outputPort, outputLabel, inputName, channelName);
+
+                // Add downstream
+                string downstreamCategory = downstreamElem->getCategory();
+                string downstreamName = downstreamElem->getName();
+                string downstreamId = addNodeToSubgraph(subGraphs, downstreamElem, downstreamName);                        
+
+                nodeIO.identifier = downstreamId;
+                nodeIO.uilabel = (writeCategoryNames && (downstreamCategory != Output::CATEGORY)) ? downstreamCategory : downstreamName;
+                nodeIO.category = downstreamCategory;
+                nodeIO.uishape = NodeIO::NodeShape::BOX;
+                nodeIO.group = EMPTY_STRING;
+                NodePtr downstreamNode = downstreamElem->asA<Node>();
+                if (downstreamNode)
+                {
+                    NodeDefPtr downstreamNodeDef = downstreamNode->getNodeDef();
+                    nodeIO.group = downstreamNodeDef ? downstreamNodeDef->getNodeGroup() : EMPTY_STRING;
+                }
+                emitDownstreamNode(nodeIO, inputName);
+
+                const string upstreamNodeName = upstreamNode ? upstreamNode->getName() : EMPTY_STRING;
+                if (upstreamNode && !processedInterfaces.count(upstreamNodeName))
+                {
+                    processedInterfaces.insert(upstreamNodeName);
+
+                    for (InputPtr input : upstreamNode->getInputs())
+                    {
+                        if (input->hasInterfaceName())
+                        {
+                            const string interfaceName = input->getInterfaceName();
+                            const ElementPtr upstreamParent = upstreamNode->getParent() ? upstreamNode->getParent() : nullptr;
+                            NodeGraphPtr upstreamGraph = nullptr;
+                            if (upstreamNode->getParent())
+                            {
+                                upstreamGraph = upstreamNode->getParent()->asA<NodeGraph>();
+                            }
+                            const InputPtr interfaceInput = upstreamGraph ? upstreamGraph->getInput(interfaceName) : nullptr;
+                            if (!interfaceInput || // Will occur with functional graphs
+                                (interfaceInput && !interfaceInput->getConnectedNode()))
+                            {
+                                // Append an extra string on to the interfacename in case the interface name
+                                // is the same as an interior node name. Note that this issue also occurs with
+                                // shader generation.
+                                string graphInterfaceName = addNodeToSubgraph(subGraphs, upstreamNode, input->getInterfaceName() + "INT");
+
+                                const string interiorNodeId = createValidName(upstreamElem->getNamePath());
+                                const string interiorNodeCategory = upstreamElem->getCategory();
+                                const string interiorNodeLabel = writeCategoryNames ? interiorNodeCategory : interiorNodeId;
+
+                                const string interfaceInputName = input->getInterfaceName();
+                                const string interiorInputName = input->getName();
+
+                                nodeIO.identifier = interiorNodeId;
+                                nodeIO.uilabel = writeCategoryNames ? interiorNodeCategory : interiorNodeLabel;
+                                nodeIO.category = interiorNodeCategory;
+                                nodeIO.uishape = NodeIO::NodeShape::ROUNDEDBOX;
+                                emitInterfaceConnection(graphInterfaceName, interfaceInputName,
+                                                        interiorInputName, nodeIO);
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+
+        if (!processedAny)
+        {
+            // Only add in the root node if no connections found during traversal
+            NodeIO nodeIO;
+            nodeIO.identifier = createValidName(root->getNamePath());
+            nodeIO.category = root->getCategory();
+            nodeIO.uilabel = writeCategoryNames ? nodeIO.category : nodeIO.identifier;
+            nodeIO.uishape = NodeIO::NodeShape::BOX;
+            emitRootNode(nodeIO);
+        }
+    }
+
+    // Add output for nodes in subgraphs if option set
+    if (_genOptions.getWriteSubgraphs())
+    {
+        emitSubgraphs(subGraphs);
+    }
+
+    // Output entire graph
+    emitGraphString();
+}
+
+// dot class methods
+
+DotGraphIoPtr DotGraphIo::create()
+{
+    return std::shared_ptr<DotGraphIo>(new DotGraphIo());
+}
+
+void DotGraphIo::emitRootNode(const NodeIO& root)
+{
+    _graphResult += GRAPH_INDENT + root.identifier + " [label= \"" + root.uilabel + "\"]\n";
+    _graphResult += GRAPH_INDENT + root.identifier + "[shape = box];\n";
+    _graphResult += GRAPH_INDENT + root.identifier;
+}
+
+void DotGraphIo::emitUpstreamNode(
+    const NodeIO& node)
+{
+    _graphResult += GRAPH_INDENT + node.identifier + " [label= \"" + node.uilabel + "\"];\n";
+    const string shape = (node.group == NodeDef::CONDITIONAL_NODE_GROUP) ? "diamond" : "box";
+    _graphResult += GRAPH_INDENT + node.identifier + "[shape = " + shape + "];\n";
+    _graphResult += GRAPH_INDENT + node.identifier;
+}
+
+void DotGraphIo::emitConnection(const string& outputName,
+                                   const string& outputLabel,
+                                   const string& inputName,
+                                   const string& channelName)
+{
+    string result = " -> ";
+    if (!inputName.empty())
+    {
+        if (!outputLabel.empty() && !outputName.empty())
+        {
+            result += outputName + ";\n";
+            if (channelName.empty())
+            {
+                result += GRAPH_INDENT + outputName + " [label= \"" + outputLabel + "." + channelName + "\"];\n";
+            }
+            else
+            {
+                result += GRAPH_INDENT + outputName + " [label= \"" + outputLabel + "\"];\n";
+            }
+            result += GRAPH_INDENT + outputName + " [label= \"" + outputLabel + "\"];\n";
+            result += GRAPH_INDENT + outputName + " [shape = ellipse];\n";
+            result += GRAPH_INDENT + outputName + " -> ";
+        }
+    }
+    
+    _graphResult += result;
+}
+
+void DotGraphIo::emitInterfaceConnection(const string& interfaceId,
+                                         const string& interfaceInputName,
+                                         const string& inputName,
+                                         const NodeIO& interiorNode)
+{
+    string result;
+    result += GRAPH_INDENT + interfaceId + " [label=\"" + interfaceInputName + "\"];\n";
+    result += GRAPH_INDENT + interfaceId + " [shape = ellipse];\n";
+    result += GRAPH_INDENT + interiorNode.identifier + " [label=\"" + interiorNode.uilabel + "\"];\n";
+    result += GRAPH_INDENT + interfaceId + " -> " + interiorNode.identifier +
+        " [label=" + GRAPH_QUOTE + "." + inputName + GRAPH_QUOTE + "];\n";
+
+    _graphResult += result;
+}
+
+void DotGraphIo::emitDownstreamNode(const NodeIO& node, const string& inputLabel)
+{
+    string result;
+    result += GRAPH_INDENT + node.identifier;
+    if (!inputLabel.empty())
+    {
+        result += " [label= \"" + inputLabel + "\"]";
+    }
+    result += ";\n";
+    
+    result += GRAPH_INDENT + node.identifier + " [label= \"" + node.uilabel + "\"];\n";
+    const string shape = (node.group == NodeDef::CONDITIONAL_NODE_GROUP) ? "diamond" : "box";
+    result += GRAPH_INDENT + node.identifier + "[shape = " + shape + "]; \n";
+
+    _graphResult += result;
+}
+
+void DotGraphIo::emitSubgraphs(std::unordered_map<string, StringSet> subGraphs)
+{
+    if (!_genOptions.getWriteSubgraphs() || subGraphs.empty())
+    {
+        return;
+    }
+
+    string result = EMPTY_STRING;
+    unsigned int clusterNumber = 1;
+    const string CLUSTER_STRING = "cluster_";
+    for (const auto& subGraph : subGraphs)
+    {
+        // Note that the graph must start with the prefix "cluster"
+        result += GRAPH_INDENT + "subgraph " + CLUSTER_STRING + std::to_string(clusterNumber)+ "{\n";
+        result += GRAPH_INDENT + "  style = filled;\n";
+        result += GRAPH_INDENT + "  fillcolor = lightyellow;\n";
+        result += GRAPH_INDENT + "  color = black;\n";
+        result += GRAPH_INDENT + "  node[style = filled, fillcolor = white];\n";
+        result += GRAPH_INDENT + "  label = \"" + subGraph.first + "\";\n";
+
+        for (auto item : subGraph.second)
+        {
+            result += GRAPH_INDENT + "  " + item + "\n";
+        }
+        result += GRAPH_INDENT  + "}\n\n";
+
+        clusterNumber++;
+    }
+
+    // Needs to emit subgraphs before the graph for GraphViz output.
+    _graphResult = result + _graphResult;
+}
+
+void DotGraphIo::emitGraphString()
+{
+    string result;
+    if (_genOptions.getWriteGraphHeader())
+    {
+        std::unordered_map<int, string> orientations;
+        orientations[(int)GraphIoGenOptions::Orientation::TOP_DOWN] = "  rankdir = TD;\n";
+        orientations[(int)GraphIoGenOptions::Orientation::BOTTOM_UP] = "  rankdir = BT;\n";
+        orientations[(int)GraphIoGenOptions::Orientation::LEFT_RIGHT] = "  rankdir = LR;\n";
+        orientations[(int)GraphIoGenOptions::Orientation::RIGHT_LEFT] = "  rankdir = RL\n";
+
+        result = "digraph {\n";
+        result += orientations[(int)_genOptions.getOrientation()];
+    }
+    
+    result += _graphResult;
+
+    if (_genOptions.getWriteGraphHeader())
+    {
+        result += "}\n";
+    }
+
+    _graphResult = result;
+}
+
+string DotGraphIo::write(GraphElementPtr graph, const StringVec& roots)
+{
+    emitGraph(graph, roots);
+    return _graphResult;
+}
+
+// Mermaid graph methods
+
+MermaidGraphIoPtr MermaidGraphIo::create()
+{
+    return std::shared_ptr<MermaidGraphIo>(new MermaidGraphIo());
+}
+
+void MermaidGraphIo::emitUpstreamNode(const NodeIO& node)
+{
+    string result;
+    if (node.group == NodeDef::CONDITIONAL_NODE_GROUP)
+    {
+        result = GRAPH_INDENT + node.identifier + "{" + node.uilabel + "}";
+    } 
+    else
+    {
+        result = GRAPH_INDENT + node.identifier + "[" + node.uilabel + "]";
+    }
+    _graphResult += result;
+}
+
+void MermaidGraphIo::emitConnection(const string& outputName,
+                                    const string& outputLabel, 
+                                    const string& inputName, 
+                                    const string& channelName)
+{
+    string result;
+
+    if (!inputName.empty())
+    {
+        string fullLabel;
+        if (!channelName.empty())
+        {
+            fullLabel = GRAPH_QUOTE + "." + channelName + " -> ." + inputName + GRAPH_QUOTE;
+        }
+        else
+        {
+            fullLabel = GRAPH_QUOTE + "." + inputName + GRAPH_QUOTE;
+        }
+        if (!outputLabel.empty() && !outputName.empty())
+        {
+            result = " --> " + outputName + "([" + outputLabel + "])\n";
+            result += GRAPH_INDENT + "style " + outputName + " fill:#1b1, color:#111\n";
+            result += GRAPH_INDENT + outputName + " --" + fullLabel + "--> ";
+        }
+        else
+        {
+            result = " --" + fullLabel + "--> ";
+        }
+    }
+    else
+    {
+        result = " --> ";
+    }
+
+    _graphResult += result;
+}
+
+void MermaidGraphIo::emitDownstreamNode(const NodeIO& node, const string& /*inputLabel*/)
+{
+    string result;
+    if (node.category != Output::CATEGORY)
+    {
+        if (node.group == NodeDef::CONDITIONAL_NODE_GROUP)
+        {
+            result = node.identifier + "{" + node.uilabel + "}" + "\n";
+        }
+        else
+        {
+            result = node.identifier + "[" + node.uilabel + "]" + "\n";
+        }
+    }
+    else
+    {
+        result = node.identifier + "([" + node.uilabel + "])" + "\n";
+        result += GRAPH_INDENT + "style " + node.identifier + " fill:#1b1, color:#111\n";
+    }
+    _graphResult += result;
+}
+
+void MermaidGraphIo::emitInterfaceConnection(const string& interfaceId,
+                                             const string& interfaceInputName,
+                                             const string& inputName,
+                                             const NodeIO& interiorNode)
+{
+    string result;
+    result = GRAPH_INDENT + interfaceId + "([" + interfaceInputName + "])";
+    result += " ==." + inputName;
+    result += "==> " + interiorNode.identifier + "[" + interiorNode.uilabel + "]" + "\n";
+    result += GRAPH_INDENT + "style " + interfaceId + " fill:#0bb, color:#111\n";
+
+    _graphResult += result;
+}
+
+void  MermaidGraphIo::emitRootNode(const NodeIO& root)
+{
+    string result = "   " + root.identifier + "[" + root.uilabel + "]\n";
+    _graphResult += result;
+}
+
+void MermaidGraphIo::emitSubgraphs(std::unordered_map<string, StringSet> subGraphs)
+{
+    string result = EMPTY_STRING;
+    if (!_genOptions.getWriteSubgraphs())
+    {
+        return;
+    }
+
+    for (auto subGraph : subGraphs)
+    {
+        result += "  subgraph " + subGraph.first + "\n";
+        for (auto item : subGraph.second)
+        {
+            result += GRAPH_INDENT + item + "\n";
+        }
+        result += "  end\n";
+    }
+
+    _graphResult += result;
+}
+
+void MermaidGraphIo::emitGraphString()
+{
+    string result;
+    if (_genOptions.getWriteGraphHeader())
+    {
+        std::unordered_map<int, string> orientations;
+        orientations[(int)GraphIoGenOptions::Orientation::TOP_DOWN] = "TD";
+        orientations[(int)GraphIoGenOptions::Orientation::BOTTOM_UP] = "BT";
+        orientations[(int)GraphIoGenOptions::Orientation::LEFT_RIGHT] = "LR";
+        orientations[(int)GraphIoGenOptions::Orientation::RIGHT_LEFT] = "RL";
+
+        result = "graph " + orientations[(int)_genOptions.getOrientation()] + "; \n";
+    }
+    result += _graphResult;
+    _graphResult = result;
+}
+
+string MermaidGraphIo::write(GraphElementPtr graph, const StringVec& roots)
+{
+    emitGraph(graph, roots);
+    return _graphResult;
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXFormat/GraphIo.h
+++ b/source/MaterialXFormat/GraphIo.h
@@ -1,0 +1,410 @@
+//
+// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#ifndef MATERIALX_GRAPHIO_H
+#define MATERIALX_GRAPHIO_H
+
+/// @file
+/// Support for the MaterialX GraphElement interchange classes
+
+#include <MaterialXCore/Library.h>
+
+#include <MaterialXCore/Document.h>
+
+#include <MaterialXFormat/Export.h>
+#include <MaterialXFormat/File.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+class GraphIo;
+class DotGraphIo;
+class MermaidGraphIo;
+
+/// A shared pointer to a GraphIo
+using GraphIoPtr = shared_ptr<GraphIo>;
+/// A shared pointer to a const GraphIo
+using ConstGraphIoPtr = shared_ptr<const GraphIo>;
+
+/// A shared pointer to a DotGraphIo
+using DotGraphIoPtr = shared_ptr<DotGraphIo>;
+/// A shared pointer to a const GraphIo
+using ConstDotGraphIoPtr = shared_ptr<const DotGraphIo>;
+
+/// A shared pointer to a MermaidGraphIo
+using MermaidGraphIoPtr = shared_ptr<MermaidGraphIo>;
+/// A shared pointer to a const MermaidGraphIo
+using ConstMermaidGraphIoPtr = shared_ptr<const MermaidGraphIo>;
+
+/// @class NodeIO
+///     Node information extracted during graph traversal and 
+///     provided to utility writer methods. This includes user
+///     interface information hints such as UI label and shape.
+/// 
+class MX_FORMAT_API NodeIO
+{
+  public:
+    /// UI node shapes
+    enum class NodeShape
+    {
+        BOX = 0,        /// Box shape. Used for non interface nodes
+        ROUNDEDBOX = 1, /// Rounded box shape. Used to indicate interface input and output nodes
+        DIAMOND = 1,    /// Diamond shape. Used to indicate conditionals.
+    };
+
+    /// Uniique Node identifier. This identifier is unique per MaterialX Document.
+    string identifier;
+
+    /// Node UI label for the identifier
+    string uilabel;
+
+    /// MaterialX node category string
+    string category;
+
+    /// MaterialX node group string
+    string group;
+
+    /// Node UI shape. Default is box.
+    NodeShape uishape = NodeShape::BOX;
+};
+
+/// @class GraphIoGenOptions
+///     Generation options for GraphIo generators    
+/// 
+class MX_FORMAT_API GraphIoGenOptions
+{
+  public:
+    GraphIoGenOptions() {}
+    virtual ~GraphIoGenOptions() {}
+
+    /// Option on whether to emit the graph header 
+    void setWriteGraphHeader(bool val)
+    {
+        _writeGraphHeader = val;
+    }
+
+    /// Get whether to emit the graph header. This is enabled by default.
+    bool getWriteGraphHeader() const
+    {
+        return _writeGraphHeader;
+    }
+
+    /// Option on whether to write node labels using the category of the node as the label as
+    /// opposed to the unique name of the Element. Default is to write category names.
+    void setWriteCategories(bool val)
+    {
+        _writeCategories = val;
+    }
+
+    /// Get whether to write categories for node labels
+    bool getWriteCategories() const
+    {
+        return _writeCategories;
+    }
+
+    /// Option on whether to write subgraph groupings or not. 
+    /// For a node definition, this can be turned off as definition graphs
+    /// are in general single nodegraphs. By default subgraphs are written.
+    void setWriteSubgraphs(bool val)
+    {
+        _writeSubgraphs = val;
+    }
+
+    /// Get whether option to write subgraphs is enabled
+    bool getWriteSubgraphs() const
+    {
+        return _writeSubgraphs;
+    }
+
+    /// Graph writing orientation hint. Some formats may or
+    /// may not support one or more of these options.
+    enum class Orientation
+    {
+        TOP_DOWN,
+        BOTTOM_UP,
+        LEFT_RIGHT,
+        RIGHT_LEFT
+    };
+
+    /// Hint on the orientation to write the graph.  
+    /// The default orientation is set to TOP_DOWN which means the root is
+    /// at the top and upstream downs are positioned downward from the root.
+    /// @param val Orientationn hint
+    void setOrientation(Orientation val)
+    {
+        _orientation = val;
+    }
+
+    /// Get whether option to write subgraphs is enabled.
+    /// @return Orientation hint
+    Orientation getOrientation() const
+    {
+        return _orientation;
+    }
+
+  protected:
+    /// Write greaph head
+    bool _writeGraphHeader = true;
+
+    /// Write category labels
+    bool _writeCategories = true;
+
+    /// Write subgraphs
+    bool _writeSubgraphs = true;
+
+    /// Orientation hint
+    Orientation _orientation = Orientation::TOP_DOWN;
+};
+
+/// @class GraphIo
+/// <summary>
+///     Interface defining classes which interpret a GraphElement and 
+///     generate output in the desired output format. 
+/// 
+///     The output is assumed to be representable by a string, but subclasses
+///     may choose their own runtime representation.
+/// 
+///     The class indicates which formats are supported via a list of string identifiers.
+///     These identifiers can be used to register the class with a GraphIoRegistry.
+/// 
+///     The default traversal logic will call into a set of utities
+///     which are responsible for emitting the appropriate output in the desired format.
+///     A derived class may chose to implement their own traversal logic as well.
+///     
+/// </summary>
+class MX_FORMAT_API GraphIo
+{
+  public:
+    GraphIo(){};
+    virtual ~GraphIo(){};
+
+    /// Returns a list of formats that the GraphIo can convert from to
+    const StringSet& supportsFormats() const
+    {
+        return _formats;
+    }
+
+    /// @name I/O methods
+    /// @{
+
+    /// Traverse a graph and return a string withe formatted output
+    /// Derived classes must implement this method.
+    /// @param graph GraphElement to write
+    /// @param roots Optional list of roots to GraphIo what upstream elements to consider>
+    /// @returns String result
+    virtual string write(GraphElementPtr graph, const StringVec& roots) = 0;
+
+    /// @}
+    /// @name Options to set before writing
+    /// @{
+
+    /// Get options for generation
+    const GraphIoGenOptions& getGenOptions() const
+    {
+        return _genOptions;
+    }
+
+    /// Set options for generation
+    void setGenOptions(const GraphIoGenOptions& options)
+    {
+        _genOptions = options;
+    }
+
+  protected:
+    /// @name Generation Utilties
+    /// @{
+
+    /// Traverse a graph and call into utility methods to emit which handle emitting the 
+    /// appropriate output. 
+    /// @param graph GraphElement to traverse
+    /// @param roots Optional list of roots indicating what upstream elements to consider.
+    ///              If empty, then all of the graph's outputs are traversed.
+    virtual void emitGraph(GraphElementPtr graph, const StringVec& roots);
+      
+    /// Emit the root node only. Called when there are no downstream connections.
+    /// @param root Root node
+    virtual void emitRootNode(const NodeIO& root)
+    {
+        (void)(root);
+    }
+
+    /// Emit the upstream node on a connection
+    /// @param node Upstream node
+    virtual void emitUpstreamNode(const NodeIO& node)
+    {
+        (void)(node);
+    }
+
+    /// Emit the connection from an upstream node to a downstream node. 
+    /// @param outputName Name of the upstream output
+    /// @param outputLabel ui labelfor the upstream output
+    /// @param inputName name of input on downstream node 
+    /// @param channelName name of channel on downstream input. 
+    /// This would be the equivalent of having an `extract` node between upstream output and downstream input.
+    /// This argument may be empty.
+    virtual void emitConnection(
+        const string& outputName,
+        const string& outputLabel, 
+        const string& inputName,
+        const string& channelName) 
+    {
+        (void)(outputName);
+        (void)(outputLabel);
+        (void)(inputName);
+        (void)(channelName);
+    }
+
+    /// Emit a connection between an interface input and a input on a node in a GraphElement
+    /// @param interfaceId Identifier for interface
+    /// @param interfaceInputName Identifier for interface input
+    /// @param inputName Name of input on interior node
+    /// @param interiorNode Interior node information
+    virtual void emitInterfaceConnection(
+        const string& interfaceId,
+        const string& interfaceInputName,
+        const string& inputName,
+        const NodeIO& interiorNode)
+    {
+        (void)(interfaceId);
+        (void)(interfaceInputName);
+        (void)(inputName);
+        (void)(interiorNode);
+    }
+
+    /// Emit downstream node and label
+    /// @param node Node information to write
+    /// @param inputLabel input on node
+    virtual void emitDownstreamNode(const NodeIO& node,
+                                    const string& inputLabel)
+    {
+        (void)(node);
+        (void)(inputLabel);
+    }
+
+    /// Emit sub-graph groupings. For now the groupings supported are NodeGraphs
+    /// @param  subGraphs List of sub-graphs to write
+    virtual void emitSubgraphs(std::unordered_map<string, StringSet> subGraphs)
+    {
+        (void)(subGraphs);
+    }
+
+    /// Write GraphElement
+    virtual void emitGraphString()
+    {
+    }
+
+    /// @}
+    /// @name Subgraph Handling Utilities
+    /// @{
+
+    /// Add an Element label subgraph list. 
+    /// Given a node and label, the label will to be used to add an identifier to the subgraph list.
+    /// @param subGraphs Structure to maintain a list of unique node identifiers per subgraph name. The subgraph name is a unique Document name.
+    /// @param node The parent of this node if it exists is the subgraph to add the label to
+    /// @param label The string used to create a uniquely labelled element in the subgraph. The subgraph path will be prepended to the lable
+    /// @return Derived label name
+    /// </summary>
+    string addNodeToSubgraph(std::unordered_map<string, StringSet>& subGraphs, 
+                             const ElementPtr node, 
+                             const string& label) const;
+
+    /// @}
+
+    /// Storage for formats supported
+    StringSet _formats;
+
+    /// Map containing restricted keywords and their replacement for identifiers
+    StringMap _restrictedMap;
+
+    /// Write options
+    GraphIoGenOptions _genOptions;
+
+    /// Written output
+    string _graphResult;
+};
+
+/// @class DotGraphIo
+///     Class which provides support for outputting to GraphViz dot format.
+/// 
+class MX_FORMAT_API DotGraphIo : public GraphIo
+{
+public:
+    DotGraphIo()
+    {
+        // Dot files
+        _formats.insert("dot");
+    }
+    virtual ~DotGraphIo() = default;
+
+    static DotGraphIoPtr create();
+
+    string write(GraphElementPtr graph, const StringVec& roots) override;
+
+  protected:
+    void emitRootNode(const NodeIO& root) override;
+    void emitUpstreamNode(const NodeIO& node) override;
+    void emitConnection(
+        const string& outputName,
+        const string& outputLabel,
+        const string& inputName,
+        const string& channelName) override;
+    void emitInterfaceConnection(
+        const string& interfaceId,
+        const string& interfaceInputName,
+        const string& inputName,
+        const NodeIO& interiorNode) override;
+    void emitDownstreamNode(const NodeIO& node, const string& inputName) override;
+    void emitSubgraphs(
+        std::unordered_map<string, StringSet> subGraphs) override;
+    void emitGraphString() override;
+};
+    
+
+/// @class MermaidGraphIo
+/// 
+///     Class which provides support for outputting to Mermaid format.
+///     Note that the output only includes the Mermaid graph itself and does not include 
+///     wrappers for embedding into Markdown or HTML.
+/// 
+class MX_FORMAT_API MermaidGraphIo : public GraphIo
+{
+  public:
+    MermaidGraphIo()
+    {
+        // Markdown and Markdown diagrams
+        _formats.insert("md");
+        _formats.insert("mmd");
+
+        // Add restricted keywords
+        _restrictedMap["default"] = "dfault";
+    }
+    virtual ~MermaidGraphIo() = default;
+
+    /// Creator
+    static MermaidGraphIoPtr create();
+
+    string write(GraphElementPtr graph, const StringVec& roots) override;
+
+  protected:
+    void emitRootNode(const NodeIO& root) override;
+    void emitUpstreamNode(const NodeIO& node) override;
+    void emitConnection(
+        const string& outputName,
+        const string& outputLabel,
+        const string& inputName,
+        const string& channelName) override;
+    void emitInterfaceConnection(
+        const string& interfaceId,
+        const string& interfaceInputName,
+        const string& inputName,
+        const NodeIO& interiorNode) override;
+    void emitDownstreamNode(const NodeIO& node, const string& inputName) override;
+    void emitSubgraphs(
+        std::unordered_map<string, StringSet> subGraphs) override;
+    void emitGraphString() override;
+};
+
+MATERIALX_NAMESPACE_END
+
+#endif

--- a/source/MaterialXTest/MaterialXFormat/GraphIO.cpp
+++ b/source/MaterialXTest/MaterialXFormat/GraphIO.cpp
@@ -1,0 +1,134 @@
+//
+// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <MaterialXTest/External/Catch/catch.hpp>
+#include <MaterialXTest/MaterialXGenShader/GenShaderUtil.h>
+
+#include <MaterialXCore/Document.h>
+
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/Util.h>
+#include <MaterialXFormat/GraphIo.h>
+
+
+namespace mx = MaterialX;
+
+TEST_CASE("GraphIo: Generate Functional Graphs", "[graphio]")
+{
+    mx::FilePathVec libraries = { "libraries/targets", "libraries/stdlib",
+                                  "libraries/pbrlib", "libraries/bxdf" };
+    mx::StringVec libraryNames = { "targets", "stdlib",
+                                  "pbrlib", "bxdf" };
+
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+    mx::FileSearchPath searchPath(currentPath);
+    loadLibraries(libraries, searchPath, stdlib);
+
+    // Create output directory.
+    mx::FilePath outputPath = mx::FilePath::getCurrentPath() / mx::FilePath("graphio");
+    outputPath.createDirectory();
+    for (const std::string& libraryName : libraryNames)
+    {
+        mx::FilePath libPath = outputPath / libraryName;
+        libPath.createDirectory();
+    }
+
+    // Create log file.
+    const mx::FilePath logPath("graphio_test.txt");
+    std::ofstream logFile;
+    logFile.open(logPath);
+
+    bool failedGeneration = false;
+
+    mx::GraphIoPtr graphers[2] = { mx::MermaidGraphIo::create(), mx::DotGraphIo::create() };
+    mx::StringVec extensions = { "md", "dot" };
+
+    for (const mx::NodeDefPtr& nodedef : stdlib->getNodeDefs())
+    {
+        std::string nodeName = nodedef->getName();
+        std::string nodeNode = nodedef->getNodeString();
+        if (nodeName.size() > 3 && nodeName.substr(0, 3) == "ND_")
+        {
+            nodeName = nodeName.substr(3);
+        }
+
+        mx::InterfaceElementPtr interface = nodedef->getImplementation();
+        mx::NodeGraphPtr nodegraph = interface ? interface->asA<mx::NodeGraph>() : nullptr;
+        if (!nodegraph)
+        {
+            logFile << "Skip generating for node with graph representation '" << nodeName << "'" << std::endl;
+            continue;
+        }
+
+        try
+        {
+            mx::StringVec roots;
+            std::vector<bool> writeCategoriesList = { true, false };
+
+            for (size_t i=0; i<2; i++)
+            {
+                mx::GraphIoGenOptions graphOptions;
+                graphOptions.setWriteSubgraphs(false);
+                graphOptions.setOrientation(mx::GraphIoGenOptions::Orientation::LEFT_RIGHT);
+                graphers[i]->setGenOptions(graphOptions);
+
+                for (auto writeCategories : writeCategoriesList)
+                {
+                    graphOptions.setWriteCategories(writeCategories);
+                    std::string graphString = graphers[i]->write(nodegraph, roots);
+                    if (!graphString.empty())
+                    {
+                        logFile << "Wrote " + (!writeCategories ? " instanced " : mx::EMPTY_STRING) + "graph for node '" << nodeName << "'" << std::endl;
+
+                        mx::FilePath libPath = outputPath;
+                        for (const std::string& libraryName : libraryNames)
+                        {
+                            const std::string uri = nodegraph->getSourceUri();
+                            if (std::string::npos != uri.find(libraryName))
+                            {
+                                libPath = outputPath / libraryName;
+                                break;
+                            }
+                        }
+
+                        const std::string filename = nodeName + (!writeCategories ? "_instance" : mx::EMPTY_STRING) + "." + extensions[i];
+                        const std::string filepath = (libPath / filename).asString();
+                        std::ofstream file;
+                        file.open(filepath);
+                        REQUIRE(file.is_open());
+                        if (extensions[i] == "md")
+                        {
+                            std::string result = "```mermaid\n";
+                            result += graphString;
+                            result += "```\n";
+                            file << result;
+                        }
+                        else
+                        {
+                            file << graphString;
+                        }
+                        file.close();
+                    }
+                    else
+                    {
+                        logFile << "Failed to write graph for node '" << nodeName << "'" << std::endl;
+                        failedGeneration = true;
+                    }
+                }
+            }
+        }
+        catch (mx::Exception& e)
+        {
+            logFile << "Error generating graph for '" << nodeName << "' : " << std::endl;
+            logFile << e.what() << std::endl;
+            failedGeneration = true;
+        }
+    }
+
+    logFile.close();
+
+    CHECK(failedGeneration == false);
+}

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -20,6 +20,8 @@
 
 #include <MaterialXCore/Unit.h>
 
+#include <MaterialXFormat/GraphIo.h>
+
 namespace mx = MaterialX;
 namespace ng = nanogui;
 
@@ -218,7 +220,7 @@ class Viewer : public ng::Screen
     void loadStandardLibraries();
     void saveShaderSource(mx::GenContext& context);
     void loadShaderSource();
-    void saveDotFiles();
+    void saveDiagrams();
 
     // Translate the current material to the target shading model.
     mx::DocumentPtr translateMaterial();
@@ -435,6 +437,15 @@ class Viewer : public ng::Screen
     unsigned int _bakeWidth;
     unsigned int _bakeHeight;
     mx::FilePath _bakeFilename;
+
+    // Diagram export
+    enum class DiagramFormat
+    {
+        MERMAID_FORMAT = 0,
+        DOT_FORMAT
+    };
+    DiagramFormat _diagramFormat;
+    bool _diagramWriteCategoryNames;
 };
 
 extern const mx::Vector3 DEFAULT_CAMERA_POSITION;

--- a/source/PyMaterialX/PyMaterialXFormat/PyGraphIO.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyGraphIO.cpp
@@ -1,0 +1,76 @@
+//
+// TM & (c) 2022 Lucasfilm Entertainment Company Ltd. and Lucasfilm Ltd.
+// All rights reserved.  See LICENSE.txt for license.
+//
+
+#include <PyMaterialX/PyMaterialX.h>
+
+#include <MaterialXFormat/GraphIo.h>
+
+namespace py = pybind11;
+namespace mx = MaterialX;
+
+class PyGraphIo : public mx::GraphIo
+{
+  public:
+    std::string write(mx::GraphElementPtr graph, const mx::StringVec& roots) override
+    {
+        PYBIND11_OVERLOAD_PURE(
+            std::string,
+            mx::GraphIo,
+            write,
+            graph,
+            roots
+        );
+    }
+};
+
+void bindPyGraphIo(py::module& mod)
+{
+    py::enum_<mx::NodeIO::NodeShape>(mod, "NodeShape")
+        .value("BOX", mx::NodeIO::NodeShape::BOX)
+        .value("ROUNDEDBOX", mx::NodeIO::NodeShape::ROUNDEDBOX)
+        .value("DIAMOND", mx::NodeIO::NodeShape::DIAMOND)
+        .export_values();
+
+    py::enum_<mx::GraphIoGenOptions::Orientation>(mod, "GraphOrientation")
+        .value("TOP_DOWN", mx::GraphIoGenOptions::Orientation::TOP_DOWN)
+        .value("BOTTOM_UP", mx::GraphIoGenOptions::Orientation::BOTTOM_UP)
+        .value("LEFT_RIGHT", mx::GraphIoGenOptions::Orientation::LEFT_RIGHT)
+        .value("RIGHT_LEFT", mx::GraphIoGenOptions::Orientation::RIGHT_LEFT)
+        .export_values();
+
+    py::class_<mx::GraphIoGenOptions>(mod, "GraphIoGenOptions")
+        .def("setWriteGraphHeader", &mx::GraphIoGenOptions::setWriteGraphHeader)
+        .def("getWriteGraphHeader", &mx::GraphIoGenOptions::getWriteGraphHeader)        
+        .def("setWriteCategories", &mx::GraphIoGenOptions::setWriteCategories)
+        .def("getWriteCategories", &mx::GraphIoGenOptions::getWriteCategories)
+        .def("setWriteSubgraphs", &mx::GraphIoGenOptions::setWriteSubgraphs)
+        .def("getWriteSubgraphs", &mx::GraphIoGenOptions::getWriteSubgraphs)
+        .def("setOrientation", &mx::GraphIoGenOptions::setOrientation)
+        .def("getOrientation", &mx::GraphIoGenOptions::getOrientation)
+        .def(py::init<>());
+
+    py::class_<mx::NodeIO>(mod, "NodeIO")
+        .def_readwrite("identifier", &mx::NodeIO::identifier)
+        .def_readwrite("uilabel", &mx::NodeIO::uilabel)
+        .def_readwrite("category", &mx::NodeIO::category)
+        .def_readwrite("group", &mx::NodeIO::group)
+        .def_readwrite("uishape", &mx::NodeIO::uishape)
+        .def(py::init<>());
+
+    py::class_<mx::GraphIo, PyGraphIo, mx::GraphIoPtr>(mod, "GraphIo")
+        .def("write", (std::string(mx::GraphIo::*)(mx::GraphElementPtr, const mx::StringVec&)) & mx::GraphIo::write)
+        .def("supportsFormats", &mx::GraphIo::supportsFormats)
+        .def("setGenOptions", &mx::GraphIo::setGenOptions)
+        .def("getGenOptions", &mx::GraphIo::getGenOptions);
+
+    py::class_<mx::DotGraphIo, mx::GraphIo, mx::DotGraphIoPtr>(mod, "DotGraphIo")
+        .def_static("create", &mx::DotGraphIo::create)
+        .def("write", (std::string (mx::DotGraphIo::*)(mx::GraphElementPtr, const mx::StringVec&)) &mx::DotGraphIo::write);
+
+    py::class_<mx::MermaidGraphIo, mx::GraphIo, mx::MermaidGraphIoPtr>(mod, "MermaidGraphIo")
+        .def_static("create", &mx::MermaidGraphIo::create)
+        .def("write", (std::string (mx::MermaidGraphIo::*)(mx::GraphElementPtr, const mx::StringVec&)) &mx::MermaidGraphIo::write);
+}
+

--- a/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
@@ -9,6 +9,7 @@ namespace py = pybind11;
 
 void bindPyFile(py::module& mod);
 void bindPyXmlIo(py::module& mod);
+void bindPyGraphIo(py::module& mod);
 void bindPyUtil(py::module& mod);
 
 PYBIND11_MODULE(PyMaterialXFormat, mod)
@@ -17,5 +18,6 @@ PYBIND11_MODULE(PyMaterialXFormat, mod)
 
     bindPyFile(mod);
     bindPyXmlIo(mod);
+    bindPyGraphIo(mod);
     bindPyUtil(mod);
 }


### PR DESCRIPTION
# `GraphIo` Support
Add a new utility class to support graph parsing and interchange. For now this is only used for output graph parsing with targets being `mermaid` and `GraphViz dot` graphs which are implemented as classes derived from NodeGraphIO

Support added:
- [x] Addition of base `GraphIo`
- [x] Graph Traversal logic utility which hides traversal logic and only requires handling of emitting nodes and edges.
- [x] Core Output Variants
   - [x] Mermaid GraphIo class + output
   - [x] GraphViz GraphIo class + output
 - [x] Basic node and edge support provided: 
    - [x] Option to emit "instance" or "category" node identifiers
    - [x] Option to emit Orientation support (LR, RL, TB, BT)
    - [x] Handling of intermediate connections (`input` -> `interfacename` and `output` -> `output` pass-throughs)
    - [x] Conditional node UI. **Note**: This is not a cheap operation as Node -> NodeDef lookup is required. Could be an    - 
    - [x] For MaterialX 1.38.6+ where inputs on functional Nodegraphs are "invalid". The core logic will just add these interface w/o name checking to avoid expensive Nodedef logic (to traverse to the nodedef to get info).
option as it's only a UI thing or we look at making NodeDef<->Node caching faster.
- [x] Python wrappers: `PyGraphIo`, `PyDotGraphIo`, `PyMermadGraphIo`, `PyGraphIoRegistry`.
- [x] Python utility using wrapper: `mxgraph.py` which allows for Mermaid and dot output option.
- [x] Testing
   - [x] Unit test with functional `nodegraph`s and documentation generation outputting both category or instance identifier variants. Produces results per definition in all core libraries into a sperate folder in the test area.
   - [x] `mxdoc` modified to have `--nodegraph` option for Markdown and HTML output. 
   - [x] CI: github workflow changed to output all definitions for `mxdoc` tests.
   - [x] New `mxgraph`  to create graphs from any document. Test added to run with chess set. 
   - [x] Replacement of current `dot` output for `MaterialXView` which does not work currently with usage of GraphIO Mermaid and GraphiViz output options. 
   

# Results

## Functional `nodegraph`s
* Supported and tested in unit test and `mxdoc.py`
* Example from Lama generation via new version of `mxdoc.py`. Mermaid graph inside HTML output, with
using `DoxygenAwesome` CSS file
<img src="https://user-images.githubusercontent.com/49369885/208774358-9699c503-3c21-4806-88df-9d8e33020cd2.png" width=80%>
Equivalent prodduced in unit tests (GraphViz output)
<img src="https://user-images.githubusercontent.com/49369885/208165862-e01c85fa-1ca6-4123-b392-a41c834f3e2e.png" width=50%>

## GraphViz Results:
* dot exporter uses the exact same logic (common) as the Mermaid one with a few methods to override
* Example brick shader (category names)
![standard_surface_brick_procedural_ dot](https://user-images.githubusercontent.com/49369885/207967813-81cf52ab-a565-4e06-ba17-330136a0d47e.svg)
* Example cascading nodegraphs
![cascade_nodegraphs_ dot](https://user-images.githubusercontent.com/49369885/207968143-b996ce58-7b32-4c4a-a1c0-bce48a180383.svg)

## Mermaid Results:
* Example Brick shader (category names)
```mermaid
graph TD;
    NG_BrickPattern_node_clamp_0[clamp] --> NG_BrickPattern_base_color_output([base_color_output]) --.base_color--> N_StandardSurface[standard_surface]
    style NG_BrickPattern_base_color_output fill:#1b1,color:#111
    NG_BrickPattern_node_mix_8[mix] --.in--> NG_BrickPattern_node_clamp_0[clamp]
    NG_BrickPattern_node_multiply_5[multiply] --.fg--> NG_BrickPattern_node_mix_8[mix]
    NG_BrickPattern_node_mix_6[mix] --.in1--> NG_BrickPattern_node_multiply_5[multiply]
    NG_BrickPattern_dirt_color([dirt_color]) ==.fg==> NG_BrickPattern_node_mix_6[mix]
    style NG_BrickPattern_dirt_color fill:#0bb,color:#111
    NG_BrickPattern_node_hsvtorgb_17[hsvtorgb] --.bg--> NG_BrickPattern_node_mix_6[mix]
    NG_BrickPattern_node_add_16[add] --.in--> NG_BrickPattern_node_hsvtorgb_17[hsvtorgb]
    NG_BrickPattern_node_combine3_color3_13[combine3] --.in1--> NG_BrickPattern_node_add_16[add]
    NG_BrickPattern_node_multiply_14[multiply] --.in1--> NG_BrickPattern_node_combine3_color3_13[combine3]
    NG_BrickPattern_hue_variation([hue_variation]) ==.in2==> NG_BrickPattern_node_multiply_14[multiply]
    style NG_BrickPattern_hue_variation fill:#0bb,color:#111
    NG_BrickPattern_node_subtract_18[subtract] --.in1--> NG_BrickPattern_node_multiply_14[multiply]
    NG_BrickPattern_node_add_19[add] --.in1--> NG_BrickPattern_node_subtract_18[subtract]
    NG_BrickPattern_node_multiply_25[multiply] --.in1--> NG_BrickPattern_node_add_19[add]
    NG_BrickPattern_hue_variation([hue_variation]) ==.in1==> NG_BrickPattern_node_multiply_25[multiply]
    style NG_BrickPattern_hue_variation fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_26[tiledimage] --.in2--> NG_BrickPattern_node_multiply_25[multiply]
    NG_BrickPattern_node_convert_1[convert] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_26[tiledimage]
    NG_BrickPattern_uvtiling([uvtiling]) ==.in==> NG_BrickPattern_node_convert_1[convert]
    style NG_BrickPattern_uvtiling fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_7[tiledimage] --.in2--> NG_BrickPattern_node_add_19[add]
    NG_BrickPattern_node_convert_1[convert] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_7[tiledimage]
    NG_BrickPattern_node_multiply_15[multiply] --.in3--> NG_BrickPattern_node_combine3_color3_13[combine3]
    NG_BrickPattern_node_add_19[add] --.in1--> NG_BrickPattern_node_multiply_15[multiply]
    NG_BrickPattern_node_multiply_20[multiply] --.in2--> NG_BrickPattern_node_multiply_15[multiply]
    NG_BrickPattern_value_variation([value_variation]) ==.in1==> NG_BrickPattern_node_multiply_20[multiply]
    style NG_BrickPattern_value_variation fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_26[tiledimage] --.in2--> NG_BrickPattern_node_multiply_20[multiply]
    NG_BrickPattern_node_rgbtohsv_12[rgbtohsv] --.in2--> NG_BrickPattern_node_add_16[add]
    NG_BrickPattern_brick_color([brick_color]) ==.in==> NG_BrickPattern_node_rgbtohsv_12[rgbtohsv]
    style NG_BrickPattern_brick_color fill:#0bb,color:#111
    NG_BrickPattern_node_multiply_23[multiply] --.mix--> NG_BrickPattern_node_mix_6[mix]
    NG_BrickPattern_dirt_amount([dirt_amount]) ==.in1==> NG_BrickPattern_node_multiply_23[multiply]
    style NG_BrickPattern_dirt_amount fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_24[tiledimage] --.in2--> NG_BrickPattern_node_multiply_23[multiply]
    NG_BrickPattern_node_convert_1[convert] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_24[tiledimage]
    NG_BrickPattern_node_tiledimage_float_7[tiledimage] --.in2--> NG_BrickPattern_node_multiply_5[multiply]
    NG_BrickPattern_node_multiply_9[multiply] --.bg--> NG_BrickPattern_node_mix_8[mix]
    NG_BrickPattern_node_color_11[constant] --.in1--> NG_BrickPattern_node_multiply_9[multiply]
    NG_BrickPattern_node_tiledimage_float_7[tiledimage] --.in2--> NG_BrickPattern_node_multiply_9[multiply]
    NG_BrickPattern_node_tiledimage_float_10[tiledimage] --.mix--> NG_BrickPattern_node_mix_8[mix]
    NG_BrickPattern_node_convert_1[convert] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_10[tiledimage]
    NG_BrickPattern_node_multiply_1[multiply] --> NG_BrickPattern_specular_roughness_output([specular_roughness_output]) --.specular_roughness--> N_StandardSurface[standard_surface]
    style NG_BrickPattern_specular_roughness_output fill:#1b1,color:#111
    NG_BrickPattern_node_divide_21[divide] --.in1--> NG_BrickPattern_node_multiply_1[multiply]
    NG_BrickPattern_roughness_amount([roughness_amount]) ==.in1==> NG_BrickPattern_node_divide_21[divide]
    style NG_BrickPattern_roughness_amount fill:#0bb,color:#111
    NG_BrickPattern_node_max_1[max] --.in2--> NG_BrickPattern_node_divide_21[divide]
    NG_BrickPattern_node_tiledimage_float_10[tiledimage] --.in1--> NG_BrickPattern_node_max_1[max]
    NG_BrickPattern_node_tiledimage_float_22[tiledimage] --.in2--> NG_BrickPattern_node_multiply_1[multiply]
    NG_BrickPattern_node_convert_1[convert] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_22[tiledimage]
    NG_BrickPattern_node_normalmap_3[normalmap] --> NG_BrickPattern_normal_output([normal_output]) --.normal--> N_StandardSurface[standard_surface]
    style NG_BrickPattern_normal_output fill:#1b1,color:#111
    NG_BrickPattern_node_tiledimage_vector3_27[tiledimage] --.in--> NG_BrickPattern_node_normalmap_3[normalmap]
    NG_BrickPattern_node_convert_1[convert] --.uvtiling--> NG_BrickPattern_node_tiledimage_vector3_27[tiledimage]
  subgraph NG_BrickPattern
    NG_BrickPattern_base_color_output
    NG_BrickPattern_brick_color
    NG_BrickPattern_dirt_amount
    NG_BrickPattern_dirt_color
    NG_BrickPattern_hue_variation
    NG_BrickPattern_node_add_16
    NG_BrickPattern_node_add_19
    NG_BrickPattern_node_clamp_0
    NG_BrickPattern_node_color_11
    NG_BrickPattern_node_combine3_color3_13
    NG_BrickPattern_node_convert_1
    NG_BrickPattern_node_divide_21
    NG_BrickPattern_node_hsvtorgb_17
    NG_BrickPattern_node_max_1
    NG_BrickPattern_node_mix_6
    NG_BrickPattern_node_mix_8
    NG_BrickPattern_node_multiply_1
    NG_BrickPattern_node_multiply_14
    NG_BrickPattern_node_multiply_15
    NG_BrickPattern_node_multiply_20
    NG_BrickPattern_node_multiply_23
    NG_BrickPattern_node_multiply_25
    NG_BrickPattern_node_multiply_5
    NG_BrickPattern_node_multiply_9
    NG_BrickPattern_node_normalmap_3
    NG_BrickPattern_node_rgbtohsv_12
    NG_BrickPattern_node_subtract_18
    NG_BrickPattern_node_tiledimage_float_10
    NG_BrickPattern_node_tiledimage_float_22
    NG_BrickPattern_node_tiledimage_float_24
    NG_BrickPattern_node_tiledimage_float_26
    NG_BrickPattern_node_tiledimage_float_7
    NG_BrickPattern_node_tiledimage_vector3_27
    NG_BrickPattern_normal_output
    NG_BrickPattern_roughness_amount
    NG_BrickPattern_specular_roughness_output
    NG_BrickPattern_uvtiling
    NG_BrickPattern_value_variation
  end
```
* Example Brick shader (instance names)
```mermaid
graph TD;
    NG_BrickPattern_node_clamp_0[NG_BrickPattern_node_clamp_0] --> NG_BrickPattern_base_color_output([base_color_output]) --.base_color--> N_StandardSurface[N_StandardSurface]
    style NG_BrickPattern_base_color_output fill:#1b1,color:#111
    NG_BrickPattern_node_mix_8[NG_BrickPattern_node_mix_8] --.in--> NG_BrickPattern_node_clamp_0[node_clamp_0]
    NG_BrickPattern_node_multiply_5[NG_BrickPattern_node_multiply_5] --.fg--> NG_BrickPattern_node_mix_8[node_mix_8]
    NG_BrickPattern_node_mix_6[NG_BrickPattern_node_mix_6] --.in1--> NG_BrickPattern_node_multiply_5[node_multiply_5]
    NG_BrickPattern_dirt_color([dirt_color]) ==.fg==> NG_BrickPattern_node_mix_6[NG_BrickPattern/node_mix_6]
    style NG_BrickPattern_dirt_color fill:#0bb,color:#111
    NG_BrickPattern_node_hsvtorgb_17[NG_BrickPattern_node_hsvtorgb_17] --.bg--> NG_BrickPattern_node_mix_6[node_mix_6]
    NG_BrickPattern_node_add_16[NG_BrickPattern_node_add_16] --.in--> NG_BrickPattern_node_hsvtorgb_17[node_hsvtorgb_17]
    NG_BrickPattern_node_combine3_color3_13[NG_BrickPattern_node_combine3_color3_13] --.in1--> NG_BrickPattern_node_add_16[node_add_16]
    NG_BrickPattern_node_multiply_14[NG_BrickPattern_node_multiply_14] --.in1--> NG_BrickPattern_node_combine3_color3_13[node_combine3_color3_13]
    NG_BrickPattern_hue_variation([hue_variation]) ==.in2==> NG_BrickPattern_node_multiply_14[NG_BrickPattern/node_multiply_14]
    style NG_BrickPattern_hue_variation fill:#0bb,color:#111
    NG_BrickPattern_node_subtract_18[NG_BrickPattern_node_subtract_18] --.in1--> NG_BrickPattern_node_multiply_14[node_multiply_14]
    NG_BrickPattern_node_add_19[NG_BrickPattern_node_add_19] --.in1--> NG_BrickPattern_node_subtract_18[node_subtract_18]
    NG_BrickPattern_node_multiply_25[NG_BrickPattern_node_multiply_25] --.in1--> NG_BrickPattern_node_add_19[node_add_19]
    NG_BrickPattern_hue_variation([hue_variation]) ==.in1==> NG_BrickPattern_node_multiply_25[NG_BrickPattern/node_multiply_25]
    style NG_BrickPattern_hue_variation fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_26[NG_BrickPattern_node_tiledimage_float_26] --.in2--> NG_BrickPattern_node_multiply_25[node_multiply_25]
    NG_BrickPattern_node_convert_1[NG_BrickPattern_node_convert_1] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_26[node_tiledimage_float_26]
    NG_BrickPattern_uvtiling([uvtiling]) ==.in==> NG_BrickPattern_node_convert_1[NG_BrickPattern/node_convert_1]
    style NG_BrickPattern_uvtiling fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_7[NG_BrickPattern_node_tiledimage_float_7] --.in2--> NG_BrickPattern_node_add_19[node_add_19]
    NG_BrickPattern_node_convert_1[NG_BrickPattern_node_convert_1] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_7[node_tiledimage_float_7]
    NG_BrickPattern_node_multiply_15[NG_BrickPattern_node_multiply_15] --.in3--> NG_BrickPattern_node_combine3_color3_13[node_combine3_color3_13]
    NG_BrickPattern_node_add_19[NG_BrickPattern_node_add_19] --.in1--> NG_BrickPattern_node_multiply_15[node_multiply_15]
    NG_BrickPattern_node_multiply_20[NG_BrickPattern_node_multiply_20] --.in2--> NG_BrickPattern_node_multiply_15[node_multiply_15]
    NG_BrickPattern_value_variation([value_variation]) ==.in1==> NG_BrickPattern_node_multiply_20[NG_BrickPattern/node_multiply_20]
    style NG_BrickPattern_value_variation fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_26[NG_BrickPattern_node_tiledimage_float_26] --.in2--> NG_BrickPattern_node_multiply_20[node_multiply_20]
    NG_BrickPattern_node_rgbtohsv_12[NG_BrickPattern_node_rgbtohsv_12] --.in2--> NG_BrickPattern_node_add_16[node_add_16]
    NG_BrickPattern_brick_color([brick_color]) ==.in==> NG_BrickPattern_node_rgbtohsv_12[NG_BrickPattern/node_rgbtohsv_12]
    style NG_BrickPattern_brick_color fill:#0bb,color:#111
    NG_BrickPattern_node_multiply_23[NG_BrickPattern_node_multiply_23] --.mix--> NG_BrickPattern_node_mix_6[node_mix_6]
    NG_BrickPattern_dirt_amount([dirt_amount]) ==.in1==> NG_BrickPattern_node_multiply_23[NG_BrickPattern/node_multiply_23]
    style NG_BrickPattern_dirt_amount fill:#0bb,color:#111
    NG_BrickPattern_node_tiledimage_float_24[NG_BrickPattern_node_tiledimage_float_24] --.in2--> NG_BrickPattern_node_multiply_23[node_multiply_23]
    NG_BrickPattern_node_convert_1[NG_BrickPattern_node_convert_1] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_24[node_tiledimage_float_24]
    NG_BrickPattern_node_tiledimage_float_7[NG_BrickPattern_node_tiledimage_float_7] --.in2--> NG_BrickPattern_node_multiply_5[node_multiply_5]
    NG_BrickPattern_node_multiply_9[NG_BrickPattern_node_multiply_9] --.bg--> NG_BrickPattern_node_mix_8[node_mix_8]
    NG_BrickPattern_node_color_11[NG_BrickPattern_node_color_11] --.in1--> NG_BrickPattern_node_multiply_9[node_multiply_9]
    NG_BrickPattern_node_tiledimage_float_7[NG_BrickPattern_node_tiledimage_float_7] --.in2--> NG_BrickPattern_node_multiply_9[node_multiply_9]
    NG_BrickPattern_node_tiledimage_float_10[NG_BrickPattern_node_tiledimage_float_10] --.mix--> NG_BrickPattern_node_mix_8[node_mix_8]
    NG_BrickPattern_node_convert_1[NG_BrickPattern_node_convert_1] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_10[node_tiledimage_float_10]
    NG_BrickPattern_node_multiply_1[NG_BrickPattern_node_multiply_1] --> NG_BrickPattern_specular_roughness_output([specular_roughness_output]) --.specular_roughness--> N_StandardSurface[N_StandardSurface]
    style NG_BrickPattern_specular_roughness_output fill:#1b1,color:#111
    NG_BrickPattern_node_divide_21[NG_BrickPattern_node_divide_21] --.in1--> NG_BrickPattern_node_multiply_1[node_multiply_1]
    NG_BrickPattern_roughness_amount([roughness_amount]) ==.in1==> NG_BrickPattern_node_divide_21[NG_BrickPattern/node_divide_21]
    style NG_BrickPattern_roughness_amount fill:#0bb,color:#111
    NG_BrickPattern_node_max_1[NG_BrickPattern_node_max_1] --.in2--> NG_BrickPattern_node_divide_21[node_divide_21]
    NG_BrickPattern_node_tiledimage_float_10[NG_BrickPattern_node_tiledimage_float_10] --.in1--> NG_BrickPattern_node_max_1[node_max_1]
    NG_BrickPattern_node_tiledimage_float_22[NG_BrickPattern_node_tiledimage_float_22] --.in2--> NG_BrickPattern_node_multiply_1[node_multiply_1]
    NG_BrickPattern_node_convert_1[NG_BrickPattern_node_convert_1] --.uvtiling--> NG_BrickPattern_node_tiledimage_float_22[node_tiledimage_float_22]
    NG_BrickPattern_node_normalmap_3[NG_BrickPattern_node_normalmap_3] --> NG_BrickPattern_normal_output([normal_output]) --.normal--> N_StandardSurface[N_StandardSurface]
    style NG_BrickPattern_normal_output fill:#1b1,color:#111
    NG_BrickPattern_node_tiledimage_vector3_27[NG_BrickPattern_node_tiledimage_vector3_27] --.in--> NG_BrickPattern_node_normalmap_3[node_normalmap_3]
    NG_BrickPattern_node_convert_1[NG_BrickPattern_node_convert_1] --.uvtiling--> NG_BrickPattern_node_tiledimage_vector3_27[node_tiledimage_vector3_27]
  subgraph NG_BrickPattern
    NG_BrickPattern_base_color_output
    NG_BrickPattern_brick_color
    NG_BrickPattern_dirt_amount
    NG_BrickPattern_dirt_color
    NG_BrickPattern_hue_variation
    NG_BrickPattern_node_add_16
    NG_BrickPattern_node_add_19
    NG_BrickPattern_node_clamp_0
    NG_BrickPattern_node_color_11
    NG_BrickPattern_node_combine3_color3_13
    NG_BrickPattern_node_convert_1
    NG_BrickPattern_node_divide_21
    NG_BrickPattern_node_hsvtorgb_17
    NG_BrickPattern_node_max_1
    NG_BrickPattern_node_mix_6
    NG_BrickPattern_node_mix_8
    NG_BrickPattern_node_multiply_1
    NG_BrickPattern_node_multiply_14
    NG_BrickPattern_node_multiply_15
    NG_BrickPattern_node_multiply_20
    NG_BrickPattern_node_multiply_23
    NG_BrickPattern_node_multiply_25
    NG_BrickPattern_node_multiply_5
    NG_BrickPattern_node_multiply_9
    NG_BrickPattern_node_normalmap_3
    NG_BrickPattern_node_rgbtohsv_12
    NG_BrickPattern_node_subtract_18
    NG_BrickPattern_node_tiledimage_float_10
    NG_BrickPattern_node_tiledimage_float_22
    NG_BrickPattern_node_tiledimage_float_24
    NG_BrickPattern_node_tiledimage_float_26
    NG_BrickPattern_node_tiledimage_float_7
    NG_BrickPattern_node_tiledimage_vector3_27
    NG_BrickPattern_normal_output
    NG_BrickPattern_roughness_amount
    NG_BrickPattern_specular_roughness_output
    NG_BrickPattern_uvtiling
    NG_BrickPattern_value_variation
  end
```
* Example of cascading nodegraph output from 2 source materials "merge" (text copied) into same graph:
```mermaid
graph TD;
    upstream1_remove_red[multiply] --> upstream1_upstream1_out2([upstream1_out2]) --.base_color--> standard_surface1[standard_surface]
    style upstream1_upstream1_out2 fill:#1b1,color:#111
    upstream2_make_red[multiply] --.in1--> upstream1_remove_red[multiply]
    upstream3_upstream_image1[image] --.in1--> upstream2_make_red[multiply]
    upstream3_file1([file1]) ==.file==> upstream3_upstream_image1[image]
    style upstream3_file1 fill:#0bb,color:#111
  subgraph upstream1
    upstream1_remove_red
    upstream1_upstream1_out2
  end
  subgraph upstream2
    upstream2_make_red
  end
  subgraph upstream3
    upstream3_file1
    upstream3_upstream_image1
  end

    upstream1_make_yellow[multiply] --> upstream1_upstream1_out1([upstream1_out1]) --.base_color--> standard_surface[standard_surface]
    style upstream1_upstream1_out1 fill:#1b1,color:#111
    upstream2_multiply_by_image[multiply] --.in1--> upstream1_make_yellow[multiply]
    upstream3_upstream_image[image] --.in1--> upstream2_multiply_by_image[multiply]
    upstream3_file([file]) ==.file==> upstream3_upstream_image[image]
    style upstream3_file fill:#0bb,color:#111
    upstream2_image[image] --.in2--> upstream2_multiply_by_image[multiply]
  subgraph upstream1
    upstream1_make_yellow
    upstream1_upstream1_out1
  end
  subgraph upstream2
    upstream2_image
    upstream2_multiply_by_image
  end
  subgraph upstream3
    upstream3_file
    upstream3_upstream_image
  end
```
* Same graphs with instance instead of category names:
```mermaid
graph TD;
    upstream1_remove_red[upstream1_remove_red] --> upstream1_upstream1_out2([upstream1_out2]) --.base_color--> standard_surface1[standard_surface1]
    style upstream1_upstream1_out2 fill:#1b1,color:#111
    upstream2_make_red[upstream2_make_red] --.in1--> upstream1_remove_red[remove_red]
    upstream3_upstream_image1[upstream3_upstream_image1] --.in1--> upstream2_make_red[make_red]
    upstream3_file1([file1]) ==.file==> upstream3_upstream_image1[upstream3/upstream_image1]
    style upstream3_file1 fill:#0bb,color:#111
  subgraph upstream1
    upstream1_remove_red
    upstream1_upstream1_out2
  end
  subgraph upstream2
    upstream2_make_red
  end
  subgraph upstream3
    upstream3_file1
    upstream3_upstream_image1
  end

    upstream1_make_yellow[upstream1_make_yellow] --> upstream1_upstream1_out1([upstream1_out1]) --.base_color--> standard_surface[standard_surface]
    style upstream1_upstream1_out1 fill:#1b1,color:#111
    upstream2_multiply_by_image[upstream2_multiply_by_image] --.in1--> upstream1_make_yellow[make_yellow]
    upstream3_upstream_image[upstream3_upstream_image] --.in1--> upstream2_multiply_by_image[multiply_by_image]
    upstream3_file([file]) ==.file==> upstream3_upstream_image[upstream3/upstream_image]
    style upstream3_file fill:#0bb,color:#111
    upstream2_image[upstream2_image] --.in2--> upstream2_multiply_by_image[multiply_by_image]
  subgraph upstream1
    upstream1_make_yellow
    upstream1_upstream1_out1
  end
  subgraph upstream2
    upstream2_image
    upstream2_multiply_by_image
  end
  subgraph upstream3
    upstream3_file
    upstream3_upstream_image
  end
```
* Conditional node test. Note TBD if this should be an option as it
is not cheap to find the corresponding NodeDef for a Node.
```mermaid
graph TD; 
  subgraph ifgreater_float
    ifgreater_float_ifgreater1
    ifgreater_float_out
  end
    ifgreater_float_ifgreater1{ifgreater} --> ifgreater_float_out([output])
    style ifgreater_float_out fill:#1b1, color:#111
```
