### PR TITLE
Add DisplayP3 colorspaces

### DIFF
--- a/documents/Specification/inprog_v1.39/MaterialX.Specification.md
+++ b/documents/Specification/inprog_v1.39/MaterialX.Specification.md
@@ -339,6 +339,8 @@ By default, MaterialX supports the following color spaces as defined in ACES 1.2
 * `lin_srgb`
 * `adobergb`
 * `lin_adobergb`
+* `srgb_displayp3`
+* `lin_displayp3`
 
 The working color space of a MaterialX document is defined by the `colorspace` attribute of its root &lt;materialx> element, and it is strongly recommended that all &lt;materialx> elements define a specific `colorspace` if they wish to use a color-managed workflow rather than relying on a default colorspace setting from an external configuration file.
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -42,8 +42,18 @@ This folder contains the standard data libraries for MaterialX, providing declar
     - [lama](bxdf/lama) : Graph definitions of the [MaterialX Lama](https://rmanwiki.pixar.com/display/REN24/MaterialX+Lama) node set.
 
 ## Color Management Library
-- MaterialX shader generation natively supports a small set of common spaces for input colors, with all color transforms implemented as language-independent MaterialX graphs. The canonical definitions of these color transforms may be found in the OpenColorIO configuration for [ACES 1.2](https://github.com/colour-science/OpenColorIO-Configs/tree/feature/aces-1.2-config/aces_1.2).
-    - lin_rec709, g18_rec709, g22_rec709, rec709_display, acescg (lin_ap1), g22_ap1, srgb_texture, lin_adobergb, adobergb
+- MaterialX shader generation natively supports a small set of common spaces for input colors, with all color transforms implemented as language-independent MaterialX graphs.The canonical definitions of these color transforms may be found in the OpenColorIO configuration for [ACES 1.2](https://github.com/colour-science/OpenColorIO-Configs/tree/feature/aces-1.2-config/aces_1.2).
+    - lin_rec709
+    - g18_rec709
+    - g22_rec709
+    - rec709_display
+    - acescg (lin_ap1)
+    - g22_ap1
+    - srgb_texture
+    - lin_adobergb
+    - adobergb
+    - srgb_displayp3
+    - lin_displayp3
 - [cmlib](cmlib)
     - [cmlib_defs.mtlx](cmlib/cmlib_defs.mtlx) : Nodedef declarations.
     - [cmlib_ng.mtlx](cmlib/cmlib_ng.mtlx) : Nodegraph definitions.

--- a/libraries/cmlib/cmlib_defs.mtlx
+++ b/libraries/cmlib/cmlib_defs.mtlx
@@ -87,4 +87,24 @@
     <output name="out" type="color4" />
   </nodedef>
 
+  <nodedef name="ND_srgb_displayp3_to_lin_rec709_color3" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_srgb_displayp3_to_lin_rec709_color4" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <nodedef name="ND_lin_displayp3_to_lin_rec709_color3" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_lin_displayp3_to_lin_rec709_color4" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" />
+    <output name="out" type="color4" />
+  </nodedef>
+
 </materialx>

--- a/libraries/cmlib/cmlib_defs.mtlx
+++ b/libraries/cmlib/cmlib_defs.mtlx
@@ -88,22 +88,22 @@
   </nodedef>
 
   <nodedef name="ND_srgb_displayp3_to_lin_rec709_color3" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_srgb_displayp3_to_lin_rec709_color4" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_lin_displayp3_to_lin_rec709_color3" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_lin_displayp3_to_lin_rec709_color4" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
     <output name="out" type="color4" />
   </nodedef>
 

--- a/libraries/cmlib/cmlib_ng.mtlx
+++ b/libraries/cmlib/cmlib_ng.mtlx
@@ -312,7 +312,7 @@
     <convert name="asColor" type="color3">
       <input name="in" type="vector3" nodename="transform" />
     </convert>
-    <output name="out" type="color3" nodename="transform" />
+    <output name="out" type="color3" nodename="asColor" />
   </nodegraph>
 
   <nodegraph name="NG_srgb_displayp3_to_lin_rec709_color4" nodedef="ND_srgb_displayp3_to_lin_rec709_color4">

--- a/libraries/cmlib/cmlib_ng.mtlx
+++ b/libraries/cmlib/cmlib_ng.mtlx
@@ -294,4 +294,74 @@
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
+  <nodegraph name="NG_srgb_displayp3_to_lin_rec709_color3" nodedef="ND_srgb_displayp3_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33" value="1.22493029, -0.22492968, 0.00000006, -0.04205868,  1.04205894, -0.00000001, -0.01964128, -0.07864794, 1.09828925" />
+    </constant>
+    <!--  Use srgb_texture_to_lin_rec709 to convert from sRGB to Lin before passing to the mat conversion -->
+    <srgb_texture_to_lin_rec709 name="srgb_transform" type="color3">
+      <input name="in" type="color3" interfacename="in" />
+    </srgb_texture_to_lin_rec709>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" nodename="srgb_transform" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="transform" />
+  </nodegraph>
+
+  <nodegraph name="NG_srgb_displayp3_to_lin_rec709_color4" nodedef="ND_srgb_displayp3_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <srgb_displayp3_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </srgb_displayp3_to_lin_rec709>
+    <combine4 name="asColor4" type="color4">
+      <input name="in1" type="float" nodename="transform" channels="r" />
+      <input name="in2" type="float" nodename="transform" channels="g" />
+      <input name="in3" type="float" nodename="transform" channels="b" />
+      <input name="in4" type="float" interfacename="in" channels="a" />
+    </combine4>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <nodegraph name="NG_lin_displayp3_to_lin_rec709_color3" nodedef="ND_lin_displayp3_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33" value="1.22493029, -0.22492968, 0.00000006, -0.04205868,  1.04205894, -0.00000001, -0.01964128, -0.07864794, 1.09828925" />
+    </constant>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" interfacename="in" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <nodegraph name="NG_lin_displayp3_to_lin_rec709_color4" nodedef="ND_lin_displayp3_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <lin_displayp3_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </lin_displayp3_to_lin_rec709>
+    <combine4 name="asColor4" type="color4">
+      <input name="in1" type="float" nodename="transform" channels="r" />
+      <input name="in2" type="float" nodename="transform" channels="g" />
+      <input name="in3" type="float" nodename="transform" channels="b" />
+      <input name="in4" type="float" interfacename="in" channels="a" />
+    </combine4>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -64,6 +64,20 @@
       <input name="base_color" type="color3" value="1, 1, 1" nodename="image_lin_adobergb" />
     </standard_surface>
     <output name="image_lin_adobergb_output" type="surfaceshader" nodename="image_lin_adobergb_standard_surface8" />
+    <image name="image_srgb_displayp3" type="color3">
+      <input name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_displayp3" />
+    </image>
+    <standard_surface name="image_srgb_displayp3_standard_surface9" type="surfaceshader">
+      <input name="base_color" type="color3" nodename="image_srgb_displayp3" />
+    </standard_surface>
+    <output name="image_srgb_displayp3_output" type="surfaceshader" nodename="image_srgb_displayp3_standard_surface9" />
+    <image name="image_lin_displayp3" type="color3">
+      <input name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_displayp3" />
+    </image>
+    <standard_surface name="image_lin_displayp3_standard_surface9" type="surfaceshader">
+      <input name="base_color" type="color3" nodename="image_lin_displayp3" />
+    </standard_surface>
+    <output name="image_lin_displayp3_output" type="surfaceshader" nodename="image_lin_displayp3_standard_surface10" />
     <constant name="color_lin_rec709" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_rec709" />
     </constant>
@@ -127,5 +141,19 @@
       <input name="base_color" type="color3" value="1, 1, 1" nodename="color_lin_adobergb" channels="rgb" />
     </standard_surface>
     <output name="color_lin_adobergb_output" type="surfaceshader" nodename="color_lin_adobergb_standard_surface8" />
+    <constant name="color_srgb_displayp3" type="color4">
+      <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="srgb_displayp3" />
+    </constant>
+    <standard_surface name="color_srgb_displayp3_standard_surface5" type="surfaceshader">
+      <input name="base_color" type="color3" nodename="color_srgb_displayp3" channels="rgb" />
+    </standard_surface>
+    <output name="color_srgb_displayp3_output" type="surfaceshader" nodename="color_srgb_displayp3_standard_surface9" />
+    <constant name="color_lin_displayp3" type="color4">
+      <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_displayp3" />
+    </constant>
+    <standard_surface name="color_lin_displayp3_standard_surface5" type="surfaceshader">
+      <input name="base_color" type="color3" nodename="color_lin_displayp3" channels="rgb" />
+    </standard_surface>
+    <output name="color_lin_displayp3_output" type="surfaceshader" nodename="color_lin_displayp3_standard_surface9" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -74,7 +74,7 @@
     <image name="image_lin_displayp3" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_displayp3" />
     </image>
-    <standard_surface name="image_lin_displayp3_standard_surface9" type="surfaceshader">
+    <standard_surface name="image_lin_displayp3_standard_surface10" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_lin_displayp3" />
     </standard_surface>
     <output name="image_lin_displayp3_output" type="surfaceshader" nodename="image_lin_displayp3_standard_surface10" />

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -147,13 +147,13 @@
     <standard_surface name="color_srgb_displayp3_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_srgb_displayp3" channels="rgb" />
     </standard_surface>
-    <output name="color_srgb_displayp3_output" type="surfaceshader" nodename="color_srgb_displayp3_standard_surface9" />
+    <output name="color_srgb_displayp3_output" type="surfaceshader" nodename="color_srgb_displayp3_standard_surface5" />
     <constant name="color_lin_displayp3" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_displayp3" />
     </constant>
     <standard_surface name="color_lin_displayp3_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_lin_displayp3" channels="rgb" />
     </standard_surface>
-    <output name="color_lin_displayp3_output" type="surfaceshader" nodename="color_lin_displayp3_standard_surface9" />
+    <output name="color_lin_displayp3_output" type="surfaceshader" nodename="color_lin_displayp3_standard_surface5" />
   </nodegraph>
 </materialx>


### PR DESCRIPTION
This PR adds support for the [DisplayP3](https://www.color.org/chardata/rgb/DisplayP3.xalter) colorspace, a wider gamut range for computer displays that is standard in the Apple ecosystem and elsewhere. More information can be found in this [developer video](https://developer.apple.com/videos/play/wwdc2017/821/).

DisplayP3 uses the DCI-P3 gamut with a D65 white point and an sRGB transfer curve. In keeping with discussions with the OCIO group, we've opted to name it in the form `<transfer_curve>_<gamut>` for consistency.

Hence we add the following two colorspaces:

* srgb_displayp3
* lin_displayp3

The matrix3x3 values are derived from Nuke

<img width="596" alt="image" src="https://github.com/AcademySoftwareFoundation/MaterialX/assets/4443090/3050491e-1cda-4916-bba5-c31980c16042">
