### PR TITLE
Restore three.js to r136

### DIFF
--- a/javascript/MaterialXView/package-lock.json
+++ b/javascript/MaterialXView/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "dat.gui": "^0.7.9",
-        "three": "^0.140.2",
-        "webpack": "^5.88.1"
+        "three": "^0.136.0",
+        "webpack": "^5.88.2"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^8.1.1",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-gsF+c/0XOguWgaOgvFs+xnnRqt9GwgTvIks36WpE6ueeI4KCEHHd8K/CKHqhOqrJKsYH8m27kRzQEvWXAwXUTw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.1.tgz",
+      "integrity": "sha512-XpNDc4Z5Tb4x+SW1MriMVeIsMoONHCkWFMkR/aPJbzEsxqHy+4Glu/BqTdPrApfDeMaXbtNh6bseNgl5KaWrSg==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -245,9 +245,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.4.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -798,9 +798,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001515",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001515.tgz",
-      "integrity": "sha512-eEFDwUOZbE24sb+Ecsx3+OvNETqjWIdabMy52oOkIgcUtAsQifjUG9q4U9dgTHJM2mfk4uEPxc0+xuFdJ629QA==",
+      "version": "1.0.30001517",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
+      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1223,9 +1223,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.460",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.460.tgz",
-      "integrity": "sha512-kKiHnbrHME7z8E6AYaw0ehyxY5+hdaRmeUbjBO22LZMdqTYCO29EvF0T1cQ3pJ1RN5fyMcHl1Lmcsdt9WWJpJQ=="
+      "version": "1.4.470",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.470.tgz",
+      "integrity": "sha512-zZM48Lmy2FKWgqyvsX9XK+J6FfP7aCDUFLmgooLJzA7v1agCs/sxSoBpTIwDLhmbhpx9yJIxj2INig/ncjJRqg=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -1427,9 +1427,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3405,9 +3405,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
-      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "version": "5.19.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
+      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -3468,9 +3468,9 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/three": {
-      "version": "0.140.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.140.2.tgz",
-      "integrity": "sha512-DdT/AHm/TbZXEhQKQpGt5/iSgBrmXpjU26FNtj1KhllVPTKj1eG4X/ShyD5W2fngE+I1s1wa4ttC4C3oCJt7Ag=="
+      "version": "0.136.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.136.0.tgz",
+      "integrity": "sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A=="
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -3500,9 +3500,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "dev": true
     },
     "node_modules/type-is": {
@@ -3625,9 +3625,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.88.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
+      "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",

--- a/javascript/MaterialXView/package.json
+++ b/javascript/MaterialXView/package.json
@@ -11,8 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "dat.gui": "^0.7.9",
-    "three": "^0.140.2",
-    "webpack": "^5.88.1"
+    "three": "^0.136.0",
+    "webpack": "^5.88.2"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^8.1.1",

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -777,7 +777,7 @@ export class Material
         Object.assign(uniforms, {
             u_numActiveLightSources: { value: lights.length },
             u_lightData: { value: lightData },
-            u_envMatrix: { value: new THREE.Matrix4().multiplyMatrices(getLightRotation(), new THREE.Matrix4().makeScale(1, -1, 1)) },
+            u_envMatrix: { value: getLightRotation() },
             u_envRadiance: { value: radianceTexture },
             u_envRadianceMips: { value: Math.trunc(Math.log2(Math.max(radianceTexture.image.width, radianceTexture.image.height))) + 1 },
             u_envRadianceSamples: { value: 16 },


### PR DESCRIPTION
This changelist restores three.js to r136, as we'll need updates to our mipmap selection for environment radiance textures before moving to newer versions.