### PR TITLE
Static analysis optimizations

### DIFF
--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -222,10 +222,7 @@ class MX_FORMAT_API FileSearchPath
     using ConstIterator = FilePathVec::const_iterator;
 
   public:
-    FileSearchPath()
-    {
-    }
-    ~FileSearchPath() { }
+    FileSearchPath() = default;
 
     /// Construct a search path from a string.
     /// @param searchPath A string containing a sequence of file paths joined

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -193,7 +193,7 @@ ValuePtr Syntax::getSwizzledValue(ValuePtr value, const TypeDesc* srcType, const
     {
         if (i == channels.size() - 1)
         {
-            delimiter = "";
+            delimiter.clear();
         }
 
         const char ch = channels[i];

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -25,13 +25,13 @@ const string MIX_CATEGORY("mix");
 const string MIX_FG_INPUT("fg");
 const string MIX_BG_INPUT("bg");
 
-bool isEqual(const float& v1, const float& v2)
+bool isEqual(float v1, float v2)
 {
     const float EPSILON = 0.00001f;
     return std::abs(v1 - v2) < EPSILON;
 }
 
-bool isEqual(ValuePtr value, const float& f)
+bool isEqual(ValuePtr value, float f)
 {
     if (value->isA<float>() && isEqual(value->asA<float>(), f))
     {

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -309,7 +309,7 @@ void OslRenderer::compileOSL(const FilePath& oslFilePath)
     }
 }
 
-void OslRenderer::createProgram(const ShaderPtr shader)
+void OslRenderer::createProgram(ShaderPtr shader)
 {
     StageMap stages = { {Stage::PIXEL, shader->getStage(Stage::PIXEL).getSourceCode()} };
     createProgram(stages);


### PR DESCRIPTION
This changelist addresses a handful of static analysis optimizations flagged by PVS-Studio:

- Add an explicitly defaulted constructor to the FilePath class.
- Use std::string::clear instead of empty string assignment in Syntax::getSwizzledValue.
- Pass float arguments by value in isEqual helper functions.
- Remove an unneeded const qualifier in OslRenderer::compileOSL.