### PR TITLE
Graph Editor: add log when opening a new file

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -175,6 +175,7 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
     {
         if (!filename.isEmpty())
         {
+            std::cout << ">>> Reading file " << filename.asString() << std::endl;
             mx::readFromXmlFile(doc, filename, _searchPath, &readOptions);
             doc->importLibrary(_stdLib);
             std::string message;


### PR DESCRIPTION
Add small log for when a new material is opened making it easier to see where validation errors in the console belong to (when opening multiple files during a session)

See https://github.com/AcademySoftwareFoundation/MaterialX/issues/1398#issuecomment-1683784647