### PR TITLE
Validate node output types

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -224,6 +224,11 @@ bool Node::validate(string* message) const
         bool exactMatch = hasExactInputMatch(nodeDef, &matchMessage);
         validateRequire(exactMatch, res, message, "Node interface error: " + matchMessage);
     }
+    else
+    {
+        bool categoryDeclared = !getDocument()->getMatchingNodeDefs(getCategory()).empty();
+        validateRequire(!categoryDeclared, res, message, "Node interface doesn't support this output type");
+    }
 
     return InterfaceElement::validate(message) && res;
 }


### PR DESCRIPTION
This changelist adds a check for node output types in document validation, providing more useful feedback when evaluating new node proposals.