### PR TITLE
Refinements to checkerboard node

### DIFF
--- a/documents/Specification/MaterialX.Specification.md
+++ b/documents/Specification/MaterialX.Specification.md
@@ -787,8 +787,8 @@ Standard Procedural nodes:
 * **`checkerboard`**: a 2D checkerboard pattern.
     * `color1` (color3): The first color used in the checkerboard pattern.
     * `color2` (color3): The second color used in the checkerboard pattern.
-    * `freq` (vector2): The frequency of checkers, with higher values producing smaller squares. Default is (8, 8).
-    * `offset` (vector2): Shift the pattern in 2d space. Default is (0, 0).
+    * `uvtiling` (vector2): The tiling of the checkerboard pattern along each axis, with higher values producing smaller squares. Default is (8, 8).
+    * `uvoffset` (vector2): The offset of the checkerboard pattern along each axis. Default is (0, 0).
     * `texcoord` (vector2): The input 2d space. Default is the first texture coordinates.
 
 <a id="node-noise2d"> </a>

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1083,8 +1083,8 @@
   <nodedef name="ND_checkerboard_color3" node="checkerboard" nodegroup="procedural2d">
     <input name="color1" type="color3" uiname="Color 1" value="1.0, 1.0, 1.0" doc="The first color used in the checkerboard pattern." />
     <input name="color2" type="color3" uiname="Color 2" value="0.0, 0.0, 0.0" doc="The second color used in the checkerboard pattern." />
-    <input name="freq" type="vector2" uiname="Frequency" value="8, 8" doc="The frequency of checkers, with higher values producing smaller squares. Default is (8, 8)." />
-    <input name="offset" type="vector2" uiname="Offset" value="0, 0" doc="Shift the pattern in 2d space. Default is (0, 0)." />
+    <input name="uvtiling" type="vector2" uiname="UV Tiling" value="8, 8" doc="The tiling of the checkerboard pattern along each axis, with higher values producing smaller squares. Default is (8, 8)." />
+    <input name="uvoffset" type="vector2" uiname="UV Offset" value="0, 0" doc="The offset of the checkerboard pattern along each axis. Default is (0, 0)." />
     <input name="texcoord" type="vector2" uiname="Texture Coordinates" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." />
     <output name="out" type="color3" />
   </nodedef>

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1376,47 +1376,31 @@
     A 2D checkerboard pattern.
   -->
   <nodegraph name="NG_checkerboard_color3" nodedef="ND_checkerboard_color3">
-    <separate2 name="N_mtlxseparate2" type="multioutput">
-      <input name="in" type="vector2" nodename="N_mtlxplace2d1" />
-    </separate2>
-    <modulo name="N_mtlxmodulo1" type="float">
-      <input name="in1" type="float" nodename="N_mtlxseparate2" output="outx" />
-      <input name="in2" type="float" value="2" />
-    </modulo>
-    <multiply name="N_mult" type="vector2">
+    <multiply name="N_mtlxmult" type="vector2">
       <input name="in1" type="vector2" interfacename="texcoord" />
-      <input name="in2" type="vector2" interfacename="freq" />
+      <input name="in2" type="vector2" interfacename="uvtiling" />
     </multiply>
-    <modulo name="N_mtlxmodulo2" type="float">
-      <input name="in1" type="float" nodename="N_mtlxseparate2" output="outy" />
+    <subtract name="N_mtlxsubtract" type="vector2">
+      <input name="in1" type="vector2" nodename="N_mtlxmult" />
+      <input name="in2" type="vector2" interfacename="uvoffset" />
+    </subtract>
+    <floor name="N_mtlxfloor" type="vector2">
+      <input name="in" type="vector2" nodename="N_mtlxsubtract" />
+    </floor>
+    <dotproduct name="N_mtlxdotproduct" type="float">
+      <input name="in1" type="vector2" nodename="N_mtlxfloor" />
+      <input name="in2" type="vector2" value="1, 1" />
+    </dotproduct>
+    <modulo name="N_modulo" type="float">
+      <input name="in1" type="float" nodename="N_mtlxdotproduct" />
       <input name="in2" type="float" value="2" />
     </modulo>
-    <floor name="N_mtlxfloor2" type="float">
-      <input name="in" type="float" nodename="N_mtlxmodulo1" />
-    </floor>
-    <floor name="N_mtlxfloor3" type="float">
-      <input name="in" type="float" nodename="N_mtlxmodulo2" />
-    </floor>
-    <add name="N_mtlxadd2" type="float">
-      <input name="in1" type="float" nodename="N_mtlxfloor2" />
-      <input name="in2" type="float" nodename="N_mtlxfloor3" />
-    </add>
-    <ifequal name="N_mtlxifequal2" type="float">
-      <input name="value1" type="float" nodename="N_mtlxadd2" />
-      <input name="value2" type="float" value="1" />
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" value="0" />
-    </ifequal>
-    <place2d name="N_mtlxplace2d1" type="vector2">
-      <input name="texcoord" type="vector2" nodename="N_mult" />
-      <input name="offset" type="vector2" interfacename="offset" />
-    </place2d>
-    <mix name="N_mix_color3" type="color3">
+    <mix name="N_mtlxmix" type="color3">
       <input name="bg" type="color3" interfacename="color2" />
       <input name="fg" type="color3" interfacename="color1" />
-      <input name="mix" type="float" nodename="N_mtlxifequal2" />
+      <input name="mix" type="float" nodename="N_modulo" />
     </mix>
-    <output name="out" type="color3" nodename="N_mix_color3" />
+    <output name="out" type="color3" nodename="N_mtlxmix" />
   </nodegraph>
 
   <!--


### PR DESCRIPTION
- Rename tiling inputs to 'uvtiling' and 'uvoffset', aligning them with the latest conventions for tiling pattern nodes.
- Minor optimizations to the checkerboard graph, taking advantage of vector operations where possible.