### PR TITLE
Add HwImplementation class

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -913,31 +913,9 @@ ShaderNodeImplPtr GlslShaderGenerator::getImplementation(const NodeDef& nodedef,
     return impl;
 }
 
-const string GlslImplementation::SPACE = "space";
-const string GlslImplementation::INDEX = "index";
-const string GlslImplementation::GEOMPROP = "geomprop";
-
-namespace
-{
-
-// List name of inputs that are not to be editable and
-// published as shader uniforms in GLSL.
-const std::set<string> IMMUTABLE_INPUTS =
-{
-    // Geometric node inputs are immutable since a shader needs regeneration if they change.
-    "index", "space", "attrname"
-};
-
-} // anonymous namespace
-
 const string& GlslImplementation::getTarget() const
 {
     return GlslShaderGenerator::TARGET;
-}
-
-bool GlslImplementation::isEditable(const ShaderInput& input) const
-{
-    return IMMUTABLE_INPUTS.count(input.getName()) == 0;
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -88,30 +88,13 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
 };
 
 /// Base class for common GLSL node implementations
-class MX_GENGLSL_API GlslImplementation : public ShaderNodeImpl
+class MX_GENGLSL_API GlslImplementation : public HwImplementation
 {
   public:
     const string& getTarget() const override;
 
-    bool isEditable(const ShaderInput& input) const override;
-
   protected:
     GlslImplementation() { }
-
-    // Integer identifiers for coordinate spaces.
-    // The order must match the order given for
-    // the space enum string in stdlib.
-    enum Space
-    {
-        MODEL_SPACE = 0,
-        OBJECT_SPACE = 1,
-        WORLD_SPACE = 2
-    };
-
-    /// Internal string constants
-    static const string SPACE;
-    static const string INDEX;
-    static const string GEOMPROP;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -1415,31 +1415,9 @@ ShaderNodeImplPtr MslShaderGenerator::getImplementation(const NodeDef& nodedef, 
     return impl;
 }
 
-const string MslImplementation::SPACE = "space";
-const string MslImplementation::INDEX = "index";
-const string MslImplementation::GEOMPROP = "geomprop";
-
-namespace
-{
-
-// List name of inputs that are not to be editable and
-// published as shader uniforms in MSL.
-const std::set<string> IMMUTABLE_INPUTS =
-{
-    // Geometric node inputs are immutable since a shader needs regeneration if they change.
-    "index", "space", "attrname"
-};
-
-} // namespace
-
 const string& MslImplementation::getTarget() const
 {
     return MslShaderGenerator::TARGET;
-}
-
-bool MslImplementation::isEditable(const ShaderInput& input) const
-{
-    return IMMUTABLE_INPUTS.count(input.getName()) == 0;
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMsl/MslShaderGenerator.h
+++ b/source/MaterialXGenMsl/MslShaderGenerator.h
@@ -115,30 +115,13 @@ class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
 };
 
 /// Base class for common MSL node implementations
-class MX_GENMSL_API MslImplementation : public ShaderNodeImpl
+class MX_GENMSL_API MslImplementation : public HwImplementation
 {
   public:
     const string& getTarget() const override;
 
-    bool isEditable(const ShaderInput& input) const override;
-
   protected:
     MslImplementation() { }
-
-    // Integer identifiers for coordinate spaces.
-    // The order must match the order given for
-    // the space enum string in stdlib.
-    enum Space
-    {
-        MODEL_SPACE = 0,
-        OBJECT_SPACE = 1,
-        WORLD_SPACE = 2
-    };
-
-    /// Internal string constants
-    static const string SPACE;
-    static const string INDEX;
-    static const string GEOMPROP;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -12,6 +12,24 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
+const string HwImplementation::SPACE = "space";
+const string HwImplementation::INDEX = "index";
+const string HwImplementation::GEOMPROP = "geomprop";
+
+namespace
+{
+
+// When node inputs with these names are modified, we assume the
+// associated HW shader must be recompiled.
+const StringSet IMMUTABLE_INPUTS =
+{
+    "index",
+    "space",
+    "attrname"
+};
+
+} // anonymous namespace
+
 namespace HW
 {
 
@@ -617,6 +635,11 @@ void HwShaderGenerator::addStageLightingUniforms(GenContext& context, ShaderStag
         ShaderPort* numActiveLights = addStageUniform(HW::PRIVATE_UNIFORMS, Type::INTEGER, HW::T_NUM_ACTIVE_LIGHT_SOURCES, stage);
         numActiveLights->setValue(Value::createValue<int>(0));
     }
+}
+
+bool HwImplementation::isEditable(const ShaderInput& input) const
+{
+    return IMMUTABLE_INPUTS.count(input.getName()) == 0;
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -340,6 +340,31 @@ class MX_GENSHADER_API HwShaderGenerator : public ShaderGenerator
     mutable ClosureContext _defEmission;
 };
 
+/// @class HwShaderGenerator
+/// Base class for HW node implementations.
+class MX_GENSHADER_API HwImplementation : public ShaderNodeImpl
+{
+  public:
+    bool isEditable(const ShaderInput& input) const override;
+
+  protected:
+    HwImplementation() { }
+
+    // Integer identifiers for coordinate spaces.
+    // The order must match the order given for the space enum string in stdlib.
+    enum Space
+    {
+        MODEL_SPACE = 0,
+        OBJECT_SPACE = 1,
+        WORLD_SPACE = 2
+    };
+
+    /// Internal string constants
+    static const string SPACE;
+    static const string INDEX;
+    static const string GEOMPROP;
+};
+
 /// @class HwResourceBindingContext
 /// Class representing a context for resource binding for hardware resources.
 class MX_GENSHADER_API HwResourceBindingContext : public GenUserData

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
@@ -12,8 +12,6 @@
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 
-#include <string>
-
 namespace py = pybind11;
 namespace mx = MaterialX;
 

--- a/source/PyMaterialX/PyMaterialXGenMdl/PyMdlShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMdl/PyMdlShaderGenerator.cpp
@@ -8,11 +8,8 @@
 #include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 
-#include <string>
-
 namespace py = pybind11;
 namespace mx = MaterialX;
-
 
 void bindPyMdlShaderGenerator(py::module& mod)
 {

--- a/source/PyMaterialX/PyMaterialXGenMsl/PyMslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMsl/PyMslShaderGenerator.cpp
@@ -10,8 +10,6 @@
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 
-#include <string>
-
 namespace py = pybind11;
 namespace mx = MaterialX;
 

--- a/source/PyMaterialX/PyMaterialXGenOsl/PyOslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenOsl/PyOslShaderGenerator.cpp
@@ -9,8 +9,6 @@
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/Shader.h>
 
-#include <string>
-
 namespace py = pybind11;
 namespace mx = MaterialX;
 

--- a/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
@@ -9,8 +9,6 @@
 #include <MaterialXGenShader/GenUserData.h>
 #include <MaterialXGenShader/HwShaderGenerator.h>
 
-#include <string>
-
 namespace py = pybind11;
 namespace mx = MaterialX;
 


### PR DESCRIPTION
This changelist adds an intermediate HwImplementation class, allowing the sharing of common features between node implementations in hardware shading languages.