### PR TITLE
Fixed code errors in Python scripts flagged by pyflakes.

### DIFF
--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -25,7 +25,7 @@ def validateCode(sourceCodeFile, codevalidator, codevalidatorArgs):
         print(cmd_flatten)
         try:
             output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-            result = output.decode(encoding='utf-8')
+            return output.decode(encoding='utf-8')
         except subprocess.CalledProcessError as out:                                                                                                   
             return (out.output.decode(encoding='utf-8'))
     return ""
@@ -83,7 +83,7 @@ def main():
         try:
             mx.loadLibraries(libraryFolders, searchPath, stdlib)
             doc.importLibrary(stdlib)
-        except err:
+        except Exception as err:
             print('Generation failed: "', err, '"')
             sys.exit(-1)
 

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -3,9 +3,11 @@
 Generate MDL implementation directory based on MaterialX nodedefs
 '''
 
-import sys
 import os
-import string; os.environ['PYTHONIOENCODING'] = 'utf-8'
+import sys
+
+os.environ['PYTHONIOENCODING'] = 'utf-8'
+
 import MaterialX as mx
 
 def usage():
@@ -345,7 +347,7 @@ def main():
 
     doc = mx.createDocument()
     searchPath = os.path.join(_startPath, 'libraries')
-    libraryPath = os.path.join(searchPath, 'stdlib')
+    libraryPath = os.path.join(searchPath, LIBRARY)
     _loadLibraries(doc, searchPath, libraryPath)
 
     DEFINITION_PREFIX = 'ND_'
@@ -522,7 +524,7 @@ def main():
             if isinstance(elem, mx.Output):
                 outputValue = elem.getAttribute('default')
                 if outputValue == '[]':
-                    outputvalue = ''
+                    outputValue = ''
                 if not outputValue:
                     outputValue = elem.getAttribute('defaultinput')
                     if outputValue:

--- a/python/Scripts/mxdoc.py
+++ b/python/Scripts/mxdoc.py
@@ -3,7 +3,9 @@
 Print markdown documentation for each nodedef in the given document.
 '''
 
-import sys, os, argparse
+import argparse
+import sys
+
 import MaterialX as mx
 
 HEADERS = ('Name', 'Type', 'Default Value',

--- a/python/Scripts/mxformat.py
+++ b/python/Scripts/mxformat.py
@@ -4,7 +4,9 @@ Reformat a folder of MaterialX documents in place, optionally upgrading
 the documents to the latest version of the standard.
 '''
 
-import sys, os, argparse
+import argparse
+import os
+
 import MaterialX as mx
 
 def main():

--- a/python/Scripts/mxvalidate.py
+++ b/python/Scripts/mxvalidate.py
@@ -3,7 +3,9 @@
 Verify that the given file is a valid MaterialX document.
 '''
 
-import sys, os, argparse
+import argparse
+import sys
+
 import MaterialX as mx
 
 def main():
@@ -25,7 +27,7 @@ def main():
         stdlib = mx.createDocument()
         try:
             mx.loadLibraries(mx.getDefaultDataLibraryFolders(), mx.getDefaultDataSearchPath(), stdlib)            
-        except err:
+        except Exception as err:
             print(err)
             sys.exit(0)
         doc.importLibrary(stdlib)


### PR DESCRIPTION
```bash
$ flake8 python/scripts --select F
python/scripts/generateshader.py:28:13: F841 local variable 'result' is assigned to but never used
python/scripts/generateshader.py:86:16: F821 undefined name 'err'
python/scripts/generateshader.py:87:43: F821 undefined name 'err'
python/scripts/genmdl.py:8:1: F401 'string' imported but unused
python/scripts/genmdl.py:344:5: F841 local variable 'LIBRARY' is assigned to but never used
python/scripts/genmdl.py:525:21: F841 local variable 'outputvalue' is assigned to but never used
python/scripts/mxdoc.py:6:1: F401 'os' imported but unused
python/scripts/mxformat.py:7:1: F401 'sys' imported but unused
python/scripts/mxvalidate.py:6:1: F401 'os' imported but unused
python/scripts/mxvalidate.py:28:16: F821 undefined name 'err'
python/scripts/mxvalidate.py:29:19: F821 undefined name 'err'
```

With this patch:
```bash
$ flake8 python/scripts --select F --count
0
```

Found while working on #1595.

This commit follows 83ae82eefa9e34e081f1341e34b194e84ad5b151.