### PR TITLE
Remove unneeded clamp in UsdPreviewSurface

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -267,13 +267,8 @@
     </uniform_edf>
 
     <!-- Surface Shader Constructor -->
-    <clamp name="opacity_clamped" type="float">
-      <input name="in" type="float" interfacename="opacity" />
-      <input name="low" type="float" value="0.00001" />
-      <input name="high" type="float" value="1.0" />
-    </clamp>
     <ifgreatereq name="cutout_opacity" type="float">
-      <input name="value1" type="float" nodename="opacity_clamped" />
+      <input name="value1" type="float" interfacename="opacity" />
       <input name="value2" type="float" interfacename="opacityThreshold" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />


### PR DESCRIPTION
This changelist removes an unneeded clamp in the graph definition of UsdPreviewSurface, providing a small simplification to its generated shader code in all languages.

The formal specification for UsdPreviewSurface may be found at https://openusd.org/release/spec_usdpreviewsurface.html, and this clamp is not required to match its expected behavior for opacity.