### PR TITLE
Disable stb_image warning for Clang on Mac

### DIFF
--- a/source/MaterialXRender/External/StbImage/stb_image_write.h
+++ b/source/MaterialXRender/External/StbImage/stb_image_write.h
@@ -732,11 +732,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-#ifdef __STDC_WANT_SECURE_LIB__
-      len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
-#else
-      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
-#endif
+      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
       s->func(s->context, buffer, len);
 
       for(i=0; i < y; i++)

--- a/source/MaterialXRender/External/StbImage/stb_image_write.h
+++ b/source/MaterialXRender/External/StbImage/stb_image_write.h
@@ -732,7 +732,11 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
       char header[] = "#?RADIANCE\n# Written by stb_image_write.h\nFORMAT=32-bit_rle_rgbe\n";
       s->func(s->context, header, sizeof(header)-1);
 
-      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#ifdef __STDC_WANT_SECURE_LIB__
+      len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#else
+      len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#endif
       s->func(s->context, buffer, len);
 
       for(i=0; i < y; i++)

--- a/source/MaterialXRender/StbImageLoader.cpp
+++ b/source/MaterialXRender/StbImageLoader.cpp
@@ -16,6 +16,11 @@
 #define STB_IMAGE_STATIC 1
 #include <MaterialXRender/External/StbImage/stb_image.h>
 
+#if defined(__APPLE__)
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #define STB_IMAGE_WRITE_STATIC 1
 #include <MaterialXRender/External/StbImage/stb_image_write.h>
@@ -116,5 +121,9 @@ ImagePtr StbImageLoader::loadImage(const FilePath& filePath)
     image->setResourceBufferDeallocator(&stbi_image_free);
     return image;
 }
+
+#if defined(__APPLE__)
+    #pragma clang diagnostic pop
+#endif
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
Buitling with warning-as-errors on Clang14 on Mac detects a deprecated function usage in stb_image
For now patch this by disabling this warning when building this file.
 
The current rev of this code still has this issue as noted [in this issue](https://github.com/nothings/stb/issues/1446).
