### PR TITLE
Add empty vector check to node paste

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3796,11 +3796,11 @@ void Graph::drawGraph(ImVec2 mousePos)
             linkGraph();
             ImVec2 canvasPos = ed::ScreenToCanvas(mousePos);
             // place the copied nodes or the individual new nodes
-            if ((int) _copiedNodes.size() > 0)
+            if (!_copiedNodes.empty())
             {
                 positionPasteBin(canvasPos);
             }
-            else
+            else if (!_graphNodes.empty())
             {
                 ed::SetNodePosition(_graphNodes.back()->getId(), canvasPos);
             }


### PR DESCRIPTION
This changelist adds an empty vector check to node paste operations in the graph editor, addressing a case where copying nodes from a deleted material would trigger a crash.