### PR TITLE
Update UI library used for Web Viewer

### DIFF
--- a/javascript/MaterialXView/package-lock.json
+++ b/javascript/MaterialXView/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "dat.gui": "^0.7.9",
+        "lil-gui": "^0.19.1",
         "three": "^0.152.2",
         "webpack": "^5.89.0"
       },
@@ -2245,6 +2246,11 @@
         "picocolors": "^1.0.0",
         "shell-quote": "^1.8.1"
       }
+    },
+    "node_modules/lil-gui": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/lil-gui/-/lil-gui-0.19.1.tgz",
+      "integrity": "sha512-9dbIg+UxS8RIROI6OH5gV2KrVE0Cn37bcLOQGF2GKN8ibTxDrUSLzzZfkQR82LnZsgs7DEZOOGfn3zhtd6hk0Q=="
     },
     "node_modules/loader-runner": {
       "version": "4.3.0",

--- a/javascript/MaterialXView/package.json
+++ b/javascript/MaterialXView/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dat.gui": "^0.7.9",
+    "lil-gui": "^0.19.1",
     "three": "^0.152.2",
     "webpack": "^5.89.0"
   },

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -9,7 +9,7 @@ import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 
 import { prepareEnvTexture, getLightRotation, findLights, registerLights, getUniformValues } from './helper.js'
 import { Group } from 'three';
-import { GUI } from 'dat.gui';
+import GUI from 'lil-gui'; 
 
 const ALL_GEOMETRY_SPECIFIER = "*";
 const NO_GEOMETRY_SPECIFIER = "";
@@ -445,13 +445,10 @@ export class Editor
     //
     clearFolders()
     {
-        Array.from(document.getElementsByClassName('folder')).forEach(
+        Array.from(document.getElementsByClassName('lil-gui')).forEach(
             function (element, index, array) {
                 if (element.className) {
-                    let child = element.firstElementChild;
-                    if (child && child.className == 'dg') {
-                        element.remove();
-                    }
+                    element.remove();
                 }
             }
         );
@@ -466,16 +463,7 @@ export class Editor
         // Search document to find GUI elements and remove them
         // If not done then multiple GUIs will be created from different
         // threads.
-        Array.from(document.getElementsByClassName('dg')).forEach(
-            function (element, index, array) {
-                if (element.className) {
-                    element.remove();
-                }
-            }
-        );
-    
-        // Create new GUI.
-        this._gui = new GUI();
+        this.clearFolders();
         this._gui.open();
         
         return this._gui;


### PR DESCRIPTION
### Change

- Switch to `lil-gui` which fixes a number of dat-gui issues including all input which did not show up anymore (regresssion). 
- Same GUI lib as used for ThreeJS examples for consistency. 

### Examples

- lil-gui is mostly a 1:1 replacement. The clearing of UI on material change or initialization (to handle threaded load), is simplified to finding the appropriate DOM element.
- performance "appears" to be a a bit better, possibly due to delayed UI building / display after material loading.

![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/503c29fb-0ee1-41f6-b46a-d2d2620c865c)

![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/c6b014af-885c-4f21-8859-d495a0ea6d7d)

