### PR TITLE
Improvements to file I/O options in graph editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -174,7 +174,7 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
         else
         {
             std::cerr << "Include file not found: " << filename.asString() << std::endl;
-        }        
+        }
     };
 
     mx::DocumentPtr doc = mx::createDocument();

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -177,13 +177,13 @@ mx::DocumentPtr Graph::loadDocument(mx::FilePath filename)
         {
             mx::readFromXmlFile(doc, filename, _searchPath, &readOptions);
             doc->importLibrary(_stdLib);
-
             std::string message;
             if (!doc->validate(&message))
             {
                 std::cerr << "*** Validation warnings for " << filename.asString() << " ***" << std::endl;
                 std::cerr << message << std::endl;
             }
+            
             // Cache the currently loaded file
             _materialFilename = filename;
         }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3000,9 +3000,18 @@ void Graph::loadGraphFromFile(bool prompt)
         }
         else
         {
-            loadDocument(_materialFilename);
+            _graphDoc = loadDocument(_materialFilename);
+
+            // Rebuild the UI
+            _initial = true;
+            buildUiBaseGraph(_graphDoc);
+            _currGraphElem = _graphDoc;
+            _prevUiNode = nullptr;
+
+            _renderer->setDocument(_graphDoc);
+            _renderer->updateMaterials(nullptr);
         }
-    }
+    }   
 }
 
 void Graph::saveGraphToFile(bool saveAs)

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -162,7 +162,7 @@ class Graph
 
     RenderViewPtr _renderer;
 
-    // document and intializing information    
+    // document and intializing information
     mx::FilePath _materialFilename;
     mx::DocumentPtr _graphDoc;
     mx::StringSet _xincludeFiles;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -36,6 +36,7 @@ class Graph
 {
   public:
     Graph(const std::string& materialFilename,
+          bool isDefaultFilename,
           const std::string& meshFilename,
           const mx::FileSearchPath& searchPath,
           const mx::FilePathVec& libraryFolders,
@@ -106,7 +107,7 @@ class Graph
     void createEdge(UiNodePtr upNode, UiNodePtr downNode, mx::InputPtr connectingInput);
     void removeEdge(int downNode, int upNode, UiPinPtr pin);
 
-    void writeText(std::string filename, mx::FilePath filePath);
+    void saveDocument(mx::FilePath filePath);
     void savePosition();
     bool checkPosition(UiNodePtr node);
 
@@ -148,8 +149,8 @@ class Graph
 
     // File I/O
     void clearGraph();
-    void loadGraphFromFile();
-    void saveGraphToFile();
+    void loadGraphFromFile(bool prompt);
+    void saveGraphToFile(bool saveAs);
     void loadGeometry();
 
     mx::StringVec _geomFilter;
@@ -161,7 +162,7 @@ class Graph
 
     RenderViewPtr _renderer;
 
-    // document and intializing information
+    // document and intializing information    
     mx::FilePath _materialFilename;
     mx::DocumentPtr _graphDoc;
     mx::StringSet _xincludeFiles;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -36,7 +36,6 @@ class Graph
 {
   public:
     Graph(const std::string& materialFilename,
-          bool isDefaultFilename,
           const std::string& meshFilename,
           const mx::FileSearchPath& searchPath,
           const mx::FilePathVec& libraryFolders,
@@ -150,7 +149,7 @@ class Graph
     // File I/O
     void clearGraph();
     void loadGraphFromFile(bool prompt);
-    void saveGraphToFile(bool saveAs);
+    void saveGraphToFile();
     void loadGeometry();
 
     mx::StringVec _geomFilter;

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -98,6 +98,7 @@ int main(int argc, char* const argv[])
     }
 
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx";
+    bool isDefaultFilename = true;
     std::string meshFilename = "resources/Geometry/shaderball.glb";
     mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::FilePathVec libraryFolders;
@@ -112,7 +113,11 @@ int main(int argc, char* const argv[])
 
         if (token == "--material")
         {
-            materialFilename = nextToken;
+            if (nextToken != materialFilename)
+            {
+                materialFilename = nextToken;
+                isDefaultFilename = true;
+            }
         }
         else if (token == "--mesh")
         {
@@ -214,6 +219,7 @@ int main(int argc, char* const argv[])
 
     // Create graph editor.
     Graph* graph = new Graph(materialFilename,
+                             isDefaultFilename,
                              meshFilename,
                              searchPath,
                              libraryFolders,

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -98,7 +98,6 @@ int main(int argc, char* const argv[])
     }
 
     std::string materialFilename = "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx";
-    bool isDefaultFilename = true;
     std::string meshFilename = "resources/Geometry/shaderball.glb";
     mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
     mx::FilePathVec libraryFolders;
@@ -116,7 +115,6 @@ int main(int argc, char* const argv[])
             if (nextToken != materialFilename)
             {
                 materialFilename = nextToken;
-                isDefaultFilename = false;
             }
         }
         else if (token == "--mesh")
@@ -219,7 +217,6 @@ int main(int argc, char* const argv[])
 
     // Create graph editor.
     Graph* graph = new Graph(materialFilename,
-                             isDefaultFilename,
                              meshFilename,
                              searchPath,
                              libraryFolders,

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -112,10 +112,7 @@ int main(int argc, char* const argv[])
 
         if (token == "--material")
         {
-            if (nextToken != materialFilename)
-            {
-                materialFilename = nextToken;
-            }
+            materialFilename = nextToken;
         }
         else if (token == "--mesh")
         {

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char* const argv[])
             if (nextToken != materialFilename)
             {
                 materialFilename = nextToken;
-                isDefaultFilename = true;
+                isDefaultFilename = false;
             }
         }
         else if (token == "--mesh")


### PR DESCRIPTION
### Issues:

Address some file load/save usability concerns:

- Shortcut to refresh: https://github.com/AcademySoftwareFoundation/MaterialX/issues/1398#issuecomment-1680098103
- Quick save: https://github.com/AcademySoftwareFoundation/MaterialX/issues/1398#issuecomment-1680360553

- CTRL_S as file save (instead of save as)
- CTRL_SHIFT_S as file save-as
- CTRL_R as reload (refresh)

### Logic Changes:

- Change CTRL_S to be save if there is a file loaded. Will not save the initial default node configuration, but will if a specific file was loaded from the command line.
- Add CTRL_SHIFT_S which will bring up the File->Save dialog.
- Add CTRL_R to reload the current document if there is any.
- Add some misc. logging information for these.

( @marwie, Please take a look if this matches the proposed behaviour.
@lfl-eholthouser, Please review if this behaviour is matches what you'd like to see.
Thanks ).

### UI Changes:

- This is how the File dialog looks:

![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/bf48271f-dd73-4353-ab28-e02e2c539dc9)
