### PR TITLE
Remove exceptions from topologicalSort

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -439,9 +439,7 @@ vector<ElementPtr> GraphElement::topologicalSort() const
         }
     }
 
-    size_t visitCount = 0;
     vector<ElementPtr> result;
-
     while (!childQueue.empty())
     {
         // Pop the queue and add to topological order.
@@ -467,14 +465,6 @@ vector<ElementPtr> GraphElement::topologicalSort() const
                 }
             }
         }
-
-        visitCount++;
-    }
-
-    // Check if there was a cycle.
-    if (visitCount != children.size())
-    {
-        throw ExceptionFoundCycle("Encountered a cycle in graph: " + getName());
     }
 
     return result;

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -308,7 +308,6 @@ class MX_CORE_API GraphElement : public InterfaceElement
 
     /// Return a vector of all children (nodes and outputs) sorted in
     /// topological order.
-    /// @throws ExceptionFoundCycle if a cycle is encountered.
     vector<ElementPtr> topologicalSort() const;
 
     /// If not yet present, add a geometry node to this graph matching the given property

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1225,12 +1225,6 @@ void ShaderGraph::topologicalSort()
             }
         }
     }
-
-    // Check if there was a cycle.
-    if (count != _nodeMap.size())
-    {
-        throw ExceptionFoundCycle("Encountered a cycle in graph: " + getName());
-    }
 }
 
 void ShaderGraph::setVariableNames(GenContext& context)

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -103,7 +103,6 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     void addDefaultGeomNode(ShaderInput* input, const GeomPropDef& geomprop, GenContext& context);
 
     /// Sort the nodes in topological order.
-    /// @throws ExceptionFoundCycle if a cycle is encountered.
     void topologicalSort();
 
     /// Return an iterator for traversal upstream from the given output


### PR DESCRIPTION
This changelist removes cycle exceptions from the topologicalSort methods in MaterialX, as these functions are already protected from recursion, and clients have more robust ways of checking for cycles in graphs (e.g. hasUpstreamCycle).

This addresses edge cases in MaterialXGraphEditor where certain graph configurations could trigger a crash.