### PR TITLE
Fix value types for swizzles in shader generation

### DIFF
--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -264,7 +264,7 @@ ValuePtr Syntax::getSwizzledValue(ValuePtr value, const TypeDesc* srcType, const
         ss << delimiter;
     }
 
-    return Value::createValueFromStrings(ss.str(), getTypeName(dstType));
+    return Value::createValueFromStrings(ss.str(), dstType->getName());
 }
 
 bool Syntax::typeSupported(const TypeDesc*) const


### PR DESCRIPTION
For the swizzling logic on inputs in the base shader generator, the returned type of the Value after swizzling can be incorrect as it looks up the type based on the Value's Type as mapped to a `TypeDesc` -- as opposed just the Type. The `TypeDesc` type can end up not being a valid Type which results in a default `string` Value being returned.
 
This occurs for the "channels" conversion for instance for "color3" for MSL and GLSL as the TypeDesc type
is "vec3" instead of the correct type which is "color3". 

The input port will end up being exposed as an input uniform on the shader. The binding process for the  
default GLSL renderer does not use the type of the Value stored in the uniform block input but instead uses the native GLSL type. MSL does however use the Value type so ends up trying to bind to a string Value instead of a color3. This fails so no value is set. 

This address the issue mentioned in this  [PR](https://github.com/AcademySoftwareFoundation/MaterialX/pull/1327)
so that the other fix is not required.

<img width="552" alt="Screenshot 2023-04-19 at 11 00 11 PM" src="https://user-images.githubusercontent.com/49369885/233247534-93257a9b-6b7e-4555-9d48-cdf8072ca989.png">

This is a simpler graph which demonstrates this issue, as opposed to the color space test:
```
<?xml version="1.0"?>
<materialx version="1.38" colorspace="lin_rec709">
  <nodegraph name="ng1">
    <constant name="color4_constant" type="color4">
      <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0"  />
    </constant>
    <add name="add1" type="color3">
      <input name="in1" type="color3" nodename="color4_constant" channels="rgb" />      
    </add>
    <output name="outc" type="color3" nodename="add1" />
  </nodegraph>
</materialx>
``` 

## Test Results
* Base tests with "stdlib/channels" additionally run for GLSL / MSL 
[GLSL_MSL_channel_tests.pdf](https://github.com/AcademySoftwareFoundation/MaterialX/files/11286737/GLSL_MSL_channel_tests.pdf)

* Base tests with "stdlib/channels" additionally run for GLSL / OSL (legacy)
[GLSL_OSL_channel_tests.pdf](https://github.com/AcademySoftwareFoundation/MaterialX/files/11287014/GLSL_OSL_channel_tests.pdf)
|  Note: There is no affect on OSL and MDL since they don't use the reflection information from the MaterialX Shader created for rendering -- just the uses the OSL and MDL code generated.


