### PR TITLE
Fixed an off-by-one index check in `Element::setChildIndex()`.

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -168,7 +168,7 @@ void Element::setChildIndex(const string& name, int index)
         return;
     }
 
-    if (index < 0 || index > (int) _childOrder.size())
+    if (index < 0 || index >= (int) _childOrder.size())
     {
         throw Exception("Invalid child index");
     }

--- a/source/MaterialXTest/MaterialXCore/Element.cpp
+++ b/source/MaterialXTest/MaterialXCore/Element.cpp
@@ -54,6 +54,9 @@ TEST_CASE("Element", "[element]")
     REQUIRE(*doc2 != *doc);
     doc2->setChildIndex("elem1", doc2->getChildIndex("elem2"));
     REQUIRE(*doc2 == *doc);
+    REQUIRE_THROWS_AS(doc2->setChildIndex("elem1", -100), mx::Exception);
+    REQUIRE_THROWS_AS(doc2->setChildIndex("elem1", -1), mx::Exception);
+    REQUIRE_THROWS_AS(doc2->setChildIndex("elem1", 2), mx::Exception);
     REQUIRE_THROWS_AS(doc2->setChildIndex("elem1", 100), mx::Exception);
     REQUIRE(*doc2 == *doc);
 


### PR DESCRIPTION
Extended the existing test case:
valid values for `index` in the test case are `0` and `1` only.

Minimal repro via Python bindings:
```bash
$ python3 -c 'import MaterialX as mx; d = mx.createDocument(); b = d.addBackdrop(); d.setChildIndex(b.getName(), 1)'
```
Without this patch:
```bash
Segmentation fault
```
With this patch:
```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
LookupError: Invalid child index
```

Ran the tests locally via `make && make test`:
```bash
100% tests passed, 0 tests failed out of 73
```

Update #1581