### PR TITLE
Improve geomprop handling and fix enum value remapping

### DIFF
--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -251,46 +251,36 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
     ShaderGraphPtr graph = ShaderGraph::create(nullptr, name, element, context);
     ShaderPtr shader = std::make_shared<Shader>(name, graph);
 
-    // If the given element is a functional nodegraph we may have inputs with 
-    // default geomprops assigned. In order to bind the corresponding geometric 
-    // data to these inputs we can insert geomprop nodes in the graph.
-    ElementPtr parent = element->getParent();
-    if (parent && parent->isA<NodeGraph>())
+    // Check if there are inputs with default geomprops assigned. In order to bind the
+    // corresponding data to these inputs we insert geomprop nodes in the graph.
+    bool geomNodeAdded = false;
+    for (ShaderGraphInputSocket* socket : graph->getInputSockets())
     {
-        NodeDefPtr nodedef = parent->asA<NodeGraph>()->getNodeDef();
-        if (nodedef)
+        if (!socket->getGeomProp().empty())
         {
-            // It's a functional nodegraph so check all inputs for geomprop assignments.
-            bool nodeAdded = false;
-            for (ShaderGraphInputSocket* socket : graph->getInputSockets())
+            ConstDocumentPtr doc = element->getDocument();
+            GeomPropDefPtr geomprop = doc->getGeomPropDef(socket->getGeomProp());
+            if (geomprop)
             {
-                if (!socket->getGeomProp().empty())
+                // A default geomprop was assigned to this graph input.
+                // For all internal connections to this input, break the connection 
+                // and assing a geomprop node that generates this data.
+                // Note: If a geomprop node exists already it is reused, 
+                // so only a single node per geometry type is created.
+                ShaderInputVec connections = socket->getConnections();
+                for (auto connection : connections)
                 {
-                    InputPtr input = nodedef->getActiveInput(socket->getName());
-                    GeomPropDefPtr geomprop = input ? input->getDefaultGeomProp() : nullptr;
-                    if (geomprop)
-                    {
-                        // A default geomprop was assigned to this graph input.
-                        // For all internal connections to this input, break the connection 
-                        // and assing a geomprop node that generates this data.
-                        // Note: If a geomprop node exists already it is reused, 
-                        // so only a single node per geometry type is created.
-                        ShaderInputVec connections = socket->getConnections();
-                        for (auto connection : connections)
-                        {
-                            connection->breakConnection();
-                            graph->addDefaultGeomNode(connection, *geomprop, context);
-                            nodeAdded = true;
-                        }
-                    }
+                    connection->breakConnection();
+                    graph->addDefaultGeomNode(connection, *geomprop, context);
+                    geomNodeAdded = true;
                 }
             }
-            // If nodes where added we need to re-sort the nodes in topological order.
-            if (nodeAdded)
-            {
-                graph->topologicalSort();
-            }
         }
+    }
+    // If nodes where added we need to re-sort the nodes in topological order.
+    if (geomNodeAdded)
+    {
+        graph->topologicalSort();
     }
 
     // Create vertex stage.

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -277,7 +277,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
             }
         }
     }
-    // If nodes where added we need to re-sort the nodes in topological order.
+    // If nodes were added we need to re-sort the nodes in topological order.
     if (geomNodeAdded)
     {
         graph->topologicalSort();

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -264,7 +264,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
             {
                 // A default geomprop was assigned to this graph input.
                 // For all internal connections to this input, break the connection 
-                // and assing a geomprop node that generates this data.
+                // and assign a geomprop node that generates this data.
                 // Note: If a geomprop node exists already it is reused, 
                 // so only a single node per geometry type is created.
                 ShaderInputVec connections = socket->getConnections();

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -712,40 +712,49 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
             }
 
             // Handle node input ports
-            for (const ValueElementPtr& nodedefPort : nodeDef->getActiveValueElements())
+            for (const InputPtr& nodedefInput : nodeDef->getActiveInputs())
             {
-                InputPtr nodedefInputPort = nodedefPort->asA<Input>();
-                if (!nodedefInputPort)
-                {
-                    continue;
-                }
-
-                ShaderGraphInputSocket* inputSocket = graph->getInputSocket(nodedefPort->getName());
-                ShaderInput* input = newNode->getInput(nodedefPort->getName());
+                ShaderGraphInputSocket* inputSocket = graph->getInputSocket(nodedefInput->getName());
+                ShaderInput* input = newNode->getInput(nodedefInput->getName());
                 if (!inputSocket || !input)
                 {
-                    throw ExceptionShaderGenError("Node port '" + nodedefPort->getName() + "' doesn't match an existing input on graph '" + graph->getName() + "'");
+                    throw ExceptionShaderGenError("Node input '" + nodedefInput->getName() + "' doesn't match an existing input on graph '" + graph->getName() + "'");
                 }
 
-                ValueElementPtr nodePort = node->getValueElement(nodedefPort->getName());
-                if (nodePort)
+                // Copy data from node element to shadergen representation
+                InputPtr nodeInput = node->getInput(nodedefInput->getName());
+                if (nodeInput)
                 {
-                    ValuePtr value = nodePort->getResolvedValue();
+                    ValuePtr value = nodeInput->getResolvedValue();
                     if (value)
                     {
-                        inputSocket->setValue(value);
+                        const string& valueString = value->getValueString();
+                        std::pair<const TypeDesc*, ValuePtr> enumResult;
+                        const TypeDesc* type = TypeDesc::get(nodedefInput->getType());
+                        const string& enumNames = nodedefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+                        if (context.getShaderGenerator().getSyntax().remapEnumeration(valueString, type, enumNames, enumResult))
+                        {
+                            inputSocket->setValue(enumResult.second);
+                        }
+                        else
+                        {
+                            inputSocket->setValue(value);
+                        }
                     }
 
-                    inputSocket->setPath(nodePort->getNamePath());
-                    input->setPath(inputSocket->getPath());
-
-                    const string& unit = nodePort->getUnit();
+                    const string path = nodeInput->getNamePath();
+                    if (!path.empty())
+                    {
+                        inputSocket->setPath(path);
+                        input->setPath(path);
+                    }
+                    const string& unit = nodeInput->getUnit();
                     if (!unit.empty())
                     {
                         inputSocket->setUnit(unit);
                         input->setUnit(unit);
                     }
-                    const string& colorSpace = nodePort->getColorSpace();
+                    const string& colorSpace = nodeInput->getColorSpace();
                     if (!colorSpace.empty())
                     {
                         inputSocket->setColorSpace(colorSpace);
@@ -753,17 +762,7 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
                     }
                 }
 
-                if (nodedefPort->isA<Input>())
-                {
-                    GeomPropDefPtr geomprop = nodedefPort->asA<Input>()->getDefaultGeomProp();
-                    if (geomprop)
-                    {
-                        inputSocket->setGeomProp(geomprop->getName());
-                        input->setGeomProp(geomprop->getName());
-                    }
-                }
-
-                // Connect to the graph input
+                // Connect graph socket to the node input
                 inputSocket->makeConnection(input);
 
                 // Share metadata.


### PR DESCRIPTION
This changelist extends the support for default geomprops in GLSL to all graphs and not only functional graphs. 

It also fixes an issue where remapping of enum values were not done properly when running codegen on single nodes.

These changes should resolve logged issue #1268.
