### PR TITLE
Add drag & drop loading to Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/dropHandling.js
+++ b/javascript/MaterialXView/source/dropHandling.js
@@ -1,0 +1,197 @@
+import * as THREE from 'three';
+
+const debugFileHandling = true;
+let loadingCallback;
+
+export function setLoadingCallback(cb) {
+    loadingCallback = cb;
+}
+
+export function dropHandler(ev) {
+    if (debugFileHandling) console.log('File(s) dropped', ev.dataTransfer.items, ev.dataTransfer.files);
+
+    // Prevent default behavior (Prevent file from being opened)
+    ev.preventDefault();
+
+    if (ev.dataTransfer.items)
+    {
+        const allEntries = [];
+
+        let haveGetAsEntry = false;
+        if (ev.dataTransfer.items.length > 0)
+        haveGetAsEntry = ("getAsEntry" in ev.dataTransfer.items[0]) || ("webkitGetAsEntry" in ev.dataTransfer.items[0]);
+
+        if (haveGetAsEntry) {
+        for (var i = 0; i < ev.dataTransfer.items.length; i++)
+        {
+            let item = ev.dataTransfer.items[i];
+            let entry = ("getAsEntry" in item) ? item.getAsEntry() : item.webkitGetAsEntry();
+            allEntries.push(entry);
+        }
+        handleFilesystemEntries(allEntries);
+        return;
+        }
+
+        for (var i = 0; i < ev.dataTransfer.items.length; i++)
+        {
+        let item = ev.dataTransfer.items[i];
+        
+        // API when there's no "getAsEntry" support
+        console.log(item.kind, item, entry);
+        if (item.kind === 'file')
+        {
+            var file = item.getAsFile();
+            testAndLoadFile(file);
+        }
+        // could also be a directory
+        else if (item.kind === 'directory')
+        {
+            var dirReader = item.createReader();
+            dirReader.readEntries(function(entries) {
+            for (var i = 0; i < entries.length; i++) {
+                console.log(entries[i].name);
+                var entry = entries[i];
+                if (entry.isFile) {
+                entry.file(function(file) {
+                    testAndLoadFile(file);
+                });
+                }
+            }
+            });
+        }
+        }
+    } else {
+        for (var i = 0; i < ev.dataTransfer.files.length; i++) {
+            let file = ev.dataTransfer.files[i];
+            testAndLoadFile(file);
+        }
+    }
+}
+
+export function dragOverHandler(ev) {
+    ev.preventDefault();
+}
+
+async function handleFilesystemEntries(entries) {
+    const allFiles = [];
+    const fileIgnoreList = [
+      '.gitignore',
+      'README.md',
+      '.DS_Store',
+    ]
+    const dirIgnoreList = [
+      '.git',
+      'node_modules',
+    ]
+
+    for (let entry of entries) {
+      if (debugFileHandling) console.log("file entry", entry)
+      if (entry.isFile) {
+        if (debugFileHandling) console.log("single file", entry);
+        if (fileIgnoreList.includes(entry.name)) {
+          continue;
+        }
+        allFiles.push(entry);
+      }
+      else if (entry.isDirectory) {
+        if (dirIgnoreList.includes(entry.name)) {
+          continue;
+        }
+        const files = await readDirectory(entry);
+        if (debugFileHandling) console.log("all files", files);
+        for (const file of files) {
+          if (fileIgnoreList.includes(file.name)) {
+            continue;
+          }
+          allFiles.push(file);
+        }
+      }
+    }
+
+    // sort so mtlx files come first
+    allFiles.sort((a, b) => {
+        if (a.name.endsWith('.mtlx') && !b.name.endsWith('.mtlx')) {
+            return -1;
+        }
+        if (!a.name.endsWith('.mtlx') && b.name.endsWith('.mtlx')) {
+            return 1;
+        }
+        return 0;
+    });
+
+    if (debugFileHandling) console.log("all files", allFiles);
+
+    const imageLoader = new THREE.ImageLoader();
+
+    // put all files in three' Cache
+    for (const fileEntry of allFiles) {
+        const allowedFileTypes = [
+            'png', 'jpg', 'jpeg'
+        ];
+
+        const ext = fileEntry.fullPath.split('.').pop();
+        if (!allowedFileTypes.includes(ext)) {
+            console.log("skipping file", fileEntry.fullPath);
+            continue;
+        }
+
+
+        const buffer = await new Promise((resolve, reject) => {
+            fileEntry.file(function(file) {
+                var reader = new FileReader();
+                reader.onloadend = function(e) {
+                    resolve(this.result);
+                };
+                reader.readAsArrayBuffer(file);
+            }, (e) => {
+                console.error("Error reading file ", e);
+            });
+        });
+
+        const img = await imageLoader.loadAsync(URL.createObjectURL(new Blob([buffer])));
+        console.log("caching file", fileEntry.fullPath, img);
+        THREE.Cache.add(fileEntry.fullPath, img);
+    }
+
+    loadingCallback(allFiles[0]);
+}
+
+async function readDirectory(directory) {
+    let entries = [];
+    let getEntries = async (directory) => {
+        let dirReader = directory.createReader();
+        await new Promise((resolve, reject) => {
+        dirReader.readEntries(
+            async (results) => {
+            if (results.length) {
+                // entries = entries.concat(results);
+                for (let entry of results) {
+                if (entry.isDirectory) {
+                    await getEntries(entry);
+                }
+                else {
+                    entries.push(entry);
+                }
+                }
+            }
+            resolve();
+            },
+            (error) => {
+            /* handle error — error is a FileError object */
+            },
+        )}
+    )};
+
+    await getEntries(directory);
+    return entries;
+}
+
+function testAndLoadFile(file) {
+    let ext = file.name.split('.').pop();
+    if (debugFileHandling) console.log(file.name + ", " + file.size + ", " + ext);
+    if(ext == 'usd' || ext == 'usdz' || ext == 'usda' || ext == 'usdc') {
+        clearStage();
+        // loadFile(file);
+        loadingCallback(file);
+    }
+}

--- a/javascript/MaterialXView/source/dropHandling.js
+++ b/javascript/MaterialXView/source/dropHandling.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import * as fflate from 'three/examples/jsm/libs/fflate.module.js';
 
-const debugFileHandling = true;
+const debugFileHandling = false;
 let loadingCallback;
 
 export function setLoadingCallback(cb) {

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -118,7 +118,7 @@ function init()
 
     setLoadingCallback(file => {
         console.log("Loading callback", file);
-        materialFilename = file.fullPath;
+        materialFilename = file.fullPath || file.name;
         viewer.getEditor().clearFolders();
         viewer.getMaterial().loadMaterials(viewer, materialFilename, file);
         viewer.getEditor().updateProperties(0.9);

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -116,8 +116,11 @@ function init()
         console.error(Number.isInteger(err) ? this.getMx().getExceptionMessage(err) : err);
     })
 
+    // allow dropping files and directories
+    document.addEventListener('drop', dropHandler, false);
+    document.addEventListener('dragover', dragOverHandler, false);
+
     setLoadingCallback(file => {
-        console.log("Loading callback", file);
         materialFilename = file.fullPath || file.name;
         viewer.getEditor().clearFolders();
         viewer.getMaterial().loadMaterials(viewer, materialFilename);
@@ -125,14 +128,8 @@ function init()
         viewer.getScene().setUpdateTransforms();
     });
 
-    // allow dropping files and directories
-
-    document.addEventListener('drop', dropHandler, false);
-    document.addEventListener('dragover', dragOverHandler, false);
-
-    // enable three.js Cache
+    // enable three.js Cache so that dropped files can reference each other
     THREE.Cache.enabled = true;
-    window.THREE = THREE;
 }
 
 function onWindowResize() 

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -120,7 +120,7 @@ function init()
         console.log("Loading callback", file);
         materialFilename = file.fullPath || file.name;
         viewer.getEditor().clearFolders();
-        viewer.getMaterial().loadMaterials(viewer, materialFilename, file);
+        viewer.getMaterial().loadMaterials(viewer, materialFilename);
         viewer.getEditor().updateProperties(0.9);
         viewer.getScene().setUpdateTransforms();
     });

--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -12,6 +12,7 @@ import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
 import { GammaCorrectionShader } from 'three/examples/jsm/shaders/GammaCorrectionShader.js';
 
 import { Viewer } from './viewer.js'
+import { dropHandler, dragOverHandler, setLoadingCallback } from './dropHandling.js';
 
 let renderer, composer, orbitControls;
 
@@ -115,6 +116,23 @@ function init()
         console.error(Number.isInteger(err) ? this.getMx().getExceptionMessage(err) : err);
     })
 
+    setLoadingCallback(file => {
+        console.log("Loading callback", file);
+        materialFilename = file.fullPath;
+        viewer.getEditor().clearFolders();
+        viewer.getMaterial().loadMaterials(viewer, materialFilename, file);
+        viewer.getEditor().updateProperties(0.9);
+        viewer.getScene().setUpdateTransforms();
+    });
+
+    // allow dropping files and directories
+
+    document.addEventListener('drop', dropHandler, false);
+    document.addEventListener('dragover', dragOverHandler, false);
+
+    // enable three.js Cache
+    THREE.Cache.enabled = true;
+    window.THREE = THREE;
 }
 
 function onWindowResize() 

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -561,20 +561,6 @@ export class Material
 
     async loadMaterialFile(loader, materialFilename, fileEntry = undefined)
     {
-        if (fileEntry) {
-            return new Promise((resolve, reject) => {
-                fileEntry.file(function(file) {
-                    var reader = new FileReader();
-                    reader.onloadend = function(e) {
-                        resolve(this.result);
-                    };
-                    reader.readAsText(file);
-                }, (e) => {
-                    console.error("Error reading file ", e);
-                });
-            });
-        }
-
         return new Promise((resolve, reject) => {
             loader.load(materialFilename, data => resolve(data), null, reject);
         });

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -559,14 +559,14 @@ export class Material
         shaderElement.setNodeName(ssName);
     }
 
-    async loadMaterialFile(loader, materialFilename, fileEntry = undefined)
+    async loadMaterialFile(loader, materialFilename)
     {
         return new Promise((resolve, reject) => {
             loader.load(materialFilename, data => resolve(data), null, reject);
         });
     }
 
-    async loadMaterials(viewer, materialFilename, file = undefined)
+    async loadMaterials(viewer, materialFilename)
     {
         var startTime = performance.now();
 
@@ -580,7 +580,7 @@ export class Material
 
         const fileloader = viewer.getFileLoader(); 
 
-        let mtlxMaterial = await viewer.getMaterial().loadMaterialFile(fileloader, materialFilename, file);
+        let mtlxMaterial = await viewer.getMaterial().loadMaterialFile(fileloader, materialFilename);
 
         // Load lighting setup into document
         doc.importLibrary(viewer.getLightRig());

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -559,14 +559,28 @@ export class Material
         shaderElement.setNodeName(ssName);
     }
 
-    async loadMaterialFile(loader, materialFilename)
+    async loadMaterialFile(loader, materialFilename, fileEntry = undefined)
     {
+        if (fileEntry) {
+            return new Promise((resolve, reject) => {
+                fileEntry.file(function(file) {
+                    var reader = new FileReader();
+                    reader.onloadend = function(e) {
+                        resolve(this.result);
+                    };
+                    reader.readAsText(file);
+                }, (e) => {
+                    console.error("Error reading file ", e);
+                });
+            });
+        }
+
         return new Promise((resolve, reject) => {
             loader.load(materialFilename, data => resolve(data), null, reject);
         });
     }
 
-    async loadMaterials(viewer, materialFilename)
+    async loadMaterials(viewer, materialFilename, file = undefined)
     {
         var startTime = performance.now();
 
@@ -580,7 +594,7 @@ export class Material
 
         const fileloader = viewer.getFileLoader(); 
 
-        let mtlxMaterial = await viewer.getMaterial().loadMaterialFile(fileloader, materialFilename);
+        let mtlxMaterial = await viewer.getMaterial().loadMaterialFile(fileloader, materialFilename, file);
 
         // Load lighting setup into document
         doc.importLibrary(viewer.getLightRig());
@@ -589,6 +603,7 @@ export class Material
 
         // Set search path. Assumes images are relative to current file
         // location.
+        if (!materialFilename) materialFilename = "/";
         const paths = materialFilename.split('/');
         paths.pop(); 
         const searchPath = paths.join('/');


### PR DESCRIPTION
This PR implements drag-drop file loading for
- .mtlx files
- .mtlx files + textures or folders with textures
- folders that contain at least one single .mtlx and textures
- .zip files containing the above

Currently, only the first found .mtlx file from any of the above will be loaded; future improvements could include
- showing a list of dropped .mtlx files to choose from
- hot reload when a .mtlx file on disk or a referenced texture changes again
  - this would turn the web viewer into a pretty nice MaterialX hand editor without having any kind of MaterialX software installed.