### PR TITLE
DRAFT: Add the concept of an Override to the MaterialX C++ API

### DIFF
--- a/source/MaterialXCore/Override.cpp
+++ b/source/MaterialXCore/Override.cpp
@@ -1,0 +1,56 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <MaterialXCore/Value.h>
+#include <MaterialXCore/Document.h>
+
+#include <MaterialXCore/Override.h>
+#include <map>
+
+
+MATERIALX_NAMESPACE_BEGIN
+
+Override::Override(
+    std::shared_ptr<Document> doc,
+    const vector<string>& properties,
+    const vector<ValuePtr>& values) :
+    _doc(doc),
+    _properties(properties),
+    _values(values)
+{
+    bool getValues = _values.size()==0;
+    _propertyInputs.resize(_properties.size());
+    int foundProps = 0;
+    for (MaterialX::ElementPtr elem : _doc->traverseTree())
+    {
+        if (elem->isA<MaterialX::Input>())
+        {
+            MaterialX::InputPtr pInput = elem->asA<MaterialX::Input>();
+            for (int i = 0; i < properties.size(); i++)
+            {
+                if (pInput->getNamePath().compare(properties[i])==0)
+                {
+                    _propertyInputs[i] = pInput;
+                    foundProps++;
+                }
+            }
+            if (foundProps == _propertyInputs.size())
+                break;
+        }
+    }
+
+    for (int i = 0; i < properties.size(); i++)
+    {
+        _indexLookup[properties[i]] = i;
+        if (getValues && _propertyInputs[i])
+        {
+            auto val = _propertyInputs[i]->getValue();
+            _values.push_back(val->copy());
+
+        }
+    }
+
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXCore/Override.cpp
+++ b/source/MaterialXCore/Override.cpp
@@ -19,8 +19,13 @@ Override::Override(
     _properties(properties),
     _values(values)
 {
+    // Should we get default input values from document?
     bool getValues = _values.size()==0;
+
+    // Find the document inputs associated with the override properties.
+    // The material inputs are at the start of the traversed tree, so a linear search is most efficent.
     _propertyInputs.resize(_properties.size());
+    // Count how many properties have been found.
     int foundProps = 0;
     for (MaterialX::ElementPtr elem : _doc->traverseTree())
     {
@@ -35,18 +40,24 @@ Override::Override(
                     foundProps++;
                 }
             }
+
+            // Stop the search once all properties have been found.
             if (foundProps == _propertyInputs.size())
                 break;
         }
     }
 
+    // Build the index lookup map and set defaults.
     for (int i = 0; i < properties.size(); i++)
     {
         _indexLookup[properties[i]] = i;
         if (getValues && _propertyInputs[i])
         {
             auto val = _propertyInputs[i]->getValue();
-            _values.push_back(val->copy());
+            if (val)
+                _values.push_back(val->copy());
+            else
+                _values.push_back(Value::createValue(nullptr));
 
         }
     }

--- a/source/MaterialXCore/Override.cpp
+++ b/source/MaterialXCore/Override.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXCore/Override.h>
 #include <map>
 
-
 MATERIALX_NAMESPACE_BEGIN
 
 Override::Override(
@@ -20,7 +19,7 @@ Override::Override(
     _values(values)
 {
     // Should we get default input values from document?
-    bool getValues = _values.size()==0;
+    bool getValues = _values.size() == 0;
 
     // Find the document inputs associated with the override properties.
     // The material inputs are at the start of the traversed tree, so a linear search is most efficent.
@@ -34,7 +33,7 @@ Override::Override(
             MaterialX::InputPtr pInput = elem->asA<MaterialX::Input>();
             for (int i = 0; i < properties.size(); i++)
             {
-                if (pInput->getNamePath().compare(properties[i])==0)
+                if (pInput->getNamePath().compare(properties[i]) == 0)
                 {
                     _propertyInputs[i] = pInput;
                     foundProps++;
@@ -57,11 +56,22 @@ Override::Override(
             if (val)
                 _values.push_back(val->copy());
             else
-                _values.push_back(Value::createValue(nullptr));
-
+                _values.push_back(Value::createValue(""));
         }
     }
+}
 
+Override::Override(const Override& other) :
+    _doc(other._doc),
+    _propertyInputs(other._propertyInputs),
+    _properties(other._properties),
+    _indexLookup(other._indexLookup)
+{
+    // Shallow copy all the members except _values, which are cloned.
+    for (int i = 0; i < _properties.size(); i++)
+    {
+        _values.push_back(other._values[i]->copy());
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXCore/Override.h
+++ b/source/MaterialXCore/Override.h
@@ -30,6 +30,7 @@ class MX_CORE_API Override
         std::shared_ptr<Document> doc,
         const vector<string>& properties,
         const vector<ValuePtr>& values = {});
+    Override(const Override& other);
     ~Override() { }
 
     /// Create an override for this document with a list of properties.
@@ -45,6 +46,12 @@ class MX_CORE_API Override
         return std::make_shared<Override>(doc, properties, values);
     }
 
+    /// Create override from an existing override object.
+    /// @param other An existing Override to copy.
+    static OverridePtr copy(OverridePtr other)
+    {
+        return std::make_shared<Override>(*other);
+    }
 
     /// Set the value of the named override property.
     /// @param name The name of the property to set.

--- a/source/MaterialXCore/Override.h
+++ b/source/MaterialXCore/Override.h
@@ -1,0 +1,68 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_OVERRIDE_H
+#define MATERIALX_OVERRIDE_H
+
+/// @file
+/// Geometric element subclasses
+
+#include <MaterialXCore/Export.h>
+#include <MaterialXCore/Value.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+class Document;
+class Element;
+class Input;
+class Value;
+
+using OverridePtr = shared_ptr<class Override>;
+
+/// @class Override
+/// .
+class MX_CORE_API Override
+{
+  public:
+    Override(
+        std::shared_ptr<Document> doc,
+        const vector<string>& properties,
+        const vector<ValuePtr>& values = {});
+    ~Override() { }
+
+    static OverridePtr create(
+        std::shared_ptr<Document> doc,
+        const vector<string>& properties,
+        const vector<ValuePtr>& values = {})
+    {
+        return std::make_shared<Override>(doc, properties, values);
+    }
+
+    template<typename T>
+    void setValue(const string& name, const T& val) {
+        int idx = getIndex(name);
+        _values[idx] = Value::createValue(val);
+    }
+    int getIndex(const string& propName) {
+        return _indexLookup[propName];
+    }
+    std::shared_ptr<Document> getDocument() { return _doc; }
+
+    std::shared_ptr<Input> getPropertyInput(int n) { return _propertyInputs[n]; }
+    ValuePtr getValue(int n) { return _values[n]; }
+    string getPropertyName(int n) { return _properties[n]; }
+
+    int getPropertyCount() { return int(_properties.size()); }
+  private:
+    std::shared_ptr<Document> _doc;
+    vector<string> _properties;
+    vector<std::shared_ptr<Input>> _propertyInputs;
+    vector<ValuePtr> _values;
+    std::unordered_map<string, int> _indexLookup;
+};
+
+MATERIALX_NAMESPACE_END
+
+#endif

--- a/source/MaterialXCore/Override.h
+++ b/source/MaterialXCore/Override.h
@@ -95,6 +95,8 @@ class MX_CORE_API Override
     /// @return The property count.
     int getPropertyCount() { return int(_properties.size()); }
 
+    // TODO: Add the ability to serialize overrides (to/from XML, JSON, etc.)
+    // TODO: Add the method to produce an entirely new document from an override (a copy of the original document with inputs set to values in override.).
   private:
     std::shared_ptr<Document> _doc;
     vector<string> _properties;

--- a/source/MaterialXCore/Override.h
+++ b/source/MaterialXCore/Override.h
@@ -7,7 +7,7 @@
 #define MATERIALX_OVERRIDE_H
 
 /// @file
-/// Geometric element subclasses
+/// Material property override classes
 
 #include <MaterialXCore/Export.h>
 #include <MaterialXCore/Value.h>
@@ -22,7 +22,7 @@ class Value;
 using OverridePtr = shared_ptr<class Override>;
 
 /// @class Override
-/// .
+/// Specifies a list of properties (names and values) that override the input values for a document.
 class MX_CORE_API Override
 {
   public:
@@ -32,6 +32,11 @@ class MX_CORE_API Override
         const vector<ValuePtr>& values = {});
     ~Override() { }
 
+    /// Create an override for this document with a list of properties.
+    /// @param doc The document to override.
+    /// @param properties Vector of property names, each one must match the path name of an input in the document.
+    /// @param values Optional vector of values to override the ones in the document, length must match properties.  If not provided values are initialized with defaults from the document.
+    /// @return Pointer to the new override object.
     static OverridePtr create(
         std::shared_ptr<Document> doc,
         const vector<string>& properties,
@@ -40,21 +45,49 @@ class MX_CORE_API Override
         return std::make_shared<Override>(doc, properties, values);
     }
 
-    template<typename T>
-    void setValue(const string& name, const T& val) {
+
+    /// Set the value of the named override property.
+    /// @param name The name of the property to set.
+    /// @param val The value to set, any valid MaterialX type.
+    template <typename T>
+    void setValue(const string& name, const T& val)
+    {
         int idx = getIndex(name);
         _values[idx] = Value::createValue(val);
     }
-    int getIndex(const string& propName) {
-        return _indexLookup[propName];
+
+    /// Get the index of the named property
+    /// @param name The name of the property to lookup.
+    /// @return The index (or -1 if property name is not found.)
+    int getIndex(const string& propName)
+    {
+        auto iter = _indexLookup.find(propName);
+        if (iter == _indexLookup.end())
+            return -1;
+
+        return iter->second;
     }
+
+    /// Get the document for this override.
+    /// @return The document being overriden.
     std::shared_ptr<Document> getDocument() { return _doc; }
 
+    /// Get the document input for the Nth property being overriden.
+    /// @return Pointer to the input within the document.
     std::shared_ptr<Input> getPropertyInput(int n) { return _propertyInputs[n]; }
+
+    /// Get the current value of of the Nth property being overriden.
+    /// @return The current value.
     ValuePtr getValue(int n) { return _values[n]; }
+
+    /// Get the name of the Nth property being overriden.
+    /// @return The full path name of the input associated with the override property.
     string getPropertyName(int n) { return _properties[n]; }
 
+    /// Get the number of properties in this override.
+    /// @return The property count.
     int getPropertyCount() { return int(_properties.size()); }
+
   private:
     std::shared_ptr<Document> _doc;
     vector<string> _properties;

--- a/source/MaterialXRenderGlsl/GlslMaterial.cpp
+++ b/source/MaterialXRenderGlsl/GlslMaterial.cpp
@@ -68,7 +68,7 @@ bool GlslShaderMaterialState::generateShader(GenContext& context)
 
     _hasTransparency = isTransparentSurface(_def.elem, context.getShaderGenerator().getTarget());
 
-    // TODO: Just proof-of-concept code, we will need handle the case were generateShader is 
+    // TODO: Just proof-of-concept code, we will need handle the case where generateShader is 
     // called twice on the same shared state, with different contexts.
     GenContext materialContext = context;
     materialContext.getOptions().hwTransparency = _hasTransparency;

--- a/source/MaterialXRenderGlsl/GlslMaterial.cpp
+++ b/source/MaterialXRenderGlsl/GlslMaterial.cpp
@@ -68,7 +68,8 @@ bool GlslShaderMaterialState::generateShader(GenContext& context)
 
     _hasTransparency = isTransparentSurface(_def.elem, context.getShaderGenerator().getTarget());
 
-    // TODO: Just proof-of-concept code, we will need handle the case were generateShader is called twice on the same shared state, with different contexts.
+    // TODO: Just proof-of-concept code, we will need handle the case were generateShader is 
+    // called twice on the same shared state, with different contexts.
     GenContext materialContext = context;
     materialContext.getOptions().hwTransparency = _hasTransparency;
 

--- a/source/MaterialXRenderGlsl/GlslMaterial.h
+++ b/source/MaterialXRenderGlsl/GlslMaterial.h
@@ -16,17 +16,21 @@
 #include <MaterialXGenShader/UnitSystem.h>
 
 MATERIALX_NAMESPACE_BEGIN
-using GlslMaterialDefinitionStatePtr = std::shared_ptr<class GlslMaterialDefinitionState>;
 
-class GlslMaterialDefinitionState : public MaterialDefinitionState
+using GlslShaderMaterialStatePtr = std::shared_ptr<class GlslShaderMaterialState>;
+
+/// @class GlslShaderMaterialState
+/// Sub-class of ShaderMaterialState contain a glProgram that is created in generateShader.
+class GlslShaderMaterialState : public ShaderMaterialState
 {
   public:
-    GlslMaterialDefinitionState(const MaterialDefinition& def) :
-        MaterialDefinitionState(def) { }
+    GlslShaderMaterialState(const ShaderMaterialDefinition& def) :
+        ShaderMaterialState(def) { }
 
-    static GlslMaterialDefinitionStatePtr create(const MaterialDefinition& def)
+    /// Static creation function.
+    static GlslShaderMaterialStatePtr create(const ShaderMaterialDefinition& def)
     {
-        return std::make_shared<GlslMaterialDefinitionState>(def);
+        return std::make_shared<GlslShaderMaterialState>(def);
     }
 
     bool generateShader(GenContext& context) override;
@@ -67,7 +71,7 @@ class MX_RENDERGLSL_API GlslMaterial : public ShaderMaterial
     /// Return the underlying GLSL program.
     GlslProgramPtr getProgram() const
     {
-        return _pState ? std::static_pointer_cast<GlslMaterialDefinitionState>(_pState)->getProgram() : nullptr;
+        return _pState ? std::static_pointer_cast<GlslShaderMaterialState>(_pState)->getProgram() : nullptr;
     }
 
     /// Bind shader
@@ -123,12 +127,12 @@ class MX_RENDERGLSL_API GlslMaterial : public ShaderMaterial
 
   protected:
     void clearShader() override;
-    virtual MaterialDefinitionStatePtr createDefinitionState() override {
-        return GlslMaterialDefinitionState::create(_def);
+    virtual ShaderMaterialStatePtr createState() override {
+        return GlslShaderMaterialState::create(_def);
     }
 
   private:
-    GlslMaterialDefinitionStatePtr getState() const;
+    GlslShaderMaterialStatePtr getState() const;
 };
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
As discussed in this [Jira](https://github.com/AcademySoftwareFoundation/MaterialX/issues/1558), the current MaterialX API has no means of specifying a MaterialX material without a specifying a new MaterialX network graph (which must be parsed, code generated and compiled separately).  There is no way to specify that a material is set a of data-only changes and does not require a new material network, which is the common case in most real world scenes (where you have a handful of actually distinct material networks, and a large number of materials that only vary by a few vector or scalar data items.).  This an important omission from the API and which as well as losing important information when a scene's materials are represented with the MaterialX API, has huge performance implications due to the extra parsing, code generation and compilation entailed (see [this comment](https://github.com/AcademySoftwareFoundation/MaterialX/issues/1558#issuecomment-1763249574) for a detailed breakdown of the performance implications of this)

This PR introduces the concept of an `Override` to the MaterialXCore API.  This is a small addition to the API, the `Override` class is constructed with an existing MaterialX document and flat list of named properties (each being the string path to an input in the original document):
```
			override = mx::Override::create(doc, { "SimpleMaterial/base_color" });
```

The properties within the `Override` can then be changed individually by passing a valid MaterialX value type to the `setValue` method:
``` 
		override->setValue("SimpleMaterial/base_color", mx::Color3(r, g, b));
```

In this way the `Override` class adds the ability to specify a material (that is still a well defined MaterialX material, with a standardized appearance just as if it was specified with a MaterialX document directly) that is just a set of "plain old data" overrides from a pre-existing network, without forcing the renderer to parse and code generate a new material network unnecessarily.  The renderer does not have to treat an override material differently, it can just create a new material network for each one, and the results will be identical, but huge performance gains can be achieved by taking advantage of the extra information provided by the Override API.

To demonstrate this, and the massive performance improvement this allows, the PR also contains a proof-of-concept implementation of using `Override` in the `MaterialXRenderGlsl` library.  This adds a `setOverride` method to `ShaderMaterial` class allowing multiple materials to share the same document, element and node, but vary with different overrides:
```
	for (int i = 0; i < numMaterials; i++) {
		        mx::MaterialPtr pMtl = mx::GlslMaterial::create();
			pMtl->setDocument(doc);
			pMtl->setElement(typedElem);
			pMtl->setMaterialNode(materialNode);
			pMtl->setOverride(overrides[i]);
     }
```
The POC implementation adds a new bind method which `bindUniformOverrides` will bind the override properties to the current render state.:
```
				pMtl->bindViewInformation(viewCamera);
				pMtl->bindLighting(lightHandler, imageHandler, shadowState);
				pMtl->bindShader();
				pMtl->bindImages(imageHandler, { "" });
				pMtl->bindUniformOverrides();
   
```

These two Gists show the difference between having to create a [new material network for each material](https://gist.github.com/gareth-morgan-autodesk/704364c359a7a0c7ee9280feebd0b24e), and [using material overrides](https://gist.github.com/gareth-morgan-autodesk/74362c042afbc76fe49ca26b8c4e4408).