### PR TITLE
Improve robustness of unit tests

### DIFF
--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -143,6 +143,12 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
                                    " does not include proper tokens for rendering");
     }
 
+    // Set the working directory for rendering.
+    FileSearchPath searchPath = getDefaultDataSearchPath();
+    FilePath rootPath = searchPath.isEmpty() ? FilePath() : searchPath[0];
+    FilePath origWorkingPath = FilePath::getCurrentPath();
+    rootPath.setCurrentPath();
+
     // Write scene file
     const string sceneFileName("scene_template.xml");
     std::ofstream shaderFileStream;
@@ -177,6 +183,9 @@ void OslRenderer::renderOSL(const FilePath& dirPath, const string& shaderName, c
             break;
         }
     }
+
+    // Restore the working directory after rendering.
+    origWorkingPath.setCurrentPath();
 
     // Report errors on a non-zero return value.
     if (returnValue)

--- a/source/MaterialXTest/Main.cpp
+++ b/source/MaterialXTest/Main.cpp
@@ -13,10 +13,8 @@ namespace mx = MaterialX;
 int main(int argc, char* const argv[])
 {
     Catch::Session session;
-
-#ifndef _DEBUG
     session.configData().showDurations = Catch::ShowDurations::Always;
-#endif
+
 #ifdef CATCH_PLATFORM_WINDOWS
     BOOL inDebugger = IsDebuggerPresent();
     if (inDebugger)
@@ -28,18 +26,6 @@ int main(int argc, char* const argv[])
         session.configData().outputFilename = "";
     }
 #endif
-
-    // If the current path has no valid resources folder, as can occur when launching the
-    // test suite from an IDE, then align the current path with the module path.
-    mx::FilePath resourcesPath = mx::FilePath::getCurrentPath() / "resources";
-    if (!resourcesPath.exists())
-    {
-        resourcesPath = mx::FilePath::getModulePath().getParentPath() / "resources";
-        if (resourcesPath.exists())
-        {
-            resourcesPath.getParentPath().setCurrentPath();
-        }
-    }
 
     int returnCode = session.applyCommandLine(argc, argv);
     if (returnCode != 0)

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -111,22 +111,24 @@ TEST_CASE("Document", "[document]")
 
 TEST_CASE("Version", "[document]")
 {
-    mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_ng.mtlx"), doc);
-    mx::FileSearchPath searchPath("resources/Materials/TestSuite/stdlib/upgrade/");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, stdlib);
+    searchPath.append(searchPath.find("resources/Materials/TestSuite/stdlib/upgrade"));
 
     // 1.36 to 1.37
     {
+        mx::DocumentPtr doc = mx::createDocument();
         mx::readFromXmlFile(doc, "1_36_to_1_37.mtlx", searchPath);
+        doc->importLibrary(stdlib);
         REQUIRE(doc->validate());
 
         mx::XmlWriteOptions writeOptions;
         writeOptions.writeXIncludeEnable = true;
-        mx::writeToXmlFile(doc, "1_36_to_1_37_updated.mtlx", &writeOptions);
+        std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
 
         mx::DocumentPtr doc2 = mx::createDocument();
-        mx::readFromXmlFile(doc2, "1_36_to_1_37_updated.mtlx");
+        mx::readFromXmlString(doc2, xmlString);
         REQUIRE(doc2->validate());
 
         // Check conversion to desired types occurred
@@ -160,18 +162,17 @@ TEST_CASE("Version", "[document]")
 
     // 1.37 to 1.38
     {
-        doc = mx::createDocument();
-        mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
-        mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_ng.mtlx"), doc);
+        mx::DocumentPtr doc = mx::createDocument();
         mx::readFromXmlFile(doc, "1_37_to_1_38.mtlx", searchPath);
+        doc->importLibrary(stdlib);
         REQUIRE(doc->validate());
 
         mx::XmlWriteOptions writeOptions;
         writeOptions.writeXIncludeEnable = false;
-        mx::writeToXmlFile(doc, "1_37_to_1_38_updated.mtlx", &writeOptions);
+        std::string xmlString = mx::writeToXmlString(doc, &writeOptions);
 
         mx::DocumentPtr doc2 = mx::createDocument();
-        mx::readFromXmlFile(doc2, "1_37_to_1_38_updated.mtlx");
+        mx::readFromXmlString(doc2, xmlString);
         REQUIRE(doc2->validate());
 
         // atan2 test

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -61,12 +61,9 @@ TEST_CASE("Material", "[material]")
 
 TEST_CASE("Material Discovery", "[material]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-
-    const mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath searchPath(currentPath / mx::FilePath("resources/Materials/TestSuite"));
-    mx::FilePath filename = "stdlib/materials/material_node_discovery.mtlx";
-    mx::readFromXmlFile(doc, filename, searchPath);
+    mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/materials/material_node_discovery.mtlx", searchPath);
 
     // 1. Find all materials referenced by material assignments
     //    which are found in connected nodegraphs

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -139,8 +139,9 @@ TEST_CASE("Node", "[node]")
 TEST_CASE("Flatten", "[nodegraph]")
 {
     // Read an example containing graph-based custom nodes.
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-    mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/shader/surface.mtlx");
+    mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/shader/surface.mtlx", searchPath);
     REQUIRE(doc->validate());
 
     // Count root-level, nested, and custom nodes.
@@ -174,8 +175,8 @@ TEST_CASE("Flatten", "[nodegraph]")
 
 TEST_CASE("Inheritance", "[nodedef]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
     mx::loadLibraries({ "libraries" }, searchPath, doc);
     REQUIRE(doc->validate());
     auto nodedef = doc->getNodeDef("ND_standard_surface_surfaceshader");
@@ -559,13 +560,12 @@ TEST_CASE("Organization", "[nodegraph]")
 
 TEST_CASE("Tokens", "[nodegraph]")
 {
-    mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_ng.mtlx"), doc);
-    mx::FileSearchPath searchPath("resources/Materials/TestSuite/stdlib/texture/");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, stdlib);
 
-    mx::readFromXmlFile(doc, "tokenGraph.mtlx", searchPath);
-    doc->validate();
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/texture/tokenGraph.mtlx", searchPath);
 
     mx::StringVec graphNames = { "Tokenized_Image_2k_png", "Tokenized_Image_4k_jpg" };
     mx::StringVec resolutionStrings = { "2k", "4k" };
@@ -597,13 +597,13 @@ TEST_CASE("Tokens", "[nodegraph]")
 
 TEST_CASE("Node Definition Creation", "[nodedef]")
 {
-    mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_ng.mtlx"), doc);
-    mx::FileSearchPath searchPath("resources/Materials/TestSuite/stdlib/definition/");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, stdlib);
 
-    mx::readFromXmlFile(doc, "definition_from_nodegraph.mtlx", searchPath);
-    REQUIRE(doc->validate());
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/definition/definition_from_nodegraph.mtlx", searchPath);
+    doc->importLibrary(stdlib);
 
     mx::NodeGraphPtr graph = doc->getNodeGraph("test_colorcorrect");
     REQUIRE(graph);
@@ -721,7 +721,5 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
         }
         REQUIRE(findDefault);
     }
-
     REQUIRE(doc->validate());
-    mx::writeToXmlFile(doc, "definition_from_nodegraph_out.mtlx");
 }

--- a/source/MaterialXTest/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXTest/MaterialXCore/Traversal.cpp
@@ -176,14 +176,9 @@ TEST_CASE("IntraGraph Traversal", "[traversal]")
 
 TEST_CASE("InterGraph Traversal", "[traversal]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath searchPath(currentPath);
-    mx::loadLibraries({ "libraries" }, searchPath, doc);
-
-    mx::FilePath testFile = currentPath / mx::FilePath("resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx");
-    mx::readFromXmlFile(doc, testFile, searchPath);
-    REQUIRE(doc->validate());
+    mx::readFromXmlFile(doc, "resources/Materials/TestSuite/stdlib/nodegraph_inputs/nodegraph_nodegraph.mtlx", searchPath);
 
     for (mx::NodeGraphPtr graph : doc->getNodeGraphs())
     {

--- a/source/MaterialXTest/MaterialXCore/Unit.cpp
+++ b/source/MaterialXTest/MaterialXCore/Unit.cpp
@@ -17,8 +17,10 @@ const float EPSILON = 1e-4f;
 
 TEST_CASE("UnitAttribute", "[unit]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
+
     std::vector<mx::UnitTypeDefPtr> unitTypeDefs = doc->getUnitTypeDefs();
     REQUIRE(!unitTypeDefs.empty());
 
@@ -60,8 +62,9 @@ TEST_CASE("UnitAttribute", "[unit]")
 
 TEST_CASE("UnitEvaluation", "[unit]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-    mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
 
     //
     // Test distance converter
@@ -117,11 +120,11 @@ TEST_CASE("UnitEvaluation", "[unit]")
 
 TEST_CASE("UnitDocument", "[unit]")
 {
-    mx::FilePath libraryPath("libraries/stdlib");
-    mx::FilePath examplesPath("resources/Materials/TestSuite/stdlib/units");
-    std::string searchPath = libraryPath.asString() +
-        mx::PATH_LIST_SEPARATOR +
-        examplesPath.asString();
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, stdlib);
+    mx::FilePath examplesPath = searchPath.find("resources/Materials/TestSuite/stdlib/units");
+    searchPath.append(examplesPath);
 
     static const std::string DISTANCE_DEFAULT("meter");
 
@@ -130,7 +133,7 @@ TEST_CASE("UnitDocument", "[unit]")
     {
         mx::DocumentPtr doc = mx::createDocument();
         mx::readFromXmlFile(doc, filename, searchPath);
-        mx::loadLibrary(mx::FilePath::getCurrentPath() / mx::FilePath("libraries/stdlib/stdlib_defs.mtlx"), doc);
+        doc->importLibrary(stdlib);
 
         mx::UnitTypeDefPtr distanceTypeDef = doc->getUnitTypeDef("distance");
         REQUIRE(distanceTypeDef);
@@ -149,11 +152,14 @@ TEST_CASE("UnitDocument", "[unit]")
             mx::NodePtr pNode = elem->asA<mx::Node>();
             if (pNode)
             {
-                if (pNode->getInputCount()) {
-                    for (mx::InputPtr input : pNode->getInputs()) {
+                if (pNode->getInputCount())
+                {
+                    for (mx::InputPtr input : pNode->getInputs())
+                    {
                         const std::string type = input->getType();
                         const mx::ValuePtr value = input->getValue();
-                        if (input->hasUnit() && value) {
+                        if (input->hasUnit() && value)
+                        {
                             if (type == "float")
                             {
                                 float originalval = value->asA<float>();

--- a/source/MaterialXTest/MaterialXFormat/File.cpp
+++ b/source/MaterialXTest/MaterialXFormat/File.cpp
@@ -32,32 +32,27 @@ TEST_CASE("Syntactic operations", "[file]")
 
 TEST_CASE("File system operations", "[file]")
 {
-    mx::StringVec filenames =
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePathVec examplePaths =
     {
         "libraries/stdlib/stdlib_defs.mtlx",
         "resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx",
         "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx",
     };
-
-    for (const std::string& filename : filenames)
+    for (const mx::FilePath& path : examplePaths)
     {
-        mx::FilePath path(filename);
-        REQUIRE(path.exists());
-        REQUIRE(mx::FileSearchPath().find(path).exists());
+        REQUIRE(searchPath.find(path).exists());
     }
 
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FilePath modulePath = mx::FilePath::getModulePath();
-    bool expectedPaths = currentPath == modulePath ||
-                         currentPath == modulePath.getParentPath();
-    REQUIRE(expectedPaths);
+    REQUIRE(mx::FilePath::getCurrentPath().exists());
+    REQUIRE(mx::FilePath::getModulePath().exists());
 }
 
 TEST_CASE("File search path operations", "[file]")
 {
-    mx::FileSearchPath searchPath = "libraries/stdlib" + 
-                                    mx::PATH_LIST_SEPARATOR + 
-                                    "resources/Materials/Examples/StandardSurface";
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    searchPath.append(searchPath.find("libraries/stdlib"));
+    searchPath.append(searchPath.find("resources/Materials/Examples/StandardSurface"));
 
     mx::FilePathVec filenames =
     {
@@ -102,10 +97,8 @@ TEST_CASE("Flatten filenames", "[file]")
     image2->setInputValue("file", "brass_color.jpg", mx::FILENAME_TYPE_STRING);
 
     // 2. Test resolving to absolute paths
-    mx::FilePath rootPath(mx::FilePath::getCurrentPath());
-
-    mx::FileSearchPath searchPath;
-    searchPath.append(rootPath);
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath rootPath = searchPath.isEmpty() ? mx::FilePath() : searchPath[0];
 
     mx::flattenFilenames(doc1, searchPath);    
     REQUIRE(nodeGraph->getFilePrefix() == mx::EMPTY_STRING);

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -14,11 +14,11 @@ namespace mx = MaterialX;
 
 TEST_CASE("Load content", "[xmlio]")
 {
-    mx::FilePath libraryPath("libraries/stdlib");
-    mx::FilePath examplesPath("resources/Materials/Examples/StandardSurface");
-    mx::FileSearchPath searchPath = libraryPath.asString() +
-        mx::PATH_LIST_SEPARATOR +
-        examplesPath.asString();
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath libraryPath = searchPath.find("libraries/stdlib");
+    mx::FilePath examplesPath = searchPath.find("resources/Materials/Examples/StandardSurface");
+    searchPath.append(libraryPath);
+    searchPath.append(examplesPath);
 
     // Read the standard library.
     std::vector<mx::DocumentPtr> libs;
@@ -242,7 +242,8 @@ TEST_CASE("Load content", "[xmlio]")
 
 TEST_CASE("Comments and newlines", "[xmlio]")
 {
-    mx::FilePath testPath("resources/Materials/Examples/StandardSurface/standard_surface_chess_set.mtlx");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath testPath = searchPath.find("resources/Materials/Examples/StandardSurface/standard_surface_chess_set.mtlx");
 
     // Read the example file into an XML string buffer.
     std::string origXml = mx::readFile(testPath);

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -91,10 +91,7 @@ TEST_CASE("GenShader: GLSL Implementation Check", "[genglsl]")
 TEST_CASE("GenShader: GLSL Unique Names", "[genglsl]")
 {
     mx::GenContext context(mx::GlslShaderGenerator::create());
-
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    context.registerSourceCodeSearchPath(currentPath);
-
+    context.registerSourceCodeSearchPath(mx::getDefaultDataSearchPath());
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
@@ -102,8 +99,7 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
 {
     mx::DocumentPtr doc = mx::createDocument();
 
-    mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath());
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     loadLibraries({ "libraries" }, searchPath, doc);
 
     mx::NodeDefPtr pointLightShader = doc->getNodeDef("ND_point_light");
@@ -146,20 +142,17 @@ const std::string GlslTypeToString(GlslType e) throw()
 
 static void generateGlslCode(GlslType type = GlslType::Glsl400)
 {
-    mx::FilePathVec testRootPaths;
-    testRootPaths.push_back("resources/Materials/TestSuite");
-    testRootPaths.push_back("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath();
-    const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
-    bool writeShadersToDisk = false;
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
-    const mx::GenOptions genOptions;
-    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
+    mx::FilePathVec testRootPaths;
+    testRootPaths.push_back(searchPath.find("resources/Materials/TestSuite"));
+    testRootPaths.push_back(searchPath.find("resources/Materials/Examples/StandardSurface"));
 
     const mx::FilePath logPath("genglsl_" + GlslTypeToString(type) + "_generate_test.txt");
 
+    bool writeShadersToDisk = false;
     GlslShaderGeneratorTester tester((type == GlslType::GlslVulkan) ? mx::VkShaderGenerator::create() : mx::GlslShaderGenerator::create(),
-                                     testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
+                                     testRootPaths, searchPath, logPath, writeShadersToDisk);
 
     // Add resource binding context for glsl 4.20
     if (type == GlslType::Glsl420)
@@ -170,6 +163,8 @@ static void generateGlslCode(GlslType type = GlslType::Glsl400)
         tester.addUserData(mx::HW::USER_DATA_BINDING_CONTEXT, glslresourceBinding);
     }
 
+    const mx::GenOptions genOptions;
+    mx::FilePath optionsFilePath = searchPath.find("resources/Materials/TestSuite/_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }
 

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
@@ -19,9 +19,8 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
     GlslShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
-                              const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
-                              const mx::FilePath& logFilePath, bool writeShadersToDisk) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
+                              const mx::FileSearchPath& searchPath, const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, searchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override
@@ -42,7 +41,7 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         ParentClass::setupDependentLibraries();
 
-        mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/lights");
+        mx::FilePath lightDir = mx::getDefaultDataSearchPath().find("resources/Materials/TestSuite/lights");
         loadLibrary(lightDir / mx::FilePath("light_compound_test.mtlx"), _dependLib);
         loadLibrary(lightDir / mx::FilePath("light_rig_test_1.mtlx"), _dependLib);
     }

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -112,9 +112,9 @@ class MdlStringResolver : public mx::StringResolver
         std::ofstream* logFile,
         std::initializer_list<mx::FilePath> additionalSearchpaths)
     {
-        // Note: These paths are based on
-        mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-        mx::FilePath coreModulePath = currentPath / std::string(MATERIALX_INSTALL_MDL_MODULE_PATH) / "mdl";
+        mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+        mx::FilePath rootPath = searchPath.isEmpty() ? mx::FilePath() : searchPath[0];
+        mx::FilePath coreModulePath = rootPath / std::string(MATERIALX_INSTALL_MDL_MODULE_PATH) / "mdl";
         mx::FilePath coreModulePath2 = coreModulePath / mx::FilePath("materialx");
 
         // use the source search paths as base
@@ -130,7 +130,7 @@ class MdlStringResolver : public mx::StringResolver
         }
 
         // add additional search paths for the tests
-        paths.append(currentPath);
+        paths.append(rootPath);
         paths.append(coreModulePath);
         paths.append(coreModulePath2);
         for (const auto& addSp : additionalSearchpaths)
@@ -209,7 +209,7 @@ void MdlShaderGeneratorTester::preprocessDocument(mx::DocumentPtr doc)
     if (!_mdlCustomResolver)
         _mdlCustomResolver = MdlStringResolver::create();
 
-    _mdlCustomResolver->initialize(doc, &_logFile, { _libSearchPath.asString() });
+    _mdlCustomResolver->initialize(doc, &_logFile, { _searchPath.asString() });
     mx::flattenFilenames(doc, _mdlCustomResolver->getMdlSearchPaths(), _mdlCustomResolver);
 }
 
@@ -282,18 +282,19 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
         renderCommand += " --mdl_path \"" + moduleToTestPath.asString() + "\"";
         renderCommand += " --mdl_path \"" + moduleToTestPath.getParentPath().asString() + "\"";
 
-        mx::FilePath currentPath = mx::FilePath::getCurrentPath();
+        mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+        mx::FilePath rootPath = searchPath.isEmpty() ? mx::FilePath() : searchPath[0];
         // set environment
-        std::string iblFile = (currentPath / "resources/lights/san_giuseppe_bridge.hdr").asString();
+        std::string iblFile = (rootPath / "resources/lights/san_giuseppe_bridge.hdr").asString();
         renderCommand += " --hdr \"" + iblFile + "\" --hdr_rotate 90";
         // set scene
         renderCommand += " --uv_scale 0.5 1.0 --uv_offset 0.0 0.0 --uv_repeat";
         renderCommand += " --camera 0 0 3 0 0 0 --fov 45";
 
         // set the material
-        // compute the MDL module name as fully qualified name wrt to the "currentPath/resources" as MDL search path
+        // compute the MDL module name as fully qualified name wrt to the "rootPath/resources" as MDL search path
         std::string mdlModuleName = "::resources::";
-        for (size_t s = currentPath.size() + 1; s < moduleToTestPath.size(); ++s)
+        for (size_t s = rootPath.size() + 1; s < moduleToTestPath.size(); ++s)
         {
             mdlModuleName += moduleToTestPath[s] + "::";
         }
@@ -348,24 +349,22 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
 
 TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
 {
-    mx::FilePathVec testRootPaths;
-    testRootPaths.push_back("resources/Materials/TestSuite");
-    testRootPaths.push_back("resources/Materials/Examples");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath srcSearchPath(libSearchPath.asString());
-    srcSearchPath.append(libSearchPath / mx::FilePath("libraries/stdlib/genmdl"));
+    mx::FilePathVec testRootPaths;
+    testRootPaths.push_back(searchPath.find("resources/Materials/TestSuite"));
+    testRootPaths.push_back(searchPath.find("resources/Materials/Examples/StandardSurface"));
 
     const mx::FilePath logPath("genmdl_mdl_generate_test.txt");
 
     // Write shaders and try to compile only if mdlc exe specified.
     std::string mdlcExec(MATERIALX_MDLC_EXECUTABLE);
     bool writeShadersToDisk = !mdlcExec.empty();
-    MdlShaderGeneratorTester tester(mx::MdlShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
+    MdlShaderGeneratorTester tester(mx::MdlShaderGenerator::create(), testRootPaths, searchPath, logPath, writeShadersToDisk);
     tester.addSkipLibraryFiles();
 
     mx::GenOptions genOptions;
     genOptions.targetColorSpaceOverride = "lin_rec709";
-    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
+    mx::FilePath optionsFilePath = searchPath.find("resources/Materials/TestSuite/_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
@@ -21,9 +21,8 @@ class MdlShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
     MdlShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const std::vector<mx::FilePath>& testRootPaths,
-                             const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath,
-                             const mx::FilePath& logFilePath, bool writeShadersToDisk) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
+                             const mx::FileSearchPath& searchPath, const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, searchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
@@ -90,20 +90,15 @@ TEST_CASE("GenShader: MSL Implementation Check", "[genmsl]")
 TEST_CASE("GenShader: MSL Unique Names", "[genmsl]")
 {
     mx::GenContext context(mx::MslShaderGenerator::create());
-
-    mx::FilePath searchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    context.registerSourceCodeSearchPath(searchPath);
-
+    context.registerSourceCodeSearchPath(mx::getDefaultDataSearchPath());
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
 TEST_CASE("GenShader: MSL Bind Light Shaders", "[genmsl]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-
-    mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
-    loadLibraries({ "targets", "stdlib", "pbrlib", "lights" }, searchPath, doc);
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
 
     mx::NodeDefPtr pointLightShader = doc->getNodeDef("ND_point_light");
     mx::NodeDefPtr spotLightShader = doc->getNodeDef("ND_spot_light");
@@ -111,7 +106,7 @@ TEST_CASE("GenShader: MSL Bind Light Shaders", "[genmsl]")
     REQUIRE(spotLightShader != nullptr);
 
     mx::GenContext context(mx::MslShaderGenerator::create());
-    context.registerSourceCodeSearchPath(mx::FilePath::getCurrentPath() / mx::FilePath("libraries"));
+    context.registerSourceCodeSearchPath(searchPath);
 
     mx::HwShaderGenerator::bindLightShader(*pointLightShader, 42, context);
     REQUIRE_THROWS(mx::HwShaderGenerator::bindLightShader(*spotLightShader, 42, context));
@@ -124,27 +119,22 @@ TEST_CASE("GenShader: MSL Bind Light Shaders", "[genmsl]")
 
 static void generateMslCode()
 {
-    const mx::FilePath testRootPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite");
-    const mx::FilePath testRootPath2 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface");
-    const mx::FilePath testRootPath3 = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/UsdPreviewSurface");
-    mx::FilePathVec testRootPaths;
-    testRootPaths.push_back(testRootPath);
-    testRootPaths.push_back(testRootPath2);
-    testRootPaths.push_back(testRootPath3);
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath() / mx::FilePath("libraries");
-    const mx::FileSearchPath srcSearchPath(libSearchPath.asString());
-    bool writeShadersToDisk = false;
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
-    const mx::GenOptions genOptions;
-    mx::FilePath optionsFilePath = testRootPath / mx::FilePath("_options.mtlx");
+    mx::FilePathVec testRootPaths;
+    testRootPaths.push_back(searchPath.find("resources/Materials/TestSuite"));
+    testRootPaths.push_back(searchPath.find("resources/Materials/Examples/StandardSurface"));
 
     const mx::FilePath logPath("genmsl_msl23_layout_generate_test.txt");
 
-    MslShaderGeneratorTester tester(mx::MslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
+    bool writeShadersToDisk = false;
+    MslShaderGeneratorTester tester(mx::MslShaderGenerator::create(), testRootPaths, searchPath, logPath, writeShadersToDisk);
 
     // Set binding context to handle resource binding layouts
     tester.addUserData(mx::HW::USER_DATA_BINDING_CONTEXT, mx::MslResourceBindingContext::create());
     
+    const mx::GenOptions genOptions;
+    mx::FilePath optionsFilePath = searchPath.find("resources/Materials/TestSuite/_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }
 

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
@@ -23,9 +23,8 @@ class MslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
     MslShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
-                              const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
-                              const mx::FilePath& logFilePath, bool writeShadersToDisk) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
+                             const mx::FileSearchPath& searchPath, const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, searchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override
@@ -46,7 +45,7 @@ class MslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         ParentClass::setupDependentLibraries();
 
-        mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/lights");
+        mx::FilePath lightDir = mx::getDefaultDataSearchPath().find("resources/Materials/TestSuite/lights");
         loadLibrary(lightDir / mx::FilePath("light_compound_test.mtlx"), _dependLib);
         loadLibrary(lightDir / mx::FilePath("light_rig_test_1.mtlx"), _dependLib);
     }

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -95,18 +95,13 @@ TEST_CASE("GenShader: OSL Implementation Check", "[genosl]")
 TEST_CASE("GenShader: OSL Unique Names", "[genosl]")
 {
     mx::GenContext context(mx::OslShaderGenerator::create());
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    context.registerSourceCodeSearchPath(currentPath);
-    context.registerSourceCodeSearchPath(currentPath / mx::FilePath("libraries/stdlib/genosl/include"));
-
+    context.registerSourceCodeSearchPath(mx::getDefaultDataSearchPath());
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
 TEST_CASE("GenShader: OSL Metadata", "[genosl]")
 {
-    mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath());
-
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
     mx::loadLibraries({ "libraries" }, searchPath, doc);
 
@@ -176,33 +171,27 @@ TEST_CASE("GenShader: OSL Metadata", "[genosl]")
     // Custom generators can override this method to customize which metadata gets registered.
     generator->registerShaderMetadata(doc, context);
 
-    // Generate the shader and write to file for inspection.
+    // Generate the shader.
     mx::ShaderPtr shader = generator->generate(stdSurf1->getName(), stdSurf1, context);
     REQUIRE(shader != nullptr);
-    const std::string filepath = mx::FilePath::getCurrentPath() / mx::FilePath("standardSurfaceWithMetadata.osl");
-    std::ofstream file;
-    file.open(filepath);
-    file << shader->getSourceCode();
 }
 
 static void generateOslCode()
 {
-    mx::FilePathVec testRootPaths;
-    testRootPaths.push_back("resources/Materials/TestSuite");
-    testRootPaths.push_back("resources/Materials/Examples");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
-    const mx::FilePath libSearchPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath srcSearchPath(libSearchPath.asString());
-    srcSearchPath.append(libSearchPath / mx::FilePath("libraries/stdlib/genosl/include"));
-    srcSearchPath.append(mx::FilePath::getCurrentPath());
+    mx::FilePathVec testRootPaths;
+    testRootPaths.push_back(searchPath.find("resources/Materials/TestSuite"));
+    testRootPaths.push_back(searchPath.find("resources/Materials/Examples/StandardSurface"));
+
     const mx::FilePath logPath("genosl_vanilla_generate_test.txt");
 
     bool writeShadersToDisk = false;
-    OslShaderGeneratorTester tester(mx::OslShaderGenerator::create(), testRootPaths, libSearchPath, srcSearchPath, logPath, writeShadersToDisk);
+    OslShaderGeneratorTester tester(mx::OslShaderGenerator::create(), testRootPaths, searchPath, logPath, writeShadersToDisk);
     tester.addSkipLibraryFiles();
 
     const mx::GenOptions genOptions;
-    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
+    mx::FilePath optionsFilePath = searchPath.find("resources/Materials/TestSuite/_options.mtlx");
     tester.validate(genOptions, optionsFilePath);
 }
 

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
@@ -19,9 +19,8 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     using ParentClass = GenShaderUtil::ShaderGeneratorTester;
 
     OslShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const std::vector<mx::FilePath>& testRootPaths,
-                             const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath,
-                             const mx::FilePath& logFilePath, bool writeShadersToDisk) :
-        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, libSearchPath, srcSearchPath, logFilePath, writeShadersToDisk)
+                             const mx::FileSearchPath& searchPath, const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+        GenShaderUtil::ShaderGeneratorTester(shaderGenerator, testRootPaths, searchPath, logFilePath, writeShadersToDisk)
     {}
 
     void setTestStages() override

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -58,11 +58,9 @@ TEST_CASE("GenShader: Utilities", "[genshader]")
 
 TEST_CASE("GenShader: Valid Libraries", "[genshader]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr doc = mx::createDocument();
-
-    mx::FileSearchPath searchPath;
-    searchPath.append(mx::FilePath::getCurrentPath());
-    loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib" }, searchPath, doc);
+    loadLibraries({ "libraries" }, searchPath, doc);
 
     std::string validationErrors;
     bool valid = doc->validate(&validationErrors);
@@ -109,11 +107,10 @@ TEST_CASE("GenShader: TypeDesc Check", "[genshader]")
 
 TEST_CASE("GenShader: Shader Translation", "[translate]")
 {
-    const mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath searchPath(currentPath);
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::ShaderTranslatorPtr shaderTranslator = mx::ShaderTranslator::create();
 
-    mx::FilePath testPath = currentPath / mx::FilePath("resources/Materials/Examples/StandardSurface");
+    mx::FilePath testPath = searchPath.find("resources/Materials/Examples/StandardSurface");
     for (mx::FilePath& mtlxFile : testPath.getFilesInDirectory(mx::MTLX_EXTENSION))
     {
         mx::DocumentPtr doc = mx::createDocument();
@@ -147,12 +144,11 @@ TEST_CASE("GenShader: Shader Translation", "[translate]")
 
 TEST_CASE("GenShader: Transparency Regression Check", "[genshader]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr libraries = mx::createDocument();
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath searchPath(currentPath);
     mx::loadLibraries({ "libraries" }, searchPath, libraries);
 
-    const mx::FilePath resourcePath(currentPath / "resources");
+    const mx::FilePath resourcePath = searchPath.find("resources");
     mx::StringVec failedTests;
     mx::FilePathVec testFiles = { 
         "Materials/Examples/StandardSurface/standard_surface_default.mtlx", 
@@ -200,8 +196,9 @@ TEST_CASE("GenShader: Transparency Regression Check", "[genshader]")
 
 void testDeterministicGeneration(mx::DocumentPtr libraries, mx::GenContext& context)
 {
-    const mx::FilePath testFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx");
-    const mx::string testElement = "SR_marble1";
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath testFile = searchPath.find("resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx");
+    mx::string testElement = "SR_marble1";
 
     const size_t numRuns = 10;
     mx::vector<mx::DocumentPtr> testDocs(numRuns);
@@ -234,9 +231,9 @@ void testDeterministicGeneration(mx::DocumentPtr libraries, mx::GenContext& cont
 
 TEST_CASE("GenShader: Deterministic Generation", "[genshader]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr libraries = mx::createDocument();
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
-    mx::loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib", "libraries/bxdf" }, searchPath, libraries);
+    mx::loadLibraries({ "libraries" }, searchPath, libraries);
 
 #ifdef MATERIALX_BUILD_GEN_GLSL
     {
@@ -270,8 +267,9 @@ TEST_CASE("GenShader: Deterministic Generation", "[genshader]")
 
 void checkPixelDependencies(mx::DocumentPtr libraries, mx::GenContext& context)
 {
-    const mx::FilePath testFile = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/Examples/GltfPbr/gltf_pbr_boombox.mtlx");
-    const mx::string testElement = "Material_boombox";
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath testFile = searchPath.find("resources/Materials/Examples/GltfPbr/gltf_pbr_boombox.mtlx");
+    mx::string testElement = "Material_boombox";
 
     mx::DocumentPtr testDoc = mx::createDocument();
     mx::readFromXmlFile(testDoc, testFile);
@@ -290,9 +288,9 @@ void checkPixelDependencies(mx::DocumentPtr libraries, mx::GenContext& context)
 
 TEST_CASE("GenShader: Track Dependencies", "[genshader]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr libraries = mx::createDocument();
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
-    mx::loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib", "libraries/bxdf" }, searchPath, libraries);
+    mx::loadLibraries({ "libraries" }, searchPath, libraries);
 
 #ifdef MATERIALX_BUILD_GEN_GLSL
     {
@@ -382,9 +380,9 @@ TEST_CASE("GenShader: Track Application Variables", "[genshader]")
 
     const mx::string testElement = "surfacematerial";
 
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr libraries = mx::createDocument();
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
-    mx::loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib", "libraries/bxdf" }, searchPath, libraries);
+    mx::loadLibraries({ "libraries" }, searchPath, libraries);
 
     mx::DocumentPtr testDoc = mx::createDocument();
     mx::readFromXmlString(testDoc, testDocumentString);

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -70,11 +70,11 @@ void checkImplementations(mx::GenContext& context,
                           const mx::StringSet& generatorSkipNodeDefs,
                           unsigned int expectedSkipCount)
 {
-    mx::DocumentPtr doc = mx::createDocument();
 
     const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr doc = mx::createDocument();
     loadLibraries({ "libraries/targets", "libraries/stdlib", "libraries/pbrlib" }, searchPath, doc);
 
     const std::string& target = shadergen.getTarget();
@@ -280,7 +280,7 @@ void testUniqueNames(mx::GenContext& context, const std::string& stage)
 {
     mx::DocumentPtr doc = mx::createDocument();
 
-    mx::FileSearchPath searchPath(mx::FilePath::getCurrentPath());
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     loadLibraries({ "libraries/targets", "libraries/stdlib" }, searchPath, doc);
 
     const std::string exampleName = "unique_names";
@@ -478,7 +478,7 @@ void ShaderGeneratorTester::setupDependentLibraries()
     _dependLib = mx::createDocument();
 
     // Load the standard libraries.
-    loadLibraries({ "libraries" }, _libSearchPath, _dependLib, _skipLibraryFiles);
+    loadLibraries({ "libraries" }, _searchPath, _dependLib, _skipLibraryFiles);
 }
 
 void ShaderGeneratorTester::addSkipFiles()
@@ -603,10 +603,9 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
 
     // Load in all documents to test
     mx::StringVec errorLog;
-    mx::FileSearchPath searchPath(_libSearchPath);
     for (const auto& testRoot : _testRootPaths)
     {
-        mx::loadDocuments(testRoot, searchPath, _skipFiles, overrideFiles, _documents, _documentPaths, 
+        mx::loadDocuments(testRoot, _searchPath, _skipFiles, overrideFiles, _documents, _documentPaths, 
                           nullptr, &errorLog);
     }
     CHECK(errorLog.empty());
@@ -627,7 +626,7 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
     // Create our context
     mx::GenContext context(_shaderGenerator);
     context.getOptions() = generateOptions;
-    context.registerSourceCodeSearchPath(_srcSearchPath);
+    context.registerSourceCodeSearchPath(_searchPath);
 
     // Register shader metadata defined in the libraries.
     _shaderGenerator->registerShaderMetadata(_dependLib, context);
@@ -783,7 +782,8 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
                         }
                         else
                         {
-                            path = mx::FilePath::getCurrentPath();
+                            mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+                            path = searchPath.isEmpty() ? mx::FilePath() : searchPath[0];
                         }
 
                         std::vector<mx::FilePath> sourceCodePaths;

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -156,13 +156,11 @@ class ShaderGeneratorTester
 {
   public:
     ShaderGeneratorTester(mx::ShaderGeneratorPtr shaderGenerator, const mx::FilePathVec& testRootPaths, 
-                            const mx::FilePath& libSearchPath, const mx::FileSearchPath& srcSearchPath, 
-                            const mx::FilePath& logFilePath, bool writeShadersToDisk) :
+                          const mx::FileSearchPath& searchPath, const mx::FilePath& logFilePath, bool writeShadersToDisk) :
         _shaderGenerator(shaderGenerator),
         _targetString(shaderGenerator ? shaderGenerator->getTarget() : "NULL"),
         _testRootPaths(testRootPaths),
-        _libSearchPath(libSearchPath),
-        _srcSearchPath(srcSearchPath),
+        _searchPath(searchPath),
         _logFilePath(logFilePath),
         _writeShadersToDisk(writeShadersToDisk)
     {
@@ -251,8 +249,7 @@ class ShaderGeneratorTester
     mx::DocumentPtr _dependLib;
 
     const mx::FilePathVec _testRootPaths;
-    const mx::FileSearchPath _libSearchPath;
-    const mx::FileSearchPath _srcSearchPath;
+    const mx::FileSearchPath _searchPath;
     const mx::FilePath _logFilePath;
     bool _writeShadersToDisk;
 

--- a/source/MaterialXTest/MaterialXRender/Render.cpp
+++ b/source/MaterialXTest/MaterialXRender/Render.cpp
@@ -11,6 +11,8 @@
 #include <MaterialXRender/TinyObjLoader.h>
 #include <MaterialXRender/Types.h>
 
+#include <MaterialXFormat/Util.h>
+
 #ifdef MATERIALX_BUILD_OIIO
 #include <MaterialXRender/OiioImageLoader.h>
 #endif
@@ -82,7 +84,8 @@ struct GeomHandlerTestOptions
 
 void testGeomHandler(GeomHandlerTestOptions& options)
 {
-    mx::FilePath imagePath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry/");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath imagePath = searchPath.find("resources/Geometry/");
     mx::FilePathVec files;
 
     unsigned int loadFailed = 0;
@@ -156,7 +159,8 @@ struct ImageHandlerTestOptions
 
 void testImageHandler(ImageHandlerTestOptions& options)
 {
-    mx::FilePath imagePath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Images/");
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath imagePath = searchPath.find("resources/Images/");
     mx::FilePathVec files;
 
     unsigned int loadFailed = 0;

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -132,22 +132,20 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
         testfileOverride.insert(filterFile);
     }
 
+    // Data search path
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+
     mx::ScopedTimer ioTimer(&profileTimes.ioTime);
     mx::FilePathVec dirs;
     for (const auto& root : options.renderTestPaths)
     {
-        mx::FilePathVec testRootDirs = root.getSubDirectories();
+        mx::FilePathVec testRootDirs = searchPath.find(root).getSubDirectories();
         dirs.insert(std::end(dirs), std::begin(testRootDirs), std::end(testRootDirs));
     }
     ioTimer.endTimer();
 
     // Add files to skip
     addSkipFiles();
-
-    // Library search path
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath searchPath;
-    searchPath.append(currentPath);
 
     // Load in the library dependencies once
     // This will be imported in each test document below
@@ -177,8 +175,8 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
     _shaderGenerator->getUnitSystem()->setUnitConverterRegistry(registry);
 
     mx::GenContext context(_shaderGenerator);
-    context.registerSourceCodeSearchPath(currentPath);
-    context.registerSourceCodeSearchPath(currentPath / mx::FilePath("libraries/stdlib/genosl/include"));
+    context.registerSourceCodeSearchPath(searchPath);
+    context.registerSourceCodeSearchPath(searchPath.find("libraries/stdlib/genosl/include"));
 
     // Set target unit space
     context.getOptions().targetDistanceUnit = "meter";

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -73,7 +73,7 @@ class GlslShaderRenderTester : public RenderUtil::ShaderRenderTester
 void GlslShaderRenderTester::loadAdditionalLibraries(mx::DocumentPtr document,
                                                      GenShaderUtil::TestSuiteOptions& options)
 {
-    mx::FilePath lightDir = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Materials/TestSuite/lights");
+    mx::FilePath lightDir = mx::getDefaultDataSearchPath().find("resources/Materials/TestSuite/lights");
     for (const auto& lightFile : options.lightFiles)
     {
         loadLibrary(lightDir / mx::FilePath(lightFile), document);
@@ -128,6 +128,7 @@ void GlslShaderRenderTester::createRenderer(std::ostream& log)
         // Set image handler on renderer
         mx::StbImageLoaderPtr stbLoader = mx::StbImageLoader::create();
         mx::ImageHandlerPtr imageHandler = _renderer->createImageHandler(stbLoader);
+        imageHandler->setSearchPath(mx::getDefaultDataSearchPath());
 #if defined(MATERIALX_BUILD_OIIO)
         mx::OiioImageLoaderPtr oiioLoader = mx::OiioImageLoader::create();
         imageHandler->addLoader(oiioLoader);
@@ -174,6 +175,7 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
     mx::ScopedTimer totalGLSLTime(&profileTimes.languageTimes.totalTime);
 
     const mx::ShaderGenerator& shadergen = context.getShaderGenerator();
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
     // Perform validation if requested
     if (testOptions.validateElementToRender)
@@ -271,7 +273,7 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                 {
                     if (!testOptions.renderGeometry.isAbsolute())
                     {
-                        geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry") / testOptions.renderGeometry;
+                        geomPath = searchPath.find("resources/Geometry") / testOptions.renderGeometry;
                     }
                     else
                     {
@@ -280,7 +282,7 @@ bool GlslShaderRenderTester::runRenderer(const std::string& shaderName,
                 }
                 else
                 {
-                    geomPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Geometry/sphere.obj");
+                    geomPath = searchPath.find("resources/Geometry/sphere.obj");
                 }
 
                 if (!geomHandler->hasGeometry(geomPath))
@@ -450,9 +452,9 @@ void GlslShaderRenderTester::runBake(mx::DocumentPtr doc, const mx::FileSearchPa
 
 TEST_CASE("Render: GLSL TestSuite", "[renderglsl]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath optionsFilePath = searchPath.find("resources/Materials/TestSuite/_options.mtlx");
+
     GlslShaderRenderTester renderTester(mx::GlslShaderGenerator::create());
-
-    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
-
     renderTester.validate(optionsFilePath);
 }

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -22,9 +22,8 @@ namespace mx = MaterialX;
 
 TEST_CASE("GenReference: OSL Reference", "[genreference]")
 {
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr stdlib = mx::createDocument();
-    mx::FilePath currentPath = mx::FilePath::getCurrentPath();
-    mx::FileSearchPath searchPath(currentPath);
     loadLibraries({ "libraries/targets", "libraries/stdlib" }, searchPath, stdlib);
 
     // Create renderer if requested.
@@ -38,7 +37,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
         oslIncludePaths.append(mx::FilePath(MATERIALX_OSL_INCLUDE_PATH));
         // Add in library include path for compile testing as the generated
         // shader's includes are not added with absolute paths.
-        oslIncludePaths.append(currentPath / mx::FilePath("libraries/stdlib/genosl/include"));
+        oslIncludePaths.append(searchPath.find("libraries/stdlib/genosl/include"));
         oslRenderer->setOslIncludePath(oslIncludePaths);
     }
 
@@ -46,11 +45,11 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     mx::ShaderGeneratorPtr generator = mx::OslShaderGenerator::create();
     mx::GenContext context(generator);
     context.getOptions().addUpstreamDependencies = false;
-    context.registerSourceCodeSearchPath(currentPath);
+    context.registerSourceCodeSearchPath(searchPath);
     context.getOptions().fileTextureVerticalFlip = true;
 
     // Create output directory.
-    mx::FilePath outputPath = mx::FilePath::getCurrentPath() / mx::FilePath("reference/osl");
+    mx::FilePath outputPath = searchPath.find("reference/osl");
     outputPath.getParentPath().createDirectory();
     outputPath.createDirectory();
 

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -15,6 +15,8 @@
 
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 
+#include <MaterialXFormat/Util.h>
+
 namespace mx = MaterialX;
 
 namespace
@@ -132,6 +134,7 @@ void OslShaderRenderTester::createRenderer(std::ostream& log)
 
         mx::StbImageLoaderPtr stbLoader = mx::StbImageLoader::create();
         mx::ImageHandlerPtr imageHandler = mx::ImageHandler::create(stbLoader);
+        imageHandler->setSearchPath(mx::getDefaultDataSearchPath());
 #if defined(MATERIALX_BUILD_OIIO)
         mx::OiioImageLoaderPtr oiioLoader = mx::OiioImageLoader::create();
         imageHandler->addLoader(oiioLoader);
@@ -143,7 +146,8 @@ void OslShaderRenderTester::createRenderer(std::ostream& log)
         // Pre-compile some required shaders for testrender
         if (!oslcExecutable.empty() && !testRenderExecutable.empty())
         {
-            mx::FilePath shaderPath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Utilities/");
+            mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+            mx::FilePath shaderPath = searchPath.find("resources/Utilities/");
             _renderer->setOslOutputFilePath(shaderPath);
 
             const std::string OSL_EXTENSION("osl");
@@ -309,7 +313,8 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                         _renderer->setOslShaderOutput(outputName, outputType);
 
                         // Set scene template file. For now we only have the constant color scene file
-                        mx::FilePath sceneTemplatePath = mx::FilePath::getCurrentPath() / mx::FilePath("resources/Utilities/");
+                        mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+                        mx::FilePath sceneTemplatePath = searchPath.find("resources/Utilities/");
                         sceneTemplatePath = sceneTemplatePath / sceneTemplateFile;
                         _renderer->setOslTestRenderSceneTemplateFile(sceneTemplatePath.asString());
 
@@ -366,9 +371,9 @@ TEST_CASE("Render: OSL TestSuite", "[renderosl]")
         return;
     }
 
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath optionsFilePath = searchPath.find("resources/Materials/TestSuite/_options.mtlx");
+
     OslShaderRenderTester renderTester(mx::OslShaderGenerator::create());
-
-    mx::FilePath optionsFilePath("resources/Materials/TestSuite/_options.mtlx");
-
     renderTester.validate(optionsFilePath);
 }


### PR DESCRIPTION
- Remove dependencies of MaterialXTest on the current working directory, allowing it to be launched from any location.
- Use getDefaultDataSearchPath to access search paths in MaterialXTest, aligning its behavior with that of other applications.
- Merge the concepts of library and source search paths in render testing.