### PR TITLE
Improvements to Python installation

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,9 +3,6 @@ set(SETUP_PY "${CMAKE_INSTALL_PREFIX}/python/setup.py")
 
 configure_file(${SETUP_PY_IN} ${SETUP_PY})
 
-add_custom_command(OUTPUT ${SETUP_PY}
-                   COMMAND ${PYTHON} ${SETUP_PY} build)
-
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/MaterialX" DESTINATION "python" MESSAGE_NEVER)
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Scripts" DESTINATION "python" MESSAGE_NEVER)
 
@@ -17,5 +14,5 @@ if(MATERIALX_PYTHON_OCIO_DIR)
 endif()
 
 if(MATERIALX_INSTALL_PYTHON AND PYTHON_EXECUTABLE)
-  install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install)" MESSAGE_NEVER)
+  install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install clean --all)" MESSAGE_NEVER)
 endif()

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 import os
 
 os.chdir(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
- Update setup.py from distutils to setuptools.
- Add a clean step to CMake installation, reducing duplication in the distributed Python package.
- Remove an unneeded CMake step.