### PR TITLE
Expose GLTF loader in Python

### DIFF
--- a/source/PyMaterialX/PyMaterialXRender/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyModule.cpp
@@ -19,6 +19,7 @@ void bindPyOiioImageLoader(py::module& mod);
 void bindPyTinyObjLoader(py::module& mod);
 void bindPyCamera(py::module& mod);
 void bindPyShaderRenderer(py::module& mod);
+void bindPyCgltfLoader(py::module& mod);
 
 PYBIND11_MODULE(PyMaterialXRender, mod)
 {
@@ -36,4 +37,5 @@ PYBIND11_MODULE(PyMaterialXRender, mod)
     bindPyTinyObjLoader(mod);
     bindPyCamera(mod);
     bindPyShaderRenderer(mod);
+    bindPyCgltfLoader(mod);
 }


### PR DESCRIPTION
Add GLTF loader to Python build so it's available.
> Note to @jstone-lucasfilm. Just adding file forgot to add to last PR for rendering API update #1386  