### PR TITLE
Guard against invalid nodegraphs and connections in editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2597,7 +2597,6 @@ void Graph::AddLink(ed::PinId inputPinId, ed::PinId outputPinId)
                         {
                             if (uiUpNode->getInput())
                             {
-
                                 pin->_input->setInterfaceName(uiUpNode->getName());
                             }
                             else

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -228,9 +228,6 @@ void Graph::addExtraNodes()
     std::vector<std::string> groupNode{ "ND_group", "", "group" };
     _extraNodes["Group Nodes"].push_back(groupNode);
 
-    // Add all but "nodegraph" to the node list for usage inside nodegraphs.
-    _extraNodes_NodeGraph = _extraNodes;
-
     // add nodegraph node
     std::vector<std::string> nodeGraph{ "ND_nodegraph", "", "nodegraph" };
     _extraNodes["Node Graph"].push_back(nodeGraph);
@@ -3505,12 +3502,8 @@ void Graph::addNodePopup(bool cursor)
         std::string subs(input);
         // input string length
         // filter extra nodes - includes inputs, outputs, groups, and node graphs
-
-        // Choose which list to use based on if the context is within a nodegraph
-        std::unordered_map<std::string, std::vector<std::vector<std::string>>>* nodeList = 
-            _isNodeGraph ? &_extraNodes_NodeGraph : &_extraNodes;
-
-        for (std::unordered_map<std::string, std::vector<std::vector<std::string>>>::iterator it = nodeList->begin(); it != nodeList->end(); ++it)
+        const std::string NODEGRAPH_ENTRY = "Node Graph";
+        for (std::unordered_map<std::string, std::vector<std::vector<std::string>>>::iterator it = _extraNodes.begin(); it != _extraNodes.end(); ++it)
         {
             // filter out list of nodes
             if (subs.size() > 0)
@@ -3521,8 +3514,8 @@ void Graph::addNodePopup(bool cursor)
                     std::string str(it->second[i][0]);
                     std::string nodeName = it->second[i][0];
 
-                    // Firewall check. Disallow nested nodegraphs 
-                    if (str == "nodegraph" && this->_isNodeGraph)
+                    // Disallow creating nested nodegraphs 
+                    if (_isNodeGraph && it->first == NODEGRAPH_ENTRY)
                     {
                         continue;
                     }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -228,6 +228,9 @@ void Graph::addExtraNodes()
     std::vector<std::string> groupNode{ "ND_group", "", "group" };
     _extraNodes["Group Nodes"].push_back(groupNode);
 
+    // Add all but "nodegraph" to the node list for usage inside nodegraphs.
+    _extraNodes_NodeGraph = _extraNodes;
+
     // add nodegraph node
     std::vector<std::string> nodeGraph{ "ND_nodegraph", "", "nodegraph" };
     _extraNodes["Node Graph"].push_back(nodeGraph);
@@ -2486,154 +2489,177 @@ void Graph::AddLink(ed::PinId inputPinId, ed::PinId outputPinId)
     int start_attr = int(inputPinId.Get());
     UiPinPtr inputPin = getPin(outputPinId);
     UiPinPtr outputPin = getPin(inputPinId);
-    if (inputPinId && outputPinId && (outputPin->_type == inputPin->_type))
+
+    if (!inputPin || !outputPin)
     {
-        if (inputPin->_connected == false)
+        ed::RejectNewItem();
+        return;
+    }
+
+    // Perform type check 
+    bool typesMatch = (outputPin->_type == inputPin->_type);
+    if (!typesMatch)
+    {
+        ed::RejectNewItem();
+        showLabel("Invalid connection due to mismatched types", ImColor(50, 50, 50, 255));
+        return;
+    }
+
+    if (inputPin->_connected == false)
+    {
+        int upNode = getNodeId(inputPinId);
+        int downNode = getNodeId(outputPinId);
+        UiNodePtr uiDownNode = _graphNodes[downNode];
+        UiNodePtr uiUpNode = _graphNodes[upNode];
+        if (!uiDownNode || !uiUpNode)
         {
-            int upNode = getNodeId(inputPinId);
-            int downNode = getNodeId(outputPinId);
+            ed::RejectNewItem();
+            return;
+        }
 
-            // make sure there is an implementation for node
-            const mx::ShaderGenerator& shadergen = _renderer->getGenContext().getShaderGenerator();
+        // make sure there is an implementation for node
+        const mx::ShaderGenerator& shadergen = _renderer->getGenContext().getShaderGenerator();
 
-            // Find the implementation for this nodedef if not an input or output uinode
-            if (_graphNodes[downNode]->getInput() && _isNodeGraph)
+        // Prevent direct connecting from input to output
+        if (uiDownNode->getInput() && uiUpNode->getOutput())
+        {
+            ed::RejectNewItem();
+            showLabel("Direct connections between inputs and outputs is invalid", ImColor(50, 50, 50, 255));
+            return;
+        }
+
+        // Find the implementation for this nodedef if not an input or output uinode
+        if (uiDownNode->getInput() && _isNodeGraph)
+        {
+            ed::RejectNewItem();
+            showLabel("Cannot connect to inputs inside of graph", ImColor(50, 50, 50, 255));
+            return;
+        }
+        else if (uiUpNode->getNode())
+        {
+            mx::ShaderNodeImplPtr impl = shadergen.getImplementation(*_graphNodes[upNode]->getNode()->getNodeDef(), _renderer->getGenContext());
+            if (!impl)
             {
                 ed::RejectNewItem();
-                showLabel("Cannot connect to inputs inside of graph", ImColor(50, 50, 50, 255));
+                showLabel("Invalid Connection: Node does not have an implementation", ImColor(50, 50, 50, 255));
                 return;
             }
-            else if (_graphNodes[upNode]->getNode())
-            {
-                mx::ShaderNodeImplPtr impl = shadergen.getImplementation(*_graphNodes[upNode]->getNode()->getNodeDef(), _renderer->getGenContext());
-                if (!impl)
-                {
-                    ed::RejectNewItem();
-                    showLabel("Invalid Connection: Node does not have an implementation", ImColor(50, 50, 50, 255));
-                    return;
-                }
-            }
+        }
 
-            if (ed::AcceptNewItem())
-            {
-                // Since we accepted new link, lets add one to our list of links.
-                Link link;
-                link._startAttr = start_attr;
-                link._endAttr = end_attr;
-                _currLinks.push_back(link);
-                _frameCount = ImGui::GetFrameCount();
-                _renderer->setMaterialCompilation(true);
+        if (ed::AcceptNewItem())
+        {
+            // Since we accepted new link, lets add one to our list of links.
+            Link link;
+            link._startAttr = start_attr;
+            link._endAttr = end_attr;
+            _currLinks.push_back(link);
+            _frameCount = ImGui::GetFrameCount();
+            _renderer->setMaterialCompilation(true);
 
-                if (_graphNodes[downNode]->getNode() || _graphNodes[downNode]->getNodeGraph())
+            if (uiDownNode->getNode() || uiDownNode->getNodeGraph())
+            {
+                mx::InputPtr connectingInput = nullptr;
+                for (UiPinPtr pin : uiDownNode->inputPins)
                 {
-                    mx::InputPtr connectingInput = nullptr;
-                    for (UiPinPtr pin : _graphNodes[downNode]->inputPins)
+                    if (pin->_pinId == outputPinId)
                     {
-                        if (pin->_pinId == outputPinId)
+                        addNodeInput(uiDownNode, pin->_input);
+                        // update value to be empty
+                        if (uiDownNode->getNode() && uiDownNode->getNode()->getType() == mx::SURFACE_SHADER_TYPE_STRING)
                         {
-                            addNodeInput(_graphNodes[downNode], pin->_input);
-                            // update value to be empty
-                            if (_graphNodes[downNode]->getNode() && _graphNodes[downNode]->getNode()->getType() == mx::SURFACE_SHADER_TYPE_STRING)
+                            if (uiUpNode->getOutput() != nullptr)
                             {
-                                if (_graphNodes[upNode]->getOutput() != nullptr)
-                                {
-                                    pin->_input->setConnectedOutput(_graphNodes[upNode]->getOutput());
-                                }
-                                else if (_graphNodes[upNode]->getInput() != nullptr)
-                                {
-                                    pin->_input->setInterfaceName(_graphNodes[upNode]->getName());
-                                }
-                                else
-                                {
-                                    // node graph
-                                    if (_graphNodes[upNode]->getNodeGraph() != nullptr)
-                                    {
-                                        for (UiPinPtr outPin : _graphNodes[upNode]->outputPins)
-                                        {
-                                            // set pin connection to correct output
-                                            if (outPin->_pinId == inputPinId)
-                                            {
-                                                mx::OutputPtr outputs = _graphNodes[upNode]->getNodeGraph()->getOutput(outPin->_name);
-                                                pin->_input->setConnectedOutput(outputs);
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        pin->_input->setConnectedNode(_graphNodes[upNode]->getNode());
-                                    }
-                                }
+                                pin->_input->setConnectedOutput(uiUpNode->getOutput());
+                            }
+                            else if (uiUpNode->getInput() != nullptr)
+                            {
+                                pin->_input->setInterfaceName(uiUpNode->getName());
                             }
                             else
                             {
-                                if (_graphNodes[upNode]->getInput())
+                                // node graph
+                                if (uiUpNode->getNodeGraph() != nullptr)
                                 {
-
-                                    pin->_input->setInterfaceName(_graphNodes[upNode]->getName());
+                                    for (UiPinPtr outPin : uiUpNode->outputPins)
+                                    {
+                                        // set pin connection to correct output
+                                        if (outPin->_pinId == inputPinId)
+                                        {
+                                            mx::OutputPtr outputs = uiUpNode->getNodeGraph()->getOutput(outPin->_name);
+                                            pin->_input->setConnectedOutput(outputs);
+                                        }
+                                    }
                                 }
                                 else
                                 {
-                                    if (_graphNodes[upNode]->getNode())
+                                    pin->_input->setConnectedNode(uiUpNode->getNode());
+                                }
+                            }
+                        }
+                        else
+                        {
+                            if (uiUpNode->getInput())
+                            {
+
+                                pin->_input->setInterfaceName(uiUpNode->getName());
+                            }
+                            else
+                            {
+                                if (uiUpNode->getNode())
+                                {
+                                    pin->_input->setConnectedNode(uiUpNode->getNode());
+                                }
+                                else if (uiUpNode->getNodeGraph())
+                                {
+                                    for (UiPinPtr outPin : uiUpNode->outputPins)
                                     {
-                                        pin->_input->setConnectedNode(_graphNodes[upNode]->getNode());
-                                    }
-                                    else if (_graphNodes[upNode]->getNodeGraph())
-                                    {
-                                        for (UiPinPtr outPin : _graphNodes[upNode]->outputPins)
+                                        // set pin connection to correct output
+                                        if (outPin->_pinId == inputPinId)
                                         {
-                                            // set pin connection to correct output
-                                            if (outPin->_pinId == inputPinId)
-                                            {
-                                                mx::OutputPtr outputs = _graphNodes[upNode]->getNodeGraph()->getOutput(outPin->_name);
-                                                pin->_input->setConnectedOutput(outputs);
-                                            }
+                                            mx::OutputPtr outputs = uiUpNode->getNodeGraph()->getOutput(outPin->_name);
+                                            pin->_input->setConnectedOutput(outputs);
                                         }
                                     }
                                 }
                             }
-
-                            pin->setConnected(true);
-                            pin->_input->removeAttribute(mx::ValueElement::VALUE_ATTRIBUTE);
-                            connectingInput = pin->_input;
-                            break;
                         }
-                    }
-                    // create new edge and set edge information
-                    createEdge(_graphNodes[upNode], _graphNodes[downNode], connectingInput);
-                }
-                else if (_graphNodes[downNode]->getOutput() != nullptr)
-                {
-                    mx::InputPtr connectingInput = nullptr;
-                    _graphNodes[downNode]->getOutput()->setConnectedNode(_graphNodes[upNode]->getNode());
 
-                    // create new edge and set edge information
-                    createEdge(_graphNodes[upNode], _graphNodes[downNode], connectingInput);
-                }
-                else
-                {
-                    // create new edge and set edge info
-                    UiEdge newEdge = UiEdge(_graphNodes[upNode], _graphNodes[downNode], nullptr);
-                    if (!edgeExists(newEdge))
-                    {
-                        _graphNodes[downNode]->edges.push_back(newEdge);
-                        _currEdge.push_back(newEdge);
-
-                        // update input node num and output connections
-                        _graphNodes[downNode]->setInputNodeNum(1);
-                        _graphNodes[upNode]->setOutputConnection(_graphNodes[downNode]);
+                        pin->setConnected(true);
+                        pin->_input->removeAttribute(mx::ValueElement::VALUE_ATTRIBUTE);
+                        connectingInput = pin->_input;
+                        break;
                     }
+                }
+                // create new edge and set edge information
+                createEdge(_graphNodes[upNode], _graphNodes[downNode], connectingInput);
+            }
+            else if (_graphNodes[downNode]->getOutput() != nullptr)
+            {
+                mx::InputPtr connectingInput = nullptr;
+                _graphNodes[downNode]->getOutput()->setConnectedNode(_graphNodes[upNode]->getNode());
+
+                // create new edge and set edge information
+                createEdge(_graphNodes[upNode], _graphNodes[downNode], connectingInput);
+            }
+            else
+            {
+                // create new edge and set edge info
+                UiEdge newEdge = UiEdge(_graphNodes[upNode], _graphNodes[downNode], nullptr);
+                if (!edgeExists(newEdge))
+                {
+                    _graphNodes[downNode]->edges.push_back(newEdge);
+                    _currEdge.push_back(newEdge);
+
+                    // update input node num and output connections
+                    _graphNodes[downNode]->setInputNodeNum(1);
+                    _graphNodes[upNode]->setOutputConnection(_graphNodes[downNode]);
                 }
             }
-        }
-        else
-        {
-            ed::RejectNewItem();
         }
     }
     else
     {
         ed::RejectNewItem();
-        showLabel("Invalid Connection due to Mismatch Types", ImColor(50, 50, 50, 255));
     }
 }
 
@@ -3479,7 +3505,12 @@ void Graph::addNodePopup(bool cursor)
         std::string subs(input);
         // input string length
         // filter extra nodes - includes inputs, outputs, groups, and node graphs
-        for (std::unordered_map<std::string, std::vector<std::vector<std::string>>>::iterator it = _extraNodes.begin(); it != _extraNodes.end(); ++it)
+
+        // Choose which list to use based on if the context is within a nodegraph
+        std::unordered_map<std::string, std::vector<std::vector<std::string>>>* nodeList = 
+            _isNodeGraph ? &_extraNodes_NodeGraph : &_extraNodes;
+
+        for (std::unordered_map<std::string, std::vector<std::vector<std::string>>>::iterator it = nodeList->begin(); it != nodeList->end(); ++it)
         {
             // filter out list of nodes
             if (subs.size() > 0)
@@ -3489,6 +3520,13 @@ void Graph::addNodePopup(bool cursor)
                 {
                     std::string str(it->second[i][0]);
                     std::string nodeName = it->second[i][0];
+
+                    // Firewall check. Disallow nested nodegraphs 
+                    if (str == "nodegraph" && this->_isNodeGraph)
+                    {
+                        continue;
+                    }
+
                     // allow spaces to be used to search for node names
                     std::replace(subs.begin(), subs.end(), ' ', '_');
 

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -193,6 +193,7 @@ class Graph
     // for adding new nodes
     std::unordered_map<std::string, std::vector<mx::NodeDefPtr>> _nodesToAdd;
     std::unordered_map<std::string, std::vector<std::vector<std::string>>> _extraNodes;
+    std::unordered_map<std::string, std::vector<std::vector<std::string>>> _extraNodes_NodeGraph;
 
     // stacks to dive into and out of node graphs
     std::stack<std::vector<UiNodePtr>> _graphStack;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -193,7 +193,6 @@ class Graph
     // for adding new nodes
     std::unordered_map<std::string, std::vector<mx::NodeDefPtr>> _nodesToAdd;
     std::unordered_map<std::string, std::vector<std::vector<std::string>>> _extraNodes;
-    std::unordered_map<std::string, std::vector<std::vector<std::string>>> _extraNodes_NodeGraph;
 
     // stacks to dive into and out of node graphs
     std::stack<std::vector<UiNodePtr>> _graphStack;


### PR DESCRIPTION
## Issues

Fixes: #1454 
Update: #1446

- Add firewall check for output->input connectiosn which are invalid.
- Prevent nodegraph creation inside of nodegraphs which is unimplemented, and actually creates at the root unexpectedly.

## Fixes
- Add a check for output to input connect when trying to create a link. Show the appropriate message. Also some minor variable cleanup.
- Filter out nodes to display in UI when trying to add a node. If inside a nodegraph, then filter out the "nodegraph" entry.
