### PR TITLE
Improve robustness of getDefaultDataSearchPath

### DIFF
--- a/source/MaterialXFormat/Util.cpp
+++ b/source/MaterialXFormat/Util.cpp
@@ -224,11 +224,11 @@ FileSearchPath getSourceSearchPath(ConstDocumentPtr doc)
 
 FileSearchPath getDefaultDataSearchPath()
 {
-    const FilePath DEFAULT_LIBRARY_FOLDER("libraries");
+    const FilePath REQUIRED_LIBRARY_FOLDER("libraries/targets");
     FilePath currentPath = FilePath::getModulePath();
     while (!currentPath.isEmpty())
     {
-        if ((currentPath / DEFAULT_LIBRARY_FOLDER).exists())
+        if ((currentPath / REQUIRED_LIBRARY_FOLDER).exists())
         {
             return FileSearchPath(currentPath);
         }


### PR DESCRIPTION
This changelist improves the robustness of the getDefaultDataSearchPath function in MaterialXFormat, requiring a subfolder named "libraries/targets" rather than just "libraries" before a data path is considered valid.