### PR TITLE
Graph Editor Property Panel Formatting

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -818,7 +818,8 @@ void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
 void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIProperties& uiProperties)
 {
     std::string inName = !uiProperties.uiName.empty()? uiProperties.uiName : input->getName();
-    float labelWidth = ImGui::CalcTextSize(inName.c_str()).x;
+    //float labelWidth = ImGui::CalcTextSize(inName.c_str()).x;
+    ImGui::PushItemWidth(-1);
 
     mx::ValuePtr minVal = uiProperties.uiMin;
     mx::ValuePtr maxVal = uiProperties.uiMax;
@@ -832,13 +833,10 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         {
             // updates the value to the default for new nodes
             float prev = val->asA<float>(), temp = val->asA<float>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 20);
             float min = minVal ? minVal->asA<float>() : 0.f;
             float max = maxVal ? maxVal->asA<float>() : 100.f;
             float speed = (max - min) / 1000.0f;
             ImGui::DragFloat("##hidelabel", &temp, speed, min, max);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -854,13 +852,10 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<int>())
         {
             int prev = val->asA<int>(), temp = val->asA<int>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 20);
             int min = minVal ? minVal->asA<int>() : 0;
             int max = maxVal ? maxVal->asA<int>() : 100;
             float speed = (max - min) / 100.0f;
             ImGui::DragInt("##hidelabel", &temp, speed, min, max);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -876,15 +871,14 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<mx::Color3>())
         {
             mx::Color3 prev = val->asA<mx::Color3>(), temp = val->asA<mx::Color3>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 100);
             float min = minVal ? minVal->asA<mx::Color3>()[0] : 0.f;
             float max = maxVal ? maxVal->asA<mx::Color3>()[0] : 100.f;
             float speed = (max - min) / 1000.0f;
+            ImGui::PushItemWidth(-100);
             ImGui::DragFloat3("##hidelabel", &temp[0], speed, min, max);
+            ImGui::PopItemWidth();
             ImGui::SameLine();
             ImGui::ColorEdit3("##color", &temp[0], ImGuiColorEditFlags_NoInputs);
-            ImGui::PopItemWidth();
 
             // set input value  and update materials if different from previous value
             if (prev != temp)
@@ -901,16 +895,15 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<mx::Color4>())
         {
             mx::Color4 prev = val->asA<mx::Color4>(), temp = val->asA<mx::Color4>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 100);
             float min = minVal ? minVal->asA<mx::Color4>()[0] : 0.f;
             float max = maxVal ? maxVal->asA<mx::Color4>()[0] : 100.f;
             float speed = (max - min) / 1000.0f;
+            ImGui::PushItemWidth(-100);
             ImGui::DragFloat4("##hidelabel", &temp[0], speed, min, max);
+            ImGui::PopItemWidth();
             ImGui::SameLine();
             // color edit for the color picker to the right of the color floats
             ImGui::ColorEdit4("##color", &temp[0], ImGuiColorEditFlags_NoInputs);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (temp != prev)
             {
@@ -926,13 +919,10 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<mx::Vector2>())
         {
             mx::Vector2 prev = val->asA<mx::Vector2>(), temp = val->asA<mx::Vector2>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 100);
             float min = minVal ? minVal->asA<mx::Vector2>()[0] : 0.f;
             float max = maxVal ? maxVal->asA<mx::Vector2>()[0] : 100.f;
             float speed = (max - min) / 1000.0f;
             ImGui::DragFloat2("##hidelabel", &temp[0], speed, min, max);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -948,13 +938,10 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<mx::Vector3>())
         {
             mx::Vector3 prev = val->asA<mx::Vector3>(), temp = val->asA<mx::Vector3>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 100);
             float min = minVal ? minVal->asA<mx::Vector3>()[0] : 0.f;
             float max = maxVal ? maxVal->asA<mx::Vector3>()[0] : 100.f;
             float speed = (max - min) / 1000.0f;
             ImGui::DragFloat3("##hidelabel", &temp[0], speed, min, max);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -970,13 +957,10 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<mx::Vector4>())
         {
             mx::Vector4 prev = val->asA<mx::Vector4>(), temp = val->asA<mx::Vector4>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth + 90);
             float min = minVal ? minVal->asA<mx::Vector4>()[0] : 0.f;
             float max = maxVal ? maxVal->asA<mx::Vector4>()[0] : 100.f;
             float speed = (max - min) / 1000.0f;
             ImGui::DragFloat4("##hidelabel", &temp[0], speed, min, max);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -992,10 +976,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<std::string>())
         {
             std::string prev = val->asA<std::string>(), temp = val->asA<std::string>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth);
             ImGui::InputText("##constant", &temp);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -1012,20 +993,19 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<std::string>())
         {
             std::string temp = val->asA<std::string>(), prev = val->asA<std::string>();
-            ImGui::SameLine();
             ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(.15f, .15f, .15f, 1.0f));
             ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(.2f, .4f, .6f, 1.0f));
             // browser button to select new file
+            ImGui::PushItemWidth(-100);
             if (ImGui::Button("Browse"))
             {
                 _fileDialogImage.setTitle("Node Input Dialog");
                 _fileDialogImage.open();
                 _fileDialogImage.setTypeFilters(_imageFilter);
             }
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth);
-            ImGui::Text("%s", mx::FilePath(temp).getBaseName().c_str());
             ImGui::PopItemWidth();
+            ImGui::SameLine();
+            ImGui::Text("%s", mx::FilePath(temp).getBaseName().c_str());
             ImGui::PopStyleColor();
             ImGui::PopStyleColor();
 
@@ -1057,10 +1037,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<bool>())
         {
             bool prev = val->asA<bool>(), temp = val->asA<bool>();
-            ImGui::SameLine();
-            ImGui::PushItemWidth(labelWidth);
             ImGui::Checkbox("", &temp);
-            ImGui::PopItemWidth();
             // set input value  and update materials if different from previous value
             if (prev != temp)
             {
@@ -1070,6 +1047,8 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             }
         }
     }
+
+    ImGui::PopItemWidth();
 }
 // build the initial graph of a loaded mtlx document including shader, material and nodegraph node
 void Graph::setUiNodeInfo(UiNodePtr node, const std::string& type, const std::string& category)
@@ -3046,9 +3025,7 @@ void Graph::propertyEditor()
         ImGui::SameLine();
         std::string original = _currUiNode->getName();
         std::string temp = original;
-        ImGui::PushItemWidth(100.0f);
         ImGui::InputText("##edit", &temp);
-        ImGui::PopItemWidth();
         std::string docString = "NodeDef Doc String: \n";
         if (_currUiNode->getNode())
         {
@@ -3134,6 +3111,11 @@ void Graph::propertyEditor()
             }
         }
 
+        const float TEXT_BASE_HEIGHT = ImGui::GetTextLineHeightWithSpacing() * 1.3f;
+        const int SCROLL_LINE_COUNT= 20;
+        ImGuiTableFlags tableFlags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings |
+                                     ImGuiTableFlags_BordersOuterH | ImGuiTableFlags_NoBordersInBody;
+
         ImGui::Text("Category:");
         ImGui::SameLine();
         // change button color to match background
@@ -3141,56 +3123,82 @@ void Graph::propertyEditor()
         ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(.1f, .1f, .1f, 1.0f));
         if (_currUiNode->getNode())
         {
+            ImGui::NextColumn();
             ImGui::Text("%s", _currUiNode->getNode()->getCategory().c_str());
             docString += _currUiNode->getNode()->getCategory();
-            docString += ":";
-            docString += _currUiNode->getNode()->getNodeDef()->getDocString() + "\n";
+            if (_currUiNode->getNode()->getNodeDef())
+            {
+                docString += ":";
+                docString += _currUiNode->getNode()->getNodeDef()->getDocString() + "\n";
+            }
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
             {
                 ImGui::SetTooltip("%s", _currUiNode->getNode()->getNodeDef()->getDocString().c_str());
             }
 
             ImGui::Text("Inputs:");
-            ImGui::Indent();
-
+            int count = 0;
             for (UiPinPtr input : _currUiNode->inputPins)
             {
                 if (_currUiNode->_showAllInputs || (input->getConnected() || _currUiNode->getNode()->getInput(input->_name)))
                 {
-                    mx::UIProperties uiProperties;
-                    mx::getUIProperties(input->_input, mx::EMPTY_STRING, uiProperties);
-                    std::string inputLabel = !uiProperties.uiName.empty() ? uiProperties.uiName : input->_input->getName();
-                    mx::OutputPtr out = input->_input->getConnectedOutput();
-                    // setting comment help box
-                    ImGui::PushID(int(input->_pinId.Get()));
-                    ImGui::Text("%s", inputLabel.c_str());
-                    mx::InputPtr tempInt = _currUiNode->getNode()->getNodeDef()->getActiveInput(input->_input->getName());
-                    docString += input->_name;
-                    docString += ": ";
-                    if (tempInt)
-                    {
-                        std::string newStr = _currUiNode->getNode()->getNodeDef()->getActiveInput(input->_input->getName())->getDocString();
-                        if (newStr != mx::EMPTY_STRING)
-                        {
-                            docString += newStr;
-                        }
-                    }
-                    docString += "\t \n";
-                    ImGui::SameLine();
-                    std::string typeText = " [" + input->_input->getType() + "]";
-                    ImGui::Text("%s", typeText.c_str());
-
-                    // setting constant sliders for input values
-                    if (!input->getConnected())
-                    {
-                        setConstant(_currUiNode, input->_input, uiProperties);
-                    }
-
-                    ImGui::PopID();
+                    count++;
                 }
             }
+            if (count)
+            {
+                ImVec2 tableSize(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, count));
+                bool haveTable = ImGui::BeginTable("inputs_node_table", 2, tableFlags, tableSize);
+                if (haveTable)
+                {
+                    ImGui::SetWindowFontScale(_fontScale);
+                    for (UiPinPtr input : _currUiNode->inputPins)
+                    {
+                        if (_currUiNode->_showAllInputs || (input->getConnected() || _currUiNode->getNode()->getInput(input->_name)))
+                        {
+                            ImGui::TableNextRow();
+                            ImGui::TableNextColumn();
 
-            ImGui::Unindent();
+                            mx::UIProperties uiProperties;
+                            mx::getUIProperties(input->_input, mx::EMPTY_STRING, uiProperties);
+                            std::string inputLabel = !uiProperties.uiName.empty() ? uiProperties.uiName : input->_input->getName();
+                            mx::OutputPtr out = input->_input->getConnectedOutput();
+                            // setting comment help box
+                            ImGui::PushID(int(input->_pinId.Get()));
+                            ImGui::Text("%s", inputLabel.c_str());
+                            mx::InputPtr tempInt = _currUiNode->getNode()->getNodeDef()->getActiveInput(input->_input->getName());
+                            docString += input->_name;
+                            docString += ": ";
+                            if (tempInt)
+                            {
+                                std::string newStr = _currUiNode->getNode()->getNodeDef()->getActiveInput(input->_input->getName())->getDocString();
+                                if (newStr != mx::EMPTY_STRING)
+                                {
+                                    docString += newStr;
+                                }
+                            }
+                            docString += "\t \n";
+
+                            // setting constant sliders for input values
+                            ImGui::TableNextColumn();
+                            if (!input->getConnected())
+                            {
+                                setConstant(_currUiNode, input->_input, uiProperties);
+                            }
+                            else
+                            {
+                                std::string typeText = " [" + input->_input->getType() + "]";
+                                ImGui::Text("%s", typeText.c_str());
+                            }
+
+                            ImGui::PopID();
+                        }
+                    }
+
+                    ImGui::EndTable();
+                    ImGui::SetWindowFontScale(1.0f);
+                }
+            }
             ImGui::Checkbox("Show all inputs", &_currUiNode->_showAllInputs);
         }
 
@@ -3199,29 +3207,47 @@ void Graph::propertyEditor()
             ImGui::Text("%s", _currUiNode->getCategory().c_str());
             std::vector<UiPinPtr> inputs = _currUiNode->inputPins;
             ImGui::Text("Inputs:");
-            ImGui::Indent();
-            for (size_t i = 0; i < inputs.size(); i++)
+
+            int count = static_cast<int>(inputs.size());
+            if (count)
             {
-                mx::InputPtr mxinput = inputs[i]->_input;
-                mx::UIProperties uiProperties;
-                mx::getUIProperties(mxinput, mx::EMPTY_STRING, uiProperties);
-                std::string inputLabel = !uiProperties.uiName.empty() ? uiProperties.uiName : mxinput->getName();
-
-                // setting comment help box
-                ImGui::PushID(int(inputs[i]->_pinId.Get()));
-                ImGui::Text("%s", inputLabel.c_str());
-
-                ImGui::SameLine();
-                std::string typeText = " [" + inputs[i]->_input->getType() + "]";
-                ImGui::Text("%s", typeText.c_str());
-                // setting constant sliders for input values
-                if (!inputs[i]->getConnected())
+                bool haveTable = ImGui::BeginTable("inputs_input_table", 2, tableFlags,
+                    ImVec2(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, count)));
+                if (haveTable)
                 {
-                    setConstant(_currUiNode, inputs[i]->_input, uiProperties);
+                    ImGui::SetWindowFontScale(_fontScale);
+                    for (size_t i = 0; i < inputs.size(); i++)
+                    {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+
+                        mx::InputPtr mxinput = inputs[i]->_input;
+                        mx::UIProperties uiProperties;
+                        mx::getUIProperties(mxinput, mx::EMPTY_STRING, uiProperties);
+                        std::string inputLabel = !uiProperties.uiName.empty() ? uiProperties.uiName : mxinput->getName();
+
+                        // setting comment help box
+                        ImGui::PushID(int(inputs[i]->_pinId.Get()));
+                        ImGui::Text("%s", inputLabel.c_str());
+
+                        ImGui::TableNextColumn();
+
+                        // setting constant sliders for input values
+                        if (!inputs[i]->getConnected())
+                        {
+                            setConstant(_currUiNode, inputs[i]->_input, uiProperties);
+                        }
+                        else
+                        {
+                            std::string typeText = " [" + inputs[i]->_input->getType() + "]";
+                            ImGui::Text("%s", typeText.c_str());
+                        }
+                        ImGui::PopID();
+                    }
+                    ImGui::EndTable();
+                    ImGui::SetWindowFontScale(1.0f);
                 }
-                ImGui::PopID();
             }
-            ImGui::Unindent();
         }
         else if (_currUiNode->getOutput() != nullptr)
         {
@@ -3232,36 +3258,58 @@ void Graph::propertyEditor()
             std::vector<UiPinPtr> inputs = _currUiNode->inputPins;
             ImGui::Text("%s", _currUiNode->getCategory().c_str());
             ImGui::Text("Inputs:");
-            ImGui::Indent();
             int count = 0;
+
             for (UiPinPtr input : inputs)
             {
                 if (_currUiNode->_showAllInputs || (input->getConnected() || _currUiNode->getNodeGraph()->getInput(input->_name)))
                 {
-                    mx::InputPtr mxinput = input->_input;
-                    mx::UIProperties uiProperties;
-                    mx::getUIProperties(mxinput, mx::EMPTY_STRING, uiProperties);
-                    std::string inputLabel = !uiProperties.uiName.empty() ? uiProperties.uiName : mxinput->getName();
-
-                    // setting comment help box
-                    ImGui::PushID(int(input->_pinId.Get()));
-                    ImGui::Text("%s", inputLabel.c_str());
-
-                    docString += _currUiNode->getNodeGraph()->getActiveInput(input->_input->getName())->getDocString();
-
-                    ImGui::SameLine();
-                    std::string typeText = " [" + input->_input->getType() + "]";
-                    ImGui::Text("%s", typeText.c_str());
-                    if (!input->_input->getConnectedNode() && _currUiNode->getNodeGraph()->getActiveInput(input->_input->getName()))
-                    {
-                        setConstant(_currUiNode, input->_input, uiProperties);
-                    }
-
-                    ImGui::PopID();
                     count++;
                 }
             }
-            ImGui::Unindent();
+            if (count)
+            {
+                bool haveTable = ImGui::BeginTable("inputs_nodegraph_table", 2, tableFlags,
+                    ImVec2(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, count)));
+                if (haveTable)
+                {
+                    ImGui::SetWindowFontScale(_fontScale);
+                    for (UiPinPtr input : inputs)
+                    {
+                        if (_currUiNode->_showAllInputs || (input->getConnected() || _currUiNode->getNodeGraph()->getInput(input->_name)))
+                        {
+                            ImGui::TableNextRow();
+                            ImGui::TableNextColumn();
+
+                            mx::InputPtr mxinput = input->_input;
+                            mx::UIProperties uiProperties;
+                            mx::getUIProperties(mxinput, mx::EMPTY_STRING, uiProperties);
+                            std::string inputLabel = !uiProperties.uiName.empty() ? uiProperties.uiName : mxinput->getName();
+
+                            // setting comment help box
+                            ImGui::PushID(int(input->_pinId.Get()));
+                            ImGui::Text("%s", inputLabel.c_str());
+
+                            docString += _currUiNode->getNodeGraph()->getActiveInput(input->_input->getName())->getDocString();
+
+                            ImGui::TableNextColumn();
+                            if (!input->_input->getConnectedNode() && _currUiNode->getNodeGraph()->getActiveInput(input->_input->getName()))
+                            {
+                                setConstant(_currUiNode, input->_input, uiProperties);
+                            }
+                            else
+                            {
+                                std::string typeText = " [" + input->_input->getType() + "]";
+                                ImGui::Text("%s", typeText.c_str());
+                            }
+
+                            ImGui::PopID();
+                        }
+                    }
+                    ImGui::EndTable();
+                    ImGui::SetWindowFontScale(1.0f);
+                }
+            }
             ImGui::Checkbox("Show all inputs", &_currUiNode->_showAllInputs);
         }
         ImGui::PopStyleColor();
@@ -3274,7 +3322,9 @@ void Graph::propertyEditor()
 
         if (ImGui::BeginPopup("docstring"))
         {
+            ImGui::SetWindowFontScale(1.2f * _fontScale);
             ImGui::Text("%s", docString.c_str());
+            ImGui::SetWindowFontScale(1.0f);
             ImGui::EndPopup();
         }
     }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -818,7 +818,6 @@ void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
 void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIProperties& uiProperties)
 {
     std::string inName = !uiProperties.uiName.empty()? uiProperties.uiName : input->getName();
-    //float labelWidth = ImGui::CalcTextSize(inName.c_str()).x;
     ImGui::PushItemWidth(-1);
 
     mx::ValuePtr minVal = uiProperties.uiMin;
@@ -3259,7 +3258,6 @@ void Graph::propertyEditor()
             ImGui::Text("%s", _currUiNode->getCategory().c_str());
             ImGui::Text("Inputs:");
             int count = 0;
-
             for (UiPinPtr input : inputs)
             {
                 if (_currUiNode->_showAllInputs || (input->getConnected() || _currUiNode->getNodeGraph()->getInput(input->_name)))
@@ -3322,7 +3320,7 @@ void Graph::propertyEditor()
 
         if (ImGui::BeginPopup("docstring"))
         {
-            ImGui::SetWindowFontScale(1.2f * _fontScale);
+            ImGui::SetWindowFontScale(_fontScale);
             ImGui::Text("%s", docString.c_str());
             ImGui::SetWindowFontScale(1.0f);
             ImGui::EndPopup();


### PR DESCRIPTION
Add some table formatting for  property panel in graph editor.
* Shows 2 columns with either the connection type (as before) or the value (as before). Second column is aligned right and first column aligned left.
* Table has vertical scroll-bar.

## Sample New Formatting
* Marble node graph
![image](https://user-images.githubusercontent.com/49369885/235200860-ac389947-e301-4b25-8332-73438c970c69.png)
* Marble std surf
![image](https://user-images.githubusercontent.com/49369885/235200990-2d7c90b7-5d0e-447d-a231-6a5d4cb66c98.png)
* Image node (showing browser)
![image](https://user-images.githubusercontent.com/49369885/235201289-8691efd7-e345-4ccb-b76d-7fd2f0db3ca7.png)

## Vs old formatting
![image](https://user-images.githubusercontent.com/49369885/235201698-278aff58-c004-4f15-ba58-d10e3ad3bf4e.png)
![image](https://user-images.githubusercontent.com/49369885/235201787-805a5295-ec23-480b-8708-18620d14352c.png)
![image](https://user-images.githubusercontent.com/49369885/235201903-19036d05-10d8-44d9-bd7e-4e6e59ccbf0e.png)

