### PR TITLE
Web viewer formatting improvements and fixes

### DIFF
--- a/javascript/MaterialXView/index.ejs
+++ b/javascript/MaterialXView/index.ejs
@@ -10,6 +10,15 @@
         margin: 0;
         font-family: Arial
       }
+
+      /* Property editor item color */
+      .peditoritem {
+        background-color: #334444;
+      }
+      /* Property editor folder color */
+      .peditorfolder {
+        background-color: #333333;
+      }
     </style>
   </head>
   <body style="margin: 0px; overflow: hidden;">

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -1128,7 +1128,7 @@ export class Material
                             if (uniformToUpdate && value != null) {
                                 item = currentFolder.add(material.uniforms[name], 'value');
                                 item.name(path);
-                                item.readonly(true);
+                                item.disable(true);
                                 item.domElement.classList.add('peditoritem');                                
                             }
                             break;

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -860,15 +860,7 @@ export class Material
                                     currentFolder = folderList[newFolderName];
                                     if (!currentFolder) 
                                     {
-                                        if (nodeDefInput.hasAttribute('uiadvanced'))
-                                        {
-                                            currentFolder = matUI.addFolder(uifolderName + " (Advanced)");
-                                            currentFolder.close();
-                                        }
-                                        else
-                                        {
-                                            currentFolder = matUI.addFolder(uifolderName);
-                                        }  
+                                        currentFolder = matUI.addFolder(uifolderName);
                                         currentFolder.domElement.classList.add('peditorfolder');                                
                                         folderList[newFolderName] = currentFolder;
                                     }

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -869,6 +869,7 @@ export class Material
                                         {
                                             currentFolder = matUI.addFolder(uifolderName);
                                         }  
+                                        currentFolder.domElement.classList.add('peditorfolder');                                
                                         folderList[newFolderName] = currentFolder;
                                     }
                                 }
@@ -1007,7 +1008,8 @@ export class Material
                                 }
                                 if (enumList.length == 0)
                                 {
-                                    currentFolder.add(material.uniforms[name], 'value', minValue, maxValue, step).name(path);
+                                    let w = currentFolder.add(material.uniforms[name], 'value', minValue, maxValue, step).name(path);
+                                    w.domElement.classList.add('peditoritem');
                                 }    
                                 else
                                 {
@@ -1035,6 +1037,7 @@ export class Material
                                     const defaultOption = enumList[value]; // Set the default selected option
                                     const dropdownController = currentFolder.add(enumeration, defaultOption, enumeration).name(path);
                                     dropdownController.onChange(handleDropdownChange);                                
+                                    dropdownController.domElement.classList.add('peditoritem');
                                 }
                             }
                             break;
@@ -1043,7 +1046,8 @@ export class Material
                             uniformToUpdate = material.uniforms[name];
                             if (uniformToUpdate && value != null)
                             {
-                                currentFolder.add(material.uniforms[name], 'value').name(path);
+                                let w = currentFolder.add(material.uniforms[name], 'value').name(path);
+                                w.domElement.classList.add('peditoritem');                                
                             }
                             break;
 
@@ -1085,6 +1089,7 @@ export class Material
                                 Object.keys(material.uniforms[name].value).forEach((key) => {
                                     let w = vecFolder.add(material.uniforms[name].value, 
                                         key, minValue[key], maxValue[key], step[key]).name(keyString[key]);
+                                    w.domElement.classList.add('peditoritem');                                
                                 })
                             }
                             break;
@@ -1101,11 +1106,12 @@ export class Material
                                 const color3 = new THREE.Color(dummy.color);
                                 color3.fromArray(material.uniforms[name].value);
                                 dummy.color = color3.getHex();
-                                currentFolder.addColor(dummy, 'color').name(path)
+                                let w = currentFolder.addColor(dummy, 'color').name(path)
                                     .onChange(function (value) {
                                         const color3 = new THREE.Color(value);
                                         material.uniforms[name].value.set(color3.toArray());
                                     });
+                                w.domElement.classList.add('peditoritem');                                
                             }
                             break;
 
@@ -1123,6 +1129,7 @@ export class Material
                                 item = currentFolder.add(material.uniforms[name], 'value');
                                 item.name(path);
                                 item.readonly(true);
+                                item.domElement.classList.add('peditoritem');                                
                             }
                             break;
                         default:

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -861,10 +861,6 @@ export class Material
                                     if (!currentFolder) 
                                     {
                                         currentFolder = matUI.addFolder(uifolderName);
-                                        if (nodeDefInput.hasAttribute('uiadvanced'))
-                                        {
-                                            currentFolder.close();
-                                        }
                                         currentFolder.domElement.classList.add('peditorfolder');                                
                                         folderList[newFolderName] = currentFolder;
                                     }

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -861,6 +861,10 @@ export class Material
                                     if (!currentFolder) 
                                     {
                                         currentFolder = matUI.addFolder(uifolderName);
+                                        if (nodeDefInput.hasAttribute('uiadvanced'))
+                                        {
+                                            currentFolder.close();
+                                        }
                                         currentFolder.domElement.classList.add('peditorfolder');                                
                                         folderList[newFolderName] = currentFolder;
                                     }


### PR DESCRIPTION
## Changes

- Add colouring to items and folders which can be set vis CSS. This makes it easier to tell what areas are under what folders.
- Close "ui advanced" groups and all but first material on load. Both make it so that the drop-down is not really long. Especially for the chess set or any file with more than a few materials which requires a fair bit of scrolling to find the materials (and collapse them).

## Fixes
- Fix string disable setting (was using old API)
- Fix parenting of enum widgets to be under current folder instead of top level.

## Results:

| Chess set with 1st material exanded and subsequent materials collapsed |  Standard surface to show coloring. Closing `uiadvanced` allows for the the inputs to fit. | Enumerated properly parented (Alpha Mode) |
| :--: | :--: | :--: |
| <img src="https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/f9f7d879-c686-4f2c-b7a6-853b85b50c5b" width=100%> | <img src="https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/f8b4b6bf-e897-48fa-bf7b-1e96b4ab6324" width=100%> | <img src="https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/f6bb6e16-9006-45b1-84ec-76f53819cdae"> |

For inclusion, adding in other shading models. (Only OpenPBR also has `uiadvanced`)

| OpenPBR | gltf_pbr | UsdPreviewSurface |
| :--: | :-: | :-: |
| ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/f1906bfd-423f-4e97-89ce-822e58606100) | ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/d633cd03-33bc-4b54-8368-5270e5102b60) | ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/d92243bb-868a-48a6-9897-2d75e9323a31) |

