### PR TITLE
Fix irradiance generation in MaterialXView

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -402,7 +402,7 @@ void Viewer::loadEnvironmentLight()
     }
 
     // Look for an irradiance map using an expected filename convention.
-    mx::ImagePtr envIrradianceMap = _imageHandler->getZeroImage();
+    mx::ImagePtr envIrradianceMap;
     if (!_normalizeEnvironment && !_splitDirectLight)
     {
         mx::FilePath envIrradiancePath = _envRadianceFilename.getParentPath() / IRRADIANCE_MAP_FOLDER / _envRadianceFilename.getBaseName();
@@ -410,7 +410,7 @@ void Viewer::loadEnvironmentLight()
     }
 
     // If not found, then generate an irradiance map via spherical harmonics.
-    if (envIrradianceMap == _imageHandler->getZeroImage())
+    if (!envIrradianceMap || envIrradianceMap->getWidth() == 1)
     {
         if (_generateReferenceIrradiance)
         {


### PR DESCRIPTION
This changelist fixes a regression to environment irradiance generation in MaterialXView, caused by a change to image caching logic for GLSL rendering in MaterialX 1.38.8.  This fix restores the ability to render environment maps that are missing their pre-generated irradiance data, with irradiance being generated on the fly via spherical harmonics.