### PR TITLE
Remove unused uniforms in HW generation for heighttonormal

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -33,9 +33,9 @@ ShaderNodeImplPtr HeightToNormalNodeGlsl::create()
     return std::make_shared<HeightToNormalNodeGlsl>();
 }
 
-// override removes undesirable parent ConvolutionNode shader code
 void HeightToNormalNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader&) const
 {
+    // Default filter kernels from ConvolutionNode are not used by this derived class.
 }
 
 void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -33,6 +33,11 @@ ShaderNodeImplPtr HeightToNormalNodeGlsl::create()
     return std::make_shared<HeightToNormalNodeGlsl>();
 }
 
+// override removes undesirable parent ConvolutionNode shader code
+void HeightToNormalNodeGlsl::createVariables(const ShaderNode&, GenContext&, Shader&) const
+{
+}
+
 void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                                         unsigned int, StringVec& offsetStrings) const
 {

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.h
@@ -18,6 +18,8 @@ class MX_GENGLSL_API HeightToNormalNodeGlsl : public ConvolutionNode
   public:
     static ShaderNodeImplPtr create();
 
+    void createVariables(const ShaderNode&, GenContext&, Shader& shader) const override;
+
     void emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 

--- a/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
@@ -33,6 +33,11 @@ ShaderNodeImplPtr HeightToNormalNodeMsl::create()
     return std::make_shared<HeightToNormalNodeMsl>();
 }
 
+// override removes undesirable parent ConvolutionNode shader code
+void HeightToNormalNodeMsl::createVariables(const ShaderNode&, GenContext&, Shader&) const
+{
+}
+
 void HeightToNormalNodeMsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,
                                                        unsigned int, StringVec& offsetStrings) const
 {

--- a/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
@@ -33,9 +33,9 @@ ShaderNodeImplPtr HeightToNormalNodeMsl::create()
     return std::make_shared<HeightToNormalNodeMsl>();
 }
 
-// override removes undesirable parent ConvolutionNode shader code
 void HeightToNormalNodeMsl::createVariables(const ShaderNode&, GenContext&, Shader&) const
 {
+    // Default filter kernels from ConvolutionNode are not used by this derived class.
 }
 
 void HeightToNormalNodeMsl::computeSampleOffsetStrings(const string& sampleSizeName, const string& offsetTypeString,

--- a/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.h
@@ -18,6 +18,8 @@ class MX_GENMSL_API HeightToNormalNodeMsl : public ConvolutionNode
   public:
     static ShaderNodeImplPtr create();
 
+    void createVariables(const ShaderNode&, GenContext&, Shader& shader) const override;
+
     void emitFunctionDefinition(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 


### PR DESCRIPTION
This PR addresses the undesirable shaderGen for Metal and GLSL targets when using the HeightToNormalNode.
The parent ConvolutionNode class emits a couple of filter kernel arrays, for box and gaussian weights, that may cause shader compiler issues when they remain unused.

An example diff of a dumped out Metal shader source using the `HeightToNormalNode` before (righthand side) and after (lefthand side):

![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/61437351/97d65922-7d2e-4b70-b4d5-81861012a9be)
