### PR TITLE
Follow-up fix for graph editor inputs

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -821,12 +821,6 @@ void Graph::updateMaterials(mx::InputPtr input, mx::ValuePtr value)
         else
         {
             std::string name = input->getNamePath();
-            // need to use exact interface name in order for input
-            mx::InputPtr interfaceInput = findInput(input, input->getName());
-            if (interfaceInput)
-            {
-                name = interfaceInput->getNamePath();
-            }
             // Note that if there is a topogical change due to
             // this value change or a transparency change, then
             // this is not currently caught here.


### PR DESCRIPTION
Fixes #1473 

## Fix
Remove code to find interface inputs as it finds the incorrect input if it's already an interface.
Was sending the wrong path so would not update the uniform.

This was removed from the Viewer but no here.
