### PR TITLE
Fix bug in BSDF code gen for HW languages

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -148,11 +148,6 @@
     <!-- Thin-film + Dielectric
          Note: Due to limitations in codegen, the base layer BSDF is duplicated (#1035). -->
 
-    <oren_nayar_diffuse_bsdf name="tf_diffuse_bsdf" type="BSDF">
-      <input name="color" type="color3" interfacename="base_color" />
-      <input name="normal" type="vector3" interfacename="normal" />
-    </oren_nayar_diffuse_bsdf>
-
     <dielectric_bsdf name="tf_transmission_bsdf" type="BSDF">
       <input name="weight" type="float" value="1" />
       <input name="tint" type="color3" interfacename="base_color" />
@@ -173,7 +168,7 @@
     </generalized_schlick_bsdf>
 
     <mix name="tf_transmission_mix" type="BSDF">
-      <input name="bg" type="BSDF" nodename="tf_diffuse_bsdf" />
+      <input name="bg" type="BSDF" nodename="diffuse_bsdf" />
       <input name="fg" type="BSDF" nodename="tf_transmission_bsdf" />
       <input name="mix" type="float" interfacename="transmission" />
     </mix>

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -465,9 +465,6 @@ void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& con
         return;
     }
 
-    emitComment("Emitting node '" + node.getName() + "'", stage);
-
-
     bool match = true;
 
     if (node.hasClassification(ShaderNode::Classification::CLOSURE) && !node.hasClassification(ShaderNode::Classification::SHADER))

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -465,6 +465,9 @@ void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& con
         return;
     }
 
+    emitComment("Emitting node '" + node.getName() + "'", stage);
+
+
     bool match = true;
 
     if (node.hasClassification(ShaderNode::Classification::CLOSURE) && !node.hasClassification(ShaderNode::Classification::SHADER))
@@ -500,6 +503,9 @@ void HwShaderGenerator::emitFunctionCall(const ShaderNode& node, GenContext& con
         emitLineBegin(stage);
         emitOutput(node.getOutput(), true, true, context, stage);
         emitLineEnd(stage);
+
+        // Register the node as emitted, but omit the function call.
+        stage.addFunctionCall(node, context, false);
     }
 }
 

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -365,14 +365,18 @@ void ShaderStage::addFunctionDefinition(const ShaderNode& node, GenContext& cont
     }
 }
 
-void ShaderStage::addFunctionCall(const ShaderNode& node, GenContext& context)
+void ShaderStage::addFunctionCall(const ShaderNode& node, GenContext& context, bool emitCode)
 {
+    // Register this function as being called in the current scope.
     const ClosureContext* cct = context.getClosureContext();
     const FunctionCallId id(&node, cct ? cct->getType() : 0);
-
     _scopes.back().functions.insert(id);
 
-    node.getImplementation().emitFunctionCall(node, context, *this);
+    // Emit code for the function call if not omitted.
+    if (emitCode)
+    {
+        node.getImplementation().emitFunctionCall(node, context, *this);
+    }
 }
 
 bool ShaderStage::isEmitted(const ShaderNode& node, GenContext& context) const

--- a/source/MaterialXGenShader/ShaderStage.h
+++ b/source/MaterialXGenShader/ShaderStage.h
@@ -265,7 +265,10 @@ class MX_GENSHADER_API ShaderStage
     void addFunctionDefinition(const ShaderNode& node, GenContext& context);
 
     /// Add the function call for the given node.
-    void addFunctionCall(const ShaderNode& node, GenContext& context);
+    /// This will register the function as being called in the current scope, and code for the
+    /// function call will be added to the stage. If emitCode is set to false the code for the
+    /// function call will be omitted.
+    void addFunctionCall(const ShaderNode& node, GenContext& context, bool emitCode = true);
 
     /// Return true if the function for the given node has been emitted in the current scope.
     bool isEmitted(const ShaderNode& node, GenContext& context) const;


### PR DESCRIPTION
This change list fixes a bug in code gen for HW languages, where under certain conditions the function call for a BSDF node could be generated multiple times in the same scope.

For example, if a pure reflection BSDF node, like oren_nayar_bsdf, where referenced multiple times in a graph. Then during generation of the transmission section of a GLSL surface shader the node's output variable would be emitted multiple times, giving erroneous code.

A workaround was previously to duplicate the node in the graph, as for example done in the GlftPbr graph. With this fix duplication is no longer needed.
