### PR TITLE
Improvements to 1.37 upgrade

### DIFF
--- a/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_37.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_37.mtlx
@@ -4,61 +4,110 @@
     Examples of MaterialX 1.37 syntax
   -->
 
-  <nodegraph name="atan2_graph">
-    <atan2 name="atan2_float" type="float">
-      <input name="in1" type="float" value="0.5" />
-      <input name="in2" type="float" value="1.0" />
-    </atan2>
-    <atan2 name="atan2_vector2" type="vector2">
-      <input name="in1" type="vector2" value="0.5, 0.5" />
-      <input name="in2" type="vector2" value="1.0, 1.0" />
-    </atan2>
-    <atan2 name="atan2_vector3" type="vector3">
-      <input name="in1" type="vector3" value="0.5, 0.5, 0.5" />
-      <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    </atan2>
-    <atan2 name="atan2_vector4" type="vector4">
-      <input name="in1" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
-      <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    </atan2>
-    <rotate3d name="rot1" type="vector3">
-      <input name="in" type="vector3" value="1.0, 0.0, 0.0" />
-      <input name="amount" type="float" value="10.0" />
-      <parameter name="axis" type="vector3" value="0.0, 0.0, 1.0" />
-    </rotate3d>
-  </nodegraph>
-
-  <nodedef name="ND_Test" node="test">
-    <input name="add" type="float" />
+  <nodedef name="ND_example_surface" node="example_surface">
+    <input name="diffuseColor" type="color3" value="0.18, 0.18, 0.18" />
+    <input name="metalness" type="float" value="0" />
+    <input name="roughness" type="float" value="0.01" />
+    <input name="clearcoat" type="float" value="0" />
+    <input name="clearcoatRoughness" type="float" value="0.01" />
+    <input name="transmission" type="float" value="0" />
+    <input name="ior" type="float" value="1.5" />
+    <input name="emissiveColor" type="color3" value="0, 0, 0" />
+    <output name="out" type="surfaceshader" />
   </nodedef>
-  <nodegraph name="NG_Test" nodedef="ND_Test">
-    <add name="add" type="float">
-      <input name="in1" type="float" interfacename="add" />
-      <input name="in2" type="float" value="1.0" />
+
+  <nodegraph name="NG_example_surface" nodedef="ND_example_surface">
+    <diffuse_brdf name="diffuse_bsdf" type="BSDF">
+      <input name="weight" type="float" value="1" />
+      <input name="color" type="color3" interfacename="diffuseColor" />
+      <input name="roughness" type="float" value="0" />
+    </diffuse_brdf>
+    <dielectric_btdf name="transmission_bsdf" type="BSDF">
+      <input name="weight" type="float" value="1" />
+      <input name="tint" type="color3" value="1, 1, 1" />
+      <input name="ior" type="float" interfacename="ior" />
+    </dielectric_btdf>
+    <mix name="transmission_mix" type="BSDF">
+      <input name="fg" type="BSDF" nodename="transmission_bsdf" />
+      <input name="bg" type="BSDF" nodename="diffuse_bsdf" />
+      <input name="mix" type="float" interfacename="transmission" />
+    </mix>
+    <roughness_anisotropy name="specular_roughness" type="vector2">
+      <input name="roughness" type="float" interfacename="roughness" />
+      <input name="anisotropy" type="float" value="0" />
+    </roughness_anisotropy>
+    <subtract name="one_minus_ior" type="float">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" interfacename="ior" />
+    </subtract>
+    <add name="one_plus_ior" type="float">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" interfacename="ior" />
     </add>
-    <add name="add1" type="float">
-      <input name="in1" type="float" nodename="add" />
-      <input name="in2" type="float" value="1.0" />
-    </add>
+    <divide name="div_ior" type="float">
+      <input name="in1" type="float" nodename="one_minus_ior" />
+      <input name="in2" type="float" nodename="one_plus_ior" />
+    </divide>
+    <multiply name="F0" type="float">
+      <input name="in1" type="float" nodename="div_ior" />
+      <input name="in2" type="float" nodename="div_ior" />
+    </multiply>
+    <multiply name="F0_albedo" type="color3">
+      <input name="in1" type="color3" interfacename="diffuseColor" />
+      <input name="in2" type="float" nodename="F0" />
+    </multiply>
+    <generalized_schlick_brdf name="dielectric_bsdf" type="BSDF">
+      <input name="weight" type="float" value="1" />
+      <input name="color0" type="color3" nodename="F0" channels="rrr"/>
+      <input name="color90" type="color3" value="1, 1, 1" />
+      <input name="roughness" type="vector2" nodename="specular_roughness" />
+      <input name="base" type="BSDF" nodename="transmission_mix" />
+    </generalized_schlick_brdf>
+    <conductor_brdf name="conductor_bsdf" type="BSDF">
+      <input name="weight" type="float" value="1" />
+      <input name="reflectivity" type="color3" nodename="F0_albedo" />
+      <input name="edge_color" type="color3" interfacename="diffuseColor" />
+      <input name="roughness" type="vector2" nodename="specular_roughness" />
+    </conductor_brdf>
+    <mix name="specular_bsdf" type="BSDF">
+      <input name="fg" type="BSDF" nodename="conductor_bsdf" />
+      <input name="bg" type="BSDF" nodename="dielectric_bsdf" />
+      <input name="mix" type="float" interfacename="metalness" />
+    </mix>
+    <roughness_anisotropy name="coat_roughness" type="vector2">
+      <input name="roughness" type="float" interfacename="clearcoatRoughness" />
+      <input name="anisotropy" type="float" value="0" />
+    </roughness_anisotropy>
+    <dielectric_brdf name="coat_bsdf" type="BSDF">
+      <input name="weight" type="float" interfacename="clearcoat" />
+      <input name="tint" type="color3" value="1, 1, 1" />
+      <input name="ior" type="float" value="1.5" />
+      <input name="roughness" type="vector2" nodename="coat_roughness" />
+      <input name="base" type="BSDF" nodename="specular_bsdf" />
+    </dielectric_brdf>
+    <uniform_edf name="emission_edf" type="EDF">
+      <input name="color" type="color3" interfacename="emissiveColor" />
+    </uniform_edf>
+    <surface name="surface_constructor" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="coat_bsdf" />
+      <input name="edf" type="EDF" nodename="emission_edf" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface_constructor" />
   </nodegraph>
 
-  <nodegraph name="NG_aiMixColor31">
-    <mix name="aiMixColor31" type="color3">
-      <input name="fg" type="color3" nodename="aiAbsvalColor31" />
-      <input name="bg" type="color3" nodename="aiAbsvalColor32" />
-      <input name="mix" type="float" value="0.5" />
-    </mix>
-    <absval name="aiAbsvalColor31" type="color3">
-      <input name="in" type="color3" value="1, 0, 0" />
-    </absval>
-    <absval name="aiAbsvalColor32" type="color3">
-      <input name="in" type="color3" value="0.671, 0.671, 0.671" />
-    </absval>
-    <output name="out" type="color3" nodename="aiMixColor31" />
-  </nodegraph>
-  <material name="my_surface">
-    <shaderref name="my_surface" node="standard_surface">
-      <bindinput name="base_color" type="color3" nodegraph="NG_aiMixColor31" output="out" />
+  <material name="M_example_surface">
+    <shaderref name="SR_example_surface" node="example_surface">
+      <bindinput name="diffuseColor" type="color3" value="0.2, 0.2, 0.6" />
     </shaderref>
   </material>
+
+  <atan2 name="atan2" type="float">
+    <input name="in1" type="float" value="0.5" />
+    <input name="in2" type="float" value="1.0" />
+  </atan2>
+  <rotate3d name="rot1" type="vector3">
+    <input name="in" type="vector3" value="1.0, 0.0, 0.0" />
+    <input name="amount" type="float" value="10.0" />
+    <parameter name="axis" type="vector3" value="0.0, 0.0, 1.0" />
+  </rotate3d>
 </materialx>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1040,39 +1040,7 @@ void Document::upgradeVersion()
             }
         }
 
-        // Update atan2 interface and rotate3d interface
-        const string ATAN2 = "atan2";
-        const string IN1 = "in1";
-        const string IN2 = "in2";
-        const string ROTATE3D = "rotate3d";
-        const string AXIS = "axis";
-        const string INPUT_ONE = "1.0";
-
-        // Update nodedefs
-        bool upgradeAtan2Instances = false;
-        for (auto nodedef : getMatchingNodeDefs(ATAN2))
-        {
-            InputPtr input = nodedef->getInput(IN1);
-            InputPtr input2 = nodedef->getInput(IN2);
-            string inputValue = input->getValueString();
-            // Only flip value if nodedef value is the previous versions.
-            if (inputValue == INPUT_ONE)
-            {
-                input->setValueString(input2->getValueString());
-                input2->setValueString(inputValue);
-                upgradeAtan2Instances = true;
-            }
-        }
-        for (auto nodedef : getMatchingNodeDefs(ROTATE3D))
-        {
-            ElementPtr axis = nodedef->getChild(AXIS);
-            if (axis)
-            {
-                nodedef->changeChildCategory(axis, "input");
-            }
-        }
-
-        // Update BSDF interfaces
+        // Define BSDF node pairs.
         using StringPair = std::pair<string, string>;
         const StringPair DIELECTRIC_BRDF = { "dielectric_brdf", "dielectric_bsdf" };
         const StringPair DIELECTRIC_BTDF = { "dielectric_btdf", "dielectric_bsdf" };
@@ -1085,57 +1053,11 @@ void Document::upgradeVersion()
         const StringPair SUBSURFACE_BRDF = { "subsurface_brdf", "subsurface_bsdf" };
         const StringPair THIN_FILM_BRDF = { "thin_film_brdf", "thin_film_bsdf" };
 
-        const string SCATTER_MODE = "scatter_mode";
-        const string BSDF = "BSDF";
-        const string LAYER = "layer";
-        const string TOP = "top";
-        const string BASE = "base";
-        const string INTERIOR = "interior";
-        const string ARTISTIC_IOR = "artistic_ior";
-        const string COMPLEX_IOR = "complex_ior";
-        const string REFLECTIVITY = "reflectivity";
-        const string EDGE_COLOR = "edge_color";
-        const string IOR = "ior";
-        const string EXTINCTION = "extinction";
-        const string COLOR3 = "color3";
-        const string VECTOR3 = "vector3";
-        const string CONVERT = "convert";
-        const string IN = "in";
-
-        // Function for upgrading BSDF nodedef.
-        auto upgradeBsdfNodeDef = [SCATTER_MODE](NodeDefPtr nodedef, const string& newCategory, bool addScatterMode = false)
-        {
-            if (nodedef)
-            {
-                nodedef->setName(newCategory);
-                if (addScatterMode)
-                {
-                    InputPtr mode = nodedef->addInput(SCATTER_MODE, STRING_TYPE_STRING);
-                    mode->setIsUniform(true);
-                    mode->setValueString("R");
-                    mode->setAttribute("enum", "R,T,RT");
-                }
-            }
-        };
-
-        // Update nodedefs.
-        upgradeBsdfNodeDef(getNodeDef(DIELECTRIC_BRDF.first), DIELECTRIC_BRDF.second, true);
-        upgradeBsdfNodeDef(getNodeDef(GENERALIZED_SCHLICK_BRDF.first), GENERALIZED_SCHLICK_BRDF.second, true);
-        upgradeBsdfNodeDef(getNodeDef(CONDUCTOR_BRDF.first), CONDUCTOR_BRDF.second);
-        upgradeBsdfNodeDef(getNodeDef(SHEEN_BRDF.first), SHEEN_BRDF.second);
-        upgradeBsdfNodeDef(getNodeDef(DIFFUSE_BRDF.first), DIFFUSE_BRDF.second);
-        upgradeBsdfNodeDef(getNodeDef(BURLEY_DIFFUSE_BRDF.first), BURLEY_DIFFUSE_BRDF.second);
-        upgradeBsdfNodeDef(getNodeDef(DIFFUSE_BTDF.first), DIFFUSE_BTDF.second);
-        upgradeBsdfNodeDef(getNodeDef(SUBSURFACE_BRDF.first), SUBSURFACE_BRDF.second);
-        upgradeBsdfNodeDef(getNodeDef(THIN_FILM_BRDF.first), THIN_FILM_BRDF.second);
-        removeNodeDef(DIELECTRIC_BTDF.first);
-        removeNodeDef(COMPLEX_IOR);
-
         // Function for upgrading old nested layering setup
         // to new setup with layer operators.
-        auto upgradeBsdfLayering = [TOP, BASE, LAYER, BSDF](NodePtr node)
+        auto upgradeBsdfLayering = [](NodePtr node)
         {
-            InputPtr base = node->getInput(BASE);
+            InputPtr base = node->getInput("base");
             if (base)
             {
                 NodePtr baseNode = base->getConnectedNode();
@@ -1146,13 +1068,13 @@ void Document::upgradeVersion()
                     // so we don't need to update any connection references.
                     const string oldName = node->getName();
                     node->setName(oldName + "__layer_top");
-                    NodePtr layer = parent->addNode(LAYER, oldName, BSDF);
-                    InputPtr layerTop = layer->addInput(TOP, BSDF);
-                    InputPtr layerBase = layer->addInput(BASE, BSDF);
+                    NodePtr layer = parent->addNode("layer", oldName, "BSDF");
+                    InputPtr layerTop = layer->addInput("top", "BSDF");
+                    InputPtr layerBase = layer->addInput("base", "BSDF");
                     layerTop->setConnectedNode(node);
                     layerBase->setConnectedNode(baseNode);
                 }
-                node->removeInput(BASE);
+                node->removeInput("base");
             }
         };
 
@@ -1177,31 +1099,31 @@ void Document::upgradeVersion()
                 continue;
             }
             const string& nodeCategory = node->getCategory();
-            if (upgradeAtan2Instances && nodeCategory == ATAN2)
+            if (nodeCategory == "atan2")
             {
-                InputPtr input = node->getInput(IN1);
-                InputPtr input2 = node->getInput(IN2);
+                InputPtr input = node->getInput("in1");
+                InputPtr input2 = node->getInput("in2");
                 if (input && input2)
                 {
                     input->setName(EMPTY_STRING);
-                    input2->setName(IN1);
-                    input->setName(IN2);
+                    input2->setName("in1");
+                    input->setName("in2");
                 }
                 else
                 {
                     if (input)
                     {
-                        input->setName(IN2);
+                        input->setName("in2");
                     }
                     if (input2)
                     {
-                        input2->setName(IN1);
+                        input2->setName("in1");
                     }
                 }
             }
-            else if (nodeCategory == ROTATE3D)
+            else if (nodeCategory == "rotate3d")
             {
-                ElementPtr axis = node->getChild(AXIS);
+                ElementPtr axis = node->getChild("axis");
                 if (axis)
                 {
                     node->changeChildCategory(axis, "input");
@@ -1215,8 +1137,8 @@ void Document::upgradeVersion()
             else if (nodeCategory == DIELECTRIC_BTDF.first)
             {
                 node->setCategory(DIELECTRIC_BTDF.second);
-                node->removeInput(INTERIOR);
-                InputPtr mode = node->addInput(SCATTER_MODE, STRING_TYPE_STRING);
+                node->removeInput("interior");
+                InputPtr mode = node->addInput("scatter_mode", STRING_TYPE_STRING);
                 mode->setValueString("T");
             }
             else if (nodeCategory == GENERALIZED_SCHLICK_BRDF.first)
@@ -1240,32 +1162,32 @@ void Document::upgradeVersion()
 
                 // Create an artistic_ior node to convert from artistic to physical parameterization.
                 GraphElementPtr parent = node->getParent()->asA<GraphElement>();
-                NodePtr artisticIor = parent->addNode(ARTISTIC_IOR, node->getName() + "__artistic_ior", "multioutput");
-                OutputPtr artisticIor_ior = artisticIor->addOutput(IOR, COLOR3);
-                OutputPtr artisticIor_extinction = artisticIor->addOutput(EXTINCTION, COLOR3);
+                NodePtr artisticIor = parent->addNode("artistic_ior", node->getName() + "__artistic_ior", "multioutput");
+                OutputPtr artisticIor_ior = artisticIor->addOutput("ior", "color3");
+                OutputPtr artisticIor_extinction = artisticIor->addOutput("extinction", "color3");
 
                 // Copy values and connections from conductor node to artistic_ior node.
-                InputPtr reflectivity = node->getInput(REFLECTIVITY);
+                InputPtr reflectivity = node->getInput("reflectivity");
                 if (reflectivity)
                 {
-                    InputPtr artisticIor_reflectivity = artisticIor->addInput(REFLECTIVITY, COLOR3);
+                    InputPtr artisticIor_reflectivity = artisticIor->addInput("reflectivity", "color3");
                     copyAttributes(reflectivity, artisticIor_reflectivity);
                 }
-                InputPtr edge_color = node->getInput(EDGE_COLOR);
+                InputPtr edge_color = node->getInput("edge_color");
                 if (edge_color)
                 {
-                    InputPtr artisticIor_edge_color = artisticIor->addInput(EDGE_COLOR, COLOR3);
+                    InputPtr artisticIor_edge_color = artisticIor->addInput("edge_color", "color3");
                     copyAttributes(edge_color, artisticIor_edge_color);
                 }
 
                 // Update the parameterization on the conductor node
                 // and connect it to the artistic_ior node.
-                node->removeInput(REFLECTIVITY);
-                node->removeInput(EDGE_COLOR);
-                InputPtr ior = node->addInput(IOR, COLOR3);
+                node->removeInput("reflectivity");
+                node->removeInput("edge_color");
+                InputPtr ior = node->addInput("ior", "color3");
                 ior->setNodeName(artisticIor->getName());
                 ior->setOutputString(artisticIor_ior->getName());
-                InputPtr extinction = node->addInput(EXTINCTION, COLOR3);
+                InputPtr extinction = node->addInput("extinction", "color3");
                 extinction->setNodeName(artisticIor->getName());
                 extinction->setOutputString(artisticIor_extinction->getName());
             }
@@ -1285,17 +1207,17 @@ void Document::upgradeVersion()
             {
                 node->setCategory(SUBSURFACE_BRDF.second);
             }
-            else if (nodeCategory == ARTISTIC_IOR)
+            else if (nodeCategory == "artistic_ior")
             {
-                OutputPtr ior = node->getOutput(IOR);
+                OutputPtr ior = node->getOutput("ior");
                 if (ior)
                 {
-                    ior->setType(COLOR3);
+                    ior->setType("color3");
                 }
-                OutputPtr extinction = node->getOutput(EXTINCTION);
+                OutputPtr extinction = node->getOutput("extinction");
                 if (extinction)
                 {
-                    extinction->setType(COLOR3);
+                    extinction->setType("color3");
                 }
             }
 
@@ -1306,18 +1228,18 @@ void Document::upgradeVersion()
             // since we can't modify the graph while traversing it.
             for (InputPtr input : node->getInputs())
             {
-                if (input->getOutputString() == IOR && input->getType() == VECTOR3)
+                if (input->getOutputString() == "ior" && input->getType() == "vector3")
                 {
                     NodePtr connectedNode = input->getConnectedNode();
-                    if (connectedNode && connectedNode->getCategory() == ARTISTIC_IOR)
+                    if (connectedNode && connectedNode->getCategory() == "artistic_ior")
                     {
                         artisticIorConnections.push_back(input);
                     }
                 }
-                else if (input->getOutputString() == EXTINCTION && input->getType() == VECTOR3)
+                else if (input->getOutputString() == "extinction" && input->getType() == "vector3")
                 {
                     NodePtr connectedNode = input->getConnectedNode();
-                    if (connectedNode && connectedNode->getCategory() == ARTISTIC_IOR)
+                    if (connectedNode && connectedNode->getCategory() == "artistic_ior")
                     {
                         artisticExtConnections.push_back(input);
                     }
@@ -1331,10 +1253,10 @@ void Document::upgradeVersion()
             NodePtr artisticIorNode = input->getConnectedNode();
             ElementPtr node = input->getParent();
             GraphElementPtr parent = node->getParent()->asA<GraphElement>();
-            NodePtr convert = parent->addNode(CONVERT, node->getName() + "__convert_ior", VECTOR3);
-            InputPtr convertInput = convert->addInput(IN, COLOR3);
+            NodePtr convert = parent->addNode("convert", node->getName() + "__convert_ior", "vector3");
+            InputPtr convertInput = convert->addInput("in", "color3");
             convertInput->setNodeName(artisticIorNode->getName());
-            convertInput->setOutputString(IOR);
+            convertInput->setOutputString("ior");
             input->setNodeName(convert->getName());
             input->removeAttribute(PortElement::OUTPUT_ATTRIBUTE);
         }
@@ -1343,10 +1265,10 @@ void Document::upgradeVersion()
             NodePtr artisticIorNode = input->getConnectedNode();
             ElementPtr node = input->getParent();
             GraphElementPtr parent = node->getParent()->asA<GraphElement>();
-            NodePtr convert = parent->addNode(CONVERT, node->getName() + "__convert_extinction", VECTOR3);
-            InputPtr convertInput = convert->addInput(IN, COLOR3);
+            NodePtr convert = parent->addNode("convert", node->getName() + "__convert_extinction", "vector3");
+            InputPtr convertInput = convert->addInput("in", "color3");
             convertInput->setNodeName(artisticIorNode->getName());
-            convertInput->setOutputString(EXTINCTION);
+            convertInput->setOutputString("extinction");
             input->setNodeName(convert->getName());
             input->removeAttribute(PortElement::OUTPUT_ATTRIBUTE);
         }


### PR DESCRIPTION
- Add an example shading model graph using MaterialX 1.37 syntax, allowing improved coverage of version upgrade logic in unit tests.
- Simplify the logic for 1.37 upgrades in Document::upgradeVersion, removing legacy code that was dedicated to upgrading the MaterialX standard libraries.