### PR TITLE
Improvements to shader generation tests

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -87,9 +87,6 @@
     <!-- Suggested irradiance IBL file path -->
     <input name="irradianceIBLPath" type="string" value="resources/Lights/irradiance/san_giuseppe_bridge.hdr" />
 
-    <!-- Transforms UVs of loaded geometry -->
-    <input name="transformUVs" type="matrix44" value="1.0f, 0.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -0.235f, 1.0f, 0.0f, 1.0f" />
-
     <!-- List of extra library paths for generator and render tests -->
     <input name="extraLibraryPaths" type="string" value="" />
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -480,27 +480,6 @@ void ShaderGeneratorTester::setupDependentLibraries()
     loadLibraries({ "libraries" }, _searchPath, _dependLib, _skipLibraryFiles);
 }
 
-void ShaderGeneratorTester::addSkipFiles()
-{
-    _skipFiles.insert("_options.mtlx");
-    _skipFiles.insert("light_rig_test_1.mtlx");
-    _skipFiles.insert("light_rig_test_2.mtlx");
-    _skipFiles.insert("light_compound_test.mtlx");
-    _skipFiles.insert("xinclude_search_path.mtlx");
-    _skipFiles.insert("1_38_parameter_to_input.mtlx");
-    _skipFiles.insert("1_36_to_1_37.mtlx");
-    _skipFiles.insert("1_37_to_1_38.mtlx");
-    _skipFiles.insert("material_element_to_surface_material.mtlx");
-}
-
-void ShaderGeneratorTester::addSkipNodeDefs()
-{
-}
-
-void ShaderGeneratorTester::addSkipLibraryFiles()
-{
-}
-
 LightIdMap ShaderGeneratorTester::computeLightIdMap(const std::vector<mx::NodePtr>& nodes)
 {
     std::unordered_map<std::string, unsigned int> idMap;

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -180,13 +180,13 @@ class ShaderGeneratorTester
     virtual void setTestStages() = 0;
 
     // Add files in to not examine
-    virtual void addSkipFiles();
+    virtual void addSkipFiles() { };
 
     // Add nodedefs to not examine
-    virtual void addSkipNodeDefs();
+    virtual void addSkipNodeDefs() { };
 
     // Add files to be skipped while loading libraries
-    virtual void addSkipLibraryFiles();
+    virtual void addSkipLibraryFiles() { };
 
     // Add color management
     virtual void addColorManagement();
@@ -267,8 +267,6 @@ class ShaderGeneratorTester
     std::unordered_map<std::string, mx::GenUserDataPtr> _userData;
     mx::StringSet _usedImplementations;
 };
-
-
 
 } // namespace GenShaderUtil
 


### PR DESCRIPTION
- Include all example documents by default in shader generation tests, rather than excluding a subset of the examples in all generators.
- Remove an unused input from the render test suite options, eliminating a source of syntax errors in shader generation tests.