### PR TITLE
Apply Clang formatting to MaterialXGenMsl

### DIFF
--- a/source/MaterialXGenMsl/MslResourceBindingContext.cpp
+++ b/source/MaterialXGenMsl/MslResourceBindingContext.cpp
@@ -14,7 +14,8 @@ MslResourceBindingContext::MslResourceBindingContext(
     size_t uniformBindingLocation, size_t samplerBindingLocation) :
     _hwInitUniformBindLocation(uniformBindingLocation),
     _hwInitSamplerBindLocation(samplerBindingLocation)
-{}
+{
+}
 
 void MslResourceBindingContext::initialize()
 {
@@ -64,26 +65,25 @@ void MslResourceBindingContext::emitResourceBindings(GenContext& context, const 
     generator.emitLineBreak(stage);
 }
 
-void MslResourceBindingContext::emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms, 
-                                                                ShaderStage& stage, const std::string& structInstanceName,
-                                                                const std::string& arraySuffix)
+void MslResourceBindingContext::emitStructuredResourceBindings(GenContext& context, const VariableBlock& uniforms,
+                                                               ShaderStage& stage, const std::string& structInstanceName,
+                                                               const std::string& arraySuffix)
 {
     ShaderGenerator& generator = context.getShaderGenerator();
 
     const size_t baseAlignment = 16;
     // Values are adjusted based on
     // https://developer.apple.com/metal/Metal-Shading-Language-Specification.pdf
-    std::unordered_map<const TypeDesc*, size_t> alignmentMap({
-        { Type::FLOAT, baseAlignment / 4 },
-        { Type::INTEGER, baseAlignment / 4 },
-        { Type::BOOLEAN, baseAlignment / 4 },
-        { Type::COLOR3, baseAlignment },
-        { Type::COLOR4, baseAlignment },
-        { Type::VECTOR2, baseAlignment / 2 },
-        { Type::VECTOR3, baseAlignment },
-        { Type::VECTOR4, baseAlignment },
-        { Type::MATRIX33, baseAlignment * 4 },
-        { Type::MATRIX44, baseAlignment * 4 } });
+    std::unordered_map<const TypeDesc*, size_t> alignmentMap({ { Type::FLOAT, baseAlignment / 4 },
+                                                               { Type::INTEGER, baseAlignment / 4 },
+                                                               { Type::BOOLEAN, baseAlignment / 4 },
+                                                               { Type::COLOR3, baseAlignment },
+                                                               { Type::COLOR4, baseAlignment },
+                                                               { Type::VECTOR2, baseAlignment / 2 },
+                                                               { Type::VECTOR3, baseAlignment },
+                                                               { Type::VECTOR4, baseAlignment },
+                                                               { Type::MATRIX33, baseAlignment * 4 },
+                                                               { Type::MATRIX44, baseAlignment * 4 } });
 
     // Get struct alignment and size
     // alignment, uniform member index
@@ -110,9 +110,10 @@ void MslResourceBindingContext::emitStructuredResourceBindings(GenContext& conte
 
     // Sort order from largest to smallest
     std::sort(memberOrder.begin(), memberOrder.end(),
-        [](const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b) {
-            return a.first > b.first;
-        });
+              [](const std::pair<size_t, size_t>& a, const std::pair<size_t, size_t>& b)
+    {
+        return a.first > b.first;
+    });
 
     // Emit the struct
     generator.emitLine("struct " + uniforms.getName(), stage, false);
@@ -135,12 +136,11 @@ void MslResourceBindingContext::emitStructuredResourceBindings(GenContext& conte
     }
     generator.emitScopeEnd(stage, true);
 
-
     // Emit binding information
     generator.emitLineBreak(stage);
     generator.emitLine("struct " + uniforms.getName() + "_" +
-        stage.getName(),
-    stage, false);
+                           stage.getName(),
+                       stage, false);
     generator.emitScopeBegin(stage);
     generator.emitLine(uniforms.getName() + " " + structInstanceName + arraySuffix, stage);
     generator.emitScopeEnd(stage, true);

--- a/source/MaterialXGenMsl/MslResourceBindingContext.h
+++ b/source/MaterialXGenMsl/MslResourceBindingContext.h
@@ -26,7 +26,7 @@ class MX_GENMSL_API MslResourceBindingContext : public HwResourceBindingContext
     MslResourceBindingContext(size_t uniformBindingLocation, size_t samplerBindingLocation);
 
     static MslResourceBindingContextPtr create(
-        size_t uniformBindingLocation=0, size_t samplerBindingLocation=0)
+        size_t uniformBindingLocation = 0, size_t samplerBindingLocation = 0)
     {
         return std::make_shared<MslResourceBindingContext>(
             uniformBindingLocation, samplerBindingLocation);

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -60,17 +60,17 @@ MslShaderGenerator::MslShaderGenerator() :
     //
 
     StringVec elementNames;
-    
+
     // <!-- <switch> -->
     elementNames = {
         // <!-- 'which' type : float -->
-        "IM_switch_float_"   + MslShaderGenerator::TARGET,
-        "IM_switch_color3_"  + MslShaderGenerator::TARGET,
-        "IM_switch_color4_"  + MslShaderGenerator::TARGET,
+        "IM_switch_float_" + MslShaderGenerator::TARGET,
+        "IM_switch_color3_" + MslShaderGenerator::TARGET,
+        "IM_switch_color4_" + MslShaderGenerator::TARGET,
         "IM_switch_vector2_" + MslShaderGenerator::TARGET,
         "IM_switch_vector3_" + MslShaderGenerator::TARGET,
         "IM_switch_vector4_" + MslShaderGenerator::TARGET,
-        
+
         // <!-- 'which' type : integer -->
         "IM_switch_floatI_" + MslShaderGenerator::TARGET,
         "IM_switch_color3I_" + MslShaderGenerator::TARGET,
@@ -89,7 +89,7 @@ MslShaderGenerator::MslShaderGenerator() :
         "IM_swizzle_float_vector2_" + MslShaderGenerator::TARGET,
         "IM_swizzle_float_vector3_" + MslShaderGenerator::TARGET,
         "IM_swizzle_float_vector4_" + MslShaderGenerator::TARGET,
-        
+
         // <!-- from type : color3 -->
         "IM_swizzle_color3_float_" + MslShaderGenerator::TARGET,
         "IM_swizzle_color3_color3_" + MslShaderGenerator::TARGET,
@@ -97,7 +97,7 @@ MslShaderGenerator::MslShaderGenerator() :
         "IM_swizzle_color3_vector2_" + MslShaderGenerator::TARGET,
         "IM_swizzle_color3_vector3_" + MslShaderGenerator::TARGET,
         "IM_swizzle_color3_vector4_" + MslShaderGenerator::TARGET,
-        
+
         // <!-- from type : color4 -->
         "IM_swizzle_color4_float_" + MslShaderGenerator::TARGET,
         "IM_swizzle_color4_color3_" + MslShaderGenerator::TARGET,
@@ -105,7 +105,7 @@ MslShaderGenerator::MslShaderGenerator() :
         "IM_swizzle_color4_vector2_" + MslShaderGenerator::TARGET,
         "IM_swizzle_color4_vector3_" + MslShaderGenerator::TARGET,
         "IM_swizzle_color4_vector4_" + MslShaderGenerator::TARGET,
-        
+
         // <!-- from type : vector2 -->
         "IM_swizzle_vector2_float_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector2_color3_" + MslShaderGenerator::TARGET,
@@ -113,7 +113,7 @@ MslShaderGenerator::MslShaderGenerator() :
         "IM_swizzle_vector2_vector2_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector2_vector3_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector2_vector4_" + MslShaderGenerator::TARGET,
-        
+
         // <!-- from type : vector3 -->
         "IM_swizzle_vector3_float_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector3_color3_" + MslShaderGenerator::TARGET,
@@ -121,7 +121,7 @@ MslShaderGenerator::MslShaderGenerator() :
         "IM_swizzle_vector3_vector2_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector3_vector3_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector3_vector4_" + MslShaderGenerator::TARGET,
-        
+
         // <!-- from type : vector4 -->
         "IM_swizzle_vector4_float_" + MslShaderGenerator::TARGET,
         "IM_swizzle_vector4_color3_" + MslShaderGenerator::TARGET,
@@ -293,7 +293,7 @@ ShaderPtr MslShaderGenerator::generate(const string& name, ElementPtr element, G
         context.pushUserData(HW::USER_DATA_BINDING_CONTEXT, MslResourceBindingContext::create());
         resourceBindingCtx = context.getUserData<HwResourceBindingContext>(HW::USER_DATA_BINDING_CONTEXT);
     }
-    
+
     // Make sure we initialize/reset the binding context before generation.
     if (resourceBindingCtx)
     {
@@ -309,7 +309,7 @@ ShaderPtr MslShaderGenerator::generate(const string& name, ElementPtr element, G
     ShaderStage& ps = shader->getStage(Stage::PIXEL);
     emitPixelStage(shader->getGraph(), context, ps);
     replaceTokens(_tokenSubstitutions, ps);
-    
+
     MetalizeGeneratedShader(ps);
 
     return shader;
@@ -318,29 +318,35 @@ ShaderPtr MslShaderGenerator::generate(const string& name, ElementPtr element, G
 void MslShaderGenerator::MetalizeGeneratedShader(ShaderStage& shaderStage) const
 {
     std::string sourceCode = shaderStage.getSourceCode();
-    
+
     // Used to convert shared code between GLSL pass by reference parameters to MSL pass by reference.
     // Converts "inout/out Type variableName" to "thread Type& variableName"
     size_t pos = 0;
     {
         std::array<string, 2> refKeywords = { "out", "inout" };
-        for(const auto& keyword : refKeywords)
+        for (const auto& keyword : refKeywords)
         {
             pos = sourceCode.find(keyword);
-            while(pos != std::string::npos)
+            while (pos != std::string::npos)
             {
-                char preceeding = sourceCode[pos - 1], succeeding = sourceCode[pos+keyword.length()];
+                char preceeding = sourceCode[pos - 1], succeeding = sourceCode[pos + keyword.length()];
                 bool isOutKeyword =
                     (preceeding == '(' || preceeding == ',' || std::isspace(preceeding)) &&
                     std::isspace(succeeding) &&
                     succeeding != '\n';
                 size_t beg = pos;
                 pos += keyword.length();
-                if(isOutKeyword)
+                if (isOutKeyword)
                 {
-                    while(std::isspace(sourceCode[pos])) { ++pos; }
+                    while (std::isspace(sourceCode[pos]))
+                    {
+                        ++pos;
+                    }
                     size_t typename_beg = pos;
-                    while(!std::isspace(sourceCode[pos])) { ++pos; }
+                    while (!std::isspace(sourceCode[pos]))
+                    {
+                        ++pos;
+                    }
                     size_t typename_end = pos;
                     std::string typeName = sourceCode.substr(typename_beg, typename_end - typename_beg);
                     sourceCode.replace(beg, typename_end - beg, "thread " + typeName + "&");
@@ -349,34 +355,34 @@ void MslShaderGenerator::MetalizeGeneratedShader(ShaderStage& shaderStage) const
             }
         }
     }
-    
+
     // Renames GLSL constructs that are used in shared code to MSL equivalent constructs.
     std::unordered_map<string, string> replaceTokens;
     replaceTokens["sampler2D"] = "MetalTexture";
     replaceTokens["dFdy"] = "dfdy";
     replaceTokens["dFdx"] = "dfdx";
-    
+
     auto isAllowedAfterToken = [](char ch) -> bool
     {
         return std::isspace(ch) || ch == '(' || ch == ')' || ch == ',';
     };
-    
+
     auto isAllowedBeforeToken = [](char ch) -> bool
     {
         return std::isspace(ch) || ch == '(' || ch == ',';
     };
-    
-    for(const auto& t : replaceTokens)
+
+    for (const auto& t : replaceTokens)
     {
         pos = sourceCode.find(t.first);
-        while(pos != std::string::npos)
+        while (pos != std::string::npos)
         {
-            bool isOutKeyword = isAllowedBeforeToken(sourceCode[pos-1]);
+            bool isOutKeyword = isAllowedBeforeToken(sourceCode[pos - 1]);
             size_t beg = pos;
             pos += t.first.length();
             isOutKeyword &= isAllowedAfterToken(sourceCode[pos]);
-            
-            if(isOutKeyword)
+
+            if (isOutKeyword)
             {
                 sourceCode.replace(beg, t.first.length(), t.second);
                 pos = sourceCode.find(t.first, beg + t.second.length());
@@ -387,7 +393,7 @@ void MslShaderGenerator::MetalizeGeneratedShader(ShaderStage& shaderStage) const
             }
         }
     }
-    
+
     shaderStage.setSourceCode(sourceCode);
 }
 
@@ -397,27 +403,27 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                                              bool isVertexShader, bool needsLightData) const
 {
     int tex_slot = 0;
-    int buffer_slot = isVertexShader ? std::max(static_cast<int>(stage.getInputBlock(HW::VERTEX_INPUTS).size()), 0)  : 0;
-    
-    bool entryFunctionArgs              =
+    int buffer_slot = isVertexShader ? std::max(static_cast<int>(stage.getInputBlock(HW::VERTEX_INPUTS).size()), 0) : 0;
+
+    bool entryFunctionArgs =
         situation == EMIT_GLOBAL_SCOPE_CONTEXT_ENTRY_FUNCTION_RESOURCES;
-    bool globalContextInit              =
+    bool globalContextInit =
         situation == EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_INIT;
-    bool globalContextMembers           =
+    bool globalContextMembers =
         situation == EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_DECL;
     bool globalContextConstructorParams =
         situation == EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_ARGS;
-    bool globalContextConstructorInit   =
+    bool globalContextConstructorInit =
         situation == EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_INIT;
 
     std::string separator = "";
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        if(globalContextMembers)
+        if (globalContextMembers)
         {
             emitLine("vec4 gl_FragCoord", stage);
         }
-        if(globalContextConstructorInit)
+        if (globalContextConstructorInit)
         {
             emitString("gl_FragCoord(", stage);
             emitLine(stage.getInputBlock(HW::VERTEX_DATA).getInstance() + ".pos)", stage, false);
@@ -428,15 +434,14 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
     {
         auto vertex_inputs = isVertexShader ? stage.getInputBlock(HW::VERTEX_INPUTS)
                                             : stage.getInputBlock(HW::VERTEX_DATA);
-        if(!entryFunctionArgs)
+        if (!entryFunctionArgs)
         {
-            if(isVertexShader)
+            if (isVertexShader)
             {
-                
-                for(const auto& it : vertex_inputs.getVariableOrder())
+                for (const auto& it : vertex_inputs.getVariableOrder())
                 {
                     emitString(separator, stage);
-                    if(globalContextInit)
+                    if (globalContextInit)
                     {
                         emitString(vertex_inputs.getInstance() + "." + it->getName(), stage);
                     }
@@ -448,17 +453,17 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                     {
                         emitLine(it->getName() + "(" + it->getName() + ")", stage, false);
                     }
-                    
-                    if(globalContextInit || globalContextConstructorParams || globalContextConstructorInit)
+
+                    if (globalContextInit || globalContextConstructorParams || globalContextConstructorInit)
                         separator = ", ";
-                    else if(globalContextMembers)
+                    else if (globalContextMembers)
                         separator = "\n";
                 }
             }
             else
             {
                 emitString(separator, stage);
-                if(globalContextInit)
+                if (globalContextInit)
                 {
                     emitString(vertex_inputs.getInstance(), stage);
                     separator = ", ";
@@ -466,7 +471,7 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                 else if (globalContextMembers || globalContextConstructorParams)
                 {
                     emitLine(vertex_inputs.getName() + " " + vertex_inputs.getInstance(), stage, !globalContextConstructorParams);
-                    if(globalContextConstructorParams)
+                    if (globalContextConstructorParams)
                         separator = ", ";
                     else
                         separator = "\n";
@@ -484,48 +489,50 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
             separator = ", ";
         }
     }
-    
+
     // Add all uniforms
     for (const auto& it : stage.getUniformBlocks())
     {
         const VariableBlock& uniforms = *it.second;
         bool isLightData = uniforms.getName() == HW::LIGHT_DATA;
-        
-        if(!needsLightData && isLightData) continue;
-        
-        if(isLightData)
+
+        if (!needsLightData && isLightData)
+            continue;
+
+        if (isLightData)
         {
             emitString(separator, stage);
-            if(entryFunctionArgs)
+            if (entryFunctionArgs)
             {
                 emitString(_syntax->getUniformQualifier() + " " +
-                           uniforms.getName() + "_" + stage.getName() + "& " +
-                           uniforms.getInstance() +
-                           "[[ buffer(" + std::to_string(buffer_slot++) + ") ]]",
+                               uniforms.getName() + "_" + stage.getName() + "& " +
+                               uniforms.getInstance() +
+                               "[[ buffer(" + std::to_string(buffer_slot++) + ") ]]",
                            stage);
             }
-            else if(globalContextInit)
+            else if (globalContextInit)
             {
                 emitLine(uniforms.getInstance() + "." + uniforms.getInstance(), stage, false);
             }
-            else if(globalContextMembers || globalContextConstructorParams)
+            else if (globalContextMembers || globalContextConstructorParams)
             {
                 const string structArraySuffix = "[" + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + "]";
                 emitLine((globalContextConstructorParams ? (_syntax->getUniformQualifier() + " ") : std::string()) +
-                         uniforms.getName() + " " +
-                         uniforms.getInstance() +
-                         structArraySuffix, stage, !globalContextConstructorParams);
+                             uniforms.getName() + " " +
+                             uniforms.getInstance() +
+                             structArraySuffix,
+                         stage, !globalContextConstructorParams);
             }
-            else if(globalContextConstructorInit)
+            else if (globalContextConstructorInit)
             {
                 const unsigned int maxLights = std::max(1u, context.getOptions().hwMaxActiveLightSources);
                 emitLine(uniforms.getInstance(), stage, false);
                 emitScopeBegin(stage);
-                for(unsigned int l = 0; l < maxLights; ++l)
+                for (unsigned int l = 0; l < maxLights; ++l)
                 {
                     emitString(l == 0 ? "" : ", ", stage);
                     emitLine(uniforms.getInstance() +
-                             "["+ std::to_string(l)  +"]",
+                                 "[" + std::to_string(l) + "]",
                              stage, false);
                 }
                 emitScopeEnd(stage);
@@ -533,17 +540,17 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
         }
         else
         {
-            if(!entryFunctionArgs)
+            if (!entryFunctionArgs)
             {
                 if (!uniforms.empty())
                 {
-                    for (size_t i=0; i<uniforms.size(); ++i)
+                    for (size_t i = 0; i < uniforms.size(); ++i)
                     {
-                        if(uniforms[i]->getType() != Type::FILENAME)
+                        if (uniforms[i]->getType() != Type::FILENAME)
                         {
                             emitLineBegin(stage);
                             emitString(separator, stage);
-                            if(globalContextInit)
+                            if (globalContextInit)
                             {
                                 emitString(uniforms.getInstance() + "." + uniforms[i]->getVariable(), stage);
                             }
@@ -559,7 +566,7 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                         }
                         else
                         {
-                            if(globalContextInit)
+                            if (globalContextInit)
                             {
                                 emitString(separator, stage);
                                 emitString("MetalTexture", stage);
@@ -581,10 +588,10 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                                 emitLine(uniforms[i]->getVariable() + "(" + uniforms[i]->getVariable() + ")", stage, false);
                             }
                         }
-                        
-                        if(globalContextInit || globalContextConstructorParams || globalContextConstructorInit)
+
+                        if (globalContextInit || globalContextConstructorParams || globalContextConstructorInit)
                             separator = ", ";
-                        else if(globalContextMembers)
+                        else if (globalContextMembers)
                             separator = "\n";
                     }
                 }
@@ -610,33 +617,32 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                             hasUniforms = true;
                         }
                     }
-                    
-                    if(hasUniforms)
+
+                    if (hasUniforms)
                     {
                         emitString(separator, stage);
                         emitString(_syntax->getUniformQualifier() + " " +
-                                   uniforms.getName() + "& " +
-                                   uniforms.getInstance() +
-                                   "[[ buffer(" + std::to_string(buffer_slot++) + ") ]]",
+                                       uniforms.getName() + "& " +
+                                       uniforms.getInstance() +
+                                       "[[ buffer(" + std::to_string(buffer_slot++) + ") ]]",
                                    stage);
                     }
                 }
             }
         }
-        
-        if(globalContextInit || entryFunctionArgs || globalContextConstructorParams || globalContextConstructorInit)
+
+        if (globalContextInit || entryFunctionArgs || globalContextConstructorParams || globalContextConstructorInit)
             separator = ", ";
         else
             separator = "\n";
-        
     }
-    
-    if(!isVertexShader)
+
+    if (!isVertexShader)
     {
         const VariableBlock& outputs = stage.getOutputBlock(HW::PIXEL_OUTPUTS);
-        for(auto& it : outputs.getVariableOrder())
+        for (auto& it : outputs.getVariableOrder())
         {
-            if(globalContextMembers)
+            if (globalContextMembers)
             {
                 emitLine(_syntax->getTypeName(it->getType()) + " " + it->getVariable(), stage, true);
             }
@@ -662,7 +668,7 @@ void MslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& c
 
     // Add vertex data outputs block
     emitOutputs(context, stage);
-    
+
     emitLine("struct GlobalContext", stage, false);
     emitScopeBegin(stage);
     {
@@ -671,11 +677,11 @@ void MslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& c
         emitLine(") : ", stage, false);
         emitGlobalVariables(context, stage, EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_INIT, true, false);
         emitLine("{}", stage, false);
-        
+
         emitGlobalVariables(context, stage, EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_DECL, true, false);
-        
+
         emitFunctionDefinitions(graph, context, stage);
-        
+
         const VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
         emitLine(vertexData.getName() + " VertexMain()", stage, false);
         emitScopeBegin(stage);
@@ -715,7 +721,6 @@ void MslShaderGenerator::emitVertexStage(const ShaderGraph& graph, GenContext& c
     }
     emitScopeEnd(stage);
     emitLineBreak(stage);
-
 }
 
 void MslShaderGenerator::emitSpecularEnvironment(GenContext& context, ShaderStage& stage) const
@@ -762,25 +767,25 @@ void MslShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
 {
     // Add directives
     emitLine("//Metal Shading Language version " + getVersion(), stage, false);
-    emitLine("#define __METAL__ ",      stage, false);
+    emitLine("#define __METAL__ ", stage, false);
     emitLine("#include <metal_stdlib>", stage, false);
-    emitLine("#include <simd/simd.h>",  stage, false);
-    emitLine("using namespace metal;",  stage, false);
-    
-    emitLine("#define vec2 float2",  stage, false);
-    emitLine("#define vec3 float3",  stage, false);
-    emitLine("#define vec4 float4",  stage, false);
-    emitLine("#define ivec2 int2",   stage, false);
-    emitLine("#define ivec3 int3",   stage, false);
-    emitLine("#define ivec4 int4",   stage, false);
-    emitLine("#define uvec2 uint2",  stage, false);
-    emitLine("#define uvec3 uint3",  stage, false);
-    emitLine("#define uvec4 uint4",  stage, false);
-    emitLine("#define bvec2 bool2",  stage, false);
-    emitLine("#define bvec3 bool3",  stage, false);
-    emitLine("#define bvec4 bool4",  stage, false);
-    emitLine("#define mat3 float3x3",stage, false);
-    emitLine("#define mat4 float4x4",stage, false);
+    emitLine("#include <simd/simd.h>", stage, false);
+    emitLine("using namespace metal;", stage, false);
+
+    emitLine("#define vec2 float2", stage, false);
+    emitLine("#define vec3 float3", stage, false);
+    emitLine("#define vec4 float4", stage, false);
+    emitLine("#define ivec2 int2", stage, false);
+    emitLine("#define ivec3 int3", stage, false);
+    emitLine("#define ivec4 int4", stage, false);
+    emitLine("#define uvec2 uint2", stage, false);
+    emitLine("#define uvec3 uint3", stage, false);
+    emitLine("#define uvec4 uint4", stage, false);
+    emitLine("#define bvec2 bool2", stage, false);
+    emitLine("#define bvec3 bool3", stage, false);
+    emitLine("#define bvec4 bool4", stage, false);
+    emitLine("#define mat3 float3x3", stage, false);
+    emitLine("#define mat4 float4x4", stage, false);
 
     emitLineBreak(stage);
 }
@@ -805,9 +810,9 @@ void MslShaderGenerator::emitConstantBufferDeclarations(GenContext& context,
         const VariableBlock& uniforms = *it.second;
         if (!uniforms.empty())
         {
-            if(uniforms.getName() == HW::LIGHT_DATA)
+            if (uniforms.getName() == HW::LIGHT_DATA)
                 continue;
-            
+
             emitComment("Uniform block: " + uniforms.getName(), stage);
             if (resourceBindingCtx)
             {
@@ -831,7 +836,7 @@ void MslShaderGenerator::emitLightData(GenContext& context, ShaderStage& stage) 
 {
     const VariableBlock& lightData = stage.getUniformBlock(HW::LIGHT_DATA);
     const string structArraySuffix = "[" + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + "]";
-    const string structName        = lightData.getInstance();
+    const string structName = lightData.getInstance();
     HwResourceBindingContextPtr resourceBindingCtx = getResourceBindingContext(context);
     if (resourceBindingCtx)
     {
@@ -855,13 +860,13 @@ void MslShaderGenerator::emitInputs(GenContext& context, ShaderStage& stage, con
     emitComment("Inputs block: " + inputs.getName(), stage);
     emitLine("struct " + inputs.getName(), stage, false);
     emitScopeBegin(stage);
-    
+
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         emitLine("float4 pos [[position]]", stage);
     }
-    
-    for (size_t i=0; i<inputs.size(); ++i)
+
+    for (size_t i = 0; i < inputs.size(); ++i)
     {
         string line = "";
         line += context.getShaderGenerator().getSyntax().getTypeName(inputs[i]->getType());
@@ -872,11 +877,10 @@ void MslShaderGenerator::emitInputs(GenContext& context, ShaderStage& stage, con
             line += std::to_string(i);
             line += ")]]";
         };
-        
+
         emitLine(line, stage, true);
     }
-    
-    
+
     emitScopeEnd(stage, true, false);
     emitLineBreak(stage);
 }
@@ -924,7 +928,7 @@ void MslShaderGenerator::emitOutputs(GenContext& context, ShaderStage& stage) co
             emitLineBreak(stage);
         }
     };
-    
+
     DEFINE_SHADER_STAGE(stage, Stage::VERTEX)
     {
         const VariableBlock& vertexData = stage.getOutputBlock(HW::VERTEX_DATA);
@@ -953,8 +957,8 @@ bool MslShaderGenerator::requiresLighting(const ShaderGraph& graph) const
 {
     const bool isBsdf = graph.hasClassification(ShaderNode::Classification::BSDF);
     const bool isLitSurfaceShader = graph.hasClassification(ShaderNode::Classification::SHADER) &&
-                              graph.hasClassification(ShaderNode::Classification::SURFACE) &&
-                              !graph.hasClassification(ShaderNode::Classification::UNLIT);
+                                    graph.hasClassification(ShaderNode::Classification::SURFACE) &&
+                                    !graph.hasClassification(ShaderNode::Classification::UNLIT);
     return isBsdf || isLitSurfaceShader;
 }
 
@@ -976,10 +980,10 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
     emitLineBreak(stage);
 
     emitMetalTextureClass(context, stage);
-    
+
     // Add type definitions
     emitTypeDefinitions(context, stage);
-    
+
     emitConstantBufferDeclarations(context, resourceBindingCtx, stage);
 
     // Add all constants
@@ -991,17 +995,17 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
     // Add the pixel shader output. This needs to be a float4 for rendering
     // and upstream connection will be converted to float4 if needed in emitFinalOutput()
     emitOutputs(context, stage);
-    
+
     // Determine whether lighting is required
     bool lighting = requiresLighting(graph);
-    
+
     // Define directional albedo approach
     if (lighting || context.getOptions().hwWriteAlbedoTable)
     {
         emitLine("#define DIRECTIONAL_ALBEDO_METHOD " + std::to_string(int(context.getOptions().hwDirectionalAlbedoMethod)), stage, false);
         emitLineBreak(stage);
     }
-    
+
     // Add lighting support
     if (lighting)
     {
@@ -1010,13 +1014,13 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
             const unsigned int maxLights = std::max(1u, context.getOptions().hwMaxActiveLightSources);
             emitLine("#define " + HW::LIGHT_DATA_MAX_LIGHT_SOURCES + " " + std::to_string(maxLights), stage, false);
         }
-        
+
         if (context.getOptions().hwMaxActiveLightSources > 0)
         {
             emitLightData(context, stage);
         }
     }
-    
+
     emitMathMatrixScalarMathOperators(context, stage);
     emitLine("struct GlobalContext", stage, false);
     emitScopeBegin(stage);
@@ -1026,35 +1030,35 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
         emitLine(") : ", stage, false);
         emitGlobalVariables(context, stage, EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_INIT, false, lighting);
         emitLine("{}", stage, false);
-        
+
         // Add common math functions
         emitLine("#define __DECL_GL_MATH_FUNCTIONS__", stage, false);
         emitLibraryInclude("stdlib/genmsl/lib/mx_math.metal", context, stage);
         emitLineBreak(stage);
-        
-        if(lighting)
+
+        if (lighting)
         {
             emitSpecularEnvironment(context, stage);
             emitTransmissionRender(context, stage);
         }
-        
+
         emitGlobalVariables(context, stage, EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_DECL, false, lighting);
-        
+
         // Add shadowing support
         bool shadowing = (lighting && context.getOptions().hwShadowMap) ||
-        context.getOptions().hwWriteDepthMoments;
+                         context.getOptions().hwWriteDepthMoments;
         if (shadowing)
         {
             emitLibraryInclude("pbrlib/genglsl/lib/mx_shadow.glsl", context, stage);
         }
-        
+
         // Emit directional albedo table code.
         if (context.getOptions().hwWriteAlbedoTable)
         {
             emitLibraryInclude("pbrlib/genglsl/lib/mx_table.glsl", context, stage);
             emitLineBreak(stage);
         }
-        
+
         // Set the include file to use for uv transformations,
         // depending on the vertical flip flag.
         if (context.getOptions().fileTextureVerticalFlip)
@@ -1065,25 +1069,25 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
         {
             _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv.glsl";
         }
-        
+
         // Emit uv transform code globally if needed.
         if (context.getOptions().hwAmbientOcclusion)
         {
             emitLibraryInclude("stdlib/genglsl/lib/" + _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV], context, stage);
         }
-        
+
         emitLightFunctionDefinitions(graph, context, stage);
-        
+
         // Emit function definitions for all nodes in the graph.
         emitFunctionDefinitions(graph, context, stage);
-        
+
         const ShaderGraphOutputSocket* outputSocket = graph.getOutputSocket();
-        
+
         // Add main function
         const VariableBlock& outputs = stage.getOutputBlock(HW::PIXEL_OUTPUTS);
         emitLine(outputs.getName() + " FragmentMain()", stage, false);
         emitFunctionBodyBegin(graph, context, stage);
-        
+
         if (graph.hasClassification(ShaderNode::Classification::CLOSURE) &&
             !graph.hasClassification(ShaderNode::Classification::SHADER))
         {
@@ -1110,7 +1114,7 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
                 // Emit all texturing nodes. These are inputs to any
                 // closure/shader nodes and need to be emitted first.
                 emitFunctionCalls(graph, context, stage, ShaderNode::Classification::TEXTURE);
-                
+
                 // Emit function calls for "root" closure/shader nodes.
                 // These will internally emit function calls for any dependent closure nodes upstream.
                 for (ShaderGraphOutputSocket* socket : graph.getOutputSockets())
@@ -1133,7 +1137,7 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
                 // function calls in order.
                 emitFunctionCalls(graph, context, stage);
             }
-            
+
             // Emit final output
             const ShaderOutput* outputConnection = outputSocket->getConnection();
             if (outputConnection)
@@ -1144,7 +1148,7 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
                 {
                     finalOutput = _syntax->getSwizzledVariable(finalOutput, outputConnection->getType(), channels, outputSocket->getType());
                 }
-                
+
                 if (graph.hasClassification(ShaderNode::Classification::SURFACE))
                 {
                     if (context.getOptions().hwTransparency)
@@ -1173,8 +1177,8 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
             else
             {
                 string outputValue = outputSocket->getValue() ?
-                    _syntax->getValue(outputSocket->getType(), *outputSocket->getValue()) :
-                    _syntax->getDefaultValue(outputSocket->getType());
+                                    _syntax->getValue(outputSocket->getType(), *outputSocket->getValue()) :
+                                    _syntax->getDefaultValue(outputSocket->getType());
                 if (!outputSocket->getType()->isFloat4())
                 {
                     string finalOutput = outputSocket->getVariable() + "_tmp";
@@ -1188,25 +1192,23 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
                 }
             }
         }
-        
-        
+
         {
             std::string separator = "";
             emitString("return " + outputs.getName() + "{", stage);
-            for(auto it : outputs.getVariableOrder())
+            for (auto it : outputs.getVariableOrder())
             {
                 emitString(separator + it->getVariable(), stage);
                 separator = ", ";
             }
             emitLine("}", stage, true);
         }
-        
+
         // End main function
         emitFunctionBodyEnd(graph, context, stage);
-        
     }
     emitScopeEnd(stage, true, true);
-    
+
     // Add main function
     {
         setFunctionName("FragmentMain", stage);
@@ -1230,7 +1232,7 @@ void MslShaderGenerator::emitLightFunctionDefinitions(const ShaderGraph& graph, 
 {
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
-        
+
         // Emit Light functions if requested
         if (requiresLighting(graph) && context.getOptions().hwMaxActiveLightSources > 0)
         {
@@ -1281,9 +1283,9 @@ void MslShaderGenerator::toVec4(const TypeDesc* type, string& variable)
     }
 }
 
-void MslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier, 
-                                                  GenContext&, ShaderStage& stage,
-                                                  bool assignValue) const
+void MslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier,
+                                                 GenContext&, ShaderStage& stage,
+                                                 bool assignValue) const
 {
     // A file texture input needs special handling on MSL
     if (variable->getType() == Type::FILENAME)
@@ -1308,18 +1310,19 @@ void MslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, con
         {
             str += " : " + variable->getSemantic();
         }
-        
+
         // Varying parameters of type int must be flat qualified on output from vertex stage and
         // input to pixel stage. The only way to get these is with geompropvalue_integer nodes.
-        if (qualifier.empty() && variable->getType() == Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0) {
+        if (qualifier.empty() && variable->getType() == Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0)
+        {
             str += "[[ " + MslSyntax::FLAT_QUALIFIER + " ]]";
         }
 
         if (assignValue)
         {
             const string valueStr = (variable->getValue() ?
-                _syntax->getValue(variable->getType(), *variable->getValue(), true) :
-                _syntax->getDefaultValue(variable->getType(), true));
+                                    _syntax->getValue(variable->getType(), *variable->getValue(), true) :
+                                    _syntax->getDefaultValue(variable->getType(), true));
             str += valueStr.empty() ? EMPTY_STRING : " = " + valueStr;
         }
 
@@ -1398,7 +1401,6 @@ ShaderNodeImplPtr MslShaderGenerator::getImplementation(const NodeDef& nodedef, 
     return impl;
 }
 
-
 const string MslImplementation::SPACE = "space";
 const string MslImplementation::TO_SPACE = "tospace";
 const string MslImplementation::FROM_SPACE = "fromspace";
@@ -1410,14 +1412,16 @@ const string MslImplementation::GEOMPROP = "geomprop";
 
 namespace
 {
-    // List name of inputs that are not to be editable and
-    // published as shader uniforms in MSL.
-    const std::set<string> IMMUTABLE_INPUTS = 
-    {
-        // Geometric node inputs are immutable since a shader needs regeneration if they change.
-        "index", "space", "attrname"
-    };
-}
+
+// List name of inputs that are not to be editable and
+// published as shader uniforms in MSL.
+const std::set<string> IMMUTABLE_INPUTS =
+{
+    // Geometric node inputs are immutable since a shader needs regeneration if they change.
+    "index", "space", "attrname"
+};
+
+} // namespace
 
 const string& MslImplementation::getTarget() const
 {

--- a/source/MaterialXGenMsl/MslShaderGenerator.h
+++ b/source/MaterialXGenMsl/MslShaderGenerator.h
@@ -47,7 +47,7 @@ class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
     /// The element must be an Implementation or a NodeGraph acting as implementation.
     ShaderNodeImplPtr getImplementation(const NodeDef& nodedef, GenContext& context) const override;
 
-    /// Determine the prefix of vertex data variables. 
+    /// Determine the prefix of vertex data variables.
     virtual string getVertexDataPrefix(const VariableBlock& vertexData) const;
 
   public:
@@ -67,31 +67,31 @@ class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
     virtual void emitLightData(GenContext& context, ShaderStage& stage) const;
     virtual void emitInputs(GenContext& context, ShaderStage& stage) const;
     virtual void emitOutputs(GenContext& context, ShaderStage& stage) const;
-    
+
     virtual void emitMathMatrixScalarMathOperators(GenContext& context, ShaderStage& stage) const;
     virtual void MetalizeGeneratedShader(ShaderStage& shaderStage) const;
- 
+
     void emitConstantBufferDeclarations(GenContext& context,
                                         HwResourceBindingContextPtr resourceBindingCtx,
                                         ShaderStage& stage) const;
-    
+
     enum EmitGlobalScopeContext
     {
         EMIT_GLOBAL_SCOPE_CONTEXT_ENTRY_FUNCTION_RESOURCES = 0,
-        EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_INIT              = 1,
-        EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_DECL              = 2,
-        EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_ARGS         = 3,
-        EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_INIT         = 4
+        EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_INIT = 1,
+        EMIT_GLOBAL_SCOPE_CONTEXT_MEMBER_DECL = 2,
+        EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_ARGS = 3,
+        EMIT_GLOBAL_SCOPE_CONTEXT_CONSTRUCTOR_INIT = 4
     };
-    
+
     void emitGlobalVariables(GenContext& context, ShaderStage& stage,
                              EmitGlobalScopeContext situation,
                              bool isVertexShader,
                              bool needsLightData) const;
-    
+
     void emitInputs(GenContext& context, ShaderStage& stage,
                     const VariableBlock& inputs) const;
-    
+
     virtual HwResourceBindingContextPtr getResourceBindingContext(GenContext& context) const;
 
     /// Logic to indicate whether code to support direct lighting should be emitted.
@@ -114,7 +114,6 @@ class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
     vector<ShaderNodePtr> _lightSamplingNodes;
 };
 
-
 /// Base class for common MSL node implementations
 class MX_GENMSL_API MslImplementation : public ShaderNodeImpl
 {
@@ -124,16 +123,16 @@ class MX_GENMSL_API MslImplementation : public ShaderNodeImpl
     bool isEditable(const ShaderInput& input) const override;
 
   protected:
-    MslImplementation() {}
+    MslImplementation() { }
 
     // Integer identifiers for coordinate spaces.
     // The order must match the order given for
     // the space enum string in stdlib.
     enum Space
     {
-        MODEL_SPACE  = 0,
+        MODEL_SPACE = 0,
         OBJECT_SPACE = 1,
-        WORLD_SPACE  = 2
+        WORLD_SPACE = 2
     };
 
     /// Internal string constants

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -17,7 +17,8 @@ namespace
 class MslStringTypeSyntax : public StringTypeSyntax
 {
   public:
-    MslStringTypeSyntax() : StringTypeSyntax("int", "0", "0") {}
+    MslStringTypeSyntax() :
+        StringTypeSyntax("int", "0", "0") { }
 
     string getValue(const Value& /*value*/, bool /*uniform*/) const override
     {
@@ -30,7 +31,8 @@ class MslArrayTypeSyntax : public ScalarTypeSyntax
   public:
     MslArrayTypeSyntax(const string& name) :
         ScalarTypeSyntax(name, EMPTY_STRING, EMPTY_STRING, EMPTY_STRING)
-    {}
+    {
+    }
 
     string getValue(const Value& value, bool /*uniform*/) const override
     {
@@ -50,7 +52,7 @@ class MslArrayTypeSyntax : public ScalarTypeSyntax
         }
 
         string result = "{" + values[0];
-        for (size_t i = 1; i<values.size(); ++i)
+        for (size_t i = 1; i < values.size(); ++i)
         {
             result += ", " + values[i] + "f";
         }
@@ -68,7 +70,8 @@ class MslFloatArrayTypeSyntax : public MslArrayTypeSyntax
   public:
     explicit MslFloatArrayTypeSyntax(const string& name) :
         MslArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     size_t getSize(const Value& value) const override
@@ -83,7 +86,8 @@ class MslIntegerArrayTypeSyntax : public MslArrayTypeSyntax
   public:
     explicit MslIntegerArrayTypeSyntax(const string& name) :
         MslArrayTypeSyntax(name)
-    {}
+    {
+    }
 
   protected:
     size_t getSize(const Value& value) const override
@@ -114,30 +118,28 @@ MslSyntax::MslSyntax()
 {
     // Add in all reserved words and keywords in MSL
     registerReservedWords(
-    {
-        "centroid", "flat", "smooth", "noperspective", "patch", "sample",
-        "break", "continue", "do", "for", "while", "switch", "case", "default",
-        "if", "else,", "subroutine", "in", "out", "inout",
-        "float", "double", "int", "void", "bool", "true", "false",
-        "invariant", "discard_fragment", "return",
-        "float2x2", "float2x3", "float2x4",
-        "float3x2", "float3x3", "float3x4",
-        "float4x2", "float4x3", "float4x4",
-        "float2", "float3", "float4", "int2", "int3", "int4", "bool2", "bool3", "bool4",
-        "uint", "uint2", "uint3", "uint4",
-        "lowp", "mediump", "highp", "precision",
-        "sampler",
-        "common", "partition", "active", "asm",
-        "struct", "class", "union", "enum", "typedef", "template", "this", "packed",
-        "inline", "noinline", "volatile", "public", "static", "extern", "external", "interface",
-        "long", "short", "half", "fixed", "unsigned", "superp", "input", "output",
-        "half2", "half3", "half4",
-        "sampler3DRect", "filter",
-        "texture1d", "texture2d", "texture3d", "textureCube",
-        "buffer",
-        "sizeof", "cast", "namespace", "using", "row_major",
-        "mix", "sampler"
-    });
+        { "centroid", "flat", "smooth", "noperspective", "patch", "sample",
+          "break", "continue", "do", "for", "while", "switch", "case", "default",
+          "if", "else,", "subroutine", "in", "out", "inout",
+          "float", "double", "int", "void", "bool", "true", "false",
+          "invariant", "discard_fragment", "return",
+          "float2x2", "float2x3", "float2x4",
+          "float3x2", "float3x3", "float3x4",
+          "float4x2", "float4x3", "float4x4",
+          "float2", "float3", "float4", "int2", "int3", "int4", "bool2", "bool3", "bool4",
+          "uint", "uint2", "uint3", "uint4",
+          "lowp", "mediump", "highp", "precision",
+          "sampler",
+          "common", "partition", "active", "asm",
+          "struct", "class", "union", "enum", "typedef", "template", "this", "packed",
+          "inline", "noinline", "volatile", "public", "static", "extern", "external", "interface",
+          "long", "short", "half", "fixed", "unsigned", "superp", "input", "output",
+          "half2", "half3", "half4",
+          "sampler3DRect", "filter",
+          "texture1d", "texture2d", "texture3d", "textureCube",
+          "buffer",
+          "sizeof", "cast", "namespace", "using", "row_major",
+          "mix", "sampler" });
 
     // Register restricted tokens in MSL
     StringMap tokens;
@@ -151,49 +153,38 @@ MslSyntax::MslSyntax()
     // Register syntax handlers for each data type.
     //
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOAT,
         std::make_shared<ScalarTypeSyntax>(
             "float",
             "0.0",
-            "0.0")
-    );
+            "0.0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FLOATARRAY,
         std::make_shared<MslFloatArrayTypeSyntax>(
-            "float")
-    );
+            "float"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGER,
         std::make_shared<ScalarTypeSyntax>(
             "int",
             "0",
-            "0")
-    );
+            "0"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::INTEGERARRAY,
         std::make_shared<MslIntegerArrayTypeSyntax>(
-            "int")
-    );
+            "int"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BOOLEAN,
         std::make_shared<ScalarTypeSyntax>(
             "bool",
             "false",
-            "false")
-    );
+            "false"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vec3",
@@ -201,11 +192,9 @@ MslSyntax::MslSyntax()
             "vec3(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC3_MEMBERS)
-    );
+            VEC3_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::COLOR4,
         std::make_shared<AggregateTypeSyntax>(
             "vec4",
@@ -213,11 +202,9 @@ MslSyntax::MslSyntax()
             "vec4(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC4_MEMBERS)
-    );
+            VEC4_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR2,
         std::make_shared<AggregateTypeSyntax>(
             "vec2",
@@ -225,11 +212,9 @@ MslSyntax::MslSyntax()
             "vec2(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC2_MEMBERS)
-    );
+            VEC2_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR3,
         std::make_shared<AggregateTypeSyntax>(
             "vec3",
@@ -237,11 +222,9 @@ MslSyntax::MslSyntax()
             "vec3(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC3_MEMBERS)
-    );
+            VEC3_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VECTOR4,
         std::make_shared<AggregateTypeSyntax>(
             "vec4",
@@ -249,127 +232,102 @@ MslSyntax::MslSyntax()
             "vec4(0.0)",
             EMPTY_STRING,
             EMPTY_STRING,
-            VEC4_MEMBERS)
-    );
+            VEC4_MEMBERS));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX33,
         std::make_shared<AggregateTypeSyntax>(
             "mat3",
             "mat3(1.0)",
-            "mat3(1.0)")
-    );
+            "mat3(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATRIX44,
         std::make_shared<AggregateTypeSyntax>(
             "mat4",
             "mat4(1.0)",
-            "mat4(1.0)")
-    );
+            "mat4(1.0)"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::STRING,
-        std::make_shared<MslStringTypeSyntax>()
-    );
+        std::make_shared<MslStringTypeSyntax>());
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::FILENAME,
         std::make_shared<ScalarTypeSyntax>(
             "MetalTexture",
             EMPTY_STRING,
-            EMPTY_STRING)
-    );
+            EMPTY_STRING));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::BSDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF",
             "BSDF{float3(0.0),float3(1.0), 0.0, 0.0}",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct BSDF { float3 response; float3 throughput; float thickness; float ior; };")
-    );
+            "struct BSDF { float3 response; float3 throughput; float thickness; float ior; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::EDF,
         std::make_shared<AggregateTypeSyntax>(
             "EDF",
             "EDF(0.0)",
             "EDF(0.0)",
             "float3",
-            "#define EDF float3")
-    );
+            "#define EDF float3"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF",
             "BSDF{float3(0.0),float3(1.0), 0.0, 0.0}",
-            EMPTY_STRING)
-    );
+            EMPTY_STRING));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::SURFACESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "surfaceshader",
             "surfaceshader{float3(0.0),float3(0.0)}",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct surfaceshader { float3 color; float3 transparency; };")
-    );
+            "struct surfaceshader { float3 color; float3 transparency; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::VOLUMESHADER,
         std::make_shared<AggregateTypeSyntax>(
             "volumeshader",
             "volumeshader{float3(0.0),float3(0.0)}",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct volumeshader { float3 color; float3 transparency; };")
-    );
+            "struct volumeshader { float3 color; float3 transparency; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::DISPLACEMENTSHADER,
         std::make_shared<AggregateTypeSyntax>(
             "displacementshader",
             "displacementshader{float3(0.0),1.0}",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct displacementshader { float3 offset; float scale; };")
-    );
+            "struct displacementshader { float3 offset; float scale; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::LIGHTSHADER,
         std::make_shared<AggregateTypeSyntax>(
             "lightshader",
             "lightshader{float3(0.0),float3(0.0)}",
             EMPTY_STRING,
             EMPTY_STRING,
-            "struct lightshader { float3 intensity; float3 direction; };")
-    );
+            "struct lightshader { float3 intensity; float3 direction; };"));
 
-    registerTypeSyntax
-    (
+    registerTypeSyntax(
         Type::MATERIAL,
         std::make_shared<AggregateTypeSyntax>(
             "material",
             "material{float3(0.0),float3(0.0)}",
             EMPTY_STRING,
             "surfaceshader",
-            "#define material surfaceshader")
-    );
+            "#define material surfaceshader"));
 }
 
 string MslSyntax::getOutputTypeName(const TypeDesc* type) const
@@ -382,7 +340,6 @@ bool MslSyntax::typeSupported(const TypeDesc* type) const
 {
     return type != Type::STRING;
 }
-
 
 bool MslSyntax::remapEnumeration(const string& value, const TypeDesc* type, const string& enumNames, std::pair<const TypeDesc*, ValuePtr>& result) const
 {
@@ -409,7 +366,7 @@ bool MslSyntax::remapEnumeration(const string& value, const TypeDesc* type, cons
     if (!value.empty())
     {
         StringVec valueElemEnumsVec = splitString(enumNames, ",");
-        for (size_t i=0; i<valueElemEnumsVec.size(); i++)
+        for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
         {
             valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
         }

--- a/source/MaterialXGenMsl/MslSyntax.h
+++ b/source/MaterialXGenMsl/MslSyntax.h
@@ -29,7 +29,7 @@ class MX_GENMSL_API MslSyntax : public Syntax
     const string& getUniformQualifier() const override { return UNIFORM_QUALIFIER; };
     const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
     const string& getStructKeyword() const { return STRUCT_KEYWORD; }
-    
+
     string getOutputTypeName(const TypeDesc* type) const override;
 
     bool typeSupported(const TypeDesc* type) const override;

--- a/source/MaterialXGenMsl/Nodes/BitangentNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/BitangentNodeMsl.cpp
@@ -51,7 +51,6 @@ void BitangentNodeMsl::createVariables(const ShaderNode& node, GenContext& conte
     }
 }
 
-
 void BitangentNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
     const MslShaderGenerator& shadergen = static_cast<const MslShaderGenerator&>(context.getShaderGenerator());

--- a/source/MaterialXGenMsl/Nodes/BitangentNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/BitangentNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Bitangent node implementation for MSL
 class MX_GENMSL_API BitangentNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/FrameNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/FrameNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Frame node implementation for MSL
 class MX_GENMSL_API FrameNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/GeomColorNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/GeomColorNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// GeomColor node implementation for MSL
 class MX_GENMSL_API GeomColorNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
@@ -13,33 +13,35 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    /// Name of filter function to call to compute normals from input samples
-    const string filterFunctionName = "mx_normal_from_samples_sobel";
 
-    /// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
-    /// as input, and return a 2 channel vector as output
-    const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+/// Name of filter function to call to compute normals from input samples
+const string filterFunctionName = "mx_normal_from_samples_sobel";
 
-    const unsigned int sampleCount = 9;
-    const unsigned int filterWidth = 3;
-    const float filterSize = 1.0;
-    const float filterOffset = 0.0;
-}
+/// Name of function to compute sample size in uv space. Takes uv, filter size, and filter offset
+/// as input, and return a 2 channel vector as output
+const string sampleSizeFunctionUV = "mx_compute_sample_size_uv";
+
+const unsigned int sampleCount = 9;
+const unsigned int filterWidth = 3;
+const float filterSize = 1.0;
+const float filterOffset = 0.0;
+
+} // namespace
 
 ShaderNodeImplPtr HeightToNormalNodeMsl::create()
 {
     return std::make_shared<HeightToNormalNodeMsl>();
 }
 
-void HeightToNormalNodeMsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
-                                                        unsigned int, StringVec& offsetStrings) const
+void HeightToNormalNodeMsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
+                                                       unsigned int, StringVec& offsetStrings) const
 {
     // Build a 3x3 grid of samples that are offset by the provided sample size
     for (int row = -1; row <= 1; row++)
     {
         for (int col = -1; col <= 1; col++)
         {
-            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString +  "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString + "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
         }
     }
 }
@@ -66,26 +68,26 @@ void HeightToNormalNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext&
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-        
+
         const ShaderInput* inInput = node.getInput("in");
         const ShaderInput* scaleInput = node.getInput("scale");
-        
+
         if (!inInput || !scaleInput)
         {
             throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid heighttonormal node");
         }
-        
-        // Create the input "samples". This means to emit the calls to 
+
+        // Create the input "samples". This means to emit the calls to
         // compute the sames and return a set of strings containaing
         // the variables to assign to the sample grid.
-        //  
+        //
         StringVec sampleStrings;
-        emitInputSamplesUV(node, sampleCount, filterWidth, 
-                           filterSize, filterOffset, sampleSizeFunctionUV, 
+        emitInputSamplesUV(node, sampleCount, filterWidth,
+                           filterSize, filterOffset, sampleSizeFunctionUV,
                            context, stage, sampleStrings);
-        
+
         const ShaderOutput* output = node.getOutput();
-        
+
         // Emit code to evaluate samples.
         //
         string sampleName(output->getVariable() + "_samples");
@@ -108,6 +110,5 @@ const string& HeightToNormalNodeMsl::getTarget() const
 {
     return MslShaderGenerator::TARGET;
 }
-
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.h
@@ -28,7 +28,7 @@ class MX_GENMSL_API HeightToNormalNodeMsl : public ConvolutionNode
     bool acceptsInputType(const TypeDesc* type) const override;
 
     /// Compute offset strings for sampling
-    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString, 
+    void computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                     unsigned int filterWidth, StringVec& offsetStrings) const override;
 };
 

--- a/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.cpp
@@ -50,7 +50,7 @@ void LightCompoundNodeMsl::createVariables(const ShaderNode&, GenContext& contex
     VariableBlock& lightData = ps.getUniformBlock(HW::LIGHT_DATA);
 
     // Create all light uniforms
-    for (size_t i = 0; i<_lightUniforms.size(); ++i)
+    for (size_t i = 0; i < _lightUniforms.size(); ++i)
     {
         ShaderPort* u = const_cast<ShaderPort*>(_lightUniforms[i]);
         lightData.add(u->getSelf());
@@ -65,10 +65,10 @@ void LightCompoundNodeMsl::emitFunctionDefinition(const ShaderNode& node, GenCon
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         const MslShaderGenerator& shadergen = static_cast<const MslShaderGenerator&>(context.getShaderGenerator());
-        
+
         // Emit functions for all child nodes
         shadergen.emitFunctionDefinitions(*_rootGraph, context, stage);
-        
+
         // Find any closure contexts used by this node
         // and emit the function for each context.
         vector<ClosureContext*> ccts;

--- a/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.h
@@ -19,7 +19,7 @@ class MslShaderGenerator;
 /// LightCompound node implementation for MSL
 class MX_GENMSL_API LightCompoundNodeMsl : public CompoundNode
 {
-public:
+  public:
     LightCompoundNodeMsl();
 
     static ShaderNodeImplPtr create();
@@ -34,7 +34,7 @@ public:
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     void emitFunctionDefinition(ClosureContext* cct, GenContext& context, ShaderStage& stage) const;
 
     VariableBlock _lightUniforms;

--- a/source/MaterialXGenMsl/Nodes/LightNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/LightNodeMsl.cpp
@@ -11,14 +11,16 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    const string LIGHT_DIRECTION_CALCULATION =
-        "float3 L = light.position - position;\n"
-        "float distance = length(L);\n"
-        "L /= distance;\n"
-        "result.direction = L;\n";
+
+const string LIGHT_DIRECTION_CALCULATION =
+    "float3 L = light.position - position;\n"
+    "float distance = length(L);\n"
+    "L /= distance;\n"
+    "result.direction = L;\n";
+
 }
 
-LightNodeMsl::LightNodeMsl() : 
+LightNodeMsl::LightNodeMsl() :
     _callEmission(HwShaderGenerator::ClosureContextType::EMISSION)
 {
     // Emission context
@@ -39,7 +41,7 @@ void LightNodeMsl::createVariables(const ShaderNode&, GenContext& context, Shade
     VariableBlock& lightUniforms = ps.getUniformBlock(HW::LIGHT_DATA);
     lightUniforms.add(Type::FLOAT, "intensity", Value::createValue<float>(1.0f));
     lightUniforms.add(Type::FLOAT, "exposure", Value::createValue<float>(0.0f));
-    lightUniforms.add(Type::VECTOR3, "direction", Value::createValue<Vector3>(Vector3(0.0f,1.0f,0.0f)));
+    lightUniforms.add(Type::VECTOR3, "direction", Value::createValue<Vector3>(Vector3(0.0f, 1.0f, 0.0f)));
 
     const MslShaderGenerator& shadergen = static_cast<const MslShaderGenerator&>(context.getShaderGenerator());
     shadergen.addStageLightingUniforms(context, ps);
@@ -47,13 +49,13 @@ void LightNodeMsl::createVariables(const ShaderNode&, GenContext& context, Shade
 
 void LightNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const
 {
-DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
+    DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         const MslShaderGenerator& shadergen = static_cast<const MslShaderGenerator&>(context.getShaderGenerator());
-        
+
         shadergen.emitBlock(LIGHT_DIRECTION_CALCULATION, FilePath(), context, stage);
         shadergen.emitLineBreak(stage);
-        
+
         const ShaderInput* edfInput = node.getInput("edf");
         const ShaderNode* edf = edfInput->getConnectedSibling();
         if (edf)
@@ -61,20 +63,20 @@ DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
             context.pushClosureContext(&_callEmission);
             shadergen.emitFunctionCall(*edf, context, stage);
             context.popClosureContext();
-            
+
             shadergen.emitLineBreak(stage);
-            
+
             shadergen.emitComment("Apply quadratic falloff and adjust intensity", stage);
             shadergen.emitLine("result.intensity = " + edf->getOutput()->getVariable() + " / (distance * distance)", stage);
-            
+
             const ShaderInput* intensity = node.getInput("intensity");
             const ShaderInput* exposure = node.getInput("exposure");
-            
+
             shadergen.emitLineBegin(stage);
             shadergen.emitString("result.intensity *= ", stage);
             shadergen.emitInput(intensity, context, stage);
             shadergen.emitLineEnd(stage);
-            
+
             // Emit exposure adjustment only if it matters
             if (exposure->getConnection() || (exposure->getValue() && exposure->getValue()->asA<float>() != 0.0f))
             {

--- a/source/MaterialXGenMsl/Nodes/LightNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightNodeMsl.h
@@ -23,7 +23,7 @@ class MX_GENMSL_API LightNodeMsl : public MslImplementation
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
   private:
-      mutable ClosureContext _callEmission;
+    mutable ClosureContext _callEmission;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMsl/Nodes/LightSamplerNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/LightSamplerNodeMsl.cpp
@@ -9,7 +9,9 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    const string SAMPLE_LIGHTS_FUNC_SIGNATURE = "void sampleLightSource(LightData light, float3 position, out lightshader result)";
+
+const string SAMPLE_LIGHTS_FUNC_SIGNATURE = "void sampleLightSource(LightData light, float3 position, out lightshader result)";
+
 }
 
 LightSamplerNodeMsl::LightSamplerNodeMsl()
@@ -27,13 +29,13 @@ void LightSamplerNodeMsl::emitFunctionDefinition(const ShaderNode& node, GenCont
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         const ShaderGenerator& shadergen = context.getShaderGenerator();
-        
+
         // Emit light sampler function with all bound light types
         shadergen.emitLine(SAMPLE_LIGHTS_FUNC_SIGNATURE, stage, false);
         shadergen.emitFunctionBodyBegin(node, context, stage);
         shadergen.emitLine("result.intensity = float3(0.0)", stage);
         shadergen.emitLine("result.direction = float3(0.0)", stage);
-        
+
         HwLightShadersPtr lightShaders = context.getUserData<HwLightShaders>(HW::USER_DATA_LIGHT_SHADERS);
         if (lightShaders)
         {
@@ -47,7 +49,7 @@ void LightSamplerNodeMsl::emitFunctionDefinition(const ShaderNode& node, GenCont
                 ifstatement = "else if ";
             }
         }
-        
+
         shadergen.emitFunctionBodyEnd(node, context, stage);
     }
 }

--- a/source/MaterialXGenMsl/Nodes/LightSamplerNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightSamplerNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Utility node for sampling lights for MSL.
 class MX_GENMSL_API LightSamplerNodeMsl : public MslImplementation
 {
-public:
+  public:
     LightSamplerNodeMsl();
 
     static ShaderNodeImplPtr create();

--- a/source/MaterialXGenMsl/Nodes/LightShaderNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightShaderNodeMsl.h
@@ -15,7 +15,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Used for all light shaders implemented in source code.
 class MX_GENMSL_API LightShaderNodeMsl : public SourceCodeNode
 {
-public:
+  public:
     LightShaderNodeMsl();
 
     static ShaderNodeImplPtr create();
@@ -28,7 +28,7 @@ public:
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     VariableBlock _lightUniforms;
 };
 

--- a/source/MaterialXGenMsl/Nodes/NormalNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/NormalNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Normal node implementation for MSL
 class MX_GENMSL_API NormalNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/NumLightsNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/NumLightsNodeMsl.cpp
@@ -11,7 +11,9 @@ MATERIALX_NAMESPACE_BEGIN
 
 namespace
 {
-    const string NUM_LIGHTS_FUNC_SIGNATURE = "int numActiveLightSources()";
+
+const string NUM_LIGHTS_FUNC_SIGNATURE = "int numActiveLightSources()";
+
 }
 
 NumLightsNodeMsl::NumLightsNodeMsl()

--- a/source/MaterialXGenMsl/Nodes/NumLightsNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/NumLightsNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Utility node for getting number of active lights for MSL.
 class MX_GENMSL_API NumLightsNodeMsl : public MslImplementation
 {
-public:
+  public:
     NumLightsNodeMsl();
 
     static ShaderNodeImplPtr create();

--- a/source/MaterialXGenMsl/Nodes/PositionNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/PositionNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Position node implementation for MSL
 class MX_GENMSL_API PositionNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.cpp
@@ -43,10 +43,10 @@ ShaderNodeImplPtr SurfaceNodeMsl::create()
 
 void SurfaceNodeMsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
-    // TODO: 
-    // The surface shader needs position, normal, view position and light sources. We should solve this by adding some 
+    // TODO:
+    // The surface shader needs position, normal, view position and light sources. We should solve this by adding some
     // dependency mechanism so this implementation can be set to depend on the PositionNodeMsl, NormalNodeMsl
-    // ViewDirectionNodeMsl and LightNodeMsl nodes instead? This is where the MaterialX attribute "internalgeomprops" 
+    // ViewDirectionNodeMsl and LightNodeMsl nodes instead? This is where the MaterialX attribute "internalgeomprops"
     // is needed.
     //
     ShaderStage& vs = shader.getStage(Stage::VERTEX);
@@ -135,7 +135,7 @@ void SurfaceNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& contex
             {
                 shadergen.emitLine("float3 shadowCoord = (" + HW::T_SHADOW_MATRIX + " * float4(" + prefix + HW::T_POSITION_WORLD + ", 1.0)).xyz", stage);
                 shadergen.emitLine("shadowCoord.xy = shadowCoord.xy * 0.5 + 0.5", stage);
-               
+
                 shadergen.emitLine("float2 shadowMoments = texture(" + HW::T_SHADOW_MAP + ", shadowCoord.xy).xy", stage);
                 shadergen.emitLine("float occlusion = mx_variance_shadow_occlusion(shadowMoments, shadowCoord.z)", stage);
             }
@@ -225,13 +225,12 @@ void SurfaceNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& contex
 
         shadergen.emitScopeEnd(stage);
         shadergen.emitLineBreak(stage);
-
     }
 }
 
 void SurfaceNodeMsl::emitLightLoop(const ShaderNode& node, GenContext& context, ShaderStage& stage, const string& outColor) const
 {
-    // 
+    //
     // Generate Light loop if requested
     //
     if (context.getOptions().hwMaxActiveLightSources > 0)

--- a/source/MaterialXGenMsl/Nodes/SurfaceShaderNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/SurfaceShaderNodeMsl.cpp
@@ -22,10 +22,10 @@ const string& SurfaceShaderNodeMsl::getTarget() const
 
 void SurfaceShaderNodeMsl::createVariables(const ShaderNode&, GenContext& context, Shader& shader) const
 {
-    // TODO: 
-    // The surface shader needs position, view position and light sources. We should solve this by adding some 
-    // dependency mechanism so this implementation can be set to depend on the PositionNodeMsl,  
-    // ViewDirectionNodeMsl and LightNodeMsl nodes instead? This is where the MaterialX attribute "internalgeomprops" 
+    // TODO:
+    // The surface shader needs position, view position and light sources. We should solve this by adding some
+    // dependency mechanism so this implementation can be set to depend on the PositionNodeMsl,
+    // ViewDirectionNodeMsl and LightNodeMsl nodes instead? This is where the MaterialX attribute "internalgeomprops"
     // is needed.
     //
     ShaderStage& vs = shader.getStage(Stage::VERTEX);

--- a/source/MaterialXGenMsl/Nodes/TangentNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/TangentNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Tangent node implementation for MSL
 class MX_GENMSL_API TangentNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/TexCoordNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/TexCoordNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// TexCoord node implementation for MSL
 class MX_GENMSL_API TexCoordNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/TimeNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/TimeNodeMsl.h
@@ -13,7 +13,7 @@ MATERIALX_NAMESPACE_BEGIN
 /// Time node implementation for MSL
 class MX_GENMSL_API TimeNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/TransformNormalNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/TransformNormalNodeMsl.h
@@ -13,10 +13,10 @@ MATERIALX_NAMESPACE_BEGIN
 /// TransformNormal node implementation for MSL
 class MX_GENMSL_API TransformNormalNodeMsl : public TransformVectorNodeMsl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
-protected:
+  protected:
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
     const string& getMatrix(const string& fromSpace, const string& toSpace) const override;

--- a/source/MaterialXGenMsl/Nodes/TransformPointNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/TransformPointNodeMsl.h
@@ -13,10 +13,10 @@ MATERIALX_NAMESPACE_BEGIN
 /// TransformPoint node implementation for MSL
 class MX_GENMSL_API TransformPointNodeMsl : public TransformVectorNodeMsl
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
-protected:
+  protected:
     virtual string getHomogeneousCoordinate(const ShaderInput* in, GenContext& context) const override;
 };
 

--- a/source/MaterialXGenMsl/Nodes/TransformVectorNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/TransformVectorNodeMsl.cpp
@@ -59,7 +59,6 @@ void TransformVectorNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext
         shadergen.emitString(getHomogeneousCoordinate(inInput, context), stage);
         shadergen.emitString(").xyz", stage);
         shadergen.emitLineEnd(stage);
-
     }
 }
 

--- a/source/MaterialXGenMsl/Nodes/TransformVectorNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/TransformVectorNodeMsl.h
@@ -13,14 +13,14 @@ MATERIALX_NAMESPACE_BEGIN
 /// TransformVector node implementation for MSL
 class MX_GENMSL_API TransformVectorNodeMsl : public MslImplementation
 {
-public:
+  public:
     static ShaderNodeImplPtr create();
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-protected:
+  protected:
     virtual const string& getMatrix(const string& fromSpace, const string& toSpace) const;
     virtual string getHomogeneousCoordinate(const ShaderInput* in, GenContext& context) const;
 };

--- a/source/MaterialXGenMsl/Nodes/UnlitSurfaceNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/UnlitSurfaceNodeMsl.cpp
@@ -34,7 +34,7 @@ void UnlitSurfaceNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& c
         const ShaderInput* emission = node.getInput("emission");
         const ShaderInput* emissionColor = node.getInput("emission_color");
         shadergen.emitLine(outColor + " = " + shadergen.getUpstreamResult(emission, context) + " * " + shadergen.getUpstreamResult(emissionColor, context), stage);
-        
+
         const ShaderInput* transmission = node.getInput("transmission");
         const ShaderInput* transmissionColor = node.getInput("transmission_color");
         shadergen.emitLine(outTransparency + " = " + shadergen.getUpstreamResult(transmission, context) + " * " + shadergen.getUpstreamResult(transmissionColor, context), stage);
@@ -43,7 +43,6 @@ void UnlitSurfaceNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& c
         const string surfaceOpacity = shadergen.getUpstreamResult(opacity, context);
         shadergen.emitLine(outColor + " *= " + surfaceOpacity, stage);
         shadergen.emitLine(outTransparency + " = mix(float3(1.0), " + outTransparency + ", " + surfaceOpacity + ")", stage);
-
     }
 }
 


### PR DESCRIPTION
This changelist applies Clang formatting to the C++ source in MaterialXGenMsl, providing improvements in coding style consistency.