### PR TITLE
Align default values for conductor_bsdf with specification

### DIFF
--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -76,8 +76,8 @@
   -->
   <nodedef name="ND_conductor_bsdf" node="conductor_bsdf" bsdf="R" nodegroup="pbr" doc="A reflection BSDF node based on a microfacet model and a Fresnel curve for conductors/metals.">
     <input name="weight" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="ior" type="color3" value="0.271, 0.677, 1.316" colorspace="none" />
-    <input name="extinction" type="color3" value="3.609, 2.625, 2.292" colorspace="none" />
+    <input name="ior" type="color3" value="0.183, 0.421, 1.373" colorspace="none" />
+    <input name="extinction" type="color3" value="3.424, 2.346, 1.770" colorspace="none" />
     <input name="roughness" type="vector2" value="0.05, 0.05" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
     <input name="tangent" type="vector3" defaultgeomprop="Tworld" />


### PR DESCRIPTION
The default values on the nodedef for `consductor_bsdf` was by mistake setup for Copper while the specification has values set for Gold. This change list fixes this by changing the nodedef values to align with the specification.
