### PR TITLE
Remove ImGuiFileBrowser submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "source/MaterialXGraphEditor/External/ImGuiNodeEditor"]
 	path = source/MaterialXGraphEditor/External/ImGuiNodeEditor
 	url = https://github.com/thedmd/imgui-node-editor
-[submodule "source/MaterialXGraphEditor/External/ImGuiFileBrowser"]
-	path = source/MaterialXGraphEditor/External/ImGuiFileBrowser
-	url = https://github.com/AirGuanZ/imgui-filebrowser

--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -187,31 +187,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### [ImGui FileBrowser](https://github.com/AirGuanZ/imgui-filebrowser)
-```
-MIT License
-
-Copyright (c) 2019-2022 Zhuang Guan
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
-
 ### [TinyObjLoader](https://github.com/tinyobjloader/tinyobjloader)
 ```
 The MIT License (MIT)

--- a/documents/DeveloperGuide/GraphEditor.md
+++ b/documents/DeveloperGuide/GraphEditor.md
@@ -1,6 +1,6 @@
 # MaterialX Graph Editor 
 
-The MaterialX Graph Editor is an example application for visualizing, creating, and editing MaterialX graphs.  It utilizes the ImGui framework as well as additional ImGui extensions such as the Node Editor and File Browser.
+The MaterialX Graph Editor is an example application for visualizing, creating, and editing MaterialX graphs.  It utilizes the ImGui framework as well as additional ImGui extensions such as the Node Editor.
 
 ### Example Images
 


### PR DESCRIPTION
This changelist removes the ImGuiFileBrowser submodule, which has been replaced by a native file browser in the MaterialX Graph Editor, and updates documentation to reflect the latest set of third-party dependencies.