### PR TITLE
Fix edge case in Python installation

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -14,4 +14,5 @@ setup(name='MaterialX',
       url='www.materialx.org',
       version='${MATERIALX_MAJOR_VERSION}.${MATERIALX_MINOR_VERSION}.${MATERIALX_BUILD_VERSION}',
       packages=['MaterialX'],
-      package_data={'MaterialX' : getRecursivePackageData('MaterialX')})
+      package_data={'MaterialX' : getRecursivePackageData('MaterialX')},
+      zip_safe = False)


### PR DESCRIPTION
This changelist explicitly sets zip_safe to False in setup.py, as Python's automated detection logic can make this determination incorrectly in some environments.