### PR TITLE
gitignore: Ignore .idea directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea


### PR DESCRIPTION
The Intellij IDEA family IDEs create .idea directory when opening the project with them. This directory is not used at many times, so this CL just ignore it with .gitignore.