### PR TITLE
1.39 update - rename atan2 inputs

### DIFF
--- a/documents/Specification/MaterialX.Specification.md
+++ b/documents/Specification/MaterialX.Specification.md
@@ -1148,7 +1148,7 @@ Math nodes have one or two spatially-varying inputs, and are used to perform a m
 
 <a id="node-atan2"> </a>
 
-* **`atan2`**: the arctangent of the expression (iny/inx); the output will be expressed in radians.  If both `in1` and `in2` are provided, they must be the same type.
+* **`atan2`**: the arctangent of the expression (iny/inx); the output will be expressed in radians.  If both `iny` and `inx` are provided, they must be the same type.
     * `iny` (float or vector<em>N</em>): the value or nodename for the "y" input; default is 0.0.
     * `inx` (float or vector<em>N</em>): the value or nodename for the "x" input; default is 1.0.
 

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -340,25 +340,25 @@
   <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" target="genglsl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -343,28 +343,28 @@
   <implementation name="IM_tan_float_genmdl" nodedef="ND_tan_float" sourcecode="math::tan({{in}})" target="genmdl" />
   <implementation name="IM_asin_float_genmdl" nodedef="ND_asin_float" sourcecode="math::asin({{in}})" target="genmdl" />
   <implementation name="IM_acos_float_genmdl" nodedef="ND_acos_float" sourcecode="math::acos({{in}})" target="genmdl" />
-  <implementation name="IM_atan2_float_genmdl" nodedef="ND_atan2_float" sourcecode="math::atan2({{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_atan2_float_genmdl" nodedef="ND_atan2_float" sourcecode="math::atan2({{iny}}, {{inx}})" target="genmdl" />
 
   <implementation name="IM_sin_vector2_genmdl" nodedef="ND_sin_vector2" sourcecode="math::sin({{in}})" target="genmdl" />
   <implementation name="IM_cos_vector2_genmdl" nodedef="ND_cos_vector2" sourcecode="math::cos({{in}})" target="genmdl" />
   <implementation name="IM_tan_vector2_genmdl" nodedef="ND_tan_vector2" sourcecode="math::tan({{in}})" target="genmdl" />
   <implementation name="IM_asin_vector2_genmdl" nodedef="ND_asin_vector2" sourcecode="math::asin({{in}})" target="genmdl" />
   <implementation name="IM_acos_vector2_genmdl" nodedef="ND_acos_vector2" sourcecode="math::acos({{in}})" target="genmdl" />
-  <implementation name="IM_atan2_vector2_genmdl" nodedef="ND_atan2_vector2" sourcecode="math::atan2({{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_atan2_vector2_genmdl" nodedef="ND_atan2_vector2" sourcecode="math::atan2({{iny}}, {{inx}})" target="genmdl" />
 
   <implementation name="IM_sin_vector3_genmdl" nodedef="ND_sin_vector3" sourcecode="math::sin({{in}})" target="genmdl" />
   <implementation name="IM_cos_vector3_genmdl" nodedef="ND_cos_vector3" sourcecode="math::cos({{in}})" target="genmdl" />
   <implementation name="IM_tan_vector3_genmdl" nodedef="ND_tan_vector3" sourcecode="math::tan({{in}})" target="genmdl" />
   <implementation name="IM_asin_vector3_genmdl" nodedef="ND_asin_vector3" sourcecode="math::asin({{in}})" target="genmdl" />
   <implementation name="IM_acos_vector3_genmdl" nodedef="ND_acos_vector3" sourcecode="math::acos({{in}})" target="genmdl" />
-  <implementation name="IM_atan2_vector3_genmdl" nodedef="ND_atan2_vector3" sourcecode="math::atan2({{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_atan2_vector3_genmdl" nodedef="ND_atan2_vector3" sourcecode="math::atan2({{iny}}, {{inx}})" target="genmdl" />
 
   <implementation name="IM_sin_vector4_genmdl" nodedef="ND_sin_vector4" sourcecode="math::sin({{in}})" target="genmdl" />
   <implementation name="IM_cos_vector4_genmdl" nodedef="ND_cos_vector4" sourcecode="math::cos({{in}})" target="genmdl" />
   <implementation name="IM_tan_vector4_genmdl" nodedef="ND_tan_vector4" sourcecode="math::tan({{in}})" target="genmdl" />
   <implementation name="IM_asin_vector4_genmdl" nodedef="ND_asin_vector4" sourcecode="math::asin({{in}})" target="genmdl" />
   <implementation name="IM_acos_vector4_genmdl" nodedef="ND_acos_vector4" sourcecode="math::acos({{in}})" target="genmdl" />
-  <implementation name="IM_atan2_vector4_genmdl" nodedef="ND_atan2_vector4" sourcecode="math::atan2({{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_atan2_vector4_genmdl" nodedef="ND_atan2_vector4" sourcecode="math::atan2({{iny}}, {{inx}})" target="genmdl" />
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genmdl" nodedef="ND_sqrt_float" sourcecode="math::sqrt({{in}})" target="genmdl" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -341,25 +341,25 @@
   <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="atan({{in1}}, {{in2}})" />
+  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genmsl" nodedef="ND_sqrt_float" target="genmsl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -343,25 +343,25 @@
   <implementation name="IM_tan_float_genosl" nodedef="ND_tan_float" target="genosl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" target="genosl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" target="genosl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" target="genosl" sourcecode="atan2({{in1}},{{in2}})" />
+  <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
   <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genosl" nodedef="ND_tan_vector2" target="genosl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" target="genosl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" target="genosl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" target="genosl" sourcecode="atan2({{in1}},{{in2}})" />
+  <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
   <implementation name="IM_sin_vector3_genosl" nodedef="ND_sin_vector3" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genosl" nodedef="ND_cos_vector3" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genosl" nodedef="ND_tan_vector3" target="genosl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" target="genosl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" target="genosl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" target="genosl" sourcecode="atan2({{in1}},{{in2}})" />
+  <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
   <implementation name="IM_sin_vector4_genosl" nodedef="ND_sin_vector4" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genosl" nodedef="ND_cos_vector4" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genosl" nodedef="ND_tan_vector4" target="genosl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" target="genosl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" target="genosl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" target="genosl" sourcecode="atan2({{in1}},{{in2}})" />
+  <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genosl" nodedef="ND_sqrt_float" target="genosl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1999,8 +1999,8 @@
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_float" node="atan2" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="iny" type="float" value="0.0" />
+    <input name="inx" type="float" value="1.0" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_sin_vector2" node="sin" nodegroup="math">
@@ -2024,8 +2024,8 @@
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_vector2" node="atan2" nodegroup="math">
-    <input name="in1" type="vector2" value="1.0, 1.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="iny" type="vector2" value="1.0, 1.0" />
+    <input name="inx" type="vector2" value="0.0, 0.0" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_sin_vector3" node="sin" nodegroup="math">
@@ -2049,8 +2049,8 @@
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_vector3" node="atan2" nodegroup="math">
-    <input name="in1" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="iny" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="inx" type="vector3" value="0.0, 0.0, 0.0" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_sin_vector4" node="sin" nodegroup="math">
@@ -2074,8 +2074,8 @@
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_vector4" node="atan2" nodegroup="math">
-    <input name="in1" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="iny" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="inx" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -165,13 +165,13 @@ def _writeOperatorFunc(file, outputType, arg1, functionName, arg2):
         else:
             file.write(INDENT + 'return ' + arg1 + ' ' + functionName + ' ' + arg2 + ';\n')
 
-def _writeTwoArgumentFunc(file, outputType, functionName):
+def _writeTwoArgumentFunc(file, outputType, functionName, arg1="mxp_in1", arg2="mxp_in2"):
         if outputType == 'color4':
-            file.write(INDENT + 'return mk_color4(' + functionName + '(mk_float4(mxp_in1), mk_float4(mxp_in2)));\n')
+            file.write(INDENT + 'return mk_color4(' + functionName + '(mk_float4(' + arg1 + '), mk_float4(' + arg2 + ')));\n')
         elif outputType == 'color':
-            file.write(INDENT + 'return color(' + functionName + '(float3(mxp_in1), float3(mxp_in2)));\n')
+            file.write(INDENT + 'return color(' + functionName + '(float3(' + arg1 + '), float3(' + arg2 + ')));\n')
         else:
-            file.write(INDENT + 'return ' + functionName + '(mxp_in1, mxp_in2);\n')
+            file.write(INDENT + 'return ' + functionName + '(' + arg1 + ', ' + arg2 + ');\n')
 
 def _writeThreeArgumentFunc(file, outputType, functionName, arg1, arg2, arg3):
         if outputType == 'color4':
@@ -661,7 +661,7 @@ def main():
                     _writeOneArgumentFunc(file, outputType, '::math::'+nodeCategory)
                     wroteImplementation = True
                 elif nodeCategory == 'atan2':
-                    _writeTwoArgumentFunc(file, outputType, '::math::'+nodeCategory)
+                    _writeTwoArgumentFunc(file, outputType, '::math::'+nodeCategory, arg1=mxp_iny, arg2=mxp_inx)
                     wroteImplementation = True
                 elif nodeCategory == 'sqrt':
                     _writeOneArgumentFunc(file, outputType, '::math::'+nodeCategory)

--- a/resources/Lights/envmap_shader.mtlx
+++ b/resources/Lights/envmap_shader.mtlx
@@ -15,8 +15,8 @@
 
     <!-- Compute longitude coordinate -->
     <atan2 name="angleXZ" type="float">
-      <input name="in1" type="float" nodename="viewDir" channels="x" />
-      <input name="in2" type="float" nodename="viewDir" channels="z" />
+      <input name="iny" type="float" nodename="viewDir" channels="x" />
+      <input name="inx" type="float" nodename="viewDir" channels="z" />
     </atan2>
     <multiply name="scaleXZ" type="float">
       <input name="in1" type="float" nodename="angleXZ" />

--- a/resources/Materials/TestSuite/stdlib/math/trig.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/trig.mtlx
@@ -188,29 +188,29 @@
       <input name="value" type="float" value="1.0000" />
     </constant>
     <atan2 name="atan21" type="float">
-      <input name="in1" type="float" nodename="constant1" />
-      <input name="in2" type="float" nodename="constant2" />
+      <input name="iny" type="float" nodename="constant1" />
+      <input name="inx" type="float" nodename="constant2" />
     </atan2>
     <output name="atan2_out" type="float" nodename="atan21" />
   </nodegraph>
   <nodegraph name="atan_vector2_nodegraph">
     <atan2 name="atan21" type="vector2">
-      <input name="in1" type="vector2" value="0.5, 0.5" />
-      <input name="in2" type="vector2" value="1.0, 1.0" />
+      <input name="iny" type="vector2" value="0.5, 0.5" />
+      <input name="inx" type="vector2" value="1.0, 1.0" />
     </atan2>
     <output name="atan_out" type="vector2" nodename="atan21" />
   </nodegraph>
   <nodegraph name="atan_vector3_nodegraph">
     <atan2 name="atan21" type="vector3">
-      <input name="in1" type="vector3" value="0.5, 0.5, 0.5" />
-      <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+      <input name="iny" type="vector3" value="0.5, 0.5, 0.5" />
+      <input name="inx" type="vector3" value="1.0, 1.0, 1.0" />
     </atan2>
     <output name="atan_out" type="vector3" nodename="atan21" />
   </nodegraph>
   <nodegraph name="atan_vector4_nodegraph">
     <atan2 name="atan21" type="vector4">
-      <input name="in1" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
-      <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="iny" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
+      <input name="inx" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
     </atan2>
     <output name="atan_out" type="vector4" nodename="atan21" />
   </nodegraph>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1419,6 +1419,30 @@ void Document::upgradeVersion()
                     removeNode(top->getName());
                 }
             }
+
+            NodePtr node = elem->asA<Node>();
+            if (!node)
+            {
+                continue;
+            }
+            const string& nodeCategory = node->getCategory();
+            if (nodeCategory == "atan2")
+            {
+                // rename input ports
+                // "in1" -> "iny"
+                // "in2" -> "inx"
+
+                auto input1 = node->getInput("in1");
+                if (input1)
+                {
+                    input1->setName("iny");
+                }
+                auto input2 = node->getInput("in2");
+                if (input2)
+                {
+                    input2->setName("inx");
+                }
+            }
         }
 
         removeNodeDef("ND_thin_film_bsdf");

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib.mdl
@@ -1513,14 +1513,14 @@ export float mx_acos_float(
 }
 
 export float mx_atan2_float(
-	float mxp_in1 = float(1.0),
-	float mxp_in2 = float(0.0)
+	float mxp_iny = float(1.0),
+	float mxp_inx = float(0.0)
 )
 	[[
 		anno::description("Node Group: math")
 	]]
 {
-	return ::math::atan2(mxp_in1, mxp_in2);
+	return ::math::atan2(mxp_iny, mxp_inx);
 }
 
 export float2 mx_sin_vector2(
@@ -1574,14 +1574,14 @@ export float2 mx_acos_vector2(
 }
 
 export float2 mx_atan2_vector2(
-	float2 mxp_in1 = float2(1.0, 1.0),
-	float2 mxp_in2 = float2(0.0, 0.0)
+	float2 mxp_iny = float2(1.0, 1.0),
+	float2 mxp_inx = float2(0.0, 0.0)
 )
 	[[
 		anno::description("Node Group: math")
 	]]
 {
-	return ::math::atan2(mxp_in1, mxp_in2);
+	return ::math::atan2(mxp_iny, mxp_inx);
 }
 
 export float3 mx_sin_vector3(
@@ -1635,14 +1635,14 @@ export float3 mx_acos_vector3(
 }
 
 export float3 mx_atan2_vector3(
-	float3 mxp_in1 = float3(1.0, 1.0, 1.0),
-	float3 mxp_in2 = float3(0.0, 0.0, 0.0)
+	float3 mxp_iny = float3(1.0, 1.0, 1.0),
+	float3 mxp_inx = float3(0.0, 0.0, 0.0)
 )
 	[[
 		anno::description("Node Group: math")
 	]]
 {
-	return ::math::atan2(mxp_in1, mxp_in2);
+	return ::math::atan2(mxp_iny, mxp_inx);
 }
 
 export float4 mx_sin_vector4(
@@ -1696,14 +1696,14 @@ export float4 mx_acos_vector4(
 }
 
 export float4 mx_atan2_vector4(
-	float4 mxp_in1 = float4(1.0, 1.0, 1.0, 1.0),
-	float4 mxp_in2 = float4(0.0, 0.0, 0.0, 0.0)
+	float4 mxp_iny = float4(1.0, 1.0, 1.0, 1.0),
+	float4 mxp_inx = float4(0.0, 0.0, 0.0, 0.0)
 )
 	[[
 		anno::description("Node Group: math")
 	]]
 {
-	return ::math::atan2(mxp_in1, mxp_in2);
+	return ::math::atan2(mxp_iny, mxp_inx);
 }
 
 export float mx_sqrt_float(


### PR DESCRIPTION
Renaming the input ports to align correctly with the spec
* `in1` -> `iny`
* `in2` -> `inx`

Add upgrade code to migrate port names found in documents.