### PR TITLE
Improve robustness in editor renaming

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -300,7 +300,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return the element, if any, that this one directly inherits from.
     ElementPtr getInheritsFrom() const
     {
-        return resolveNameReference<Element>(getInheritString());
+        return hasInheritString() ? resolveNameReference<Element>(getInheritString()) : nullptr;
     }
 
     /// Return true if this element has the given element as an inherited base,
@@ -745,7 +745,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// unique name for a child element.
     string createValidChildName(string name) const
     {
-        name = createValidName(name);
+        name = name.empty() ? "_" : createValidName(name);
         while (_childMap.count(name))
         {
             name = incrementName(name);

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -159,7 +159,6 @@ RenderView::RenderView(mx::DocumentPtr doc,
     _genContext(mx::GlslShaderGenerator::create()),
     _unitRegistry(mx::UnitConverterRegistry::create()),
     _splitByUdims(true),
-    _mergeMaterials(false),
     _materialCompilation(false),
     _renderTransparency(true),
     _renderDoubleSided(true),
@@ -410,18 +409,15 @@ void RenderView::updateMaterials(mx::TypedElementPtr typedElem)
     // Clear user data on the generator.
     _genContext.clearUserData();
 
-    // Clear materials if merging is not requested.
-    if (!_mergeMaterials)
+    // Clear materials.
+    for (mx::MeshPartitionPtr geom : _geometryList)
     {
-        for (mx::MeshPartitionPtr geom : _geometryList)
+        if (_materialAssignments.count(geom))
         {
-            if (_materialAssignments.count(geom))
-            {
-                assignMaterial(geom, nullptr);
-            }
+            assignMaterial(geom, nullptr);
         }
-        _materials.clear();
     }
+    _materials.clear();
 
     std::vector<mx::GlslMaterialPtr> newMaterials;
     try
@@ -434,10 +430,19 @@ void RenderView::updateMaterials(mx::TypedElementPtr typedElem)
         // Apply direct lights.
         applyDirectLights(_document);
 
-        //// Check for any udim set.
+        // Check for any udim set.
         mx::ValuePtr udimSetValue = _document->getGeomPropValue(mx::UDIM_SET_PROPERTY);
 
-        //// Create new materials.
+        // Skip material nodes without upstream shaders.
+        mx::NodePtr node = typedElem ? typedElem->asA<mx::Node>() : nullptr;
+        if (node &&
+            node->getCategory() == mx::SURFACE_MATERIAL_NODE_STRING &&
+            mx::getShaderNodes(node).empty())
+        {
+            typedElem = nullptr;
+        }
+
+        // Create new materials.
         if (!typedElem)
         {
             std::vector<mx::TypedElementPtr> elems = mx::findRenderableElements(_document);
@@ -451,7 +456,6 @@ void RenderView::updateMaterials(mx::TypedElementPtr typedElem)
         mx::NodePtr materialNode = nullptr;
         if (typedElem)
         {
-            mx::NodePtr node = typedElem->asA<mx::Node>();
             materialNode = node;
             if (udimSetValue && udimSetValue->isA<mx::StringVec>())
             {
@@ -551,14 +555,11 @@ void RenderView::updateMaterials(mx::TypedElementPtr typedElem)
 
             // Apply fallback assignments.
             mx::GlslMaterialPtr fallbackMaterial = newMaterials[0];
-            if (!_mergeMaterials || fallbackMaterial->getUdim().empty())
+            for (mx::MeshPartitionPtr geom : _geometryList)
             {
-                for (mx::MeshPartitionPtr geom : _geometryList)
+                if (!_materialAssignments[geom])
                 {
-                    if (!_materialAssignments[geom])
-                    {
-                        assignMaterial(geom, fallbackMaterial);
-                    }
+                    assignMaterial(geom, fallbackMaterial);
                 }
             }
 

--- a/source/MaterialXGraphEditor/RenderView.h
+++ b/source/MaterialXGraphEditor/RenderView.h
@@ -145,11 +145,6 @@ class RenderView
         return _materialAssignments;
     }
 
-    bool getMergeMaterials()
-    {
-        return _mergeMaterials;
-    }
-
     std::vector<mx::GlslMaterialPtr> getMaterials()
     {
         return _materials;
@@ -323,7 +318,6 @@ class RenderView
     bool _splitByUdims;
 
     // Material options
-    bool _mergeMaterials;
     bool _materialCompilation;
 
     // Unit options


### PR DESCRIPTION
- Consider a child element with an empty name string to be invalid, as this case is not supported in shader generation.
- Consider an unconnected material node to be unrenderable, as this case is not supported in shader generation.
- Skip inheritance logic for elements without inheritance strings.
- Remove the unused RenderView::_mergeMaterials boolean.