### PR TITLE
Switch to upload-artifact version 3.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,27 +250,27 @@ jobs:
 
     - name: Upload Installed Package
       if: matrix.dynamic_analysis != 'ON'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: MaterialX_${{ matrix.name }}
         path: build/installed/
 
     - name: Upload Formatted Source
       if: matrix.clang_format == 'ON'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: MaterialX_ClangFormat
         path: source
 
     - name: Upload Reference Shaders
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       if: matrix.upload_shaders == 'ON'
       with:
         name: Reference_Shaders_${{ matrix.name }}
         path: build/bin/reference/
 
     - name: Upload Renders
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       if: matrix.test_render == 'ON'
       with:
         name: Renders_${{ matrix.name }}
@@ -313,7 +313,7 @@ jobs:
 
     - name: Upload JavaScript Package
       if: matrix.build_javascript == 'ON'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v3.1.1
       with:
         name: MaterialX_JavaScript
         path: javascript/build/installed/JavaScript/MaterialX        


### PR DESCRIPTION
This changelist switches to upload-artifact version 3.1.1 in the GitHub Actions CI for MaterialX, to see if this provides better reliability than version 3.1.2.