### PR TITLE
Add braces to matrix initializers

### DIFF
--- a/source/MaterialXCore/Types.h
+++ b/source/MaterialXCore/Types.h
@@ -592,9 +592,9 @@ class MX_CORE_API Matrix33 : public MatrixN<Matrix33, float, 3>
              float m20, float m21, float m22) :
         MatrixN(Uninit{})
     {
-        _arr = { m00, m01, m02,
-                 m10, m11, m12,
-                 m20, m21, m22 };
+        _arr = { RowArray{ m00, m01, m02 },
+                 RowArray{ m10, m11, m12 },
+                 RowArray{ m20, m21, m22 } };
     }
 
     /// @name Matrix Operations
@@ -663,10 +663,10 @@ class MX_CORE_API Matrix44 : public MatrixN<Matrix44, float, 4>
              float m30, float m31, float m32, float m33) :
         MatrixN(Uninit{})
     {
-        _arr = { m00, m01, m02, m03,
-                 m10, m11, m12, m13,
-                 m20, m21, m22, m23,
-                 m30, m31, m32, m33 };
+        _arr = { RowArray{ m00, m01, m02, m03 },
+                 RowArray{ m10, m11, m12, m13 },
+                 RowArray{ m20, m21, m22, m23 },
+                 RowArray{ m30, m31, m32, m33 } };
     }
 
     /// @name Matrix Operations


### PR DESCRIPTION
This changelist adds braces to matrix initializers in Types.h, improving conformance with upcoming versions of Clang.