### PR TITLE
Replace uvindex on gltf image nodes with texcoord

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -359,7 +359,7 @@
   <nodedef name="ND_gltf_colorimage" node="gltf_colorimage" version="1.0" isdefaultversion="true" nodegroup="texture2d">
     <input name="file" type="filename" uniform="true" value="" uifolder="Image" />
     <input name="default" type="color4" value="0, 0, 0, 0" uifolder="Image" />
-    <input name="uvindex" type="integer" uniform="true" value="0" uifolder="Image" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uifolder="Image"/>
     <input name="pivot" type="vector2" value="0, 1" uifolder="Image" />
     <input name="scale" type="vector2" value="1, 1" uifolder="Image" />
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" uifolder="Image" />
@@ -375,13 +375,10 @@
   </nodedef>
 
   <nodegraph name="NG_gltf_colorimage" nodedef="ND_gltf_colorimage">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" uniform="true" interfacename="uvindex" />
-    </texcoord>
     <gltf_image name="image" type="color4">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="color4" interfacename="default" />
-      <input name="uvindex" type="integer" uniform="true" interfacename="uvindex" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" interfacename="scale" />
       <input name="rotate" type="float" interfacename="rotate" />
@@ -422,7 +419,7 @@
     <input name="file" type="filename" uniform="true" value="" />
     <input name="factor" type="color3" value="1,1,1" />
     <input name="default" type="color3" value="0, 0, 0" />
-    <input name="uvindex" type="integer" uniform="true" value="0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
     <input name="pivot" type="vector2" value="0, 1" />
     <input name="scale" type="vector2" value="1, 1" />
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" />
@@ -434,9 +431,6 @@
     <output name="out" type="color3" value="0, 0, 0" />
   </nodedef>
   <nodegraph name="NG_NG_gltf_image_color3_color3_1_0" nodedef="ND_gltf_image_color3_color3_1_0">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" uniform="true" interfacename="uvindex" />
-    </texcoord>
     <image name="image" type="color3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="color3" interfacename="default" />
@@ -458,7 +452,7 @@
       <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
@@ -480,7 +474,7 @@
     <input name="file" type="filename" uniform="true" value="" />
     <input name="factor" type="color4" value="1,1,1,1" />
     <input name="default" type="color4" value="0, 0, 0, 0" />
-    <input name="uvindex" type="integer" uniform="true" value="0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
     <input name="pivot" type="vector2" value="0, 1" />
     <input name="scale" type="vector2" value="1, 1" />
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" />
@@ -492,9 +486,6 @@
     <output name="out" type="color4" value="0, 0, 0, 0" />
   </nodedef>
   <nodegraph name="NG_gltf_image_color4_color4_1_0" nodedef="ND_gltf_image_color4_color4_1_0">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" uniform="true" interfacename="uvindex" />
-    </texcoord>
     <image name="image" type="color4">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="color4" interfacename="default" />
@@ -516,7 +507,7 @@
       <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
@@ -538,7 +529,7 @@
     <input name="file" type="filename" uniform="true" value="" />
     <input name="factor" type="float" value="1" />
     <input name="default" type="float" value="0" />
-    <input name="uvindex" type="integer" uniform="true" value="0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
     <input name="pivot" type="vector2" value="0, 1" />
     <input name="scale" type="vector2" value="1, 1" />
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" />
@@ -550,9 +541,6 @@
     <output name="out" type="float" value="0" />
   </nodedef>
   <nodegraph name="NG_gltf_image_float_float_1_0" nodedef="ND_gltf_image_float_float_1_0">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" uniform="true" interfacename="uvindex" />
-    </texcoord>
     <image name="image" type="float">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="float" interfacename="default" />
@@ -574,7 +562,7 @@
       <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
@@ -595,7 +583,7 @@
   <nodedef name="ND_gltf_image_vector3_vector3_1_0" node="gltf_image" version="1.0" isdefaultversion="true" nodegroup="texture2d">
     <input name="file" type="filename" uniform="true" value="" />
     <input name="default" type="vector3" value="0, 0, 0" />
-    <input name="uvindex" type="integer" uniform="true" value="0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
     <input name="pivot" type="vector2" value="0, 1" />
     <input name="scale" type="vector2" value="1, 1" />
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" />
@@ -607,9 +595,6 @@
     <output name="out" type="vector3" value="0, 0, 0" />
   </nodedef>
   <nodegraph name="NG_gltf_image_vector3_vector3_1_0" nodedef="ND_gltf_image_vector3_vector3_1_0">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" uniform="true" interfacename="uvindex" />
-    </texcoord>
     <image name="image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="vector3" interfacename="default" />
@@ -631,7 +616,7 @@
       <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
@@ -648,7 +633,7 @@
   <nodedef name="ND_gltf_normalmap_vector3_1_0" node="gltf_normalmap" version="1.0" isdefaultversion="true" nodegroup="texture2d">
     <input name="file" type="filename" uniform="true" value="" />
     <input name="default" type="vector3" value="0.5, 0.5, 1" />
-    <input name="uvindex" type="integer" uniform="true" value="0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
     <input name="pivot" type="vector2" value="0, 1" />
     <input name="scale" type="vector2" value="1, 1" />
     <input name="rotate" type="float" value="0" unit="degree" unittype="angle" uimin="0" uimax="360" />
@@ -660,9 +645,6 @@
     <output name="out" type="vector3" value="0, 0, 0" />
   </nodedef>
   <nodegraph name="NG_gltf_normalmap_vector3_1_0" nodedef="ND_gltf_normalmap_vector3_1_0">
-    <texcoord name="texcoord1" type="vector2">
-      <input name="index" type="integer" uniform="true" interfacename="uvindex" />
-    </texcoord>
     <image name="image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="vector3" interfacename="default" />
@@ -687,7 +669,7 @@
       <input name="in2" type="vector2" value="-1.0, 1.0" />
     </multiply>
     <place2d name="place2d" type="vector2" nodedef="ND_place2d_vector2">
-      <input name="texcoord" type="vector2" nodename="texcoord1" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" nodename="invert_scale" />
       <input name="rotate" type="float" nodename="negate_rotate" />
@@ -704,7 +686,7 @@
   <nodedef name="ND_gltf_iridescence_thickness_float_1_0" node="gltf_iridescence_thickness" version="1.0" isdefaultversion="true" nodegroup="texture2d">
     <input name="file" type="filename" uniform="true" value="" uifolder="Image" />
     <input name="default" type="vector3" value="0, 0, 0" uifolder="Image" />
-    <input name="uvindex" type="integer" uniform="true" value="0" uifolder="Image" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uifolder="Image" />
     <input name="pivot" type="vector2" value="0, 0" uifolder="Image" />
     <input name="scale" type="vector2" value="1, 1" uifolder="Image" />
     <input name="rotate" type="float" value="0" uifolder="Image" />
@@ -725,7 +707,7 @@
     <gltf_image name="thickness_image" type="vector3">
       <input name="file" type="filename" uniform="true" interfacename="file" />
       <input name="default" type="vector3" interfacename="default" />
-      <input name="uvindex" type="integer" uniform="true" interfacename="uvindex" />
+      <input name="texcoord" type="vector2" interfacename="texcoord" />
       <input name="pivot" type="vector2" interfacename="pivot" />
       <input name="scale" type="vector2" interfacename="scale" />
       <input name="rotate" type="float" interfacename="rotate" />


### PR DESCRIPTION
## Fix

Fixes #1486 

Changes the exposed input interface from `uvindex` which is an integer to `texcoord` which is a `vector2`. This allows for either

1. A `texcoord` to be attached for integer based uv set workflows (e.g. glTF).
2. A `geompropvalue ` to be attached for name based workflows (e.g. USD).

## Example

This is the boombox example using a mix of integer and named streams
```xml
<?xml version="1.0"?>
<materialx version="1.38" colorspace="lin_rec709" fileprefix="boombox/">
  <gltf_colorimage name="image_basecolor" type="multioutput" xpos="9.246377" ypos="-2.534483">
    <input name="file" type="filename" value="BoomBox_baseColor.png" colorspace="srgb_texture" />
    <input name="texcoord" type="vector2" nodename="texcoord_vector2" />
  </gltf_colorimage>
  <gltf_image name="image_orm" type="vector3" xpos="10.144928" ypos="-0.431034">
    <input name="file" type="filename" value="BoomBox_occlusionRoughnessMetallic.png" />
  </gltf_image>
  <gltf_normalmap name="image_normal" type="vector3" xpos="9.681159" ypos="0.956897">
    <input name="file" type="filename" value="BoomBox_normal.png" />
    <input name="texcoord" type="vector2" nodename="geompropvalue_vector2" />
  </gltf_normalmap>
  <gltf_image name="image_emission" type="color3" xpos="9.913043" ypos="2.784483">
    <input name="file" type="filename" value="BoomBox_emissive.png" colorspace="srgb_texture" />
  </gltf_image>
  <gltf_pbr name="SR_boombox" type="surfaceshader" xpos="13.565217" ypos="-0.931035">
    <input name="base_color" type="color3" nodename="image_basecolor" output="outcolor" />
    <input name="alpha" type="float" nodename="image_basecolor" output="outa" />
    <input name="metallic" type="float" nodename="image_orm" channels="z" />
    <input name="roughness" type="float" nodename="image_orm" channels="y" />
    <input name="occlusion" type="float" nodename="image_orm" channels="x" />
    <input name="normal" type="vector3" nodename="image_normal" />
    <input name="emissive" type="color3" nodename="image_emission" />
  </gltf_pbr>
  <surfacematerial name="Material_boombox" type="material" xpos="17.391304" ypos="0.000000">
    <input name="surfaceshader" type="surfaceshader" nodename="SR_boombox" />
  </surfacematerial>
  <texcoord name="texcoord_vector2" type="vector2" xpos="6.695652" ypos="-1.362069" />
  <geompropvalue name="geompropvalue_vector2" type="vector2" xpos="6.644928" ypos="0.422414">
    <input name="geomprop" type="string" value="UV0" />
  </geompropvalue>
</materialx>
```
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/74a027c5-e49f-434a-8fe8-91127c1f6c33)


@JGamache-autodesk please review to ensure this will solve the issue properly. Thanks.