### PR TITLE
Assign unique names to MDL implementations

### DIFF
--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -614,8 +614,8 @@
   <implementation name="IM_mix_vector4_genmdl" nodedef="ND_mix_vector4" sourcecode="math::lerp({{bg}}, {{fg}}, {{mix}})" target="genmdl" />
   <implementation name="IM_mix_vector4_vector4_genmdl" nodedef="ND_mix_vector4_vector4" sourcecode="math::lerp({{bg}}, {{fg}}, {{mix}})" target="genmdl" />
   <implementation name="IM_mix_surfaceshader_genmdl" nodedef="ND_mix_surfaceshader" sourcecode="mx::stdlib::mx_mix_surfaceshader({{fg}}, {{bg}}, {{mix}})" target="genmdl" />
-  <implementation name="IM_mix_surfaceshader_genmdl" nodedef="ND_mix_volumeshader" sourcecode="mx::stdlib::mx_mix_volumeshader({{fg}}, {{bg}}, {{mix}})" target="genmdl" />
-  <implementation name="IM_mix_surfaceshader_genmdl" nodedef="ND_mix_displacementshader" sourcecode="mx::stdlib::mx_mix_displacementshader({{fg}}, {{bg}}, {{mix}})" target="genmdl" />
+  <implementation name="IM_mix_volumeshader_genmdl" nodedef="ND_mix_volumeshader" sourcecode="mx::stdlib::mx_mix_volumeshader({{fg}}, {{bg}}, {{mix}})" target="genmdl" />
+  <implementation name="IM_mix_displacementshader_genmdl" nodedef="ND_mix_displacementshader" sourcecode="mx::stdlib::mx_mix_displacementshader({{fg}}, {{bg}}, {{mix}})" target="genmdl" />
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -81,7 +81,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
             continue;
         }
 
-        mx::InterfaceElementPtr interface = nodedef->getImplementation();
+        mx::InterfaceElementPtr interface = nodedef->getImplementation(generator->getTarget());
         if (!interface)
         {
             logFile << "Skip generating reference for unimplemented node '" << nodeName << "'" << std::endl;


### PR DESCRIPTION
This change list addresses issue #1354, renaming the implementation elements to unique names.