### PR TITLE
Update three.js to r140

### DIFF
--- a/javascript/MaterialXView/package-lock.json
+++ b/javascript/MaterialXView/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dat.gui": "^0.7.9",
-        "three": "^0.135.0",
+        "three": "^0.140.2",
         "webpack": "^5.88.1"
       },
       "devDependencies": {
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.40.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
-      "integrity": "sha512-PRVjQ4Eh9z9pmmtaq8nTjZjQwKFk7YIHIud3lRoKRBgUQjgjRmoGxxGEPXQkF+lH7QkHJRNr5F4aBgYCW0lqpQ==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.0.tgz",
+      "integrity": "sha512-gsF+c/0XOguWgaOgvFs+xnnRqt9GwgTvIks36WpE6ueeI4KCEHHd8K/CKHqhOqrJKsYH8m27kRzQEvWXAwXUTw==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -245,9 +245,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
-      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw=="
+      "version": "20.4.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
+      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
-      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001512",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
-      "integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
+      "version": "1.0.30001515",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
+      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1223,9 +1223,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.449",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.449.tgz",
-      "integrity": "sha512-TxLRpRUj/107ATefeP8VIUWNOv90xJxZZbCW/eIbSZQiuiFANCx2b7u+GbVc9X4gU+xnbvypNMYVM/WArE1DNQ=="
+      "version": "1.4.460",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.460.tgz",
+      "integrity": "sha512-kKiHnbrHME7z8E6AYaw0ehyxY5+hdaRmeUbjBO22LZMdqTYCO29EvF0T1cQ3pJ1RN5fyMcHl1Lmcsdt9WWJpJQ=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -2397,9 +2397,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.12.tgz",
-      "integrity": "sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ=="
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3405,9 +3405,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.2.tgz",
-      "integrity": "sha512-Ah19JS86ypbJzTzvUCX7KOsEIhDaRONungA4aYBjEP3JZRf4ocuDzTg4QWZnPn9DEMiMYGJPiSOy7aykoCc70w==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
+      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -3468,9 +3468,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/three": {
-      "version": "0.135.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.135.0.tgz",
-      "integrity": "sha512-kuEpuuxRzLv0MDsXai9huCxOSQPZ4vje6y0gn80SRmQvgz6/+rI0NAvCRAw56zYaWKMGMfqKWsxF9Qa2Z9xymQ=="
+      "version": "0.140.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.140.2.tgz",
+      "integrity": "sha512-DdT/AHm/TbZXEhQKQpGt5/iSgBrmXpjU26FNtj1KhllVPTKj1eG4X/ShyD5W2fngE+I1s1wa4ttC4C3oCJt7Ag=="
     },
     "node_modules/thunky": {
       "version": "1.1.0",

--- a/javascript/MaterialXView/package.json
+++ b/javascript/MaterialXView/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "dat.gui": "^0.7.9",
-    "three": "^0.135.0",
+    "three": "^0.140.2",
     "webpack": "^5.88.1"
   },
   "devDependencies": {

--- a/javascript/MaterialXView/source/helper.js
+++ b/javascript/MaterialXView/source/helper.js
@@ -20,8 +20,6 @@ const IMAGE_PATH_SEPARATOR = "/";
 export function prepareEnvTexture(texture, capabilities)
 {
     const rgbaTexture = RGBToRGBA_Float(texture);
-    // RGBELoader sets flipY to true by default
-    rgbaTexture.flipY = false;
     rgbaTexture.wrapS = THREE.RepeatWrapping;
     rgbaTexture.anisotropy = capabilities.getMaxAnisotropy();
     rgbaTexture.minFilter = THREE.LinearMipmapLinearFilter;

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -777,7 +777,7 @@ export class Material
         Object.assign(uniforms, {
             u_numActiveLightSources: { value: lights.length },
             u_lightData: { value: lightData },
-            u_envMatrix: { value: getLightRotation() },
+            u_envMatrix: { value: new THREE.Matrix4().multiplyMatrices(getLightRotation(), new THREE.Matrix4().makeScale(1, -1, 1)) },
             u_envRadiance: { value: radianceTexture },
             u_envRadianceMips: { value: Math.trunc(Math.log2(Math.max(radianceTexture.image.width, radianceTexture.image.height))) + 1 },
             u_envRadianceSamples: { value: 16 },


### PR DESCRIPTION
This changelist updates the version of three.js to r140 in the MaterialX Web Viewer, making a handful of adjustments to account for changes in environment texture conventions.