### PR TITLE
Align default precision across shading languages

### DIFF
--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -242,7 +242,10 @@ ScopedFloatFormatting::ScopedFloatFormatting(Value::FloatFormat format, int prec
     _precision(Value::getFloatPrecision())
 {
     Value::setFloatFormat(format);
-    Value::setFloatPrecision(precision);
+    if (precision >= 0)
+    {
+        Value::setFloatPrecision(precision);
+    }
 }
 
 ScopedFloatFormatting::~ScopedFloatFormatting()

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -198,7 +198,7 @@ template <class T> class MX_CORE_API TypedValue : public Value
 class MX_CORE_API ScopedFloatFormatting
 {
   public:
-    explicit ScopedFloatFormatting(Value::FloatFormat format, int precision = 6);
+    explicit ScopedFloatFormatting(Value::FloatFormat format, int precision = -1);
     ~ScopedFloatFormatting();
 
   private:

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -279,9 +279,7 @@ ShaderPtr GlslShaderGenerator::generate(const string& name, ElementPtr element, 
 {
     ShaderPtr shader = createShader(name, element, context);
 
-    // Turn on fixed float formatting to make sure float values are
-    // emitted with a decimal point and not as integers, and to avoid
-    // any scientific notation which isn't supported by all OpenGL targets.
+    // Request fixed floating-point notation for consistency across targets.
     ScopedFloatFormatting fmt(Value::FloatFormatFixed);
 
     // Make sure we initialize/reset the binding context before generation.

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -198,6 +198,9 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
 
     ShaderPtr shader = createShader(name, element, context);
 
+    // Request fixed floating-point notation for consistency across targets.
+    ScopedFloatFormatting fmt(Value::FloatFormatFixed);
+
     ShaderGraph& graph = shader->getGraph();
     ShaderStage& stage = shader->getStage(Stage::PIXEL);
 

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -283,9 +283,7 @@ ShaderPtr MslShaderGenerator::generate(const string& name, ElementPtr element, G
 {
     ShaderPtr shader = createShader(name, element, context);
 
-    // Turn on fixed float formatting to make sure float values are
-    // emitted with a decimal point and not as integers, and to avoid
-    // any scientific notation which isn't supported by all OpenGL targets.
+    // Request fixed floating-point notation for consistency across targets.
     ScopedFloatFormatting fmt(Value::FloatFormatFixed);
 
     // Make sure we initialize/reset the binding context before generation.

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -170,6 +170,9 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
 {
     ShaderPtr shader = createShader(name, element, context);
 
+    // Request fixed floating-point notation for consistency across targets.
+    ScopedFloatFormatting fmt(Value::FloatFormatFixed);
+
     ShaderGraph& graph = shader->getGraph();
     ShaderStage& stage = shader->getStage(Stage::PIXEL);
 

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -220,7 +220,6 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
 
     string getValue(const Value& value, bool uniform) const override
     {
-        ScopedFloatFormatting fmt(Value::FloatFormatFixed, 3);
         StringVec values = splitString(value.getValueString(), ",");
         return getValue(values, uniform);
     }


### PR DESCRIPTION
This changelist removes explicit overrides of floating-point precision in shader generation, making the default precision 6 decimal places across shading languages, and allowing the client to adjust the precision of generated shaders via Value::setFloatPrecision.

This addresses a slight visual regression in generated OSL (with a maximum visual error on the order of 1e-3), caused by a hard-coding of floating-point precision to 3 decimal places in OslSyntax.