### PR TITLE
Use explicit colorspace parameters in OSL texture calls

### DIFF
--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -12,6 +12,5 @@ void mx_image_color3(textureresource file, string layer, color default_value, ve
 
     color missingColor = default_value;
     vector2 st = mx_transform_uv(texcoord);
-    out = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode $extraTextureLookupArguments);
+    out = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode, "colorspace", file.colorspace);
 }
-

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -15,7 +15,7 @@ void mx_image_color4(textureresource file, string layer, color4 default_value, v
     vector2 st = mx_transform_uv(texcoord);
     float alpha;
     color rgb = texture(file.filename, st.x, st.y, "alpha", alpha, "subimage", layer,
-                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode $extraTextureLookupArguments );
+                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode, "colorspace", file.colorspace);
 
     out = color4(rgb, alpha);
 }

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -26,7 +26,6 @@
 MATERIALX_NAMESPACE_BEGIN
 
 const string OslShaderGenerator::TARGET = "genosl";
-const string OslShaderGenerator::T_FILE_EXTRA_ARGUMENTS = "$extraTextureLookupArguments";
 
 //
 // OslShaderGenerator methods
@@ -161,9 +160,6 @@ OslShaderGenerator::OslShaderGenerator() :
 
     // <!-- <surfacematerial> -->
     registerImplementation("IM_surfacematerial_" + OslShaderGenerator::TARGET, MaterialNodeOsl::create);
-
-    // Extra arguments for texture lookups.
-    _tokenSubstitutions[T_FILE_EXTRA_ARGUMENTS] = EMPTY_STRING;
 }
 
 ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -48,9 +48,6 @@ class MX_GENOSL_API OslShaderGenerator : public ShaderGenerator
     void registerShaderMetadata(const DocumentPtr& doc, GenContext& context) const override;
 
   protected:
-    // Extra file arguments for texture lookup call
-    static const string T_FILE_EXTRA_ARGUMENTS;
-
     /// Create and initialize a new OSL shader for shader generation.
     virtual ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;
 


### PR DESCRIPTION
This change list adds the parameter "colorspace" to the texture call in OSL, for sampling color3/color4 textures. Previously this was supported under the covers, by token replacement that a custom OSL generator had to setup, and only done for the Arnold OSL generator.

As discussed in issue #1463 there was a request for having this parameter used by default. Now color transformations can be done internally in OSL, if/when using an OSL version that supports this. The color transform node insertions, that are enabled by default, should then be disabled by setting `GenOptions.emitColorTransforms = false`.
