### PR TITLE
Improvements to look inheritance

### DIFF
--- a/source/MaterialXTest/MaterialXCore/Look.cpp
+++ b/source/MaterialXTest/MaterialXCore/Look.cpp
@@ -75,6 +75,7 @@ TEST_CASE("Look", "[look]")
     // Create an inherited look.
     mx::LookPtr look2 = doc->addLook();
     look2->setInheritsFrom(look);
+    REQUIRE(look2->getActiveMaterialAssigns().size() == 2);
     REQUIRE(look2->getActivePropertySetAssigns().size() == 1);
     REQUIRE(look2->getActiveVisibilities().size() == 1);
 
@@ -86,6 +87,7 @@ TEST_CASE("Look", "[look]")
 
     // Disconnect the inherited look.
     look2->setInheritsFrom(nullptr);
+    REQUIRE(look2->getActiveMaterialAssigns().empty());
     REQUIRE(look2->getActivePropertySetAssigns().empty());
     REQUIRE(look2->getActiveVisibilities().empty());
 }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1375,7 +1375,7 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
             // with later assignments superseding earlier ones.
             for (mx::LookPtr look : doc->getLooks())
             {
-                for (mx::MaterialAssignPtr matAssign : look->getMaterialAssigns())
+                for (mx::MaterialAssignPtr matAssign : look->getActiveMaterialAssigns())
                 {
                     const std::string& activeGeom = matAssign->getActiveGeom();
                     for (mx::MeshPartitionPtr part : _geometryList)


### PR DESCRIPTION
- Add support for look inheritance in the MaterialX viewer.
- Improve coverage of look inheritance in MaterialX unit tests.
- Raises statement coverage for MaterialX unit tests to 88.6%.