### PR TITLE
Add integer signature to floor and ceil

### DIFF
--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -310,6 +310,7 @@
   <implementation name="IM_floor_vector2_genglsl" nodedef="ND_floor_vector2" target="genglsl" sourcecode="floor({{in}})" />
   <implementation name="IM_floor_vector3_genglsl" nodedef="ND_floor_vector3" target="genglsl" sourcecode="floor({{in}})" />
   <implementation name="IM_floor_vector4_genglsl" nodedef="ND_floor_vector4" target="genglsl" sourcecode="floor({{in}})" />
+  <implementation name="IM_floor_integer_genglsl" nodedef="ND_floor_integer" target="genglsl" sourcecode="int(floor({{in}}))" />
 
   <!-- <ceil> -->
   <implementation name="IM_ceil_float_genglsl" nodedef="ND_ceil_float" target="genglsl" sourcecode="ceil({{in}})" />
@@ -318,6 +319,7 @@
   <implementation name="IM_ceil_vector2_genglsl" nodedef="ND_ceil_vector2" target="genglsl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_vector3_genglsl" nodedef="ND_ceil_vector3" target="genglsl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_vector4_genglsl" nodedef="ND_ceil_vector4" target="genglsl" sourcecode="ceil({{in}})" />
+  <implementation name="IM_ceil_integer_genglsl" nodedef="ND_ceil_integer" target="genglsl" sourcecode="int(ceil({{in}}))" />
 
   <!-- <power> -->
   <implementation name="IM_power_float_genglsl" nodedef="ND_power_float" target="genglsl" sourcecode="pow({{in1}}, {{in2}})" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -313,6 +313,7 @@
   <implementation name="IM_floor_vector2_genmdl" nodedef="ND_floor_vector2" sourcecode="math::floor({{in}})" target="genmdl" />
   <implementation name="IM_floor_vector3_genmdl" nodedef="ND_floor_vector3" sourcecode="math::floor({{in}})" target="genmdl" />
   <implementation name="IM_floor_vector4_genmdl" nodedef="ND_floor_vector4" sourcecode="math::floor({{in}})" target="genmdl" />
+  <implementation name="IM_floor_integer_genmdl" nodedef="ND_floor_integer" sourcecode="int(math::floor({{in}}))" target="genmdl" />
 
   <!-- <ceil> -->
   <implementation name="IM_ceil_float_genmdl" nodedef="ND_ceil_float" sourcecode="math::ceil({{in}})" target="genmdl" />
@@ -321,6 +322,8 @@
   <implementation name="IM_ceil_vector2_genmdl" nodedef="ND_ceil_vector2" sourcecode="math::ceil({{in}})" target="genmdl" />
   <implementation name="IM_ceil_vector3_genmdl" nodedef="ND_ceil_vector3" sourcecode="math::ceil({{in}})" target="genmdl" />
   <implementation name="IM_ceil_vector4_genmdl" nodedef="ND_ceil_vector4" sourcecode="math::ceil({{in}})" target="genmdl" />
+  <implementation name="IM_ceil_integer_genmdl" nodedef="ND_ceil_integer" sourcecode="int(math::ceil({{in}}))" target="genmdl" />
+
 
   <!-- <power> -->
   <implementation name="IM_power_float_genmdl" nodedef="ND_power_float" sourcecode="math::pow({{in1}}, {{in2}})" target="genmdl" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -324,7 +324,6 @@
   <implementation name="IM_ceil_vector4_genmdl" nodedef="ND_ceil_vector4" sourcecode="math::ceil({{in}})" target="genmdl" />
   <implementation name="IM_ceil_integer_genmdl" nodedef="ND_ceil_integer" sourcecode="int(math::ceil({{in}}))" target="genmdl" />
 
-
   <!-- <power> -->
   <implementation name="IM_power_float_genmdl" nodedef="ND_power_float" sourcecode="math::pow({{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_power_color3_genmdl" nodedef="ND_power_color3" sourcecode="math::pow({{in1}}, {{in2}})" target="genmdl" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -311,6 +311,7 @@
   <implementation name="IM_floor_vector2_genmsl" nodedef="ND_floor_vector2" target="genmsl" sourcecode="floor({{in}})" />
   <implementation name="IM_floor_vector3_genmsl" nodedef="ND_floor_vector3" target="genmsl" sourcecode="floor({{in}})" />
   <implementation name="IM_floor_vector4_genmsl" nodedef="ND_floor_vector4" target="genmsl" sourcecode="floor({{in}})" />
+  <implementation name="IM_floor_integer_genmsl" nodedef="ND_floor_integer" target="genmsl" sourcecode="int(floor({{in}}))" />
 
   <!-- <ceil> -->
   <implementation name="IM_ceil_float_genmsl" nodedef="ND_ceil_float" target="genmsl" sourcecode="ceil({{in}})" />
@@ -319,6 +320,7 @@
   <implementation name="IM_ceil_vector2_genmsl" nodedef="ND_ceil_vector2" target="genmsl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_vector3_genmsl" nodedef="ND_ceil_vector3" target="genmsl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_vector4_genmsl" nodedef="ND_ceil_vector4" target="genmsl" sourcecode="ceil({{in}})" />
+  <implementation name="IM_ceil_integer_genmsl" nodedef="ND_ceil_integer" target="genmsl" sourcecode="int(ceil({{in}}))" />
 
   <!-- <power> -->
   <implementation name="IM_power_float_genmsl" nodedef="ND_power_float" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -313,6 +313,7 @@
   <implementation name="IM_floor_vector2_genosl" nodedef="ND_floor_vector2" target="genosl" sourcecode="floor({{in}})" />
   <implementation name="IM_floor_vector3_genosl" nodedef="ND_floor_vector3" target="genosl" sourcecode="floor({{in}})" />
   <implementation name="IM_floor_vector4_genosl" nodedef="ND_floor_vector4" target="genosl" sourcecode="floor({{in}})" />
+  <implementation name="IM_floor_integer_genosl" nodedef="ND_floor_integer" target="genosl" sourcecode="int(floor({{in}}))" />
 
   <!-- <ceil> -->
   <implementation name="IM_ceil_float_genosl" nodedef="ND_ceil_float" target="genosl" sourcecode="ceil({{in}})" />
@@ -321,6 +322,7 @@
   <implementation name="IM_ceil_vector2_genosl" nodedef="ND_ceil_vector2" target="genosl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_vector3_genosl" nodedef="ND_ceil_vector3" target="genosl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_vector4_genosl" nodedef="ND_ceil_vector4" target="genosl" sourcecode="ceil({{in}})" />
+  <implementation name="IM_ceil_integer_genosl" nodedef="ND_ceil_integer" target="genosl" sourcecode="int(ceil({{in}}))" />
 
   <!-- <power> -->
   <implementation name="IM_power_float_genosl" nodedef="ND_power_float" target="genosl" sourcecode="pow({{in1}}, {{in2}})" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1699,6 +1699,10 @@
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
+  <nodedef name="ND_floor_integer" node="floor" nodegroup="math">
+    <input name="in" type="float" value="0.0" />
+    <output name="out" type="integer" defaultinput="in" />
+  </nodedef>
 
   <!--
     Node: <ceil>
@@ -1727,6 +1731,10 @@
   <nodedef name="ND_ceil_vector4" node="ceil" nodegroup="math">
     <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="vector4" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_ceil_integer" node="ceil" nodegroup="math">
+    <input name="in" type="float" value="0.0" />
+    <output name="out" type="integer" defaultinput="in" />
   </nodedef>
 
   <!--

--- a/resources/Materials/TestSuite/stdlib/math/math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math.mtlx
@@ -108,15 +108,6 @@
     </constant>
     <output name="out" type="vector4" nodename="sqrt1" />
   </nodegraph>
-  <nodegraph name="ceil_float_nodegraph">
-    <ceil name="ceil1" type="float">
-      <input name="in" type="float" nodename="constant1" />
-    </ceil>
-    <constant name="constant1" type="float">
-      <input name="value" type="float" value="0.5000" />
-    </constant>
-    <output name="out" type="float" nodename="ceil1" />
-  </nodegraph>
   <nodegraph name="floor_float_nodegraph">
     <floor name="floor1" type="float">
       <input name="in" type="float" nodename="constant1" />
@@ -125,6 +116,69 @@
       <input name="value" type="float" value="0.5000" />
     </constant>
     <output name="out" type="float" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="floor_vector2_nodegraph">
+    <floor name="floor1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
+    </floor>
+    <constant name="constant1" type="vector2">
+      <input name="value" type="vector2" value="0.5000, 1.5000" />
+    </constant>
+    <output name="out" type="vector2" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="floor_vector3_nodegraph">
+    <floor name="floor1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
+    </floor>
+    <constant name="constant1" type="vector3">
+      <input name="value" type="vector3" value="0.5000, 1.5000, 0.0" />
+    </constant>
+    <output name="out" type="vector3" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="floor_vector4_nodegraph">
+    <floor name="floor1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
+    </floor>
+    <constant name="constant1" type="vector4">
+      <input name="value" type="vector4" value="0.5000, 1.5000, 0.0, 1.0" />
+    </constant>
+    <output name="out" type="vector4" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="floor_color3_nodegraph">
+    <constant name="constant1" type="color3">
+      <input name="value" type="color3" value="0.5000, 1.5000, 0.0" />
+    </constant>
+    <floor name="floor1" type="color3">
+      <input name="in" type="color3" nodename="constant1" />
+    </floor>
+    <output name="out" type="color3" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="floor_color4_nodegraph">
+    <constant name="constant1" type="color4">
+      <input name="value" type="color4" value="0.5000, 1.5000, 0.0, 1.0" />
+    </constant>
+    <floor name="floor1" type="color4">
+      <input name="in" type="color4" nodename="constant1" />
+    </floor>
+    <output name="out" type="color4" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="floor_integer_nodegraph">
+    <floor name="floor1" type="integer">
+      <input name="in" type="float" nodename="constant1" />
+    </floor>
+    <constant name="constant1" type="float">
+      <input name="value" type="float" value="0.5000" />
+    </constant>
+    <output name="out" type="integer" nodename="floor1" />
+  </nodegraph>
+  <nodegraph name="ceil_float_nodegraph">
+    <ceil name="ceil1" type="float">
+      <input name="in" type="float" nodename="constant1" />
+    </ceil>
+    <constant name="constant1" type="float">
+      <input name="value" type="float" value="0.5000" />
+    </constant>
+    <output name="out" type="float" nodename="ceil1" />
   </nodegraph>
   <nodegraph name="ceil_vector2_nodegraph">
     <ceil name="ceil1" type="vector2">
@@ -171,50 +225,14 @@
     </ceil>
     <output name="out" type="color4" nodename="ceil1" />
   </nodegraph>
-  <nodegraph name="floor_vector2_nodegraph">
-    <floor name="floor1" type="vector2">
-      <input name="in" type="vector2" nodename="constant1" />
-    </floor>
-    <constant name="constant1" type="vector2">
-      <input name="value" type="vector2" value="0.5000, 1.5000" />
+  <nodegraph name="ceil_integer_nodegraph">
+    <ceil name="ceil1" type="integer">
+      <input name="in" type="float" nodename="constant1" />
+    </ceil>
+    <constant name="constant1" type="float">
+      <input name="value" type="float" value="0.5000" />
     </constant>
-    <output name="out" type="vector2" nodename="floor1" />
-  </nodegraph>
-  <nodegraph name="floor_vector3_nodegraph">
-    <floor name="floor1" type="vector3">
-      <input name="in" type="vector3" nodename="constant1" />
-    </floor>
-    <constant name="constant1" type="vector3">
-      <input name="value" type="vector3" value="0.5000, 1.5000, 0.0" />
-    </constant>
-    <output name="out" type="vector3" nodename="floor1" />
-  </nodegraph>
-  <nodegraph name="floor_vector4_nodegraph">
-    <floor name="floor1" type="vector4">
-      <input name="in" type="vector4" nodename="constant1" />
-    </floor>
-    <constant name="constant1" type="vector4">
-      <input name="value" type="vector4" value="0.5000, 1.5000, 0.0, 1.0" />
-    </constant>
-    <output name="out" type="vector4" nodename="floor1" />
-  </nodegraph>
-  <nodegraph name="floor_color3_nodegraph">
-    <constant name="constant1" type="color3">
-      <input name="value" type="color3" value="0.5000, 1.5000, 0.0" />
-    </constant>
-    <floor name="floor1" type="color3">
-      <input name="in" type="color3" nodename="constant1" />
-    </floor>
-    <output name="out" type="color3" nodename="floor1" />
-  </nodegraph>
-  <nodegraph name="floor_color4_nodegraph">
-    <constant name="constant1" type="color4">
-      <input name="value" type="color4" value="0.5000, 1.5000, 0.0, 1.0" />
-    </constant>
-    <floor name="floor1" type="color4">
-      <input name="in" type="color4" nodename="constant1" />
-    </floor>
-    <output name="out" type="color4" nodename="floor1" />
+    <output name="out" type="integer" nodename="ceil1" />
   </nodegraph>
   <nodegraph name="sign_float">
     <constant name="constant1" type="float">


### PR DESCRIPTION
Adds support to `ceil` and `floor` to output integers. There will be other tickets/discussions around improving integer support across MaterialX, but adding integer output to these nodes first would be a big help to some nodegraph contributions we'd like to contribute soon.

Thanks!