### PR TITLE
Initial C++ fuzz tests

### DIFF
--- a/source/MaterialXCore/Util.cpp
+++ b/source/MaterialXCore/Util.cpp
@@ -24,7 +24,7 @@ const std::tuple<int, int, int> LIBRARY_VERSION_TUPLE(MATERIALX_MAJOR_VERSION,
 
 bool invalidNameChar(char c)
 {
-    return !isalnum(c) && c != '_' && c != ':';
+    return !isalnum((unsigned char) c) && c != '_' && c != ':';
 }
 
 } // anonymous namespace

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -51,7 +51,7 @@ const string MATERIALX_SEARCH_PATH_ENV_VAR = "MATERIALX_SEARCH_PATH";
 
 inline bool hasWindowsDriveSpecifier(const string& val)
 {
-    return (val.length() > 1 && std::isalpha(val[0]) && (val[1] == ':'));
+    return (val.length() > 1 && std::isalpha((unsigned char) val[0]) && (val[1] == ':'));
 }
 
 //

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -370,9 +370,8 @@ void shaderGenPerformanceTest(mx::GenContext& context)
     REQUIRE(loadedDocuments.size() == documentsPaths.size());
 
     // Shuffle the order of documents and perform document library import validatation and shadergen
-    std::random_device random_dev;
-    std::mt19937 generator(random_dev());
-    std::shuffle(loadedDocuments.begin(), loadedDocuments.end(), generator);
+    std::mt19937 rng(0);
+    std::shuffle(loadedDocuments.begin(), loadedDocuments.end(), rng);
     for (const auto& doc : loadedDocuments)
     {
         doc->importLibrary(nodeLibrary);


### PR DESCRIPTION
This changelist adds initial C++ fuzz tests to the XmlIo module of the MaterialX test suite.  In these new tests, pseudo-random edits are applied to a set of source documents before import, in order to uncover edge cases that aren't yet handled in MaterialXCore and MaterialXFormat.

Also:

- Add missing type casts to invalidNameChar and hasWindowDriveSpecifier.
- Make random numbers deterministic in shaderGenPerformanceTest.