### PR TITLE
Remove MslRenderer camera initialization

### DIFF
--- a/source/MaterialXRender/ShaderRenderer.cpp
+++ b/source/MaterialXRender/ShaderRenderer.cpp
@@ -25,11 +25,11 @@ const float DEFAULT_FAR_PLANE = 100.0f;
 // ShaderRenderer methods
 //
 
-ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType, ConventionAPI conventionAPI) :
+ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType, MatrixConvention matrixConvention) :
     _width(width),
     _height(height),
     _baseType(baseType),
-    _conventionAPI(conventionAPI)
+    _matrixConvention(matrixConvention)
 {
     // Initialize a default camera.
     float fH = std::tan(DEFAULT_FIELD_OF_VIEW / 360.0f * PI) * DEFAULT_NEAR_PLANE;
@@ -37,11 +37,11 @@ ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::B
     _camera = Camera::create();
     _camera->setViewMatrix(Camera::createViewMatrix(DEFAULT_EYE_POSITION, DEFAULT_TARGET_POSITION, DEFAULT_UP_VECTOR));
 
-    if (_conventionAPI == ShaderRenderer::ConventionAPI::METAL)
+    if (_matrixConvention == ShaderRenderer::MatrixConvention::Metal)
     {
         _camera->setProjectionMatrix(Camera::createPerspectiveMatrixZP(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
     }
-    else // ConventionAPI::OPENGL (default)
+    else // MatrixConvention::OpenGL (default)
     {
         _camera->setProjectionMatrix(Camera::createPerspectiveMatrix(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
     }

--- a/source/MaterialXRender/ShaderRenderer.cpp
+++ b/source/MaterialXRender/ShaderRenderer.cpp
@@ -35,7 +35,12 @@ ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::B
     float fW = fH * 1.0f;
     _camera = Camera::create();
     _camera->setViewMatrix(Camera::createViewMatrix(DEFAULT_EYE_POSITION, DEFAULT_TARGET_POSITION, DEFAULT_UP_VECTOR));
-    _camera->setProjectionMatrix(Camera::createPerspectiveMatrix(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
+
+    #if defined (__APPLE__)
+        _camera->setProjectionMatrix(Camera::createPerspectiveMatrixZP(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
+    #else
+        _camera->setProjectionMatrix(Camera::createPerspectiveMatrix(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
+    #endif
 }
 
 void ShaderRenderer::createProgram(ShaderPtr)

--- a/source/MaterialXRender/ShaderRenderer.cpp
+++ b/source/MaterialXRender/ShaderRenderer.cpp
@@ -25,10 +25,11 @@ const float DEFAULT_FAR_PLANE = 100.0f;
 // ShaderRenderer methods
 //
 
-ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
+ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType, ConventionAPI conventionAPI) :
     _width(width),
     _height(height),
-    _baseType(baseType)
+    _baseType(baseType),
+    _conventionAPI(conventionAPI)
 {
     // Initialize a default camera.
     float fH = std::tan(DEFAULT_FIELD_OF_VIEW / 360.0f * PI) * DEFAULT_NEAR_PLANE;
@@ -36,11 +37,14 @@ ShaderRenderer::ShaderRenderer(unsigned int width, unsigned int height, Image::B
     _camera = Camera::create();
     _camera->setViewMatrix(Camera::createViewMatrix(DEFAULT_EYE_POSITION, DEFAULT_TARGET_POSITION, DEFAULT_UP_VECTOR));
 
-    #if defined (__APPLE__)
+    if (_conventionAPI == ShaderRenderer::ConventionAPI::METAL)
+    {
         _camera->setProjectionMatrix(Camera::createPerspectiveMatrixZP(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
-    #else
+    }
+    else // ConventionAPI::OPENGL (default)
+    {
         _camera->setProjectionMatrix(Camera::createPerspectiveMatrix(-fW, fW, -fH, fH, DEFAULT_NEAR_PLANE, DEFAULT_FAR_PLANE));
-    #endif
+    }
 }
 
 void ShaderRenderer::createProgram(ShaderPtr)

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -30,6 +30,12 @@ using ShaderRendererPtr = std::shared_ptr<class ShaderRenderer>;
 class MX_RENDER_API ShaderRenderer
 {
   public:
+    /// API viewing conventions designation (default to OpenGL).
+    enum class ConventionAPI
+    {
+        OPENGL = 0,
+        METAL  = 1
+    };
     /// A map with name and source code for each shader stage.
     using StageMap = StringMap;
 
@@ -123,12 +129,15 @@ class MX_RENDER_API ShaderRenderer
     /// @}
 
   protected:
-    ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType);
+    ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType,
+        ConventionAPI conventionAPI = ConventionAPI::OPENGL);
 
   protected:
     unsigned int _width;
     unsigned int _height;
     Image::BaseType _baseType;
+
+    ConventionAPI _conventionAPI;
 
     CameraPtr _camera;
     ImageHandlerPtr _imageHandler;

--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -30,11 +30,11 @@ using ShaderRendererPtr = std::shared_ptr<class ShaderRenderer>;
 class MX_RENDER_API ShaderRenderer
 {
   public:
-    /// API viewing conventions designation (default to OpenGL).
-    enum class ConventionAPI
+    /// Viewing API matrix conventions designation (default to OpenGL).
+    enum class MatrixConvention
     {
-        OPENGL = 0,
-        METAL  = 1
+        OpenGL = 0,
+        Metal  = 1
     };
     /// A map with name and source code for each shader stage.
     using StageMap = StringMap;
@@ -130,14 +130,14 @@ class MX_RENDER_API ShaderRenderer
 
   protected:
     ShaderRenderer(unsigned int width, unsigned int height, Image::BaseType baseType,
-        ConventionAPI conventionAPI = ConventionAPI::OPENGL);
+        MatrixConvention matrixConvention = MatrixConvention::OpenGL);
 
   protected:
     unsigned int _width;
     unsigned int _height;
     Image::BaseType _baseType;
 
-    ConventionAPI _conventionAPI;
+    MatrixConvention _matrixConvention;
 
     CameraPtr _camera;
     ImageHandlerPtr _imageHandler;

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -25,7 +25,7 @@ GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height, Im
 }
 
 GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
-    ShaderRenderer(width, height, baseType),
+    ShaderRenderer(width, height, baseType, ConventionAPI::OPENGL),
     _initialized(false),
     _screenColor(DEFAULT_SCREEN_COLOR_LIN_REC709)
 {

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -25,7 +25,7 @@ GlslRendererPtr GlslRenderer::create(unsigned int width, unsigned int height, Im
 }
 
 GlslRenderer::GlslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
-    ShaderRenderer(width, height, baseType, ConventionAPI::OPENGL),
+    ShaderRenderer(width, height, baseType, MatrixConvention::OpenGL),
     _initialized(false),
     _screenColor(DEFAULT_SCREEN_COLOR_LIN_REC709)
 {

--- a/source/MaterialXRenderMsl/MslRenderer.h
+++ b/source/MaterialXRenderMsl/MslRenderer.h
@@ -126,9 +126,6 @@ class MX_RENDERMSL_API MslRenderer : public ShaderRenderer
     
   protected:
     MslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType);
-
-    virtual void updateViewInformation();
-    virtual void updateWorldInformation();
     
     void triggerProgrammaticCapture();
     void stopProgrammaticCapture();
@@ -145,11 +142,6 @@ class MX_RENDERMSL_API MslRenderer : public ShaderRenderer
     MetalFramebufferPtr  _framebuffer;
 
     bool _initialized;
-
-    const Vector3 _eye;
-    const Vector3 _center;
-    const Vector3 _up;
-    float _objectScale;
 
     SimpleWindowPtr _window;
     Color3 _screenColor;

--- a/source/MaterialXRenderMsl/MslRenderer.mm
+++ b/source/MaterialXRenderMsl/MslRenderer.mm
@@ -29,7 +29,7 @@ id<MTLDevice> MslRenderer::getMetalDevice() const
 }
 
 MslRenderer::MslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
-    ShaderRenderer(width, height, baseType),
+    ShaderRenderer(width, height, baseType, ConventionAPI::METAL),
     _initialized(false),
     _screenColor(DEFAULT_SCREEN_COLOR_LIN_REC709)
 {

--- a/source/MaterialXRenderMsl/MslRenderer.mm
+++ b/source/MaterialXRenderMsl/MslRenderer.mm
@@ -37,8 +37,6 @@ MslRenderer::MslRenderer(unsigned int width, unsigned int height, Image::BaseTyp
 
     _geometryHandler = GeometryHandler::create();
     _geometryHandler->addLoader(TinyObjLoader::create());
-
-    _camera = Camera::create();
 }
 
 void MslRenderer::initialize(RenderContextHandle)

--- a/source/MaterialXRenderMsl/MslRenderer.mm
+++ b/source/MaterialXRenderMsl/MslRenderer.mm
@@ -14,13 +14,6 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-const float PI = std::acos(-1.0f);
-
-// View information
-const float FOV_PERSP = 45.0f; // degrees
-const float NEAR_PLANE_PERSP = 0.05f;
-const float FAR_PLANE_PERSP = 100.0f;
-
 //
 // MslRenderer methods
 //
@@ -38,10 +31,6 @@ id<MTLDevice> MslRenderer::getMetalDevice() const
 MslRenderer::MslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
     ShaderRenderer(width, height, baseType),
     _initialized(false),
-    _eye(0.0f, 0.0f, 3.0f),
-    _center(0.0f, 0.0f, 0.0f),
-    _up(0.0f, 1.0f, 0.0f),
-    _objectScale(1.0f),
     _screenColor(DEFAULT_SCREEN_COLOR_LIN_REC709)
 {
     _program = MslProgram::create();
@@ -160,20 +149,6 @@ void MslRenderer::setSize(unsigned int width, unsigned int height)
     
 }
 
-void MslRenderer::updateViewInformation()
-{
-    float fH = std::tan(FOV_PERSP / 360.0f * PI) * NEAR_PLANE_PERSP;
-    float fW = fH * 1.0f;
-
-    _camera->setViewMatrix(Camera::createViewMatrix(_eye, _center, _up));
-    _camera->setProjectionMatrix(Camera::createPerspectiveMatrixZP(-fW, fW, -fH, fH, NEAR_PLANE_PERSP, FAR_PLANE_PERSP));
-}
-
-void MslRenderer::updateWorldInformation()
-{
-     _camera->setWorldMatrix(Matrix44::createScale(Vector3(_objectScale)));
-}
-
 void MslRenderer::triggerProgrammaticCapture()
 {
     MTLCaptureManager*    captureManager    = [MTLCaptureManager sharedCaptureManager];
@@ -217,9 +192,6 @@ void MslRenderer::render()
 
     
     [renderCmdEncoder setCullMode:MTLCullModeBack];
-    
-    updateViewInformation();
-    updateWorldInformation();
 
     try
     {

--- a/source/MaterialXRenderMsl/MslRenderer.mm
+++ b/source/MaterialXRenderMsl/MslRenderer.mm
@@ -29,7 +29,7 @@ id<MTLDevice> MslRenderer::getMetalDevice() const
 }
 
 MslRenderer::MslRenderer(unsigned int width, unsigned int height, Image::BaseType baseType) :
-    ShaderRenderer(width, height, baseType, ConventionAPI::METAL),
+    ShaderRenderer(width, height, baseType, MatrixConvention::Metal),
     _initialized(false),
     _screenColor(DEFAULT_SCREEN_COLOR_LIN_REC709)
 {


### PR DESCRIPTION
Allow `ShaderRenderer` camera to be modified by the client in subclass renderers when using Metal.

The PR removes the Metal Renderer specific camera initialization in `MslRenderer` (and now handled by `ShaderRenderer`).

This addresses the same issue in a similar way to what was previously done for the `GlslRenderer`:

**"Improvements to ShaderRenderer"**(https://github.com/AcademySoftwareFoundation/MaterialX/commit/60b105361c65d83ce42bd5d7524d0879b6562bc8)