### PR TITLE
Improvements to mxformat.py example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,7 +203,7 @@ jobs:
       run: |
         python MaterialXTest/main.py
         python MaterialXTest/genshader.py
-        python Scripts/mxformat.py ../resources/Materials/TestSuite/stdlib/upgrade --yes --upgradeVersion True
+        python Scripts/mxformat.py ../resources/Materials/TestSuite/stdlib/upgrade --yes --upgrade
         python Scripts/mxvalidate.py ../resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx --stdlib --verbose
         python Scripts/mxdoc.py --docType md ../libraries/pbrlib/pbrlib_defs.mtlx
         python Scripts/mxdoc.py --docType html ../libraries/bxdf/standard_surface.mtlx

--- a/libraries/lights/genmsl/lights_genmsl_impl.mtlx
+++ b/libraries/lights/genmsl/lights_genmsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.37">
+<materialx version="1.38">
 
   <!-- <point_light> -->
   <implementation name="IM_point_light_genmsl" nodedef="ND_point_light" file="mx_point_light.metal" function="mx_point_light" target="genmsl" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2280,7 +2280,7 @@
     <input name="in2" type="vector4" uiname="in2" value="0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="float" />
   </nodedef>
-  
+
   <!--
     Node: <dotproduct>
     Perform a dot product of two 2-4 channel vectors

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -291,7 +291,7 @@
     <dotproduct name="N_dotBlendedN" type="float">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </dotproduct> 
+    </dotproduct>
     <divide name="N_normalizeBlendedWeights" type="vector3">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="float" nodename="N_dotBlendedN" />
@@ -411,7 +411,7 @@
     <dotproduct name="N_dotBlendedN" type="float">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </dotproduct> 
+    </dotproduct>
     <divide name="N_normalizeBlendedWeights" type="vector3">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="float" nodename="N_dotBlendedN" />
@@ -531,7 +531,7 @@
     <dotproduct name="N_dotBlendedN" type="float">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </dotproduct> 
+    </dotproduct>
     <divide name="N_normalizeBlendedWeights" type="vector3">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="float" nodename="N_dotBlendedN" />
@@ -651,7 +651,7 @@
     <dotproduct name="N_dotBlendedN" type="float">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </dotproduct> 
+    </dotproduct>
     <divide name="N_normalizeBlendedWeights" type="vector3">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="float" nodename="N_dotBlendedN" />
@@ -771,7 +771,7 @@
     <dotproduct name="N_dotBlendedN" type="float">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </dotproduct> 
+    </dotproduct>
     <divide name="N_normalizeBlendedWeights" type="vector3">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="float" nodename="N_dotBlendedN" />
@@ -891,7 +891,7 @@
     <dotproduct name="N_dotBlendedN" type="float">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </dotproduct> 
+    </dotproduct>
     <divide name="N_normalizeBlendedWeights" type="vector3">
       <input name="in1" type="vector3" nodename="N_blendPower" />
       <input name="in2" type="float" nodename="N_dotBlendedN" />
@@ -1540,7 +1540,7 @@
     </magnitude>
     <output name="out" type="float" nodename="N_mtlxmagnitude" />
   </nodegraph>
-  
+
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
   <!-- ======================================================================== -->

--- a/python/Scripts/mxformat.py
+++ b/python/Scripts/mxformat.py
@@ -1,49 +1,38 @@
 #!/usr/bin/env python
 '''
-Format MaterialX document content by reanding and writing files. Optionally
-upgrade the document version. 
+Reformat a folder of MaterialX documents in place, optionally upgrading
+the documents to the latest version of the standard.
 '''
 
 import sys, os, argparse
 import MaterialX as mx
 
-def getFiles(rootPath):
-    filelist = []
-    for subdir, dirs, files in os.walk(rootPath):
-        for file in files:
-            if file.endswith('mtlx'):
-                filelist.append(os.path.join(subdir, file)) 
-    return filelist
-
 def main():
-    parser = argparse.ArgumentParser(description="Format document by reading the file and writing it back out. Optionally update to the latest version.")
+    parser = argparse.ArgumentParser(description="Reformat a folder of MaterialX documents in place.")
     parser.add_argument("--yes", dest="yes", action="store_true", help="Proceed without asking for confirmation from the user.")
-    parser.add_argument('--checkForChanges', dest='checkForChanges', type=mx.stringToBoolean, default=True, help='Check if a file has changed. Default is True')
-    parser.add_argument('--upgradeVersion', dest='upgradeVersion', type=mx.stringToBoolean, default=False, help='Upgrade the document version. Default is False')
+    parser.add_argument('--upgrade', dest='upgrade', action="store_true", help='Upgrade documents to the latest version of the standard.')
     parser.add_argument(dest="inputFolder", help="An input folder to scan for MaterialX documents.")
     opts = parser.parse_args()
 
-    fileList = []
-    rootPath = opts.inputFolder
-    if os.path.isdir(rootPath): 
-        fileList = getFiles(rootPath)
-    else:
-        fileList.append(rootPath)
-
-    # Preserve version, comments and newlines
-    readOptions = mx.XmlReadOptions()
-    readOptions.readComments = True
-    readOptions.readNewlines = True    
-    readOptions.upgradeVersion = opts.upgradeVersion
-
     validDocs = dict()
-    for filename in fileList:
-        doc = mx.createDocument()
-        try:
-            mx.readFromXmlFile(doc, filename, mx.FileSearchPath(), readOptions)
-            validDocs[filename] = doc
-        except mx.Exception:
-            pass
+    for root, dirs, files in os.walk(opts.inputFolder):
+        for file in files:
+            if file.endswith('.mtlx'):
+                filename = os.path.join(root, file)
+                doc = mx.createDocument()
+                try:
+                    readOptions = mx.XmlReadOptions()
+                    readOptions.readComments = True
+                    readOptions.readNewlines = True    
+                    readOptions.upgradeVersion = opts.upgrade
+                    try:
+                        mx.readFromXmlFile(doc, filename, mx.FileSearchPath(), readOptions)
+                    except Exception as err:
+                        print('Skipping "' + file + '" due to exception: ' + str(err))
+                        continue
+                    validDocs[filename] = doc
+                except mx.Exception:
+                    pass
 
     if not validDocs:
         print('No MaterialX documents were found in "%s"' % (opts.inputFolder))
@@ -54,31 +43,21 @@ def main():
     mxVersion = mx.getVersionIntegers()
 
     if not opts.yes:
-        question = 'Would you like to update all %i documents in place (y/n)?' % len(validDocs)
-        if opts.upgradeVersion:
-            question = 'Would you like to update all %i documents to MaterialX v%i.%i in place (y/n)?' % (len(validDocs), mxVersion[0], mxVersion[1])
+        if opts.upgrade:
+            question = 'Would you like to upgrade all %i documents to MaterialX v%i.%i in place (y/n)?' % (len(validDocs), mxVersion[0], mxVersion[1])
+        else:
+            question = 'Would you like to reformat all %i documents in place (y/n)?' % len(validDocs)
         answer = input(question)
         if answer != 'y' and answer != 'Y':
             return
 
-    writeCount = 0
     for (filename, doc) in validDocs.items():
-        writeFile = True
-        if opts.checkForChanges:
-            origString = mx.readFile(filename)
-            docString = mx.writeToXmlString(doc)
-            if origString == docString:
-                writeFile = False
+        mx.writeToXmlFile(doc, filename)
 
-        if writeFile:
-            writeCount = writeCount + 1
-            print('- Updated file %s.' % filename)
-            mx.writeToXmlFile(doc, filename)
-
-    if opts.upgradeVersion:
-        print('Updated %i documents to MaterialX v%i.%i' % (writeCount, mxVersion[0], mxVersion[1]))
+    if opts.upgrade:
+        print('Upgraded %i documents to MaterialX v%i.%i' % (len(validDocs), mxVersion[0], mxVersion[1]))
     else:
-        print('Updated %i documents ' % writeCount)
+        print('Reformatted %i documents ' % len(validDocs))
 
 if __name__ == '__main__':
     main()

--- a/resources/Lights/goegap_split.mtlx
+++ b/resources/Lights/goegap_split.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.37">
+<materialx version="1.38">
   <directional_light name="dir_light" type="lightshader">
     <input name="direction" type="vector3" value="0.43277, -0.725547, -0.535062" />
     <input name="color" type="color3" value="0.993688, 1, 0.993529" />

--- a/resources/Lights/san_giuseppe_bridge_split.mtlx
+++ b/resources/Lights/san_giuseppe_bridge_split.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.37">
+<materialx version="1.38">
   <directional_light name="dir_light" type="lightshader">
     <input name="direction" type="vector3" value="0.514434, -0.479014, -0.711269" />
     <input name="color" type="color3" value="1, 0.894474, 0.567234" />

--- a/resources/Lights/table_mountain_split.mtlx
+++ b/resources/Lights/table_mountain_split.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.37">
+<materialx version="1.38">
   <directional_light name="dir_light" type="lightshader">
     <input name="direction" type="vector3" value="0.757663, -0.126589, -0.640251" />
     <input name="color" type="color3" value="1, 0.844753, 0.418417" />

--- a/resources/Materials/TestSuite/stdlib/upgrade/1_36_to_1_37.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/1_36_to_1_37.mtlx
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<!--
-
-Upgrade path test from 1.36 to 1.37
-
--->
 <materialx version="1.36">
+  <!--
+
+  Upgrade path test from 1.36 to 1.37
+
+  -->
 
   <!-- invert matrix to invertmatrix -->
   <invert name="invert1" type="matrix33">


### PR DESCRIPTION
- Simplify the functionality of mxformat.py, making it a more straightforward example of MaterialX Python usage.
- Add exception handling to mxformat.py, allowing it to skip documents that cannot be parsed.
- Reformat and upgrade a handful of additional documents in the repository.