### PR TITLE
Fix missing MSL case in PyMaterialX build

### DIFF
--- a/source/PyMaterialX/CMakeLists.txt
+++ b/source/PyMaterialX/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 add_subdirectory(PyMaterialXCore)
 add_subdirectory(PyMaterialXFormat)
-if (MATERIALX_BUILD_GEN_GLSL OR MATERIALX_BUILD_GEN_OSL OR MATERIALX_BUILD_GEN_MDL)
+if (MATERIALX_BUILD_GEN_GLSL OR MATERIALX_BUILD_GEN_OSL OR MATERIALX_BUILD_GEN_MDL OR MATERIALX_BUILD_GEN_MSL)
     add_subdirectory(PyMaterialXGenShader)
     if (MATERIALX_BUILD_GEN_GLSL)
         add_subdirectory(PyMaterialXGenGlsl)


### PR DESCRIPTION
Looks like a simple oversight. 