### PR TITLE
Add Save Node Positions option to editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -72,7 +72,8 @@ Graph::Graph(const std::string& materialFilename,
     _isCut(false),
     _autoLayout(false),
     _frameCount(INT_MIN),
-    _pinFilterType(mx::EMPTY_STRING)
+    _fontScale(1.0f),
+    _saveNodePositions(true)
 {
     loadStandardLibraries();
     setPinColor();
@@ -3085,6 +3086,12 @@ void Graph::graphButtons()
             ImGui::EndMenu();
         }
 
+        if (ImGui::BeginMenu("Options"))
+        {
+            ImGui::Checkbox("Save Node Positions", &_saveNodePositions);
+            ImGui::EndMenu();
+        }
+
         if (ImGui::Button("Help"))
         {
             ImGui::OpenPopup("Help");
@@ -4318,7 +4325,20 @@ void Graph::saveDocument(mx::FilePath filePath)
         filePath.addExtension(mx::MTLX_EXTENSION);
     }
 
+    mx::DocumentPtr writeDoc = _graphDoc;
+
+    // If requested, create a modified version of the document for saving.
+    if (!_saveNodePositions)
+    {
+        writeDoc = _graphDoc->copy();
+        for (mx::ElementPtr elem : writeDoc->traverseTree())
+        {
+            elem->removeAttribute("xpos");
+            elem->removeAttribute("ypos");
+        }
+    }
+
     mx::XmlWriteOptions writeOptions;
     writeOptions.elementPredicate = getElementPredicate();
-    mx::writeToXmlFile(_graphDoc, filePath, &writeOptions);
+    mx::writeToXmlFile(writeDoc, filePath, &writeOptions);
 }

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -236,7 +236,10 @@ class Graph
     std::string _pinFilterType;
 
     // DPI scaling for fonts
-    float _fontScale = 1.0f;
+    float _fontScale;
+
+    // Options
+    bool _saveNodePositions;
 };
 
 #endif


### PR DESCRIPTION
This changelist adds a Save Node Positions option to the Graph Editor, allowing the user to save a document without writing out node positions.