### PR TITLE
Add GCC 13 and Clang 15 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,18 +25,19 @@ jobs:
           python: 3.7
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_GCC_11_Python39
-          os: ubuntu-20.04
-          compiler: gcc
-          compiler_version: "11"
-          python: 3.9
-          build_javascript: ON
-
         - name: Linux_GCC_12_Python311
           os: ubuntu-22.04
           compiler: gcc
           compiler_version: "12"
           python: 3.11
+          build_javascript: ON
+
+        - name: Linux_GCC_13_Python312
+          os: ubuntu-22.04
+          compiler: gcc
+          compiler_version: "13"
+          python: 3.12
+          static_analysis: ON
 
         - name: Linux_GCC_CoverageAnalysis
           os: ubuntu-22.04
@@ -52,20 +53,19 @@ jobs:
           compiler_version: "10"
           python: 3.7
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
-          static_analysis: ON
 
-        - name: Linux_Clang_14_Python311
+        - name: Linux_Clang_15_Python312
           os: ubuntu-22.04
           compiler: clang
-          compiler_version: "14"
-          python: 3.11
+          compiler_version: "15"
+          python: 3.12
           test_render: ON
           clang_format: ON
 
-        - name: Linux_Clang_14_DynamicAnalysis
+        - name: Linux_Clang_DynamicAnalysis
           os: ubuntu-22.04
           compiler: clang
-          compiler_version: "14"
+          compiler_version: "15"
           python: None
           cmake_config: -DMATERIALX_DYNAMIC_ANALYSIS=ON
           dynamic_analysis: ON


### PR DESCRIPTION
This changelist adds GCC 13 and Clang 15 builds to GitHub CI, leveraging new support for these builds in the ubuntu-22.04 environment.