### PR TITLE
Graph Editor: Reduce graph view auto layout spacing

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -570,7 +570,7 @@ ImVec2 Graph::layoutPosition(UiNodePtr layoutNode, ImVec2 startingPos, bool init
                         UiNodePtr nextNode = layoutNode->getConnectedNode(pins[i]->_name);
                         if (nextNode)
                         {
-                            startingPos.x = (1200.f - ((layoutNode->_level) * 350)) * _fontScale;
+                            startingPos.x = (1200.f - ((layoutNode->_level) * 250)) * _fontScale;
                             ed::SetNodePosition(layoutNode->getId(), startingPos);
                             layoutNode->setPos(ImVec2(startingPos));
                             // call layout position on upstream node with newPos as -140 to the left of current node
@@ -581,7 +581,7 @@ ImVec2 Graph::layoutPosition(UiNodePtr layoutNode, ImVec2 startingPos, bool init
             }
             else
             {
-                startingPos.x = (1200.f - ((layoutNode->_level) * 350)) * _fontScale;
+                startingPos.x = (1200.f - ((layoutNode->_level) * 250)) * _fontScale;
                 layoutNode->setPos(ImVec2(startingPos));
                 // set current node position
                 ed::SetNodePosition(layoutNode->getId(), ImVec2(startingPos));


### PR DESCRIPTION
Currently spacing between graph nodes is quite large.   
This reduces the horizontal space between nodes when using AutoLayout slightly

Current layout
![20230821-133506_MaterialX_Graph_Editor-needle](https://github.com/AcademySoftwareFoundation/MaterialX/assets/5083203/a5f26c2e-0c49-42e3-845e-4af11987042a)


With reduced spacing
![20230821-133423_MaterialX_Graph_Editor-needle](https://github.com/AcademySoftwareFoundation/MaterialX/assets/5083203/0eb22245-7080-4913-86a9-01e3d7d25433)

Another example with reduced spacing
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/5083203/b7e7cd6d-16e8-4fd0-b894-d515f7db0d55)

