### PR TITLE
Fix input/output count in Element::clearContent

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -739,7 +739,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     void copyContentFrom(const ConstElementPtr& source);
 
     /// Clear all attributes and descendants from this element.
-    void clearContent();
+    virtual void clearContent();
 
     /// Using the input name as a starting point, modify it to create a valid,
     /// unique name for a child element.

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -629,4 +629,10 @@ bool InterfaceElement::hasExactInputMatch(ConstInterfaceElementPtr declaration, 
     return true;
 }
 
+void InterfaceElement::clearContent() {
+    _inputCount = 0;
+    _outputCount = 0;
+    TypedElement::clearContent();
+}
+
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -629,7 +629,8 @@ bool InterfaceElement::hasExactInputMatch(ConstInterfaceElementPtr declaration, 
     return true;
 }
 
-void InterfaceElement::clearContent() {
+void InterfaceElement::clearContent()
+{
     _inputCount = 0;
     _outputCount = 0;
     TypedElement::clearContent();

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -611,6 +611,13 @@ ConstInterfaceElementPtr InterfaceElement::getDeclaration(const string&) const
     return InterfaceElementPtr();
 }
 
+void InterfaceElement::clearContent()
+{
+    _inputCount = 0;
+    _outputCount = 0;
+    TypedElement::clearContent();
+}
+
 bool InterfaceElement::hasExactInputMatch(ConstInterfaceElementPtr declaration, string* message) const
 {
     for (InputPtr input : getActiveInputs())
@@ -627,13 +634,6 @@ bool InterfaceElement::hasExactInputMatch(ConstInterfaceElementPtr declaration, 
         }
     }
     return true;
-}
-
-void InterfaceElement::clearContent()
-{
-    _inputCount = 0;
-    _outputCount = 0;
-    TypedElement::clearContent();
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -647,6 +647,9 @@ class MX_CORE_API InterfaceElement : public TypedElement
     /// is provided, then an error message will be appended to the given string.
     bool hasExactInputMatch(ConstInterfaceElementPtr declaration, string* message = nullptr) const;
 
+    /// Clear all attributes and descendants from this element.
+    void clearContent() override;
+
     /// @}
 
   public:

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -639,6 +639,9 @@ class MX_CORE_API InterfaceElement : public TypedElement
     ///    no declaration was found.
     virtual ConstInterfaceElementPtr getDeclaration(const string& target = EMPTY_STRING) const;
 
+    /// Clear all attributes and descendants from this element.
+    void clearContent() override;
+
     /// Return true if this instance has an exact input match with the given
     /// declaration, where each input of this the instance corresponds to a
     /// declaration input of the same name and type.
@@ -646,9 +649,6 @@ class MX_CORE_API InterfaceElement : public TypedElement
     /// If an exact input match is not found, and the optional message argument
     /// is provided, then an error message will be appended to the given string.
     bool hasExactInputMatch(ConstInterfaceElementPtr declaration, string* message = nullptr) const;
-
-    /// Clear all attributes and descendants from this element.
-    void clearContent() override;
 
     /// @}
 

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -136,6 +136,24 @@ TEST_CASE("Node", "[node]")
     REQUIRE(doc->getOutputs().empty());
 }
 
+TEST_CASE("Node inputCount repro", "[node]")
+{
+    // Create a document.
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::NodePtr constant = doc->addNode("constant");
+    constant->setInputValue<float>("value", 0.5f);
+ 
+    // Check inputCount is correct after clearContent
+    constant->clearContent();
+    CHECK(constant->getInputCount() == 0);
+
+    // Validate crashes if the _inputCount is wrong so test that
+    constant->setType("float");
+    mx::OutputPtr output = doc->addOutput(mx::EMPTY_STRING, "float");
+    output->setConnectedNode(constant);
+    CHECK(doc->validate());
+}
+
 TEST_CASE("Flatten", "[nodegraph]")
 {
     // Read an example containing graph-based custom nodes.

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -143,11 +143,11 @@ TEST_CASE("Node inputCount repro", "[node]")
     mx::NodePtr constant = doc->addNode("constant");
     constant->setInputValue<float>("value", 0.5f);
  
-    // Check inputCount is correct after clearContent
+    // Check that input count is correct after clearContent
     constant->clearContent();
     CHECK(constant->getInputCount() == 0);
 
-    // Validate crashes if the _inputCount is wrong so test that
+    // Check that validate succeeds after clear and rebuild
     constant->setType("float");
     mx::OutputPtr output = doc->addOutput(mx::EMPTY_STRING, "float");
     output->setConnectedNode(constant);

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -93,6 +93,7 @@ void bindPyInterface(py::module& mod)
         .def("getDefaultVersion", &mx::InterfaceElement::getDefaultVersion)
         .def("getDeclaration", &mx::InterfaceElement::getDeclaration,
             py::arg("target") = mx::EMPTY_STRING)
+        .def("clearContent", &mx::InterfaceElement::clearContent)
         .def("hasExactInputMatch", &mx::InterfaceElement::hasExactInputMatch,
             py::arg("declaration"), py::arg("message") = nullptr)
         BIND_INTERFACE_TYPE_INSTANCE(integer, int)


### PR DESCRIPTION
When clearContent() is called on an InterfaceElement its _inputCount and _outputCount were not updated even though all inputs and outputs were removed. This led to problems including potential crash in Document::validate().