### PR TITLE
Fix selected texture being assigned to wrong slot

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1018,6 +1018,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             ImGui::PushItemWidth(-100);
             if (ImGui::Button("Browse"))
             {
+                _fileDialogInput = input;
                 _fileDialogImage.setTitle("Node Input Dialog");
                 _fileDialogImage.open();
                 _fileDialogImage.setTypeFilters(_imageFilter);
@@ -1029,7 +1030,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             ImGui::PopStyleColor();
 
             // create and load document from selected file
-            if (_fileDialogImage.hasSelected())
+            if (_fileDialogImage.hasSelected() && _fileDialogInput == input)
             {
                 // set the new filename to the complete file path
                 mx::FilePath fileName = _fileDialogImage.getSelected();

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -214,7 +214,7 @@ class Graph
     FileDialog _fileDialogSave;
     FileDialog _fileDialogImage;
     FileDialog _fileDialogGeom;
-
+    MaterialX_v1_38_8::InputPtr _fileDialogInput;
 
     bool _isNodeGraph;
 


### PR DESCRIPTION
Fix for selecting file being assigned to wrong input. See https://github.com/AcademySoftwareFoundation/MaterialX/issues/1470

This saves the input ptr the file dialogue was opened for and assigns the selected file when ready to the same input.