### PR TITLE
Add missing cctype include for VS2017

### DIFF
--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -43,6 +43,8 @@
 
 #include "MslResourceBindingContext.h"
 
+#include <cctype>
+
 MATERIALX_NAMESPACE_BEGIN
 
 const string MslShaderGenerator::TARGET = "genmsl";


### PR DESCRIPTION
    - std::isspace requires include of cctype in VS2017

Fixes #1401 