### PR TITLE
Improve robustness of TypeDesc pointer comparisons

### DIFF
--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -93,7 +93,7 @@ void GlslResourceBindingContext::emitResourceBindings(GenContext& context, const
     // Second, emit all sampler uniforms as separate uniforms with separate layout bindings
     for (auto uniform : uniforms.getVariableOrder())
     {
-        if (uniform->getType() == Type::FILENAME)
+        if (*uniform->getType() == *Type::FILENAME)
         {
             generator.emitString("layout (binding=" + std::to_string(_separateBindingLocation ? _hwUniformBindLocation++ : _hwSamplerBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
             generator.emitVariableDeclaration(uniform, EMPTY_STRING, context, stage, false);

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -782,11 +782,11 @@ void GlslShaderGenerator::toVec4(const TypeDesc* type, string& variable)
     {
         variable = "vec4(" + variable + ", 0.0, 1.0)";
     }
-    else if (type == Type::FLOAT || type == Type::INTEGER)
+    else if (*type == *Type::FLOAT || *type == *Type::INTEGER)
     {
         variable = "vec4(" + variable + ", " + variable + ", " + variable + ", 1.0)";
     }
-    else if (type == Type::BSDF || type == Type::EDF)
+    else if (*type == *Type::BSDF || *type == *Type::EDF)
     {
         variable = "vec4(" + variable + ", 1.0)";
     }
@@ -802,7 +802,7 @@ void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, co
                                                   bool assignValue) const
 {
     // A file texture input needs special handling on GLSL
-    if (variable->getType() == Type::FILENAME)
+    if (*variable->getType() == *Type::FILENAME)
     {
         // Samplers must always be uniforms
         string str = qualifier.empty() ? EMPTY_STRING : qualifier + " ";
@@ -813,7 +813,7 @@ void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, co
         string str = qualifier.empty() ? EMPTY_STRING : qualifier + " ";
         // Varying parameters of type int must be flat qualified on output from vertex stage and
         // input to pixel stage. The only way to get these is with geompropvalue_integer nodes.
-        if (qualifier.empty() && variable->getType() == Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0)
+        if (qualifier.empty() && *variable->getType() == *Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0)
         {
             str += GlslSyntax::FLAT_QUALIFIER + " ";
         }
@@ -870,7 +870,7 @@ ShaderNodeImplPtr GlslShaderGenerator::getImplementation(const NodeDef& nodedef,
     if (implElement->isA<NodeGraph>())
     {
         // Use a compound implementation.
-        if (outputType == Type::LIGHTSHADER)
+        if (*outputType == *Type::LIGHTSHADER)
         {
             impl = LightCompoundNodeGlsl::create();
         }

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -364,7 +364,7 @@ bool GlslSyntax::remapEnumeration(const string& value, const TypeDesc* type, con
     // Don't convert already supported types
     // or filenames and arrays.
     if (typeSupported(type) ||
-        type == Type::FILENAME || (type && type->isArray()))
+        *type == *Type::FILENAME || (type && type->isArray()))
     {
         return false;
     }

--- a/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/GeomColorNodeGlsl.cpp
@@ -49,11 +49,11 @@ void GeomColorNodeGlsl::emitFunctionCall(const ShaderNode& node, GenContext& con
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         string suffix = "";
-        if (output->getType() == Type::FLOAT)
+        if (*output->getType() == *Type::FLOAT)
         {
             suffix = ".r";
         }
-        else if (output->getType() == Type::COLOR3)
+        else if (*output->getType() == *Type::COLOR3)
         {
             suffix = ".rgb";
         }

--- a/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/HeightToNormalNodeGlsl.cpp
@@ -54,7 +54,7 @@ void HeightToNormalNodeGlsl::computeSampleOffsetStrings(const string& sampleSize
 bool HeightToNormalNodeGlsl::acceptsInputType(const TypeDesc* type) const
 {
     // Only support inputs which are float scalar
-    return (type == Type::FLOAT && type->isScalar());
+    return (*type == *Type::FLOAT && type->isScalar());
 }
 
 void HeightToNormalNodeGlsl::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/VkResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/VkResourceBindingContext.cpp
@@ -80,7 +80,7 @@ void VkResourceBindingContext::emitResourceBindings(GenContext& context, const V
     // Second, emit all sampler uniforms as separate uniforms with separate layout bindings
     for (auto uniform : uniforms.getVariableOrder())
     {
-        if (uniform->getType() == Type::FILENAME)
+        if (*uniform->getType() == *Type::FILENAME)
         {
             generator.emitString("layout (binding=" + std::to_string(_hwUniformBindLocation++) + ") " + syntax.getUniformQualifier() + " ", stage);
             generator.emitVariableDeclaration(uniform, EMPTY_STRING, context, stage, false);

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -287,7 +287,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
     const TypeDesc* outputType = outputSocket->getType();
     if (graph.hasClassification(ShaderNode::Classification::TEXTURE))
     {
-        if (outputType == Type::DISPLACEMENTSHADER)
+        if (*outputType == *Type::DISPLACEMENTSHADER)
         {
             emitLine("float3 displacement__ = " + result + ".geometry.displacement", stage);
             emitLine("color finalOutput__ = mk_color3("
@@ -667,7 +667,7 @@ void MdlShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
     {
         const ShaderPort* input = inputs[i];
 
-        const string& qualifier = input->isUniform() || input->getType() == Type::FILENAME ? uniformPrefix : EMPTY_STRING;
+        const string& qualifier = input->isUniform() || *input->getType() == *Type::FILENAME ? uniformPrefix : EMPTY_STRING;
         const string& type = _syntax->getTypeName(input->getType());
 
         string value = input->getValue() ? _syntax->getValue(input->getType(), *input->getValue(), true) : EMPTY_STRING;

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -492,7 +492,7 @@ const std::unordered_map<char, char> CHANNELS_TO_XYZW =
 
 string MdlSyntax::getSwizzledVariable(const string& srcName, const TypeDesc* srcType, const string& channels, const TypeDesc* dstType) const
 {
-    if (srcType == Type::COLOR3 || srcType == Type::COLOR4)
+    if (*srcType == *Type::COLOR3 || *srcType == *Type::COLOR4)
     {
         const TypeSyntax& srcSyntax = getTypeSyntax(srcType);
         const TypeSyntax& dstSyntax = getTypeSyntax(dstType);
@@ -523,7 +523,7 @@ string MdlSyntax::getSwizzledVariable(const string& srcName, const TypeDesc* src
             }
 
             string variable = srcName;
-            if (srcType == Type::COLOR3)
+            if (*srcType == *Type::COLOR3)
             {
                 variable = "float3(" + srcName + ")";
             }
@@ -567,7 +567,7 @@ bool MdlSyntax::remapEnumeration(const string& value, const TypeDesc* type, cons
     }
 
     // Don't convert filenames or arrays.
-    if (type == Type::FILENAME || (type && type->isArray()))
+    if (*type == *Type::FILENAME || (type && type->isArray()))
     {
         return false;
     }

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
@@ -46,7 +46,7 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
     //
     // 1. Handle the BSDF-over-VDF case
     //
-    if (baseInput->getType() == Type::VDF)
+    if (*baseInput->getType() == *Type::VDF)
     {
         // Make sure we have a top BSDF connected.
         if (!topInput->getConnection())

--- a/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CombineNodeMdl.cpp
@@ -33,10 +33,10 @@ void CombineNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& contex
             throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid convert node");
         }
 
-        if (in1->getType() == Type::COLOR3)
+        if (*in1->getType() == *Type::COLOR3)
         {
             const ShaderInput* in2 = node.getInput(1);
-            if (!in2 || in2->getType() != Type::FLOAT)
+            if (!in2 || *in2->getType() != *Type::FLOAT)
             {
                 throw ExceptionShaderGenError("Node '" + node.getName() + "' is not a valid convert node");
             }

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
@@ -233,7 +233,7 @@ void CompoundNodeMdl::emitFunctionSignature(const ShaderNode&, GenContext& conte
     int count = int(_rootGraph->numInputSockets());
     for (ShaderGraphInputSocket* input : _rootGraph->getInputSockets())
     {
-        const string& qualifier = input->isUniform() || input->getType() == Type::FILENAME ? uniformPrefix : EMPTY_STRING;
+        const string& qualifier = input->isUniform() || *input->getType() == *Type::FILENAME ? uniformPrefix : EMPTY_STRING;
         const string& type = syntax.getTypeName(input->getType());
 
         string value = input->getValue() ? syntax.getValue(input->getType(), *input->getValue(), true) : EMPTY_STRING;

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -50,7 +50,7 @@ void HeightToNormalNodeMdl::computeSampleOffsetStrings(const string& sampleSizeN
 bool HeightToNormalNodeMdl::acceptsInputType(const TypeDesc* type) const
 {
     // Only support inputs which are float scalar
-    return (type == Type::FLOAT && type->isScalar());
+    return (*type == *Type::FLOAT && type->isScalar());
 }
 
 void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SurfaceNodeMdl.cpp
@@ -38,7 +38,7 @@ const ShaderInput* findTransmissionIOR(const ShaderNode& node)
     }
     for (const ShaderInput* input : node.getInputs())
     {
-        if (input->getType() == Type::BSDF && input->getConnection())
+        if (*input->getType() == *Type::BSDF && input->getConnection())
         {
             const ShaderInput* ior = findTransmissionIOR(*input->getConnection()->getNode());
             if (ior)

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -604,7 +604,7 @@ void MslShaderGenerator::emitGlobalVariables(GenContext& context,
                     bool hasUniforms = false;
                     for (const ShaderPort* uniform : uniforms.getVariableOrder())
                     {
-                        if (uniform->getType() == Type::FILENAME)
+                        if (*uniform->getType() == *Type::FILENAME)
                         {
                             emitString(separator, stage);
                             emitString("texture2d<float> " + TEXTURE_NAME(uniform->getVariable()), stage);
@@ -1282,11 +1282,11 @@ void MslShaderGenerator::toVec4(const TypeDesc* type, string& variable)
     {
         variable = "float4(" + variable + ", 0.0, 1.0)";
     }
-    else if (type == Type::FLOAT || type == Type::INTEGER)
+    else if (*type == *Type::FLOAT || *type == *Type::INTEGER)
     {
         variable = "float4(" + variable + ", " + variable + ", " + variable + ", 1.0)";
     }
-    else if (type == Type::BSDF || type == Type::EDF)
+    else if (*type == *Type::BSDF || *type == *Type::EDF)
     {
         variable = "float4(" + variable + ", 1.0)";
     }
@@ -1302,7 +1302,7 @@ void MslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, con
                                                  bool assignValue) const
 {
     // A file texture input needs special handling on MSL
-    if (variable->getType() == Type::FILENAME)
+    if (*variable->getType() == *Type::FILENAME)
     {
         // Samplers must always be uniforms
         string str = qualifier.empty() ? EMPTY_STRING : qualifier + " ";
@@ -1327,7 +1327,7 @@ void MslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, con
 
         // Varying parameters of type int must be flat qualified on output from vertex stage and
         // input to pixel stage. The only way to get these is with geompropvalue_integer nodes.
-        if (qualifier.empty() && variable->getType() == Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0)
+        if (qualifier.empty() && *variable->getType() == *Type::INTEGER && !assignValue && variable->getName().rfind(HW::T_IN_GEOMPROP, 0) == 0)
         {
             str += "[[ " + MslSyntax::FLAT_QUALIFIER + " ]]";
         }
@@ -1372,7 +1372,7 @@ ShaderNodeImplPtr MslShaderGenerator::getImplementation(const NodeDef& nodedef, 
     if (implElement->isA<NodeGraph>())
     {
         // Use a compound implementation.
-        if (outputType == Type::LIGHTSHADER)
+        if (*outputType == *Type::LIGHTSHADER)
         {
             impl = LightCompoundNodeMsl::create();
         }

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -352,7 +352,7 @@ bool MslSyntax::remapEnumeration(const string& value, const TypeDesc* type, cons
     // Don't convert already supported types
     // or filenames and arrays.
     if (typeSupported(type) ||
-        type == Type::FILENAME || (type && type->isArray()))
+        *type == *Type::FILENAME || (type && type->isArray()))
     {
         return false;
     }

--- a/source/MaterialXGenMsl/Nodes/GeomColorNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/GeomColorNodeMsl.cpp
@@ -49,11 +49,11 @@ void GeomColorNodeMsl::emitFunctionCall(const ShaderNode& node, GenContext& cont
     DEFINE_SHADER_STAGE(stage, Stage::PIXEL)
     {
         string suffix = "";
-        if (output->getType() == Type::FLOAT)
+        if (*output->getType() == *Type::FLOAT)
         {
             suffix = ".r";
         }
-        else if (output->getType() == Type::COLOR3)
+        else if (*output->getType() == *Type::COLOR3)
         {
             suffix = ".rgb";
         }

--- a/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/HeightToNormalNodeMsl.cpp
@@ -54,7 +54,7 @@ void HeightToNormalNodeMsl::computeSampleOffsetStrings(const string& sampleSizeN
 bool HeightToNormalNodeMsl::acceptsInputType(const TypeDesc* type) const
 {
     // Only support inputs which are float scalar
-    return (type == Type::FLOAT && type->isScalar());
+    return (*type == *Type::FLOAT && type->isScalar());
 }
 
 void HeightToNormalNodeMsl::emitFunctionDefinition(const ShaderNode&, GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.cpp
+++ b/source/MaterialXGenOsl/Nodes/ClosureLayerNodeOsl.cpp
@@ -92,7 +92,7 @@ void ClosureLayerNodeOsl::emitFunctionCall(const ShaderNode& _node, GenContext& 
 
         // Calculate the layering result.
         emitOutputVariables(node, context, stage);
-        if (base->getOutput()->getType() == Type::VDF)
+        if (*base->getOutput()->getType() == *Type::VDF)
         {
             // Combining a surface closure with a volumetric closure is simply done with the add operator in OSL.
             shadergen.emitLine(output->getVariable() + ".response = " + topResult + ".response + " + baseResult, stage);

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -196,11 +196,11 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     // Emit shader type, determined from the first
     // output if there are multiple outputs.
     const ShaderGraphOutputSocket* outputSocket0 = graph.getOutputSocket(0);
-    if (outputSocket0->getType() == Type::SURFACESHADER)
+    if (*outputSocket0->getType() == *Type::SURFACESHADER)
     {
         emitString("surface ", stage);
     }
-    else if (outputSocket0->getType() == Type::VOLUMESHADER)
+    else if (*outputSocket0->getType() == *Type::VOLUMESHADER)
     {
         emitString("volume ", stage);
     }
@@ -250,10 +250,10 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     const VariableBlock& outputs = stage.getOutputBlock(OSL::OUTPUTS);
     const ShaderPort* singleOutput = outputs.size() == 1 ? outputs[0] : NULL;
 
-    const bool isSurfaceShaderOutput = singleOutput && singleOutput->getType() == Type::SURFACESHADER;
+    const bool isSurfaceShaderOutput = singleOutput && *singleOutput->getType() == *Type::SURFACESHADER;
 
 #ifdef MATERIALX_OSL_LEGACY_CLOSURES
-    const bool isBsdfOutput = singleOutput && singleOutput->getType() == Type::BSDF;
+    const bool isBsdfOutput = singleOutput && *singleOutput->getType() == *Type::BSDF;
 #endif
 
     if (isSurfaceShaderOutput)
@@ -301,7 +301,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     for (size_t i = 0; i < inputs.size(); ++i)
     {
         ShaderPort* input = inputs[i];
-        if (input->getType() == Type::FILENAME)
+        if (*input->getType() == *Type::FILENAME)
         {
             // Construct the textureresource variable.
             const string newVariableName = input->getVariable() + "_";
@@ -529,7 +529,7 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
         const ShaderPort* input = inputs[i];
         const string& type = _syntax->getTypeName(input->getType());
 
-        if (input->getType() == Type::FILENAME)
+        if (*input->getType() == *Type::FILENAME)
         {
             // Shader inputs of type 'filename' (textures) need special handling.
             // In OSL codegen a 'filename' is translated to the custom type 'textureresource',

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -457,7 +457,7 @@ ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element
             {
                 for (ShaderInput* input : node->getInputs())
                 {
-                    if (!input->getConnection() && input->getType() == Type::FILENAME)
+                    if (!input->getConnection() && *input->getType() == *Type::FILENAME)
                     {
                         // Create the uniform using the filename type to make this uniform into a texture sampler.
                         ShaderPort* filename = psPublicUniforms->add(Type::FILENAME, input->getVariable(), input->getValue());

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -49,7 +49,7 @@ void BlurNode::computeSampleOffsetStrings(const string& sampleSizeName, const st
 bool BlurNode::acceptsInputType(const TypeDesc* type) const
 {
     // Float 1-4 is acceptable as input
-    return ((type == Type::FLOAT && type->isScalar()) ||
+    return ((*type == *Type::FLOAT && type->isScalar()) ||
             type->isFloat2() || type->isFloat3() || type->isFloat4());
 }
 

--- a/source/MaterialXGenShader/Nodes/ClosureAddNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureAddNode.cpp
@@ -59,13 +59,13 @@ void ClosureAddNode::emitFunctionCall(const ShaderNode& _node, GenContext& conte
         const string in2Result = shadergen.getUpstreamResult(in2, context);
 
         ShaderOutput* output = node.getOutput();
-        if (output->getType() == Type::BSDF)
+        if (*output->getType() == *Type::BSDF)
         {
             emitOutputVariables(node, context, stage);
             shadergen.emitLine(output->getVariable() + ".response = " + in1Result + ".response + " + in2Result + ".response", stage);
             shadergen.emitLine(output->getVariable() + ".throughput = " + in1Result + ".throughput * " + in2Result + ".throughput", stage);
         }
-        else if (output->getType() == Type::EDF)
+        else if (*output->getType() == *Type::EDF)
         {
             shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = " + in1Result + " + " + in2Result, stage);
         }

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
@@ -171,7 +171,7 @@ void ClosureCompoundNode::emitFunctionCall(const ShaderNode& node, GenContext& c
 
             // Check if extra parameters has been added for this node.
             const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
-            if (closureType == Type::BSDF && params)
+            if (*closureType == *Type::BSDF && params)
             {
                 // Assign the parameters to the BSDF.
                 for (auto it : *params)

--- a/source/MaterialXGenShader/Nodes/ClosureLayerNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureLayerNode.cpp
@@ -95,7 +95,7 @@ void ClosureLayerNode::emitFunctionCall(const ShaderNode& _node, GenContext& con
 
             // Calculate the layering result.
             emitOutputVariables(node, context, stage);
-            if (base->getOutput()->getType() == Type::VDF)
+            if (*(base->getOutput()->getType()) == *Type::VDF)
             {
                 shadergen.emitLine(output->getVariable() + ".response = " + topResult + ".response * " + baseResult + ".throughput", stage);
                 shadergen.emitLine(output->getVariable() + ".throughput = " + topResult + ".throughput * " + baseResult + ".throughput", stage);

--- a/source/MaterialXGenShader/Nodes/ClosureMixNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureMixNode.cpp
@@ -61,13 +61,13 @@ void ClosureMixNode::emitFunctionCall(const ShaderNode& _node, GenContext& conte
         const string mixResult = shadergen.getUpstreamResult(mix, context);
 
         ShaderOutput* output = node.getOutput();
-        if (output->getType() == Type::BSDF)
+        if (*output->getType() == *Type::BSDF)
         {
             emitOutputVariables(node, context, stage);
             shadergen.emitLine(output->getVariable() + ".response = mix(" + bgResult + ".response, " + fgResult + ".response, " + mixResult + ")", stage);
             shadergen.emitLine(output->getVariable() + ".throughput = mix(" + bgResult + ".throughput, " + fgResult + ".throughput, " + mixResult + ")", stage);
         }
-        else if (output->getType() == Type::EDF)
+        else if (*output->getType() == *Type::EDF)
         {
             shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = mix(" + bgResult + ", " + fgResult + ", " + mixResult + ")", stage);
         }

--- a/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureMultiplyNode.cpp
@@ -50,7 +50,7 @@ void ClosureMultiplyNode::emitFunctionCall(const ShaderNode& _node, GenContext& 
         const string in2Result = shadergen.getUpstreamResult(in2, context);
 
         ShaderOutput* output = node.getOutput();
-        if (output->getType() == Type::BSDF)
+        if (*output->getType() == *Type::BSDF)
         {
             const string in2clamped = output->getVariable() + "_in2_clamped";
             shadergen.emitLine(syntax.getTypeName(in2->getType()) + " " + in2clamped + " = clamp(" + in2Result + ", 0.0, 1.0)", stage);
@@ -59,7 +59,7 @@ void ClosureMultiplyNode::emitFunctionCall(const ShaderNode& _node, GenContext& 
             shadergen.emitLine(output->getVariable() + ".response = " + in1Result + ".response * " + in2clamped, stage);
             shadergen.emitLine(output->getVariable() + ".throughput = " + in1Result + ".throughput * " + in2clamped, stage);
         }
-        else if (output->getType() == Type::EDF)
+        else if (*output->getType() == *Type::EDF)
         {
             shadergen.emitLine(shadergen.getSyntax().getTypeName(Type::EDF) + " " + output->getVariable() + " = " + in1Result + " * " + in2Result, stage);
         }

--- a/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
@@ -42,7 +42,7 @@ void ClosureSourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext&
                 // Check if extra parameters has been added for this node.
                 const TypeDesc* closureType = output->getType();
                 const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
-                if (closureType == Type::BSDF && params)
+                if (*closureType == *Type::BSDF && params)
                 {
                     // Assign the parameters to the BSDF.
                     for (auto it : *params)

--- a/source/MaterialXGenShader/Nodes/CombineNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CombineNode.cpp
@@ -34,7 +34,7 @@ void CombineNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
         // components to use for constructing the new value.
         //
         StringVec valueComponents;
-        if (in1->getType() == Type::FLOAT)
+        if (*in1->getType() == *Type::FLOAT)
         {
             // Get the components of the input values.
             const size_t numInputs = node.numInputs();
@@ -45,7 +45,7 @@ void CombineNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
                 valueComponents[i] = shadergen.getUpstreamResult(input, context);
             }
         }
-        else if (in1->getType() == Type::COLOR3 || in1->getType() == Type::VECTOR3)
+        else if (*in1->getType() == *Type::COLOR3 || *in1->getType() == *Type::VECTOR3)
         {
             const ShaderInput* in2 = node.getInput(1);
             if (!in2 || in2->getType() != Type::FLOAT)
@@ -84,7 +84,7 @@ void CombineNode::emitFunctionCall(const ShaderNode& node, GenContext& context, 
             // Get component from in2
             valueComponents[memberSize] = shadergen.getUpstreamResult(in2, context);
         }
-        else if (in1->getType() == Type::VECTOR2)
+        else if (*in1->getType() == *Type::VECTOR2)
         {
             const ShaderInput* in2 = node.getInput(1);
             if (!in2 || (in2->getType() != Type::VECTOR2))

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -94,12 +94,12 @@ const ShaderInput* ConvolutionNode::getSamplingInput(const ShaderNode& node) con
     if (node.hasClassification(ShaderNode::Classification::SAMPLE2D))
     {
         const ShaderInput* input = node.getInput(SAMPLE2D_INPUT);
-        return input->getType() == Type::VECTOR2 ? input : nullptr;
+        return *input->getType() == *Type::VECTOR2 ? input : nullptr;
     }
     else if (node.hasClassification(ShaderNode::Classification::SAMPLE3D))
     {
         const ShaderInput* input = node.getInput(SAMPLE3D_INPUT);
-        return input->getType() == Type::VECTOR3 ? input : nullptr;
+        return *input->getType() == *Type::VECTOR3 ? input : nullptr;
     }
     return nullptr;
 }

--- a/source/MaterialXGenShader/Nodes/HwTexCoordNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwTexCoordNode.cpp
@@ -60,11 +60,11 @@ void HwTexCoordNode::emitFunctionCall(const ShaderNode& node, GenContext& contex
         // larger datatype than the requested number of texture coordinates, if several texture
         // coordinate nodes with different width coexist).
         string suffix = EMPTY_STRING;
-        if (output->getType() == Type::VECTOR2)
+        if (*output->getType() == *Type::VECTOR2)
         {
             suffix = ".xy";
         }
-        else if (output->getType() == Type::VECTOR3)
+        else if (*output->getType() == *Type::VECTOR3)
         {
             suffix = ".xyz";
         }

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1029,7 +1029,7 @@ void ShaderGraph::optimize(GenContext& context)
         {
             // Filename dot nodes must be elided so they do not create extra samplers.
             ShaderInput* in = node->getInput("in");
-            if (in->getChannels().empty() && in->getType() == Type::FILENAME)
+            if (in->getChannels().empty() && *in->getType() == *Type::FILENAME)
             {
                 bypass(context, node, 0);
                 ++numEdits;
@@ -1240,7 +1240,7 @@ string ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorMana
     const string& sourceColorSpace = input->getActiveColorSpace();
     if (shaderPort && !sourceColorSpace.empty())
     {
-        if (shaderPort->getType() == Type::COLOR3 || shaderPort->getType() == Type::COLOR4)
+        if (*(shaderPort->getType()) == *Type::COLOR3 || *(shaderPort->getType()) == *Type::COLOR4)
         {
             // If we're converting between two identical color spaces than we have no work to do.
             if (sourceColorSpace != targetColorSpace)
@@ -1309,10 +1309,10 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
 
     // Only support convertion for float and vectors. arrays, matrices are not supported.
     // TODO: This should be provided by the UnitSystem.
-    bool supportedType = (shaderPort->getType() == Type::FLOAT ||
-                          shaderPort->getType() == Type::VECTOR2 ||
-                          shaderPort->getType() == Type::VECTOR3 ||
-                          shaderPort->getType() == Type::VECTOR4);
+    bool supportedType = (*shaderPort->getType() == *Type::FLOAT ||
+                          *shaderPort->getType() == *Type::VECTOR2 ||
+                          *shaderPort->getType() == *Type::VECTOR3 ||
+                          *shaderPort->getType() == *Type::VECTOR4);
     if (supportedType)
     {
         UnitTransform transform(sourceUnitSpace, targetUnitSpace, shaderPort->getType(), unitType);

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -229,11 +229,11 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
 
     // First, check for specific output types
     const ShaderOutput* primaryOutput = newNode->getOutput();
-    if (primaryOutput->getType() == Type::MATERIAL)
+    if (*primaryOutput->getType() == *Type::MATERIAL)
     {
         newNode->_classification = Classification::MATERIAL;
     }
-    else if (primaryOutput->getType() == Type::SURFACESHADER)
+    else if (*primaryOutput->getType() == *Type::SURFACESHADER)
     {
         if (nodeDefName == "ND_surface_unlit")
         {
@@ -244,11 +244,11 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
             newNode->_classification = Classification::SHADER | Classification::SURFACE | Classification::CLOSURE;
         }
     }
-    else if (primaryOutput->getType() == Type::LIGHTSHADER)
+    else if (*primaryOutput->getType() == *Type::LIGHTSHADER)
     {
         newNode->_classification = Classification::LIGHT | Classification::SHADER | Classification::CLOSURE;
     }
-    else if (primaryOutput->getType() == Type::BSDF)
+    else if (*primaryOutput->getType() == *Type::BSDF)
     {
         newNode->_classification = Classification::BSDF | Classification::CLOSURE;
 
@@ -278,11 +278,11 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
             newNode->_classification |= Classification::THINFILM;
         }
     }
-    else if (primaryOutput->getType() == Type::EDF)
+    else if (*primaryOutput->getType() == *Type::EDF)
     {
         newNode->_classification = Classification::EDF | Classification::CLOSURE;
     }
-    else if (primaryOutput->getType() == Type::VDF)
+    else if (*primaryOutput->getType() == *Type::VDF)
     {
         newNode->_classification = Classification::VDF | Classification::CLOSURE;
     }

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -220,42 +220,42 @@ ValuePtr Syntax::getSwizzledValue(ValuePtr value, const TypeDesc* srcType, const
             {
                 throw ExceptionShaderGenError("Given channel index: '" + string(1, ch) + "' in channels pattern is incorrect for type '" + srcType->getName() + "'.");
             }
-            if (srcType == Type::FLOAT)
+            if (*srcType == *Type::FLOAT)
             {
                 float v = value->asA<float>();
                 ss << std::to_string(v);
             }
-            else if (srcType == Type::INTEGER)
+            else if (*srcType == *Type::INTEGER)
             {
                 int v = value->asA<int>();
                 ss << std::to_string(v);
             }
-            else if (srcType == Type::BOOLEAN)
+            else if (*srcType == *Type::BOOLEAN)
             {
                 bool v = value->asA<bool>();
                 ss << std::to_string(v);
             }
-            else if (srcType == Type::COLOR3)
+            else if (*srcType == *Type::COLOR3)
             {
                 Color3 v = value->asA<Color3>();
                 ss << std::to_string(v[channelIndex]);
             }
-            else if (srcType == Type::COLOR4)
+            else if (*srcType == *Type::COLOR4)
             {
                 Color4 v = value->asA<Color4>();
                 ss << std::to_string(v[channelIndex]);
             }
-            else if (srcType == Type::VECTOR2)
+            else if (*srcType == *Type::VECTOR2)
             {
                 Vector2 v = value->asA<Vector2>();
                 ss << std::to_string(v[channelIndex]);
             }
-            else if (srcType == Type::VECTOR3)
+            else if (*srcType == *Type::VECTOR3)
             {
                 Vector3 v = value->asA<Vector3>();
                 ss << std::to_string(v[channelIndex]);
             }
-            else if (srcType == Type::VECTOR4)
+            else if (*srcType == *Type::VECTOR4)
             {
                 Vector4 v = value->asA<Vector4>();
                 ss << std::to_string(v[channelIndex]);

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -39,14 +39,14 @@ TypeDesc::TypeDesc(const string& name, unsigned char basetype, unsigned char sem
 {
 }
 
-bool TypeDesc::operator==(const TypeDesc& other) const
+bool TypeDesc::operator==(const TypeDesc& rhs) const
 {
-    return (this->_name == other._name);
+    return (this->_name == rhs._name);
 }
 
-bool TypeDesc::operator!=(const TypeDesc& other) const
+bool TypeDesc::operator!=(const TypeDesc& rhs) const
 {
-    return !(*this == other);
+    return !(*this == rhs);
 }
 
 const TypeDesc* TypeDesc::registerType(const string& name, unsigned char basetype, unsigned char semantic, size_t size,

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -39,6 +39,16 @@ TypeDesc::TypeDesc(const string& name, unsigned char basetype, unsigned char sem
 {
 }
 
+bool TypeDesc::operator==(const TypeDesc& other) const
+{
+    return (this->_name == other._name);
+}
+
+bool TypeDesc::operator!=(const TypeDesc& other) const
+{
+    return !(*this == other);
+}
+
 const TypeDesc* TypeDesc::registerType(const string& name, unsigned char basetype, unsigned char semantic, size_t size,
                                        bool editable, const std::unordered_map<char, int>& channelMapping)
 {

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -57,6 +57,12 @@ class MX_GENSHADER_API TypeDesc
     static const TypeDesc* registerType(const string& name, unsigned char basetype, unsigned char semantic = SEMANTIC_NONE,
                                         size_t size = 1, bool editable = true, const ChannelMap& channelMapping = ChannelMap());
 
+    /// Equality operator overload
+    bool operator==(const TypeDesc& other) const;
+
+    /// Inequality operator overload
+    bool operator!=(const TypeDesc& other) const;
+
     /// Get a type descriptor for given name.
     /// Returns an empty shared pointer if no type with the given name is found.
     static const TypeDesc* get(const string& name);

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -58,10 +58,10 @@ class MX_GENSHADER_API TypeDesc
                                         size_t size = 1, bool editable = true, const ChannelMap& channelMapping = ChannelMap());
 
     /// Equality operator overload
-    bool operator==(const TypeDesc& other) const;
+    bool operator==(const TypeDesc& rhs) const;
 
     /// Inequality operator overload
-    bool operator!=(const TypeDesc& other) const;
+    bool operator!=(const TypeDesc& rhs) const;
 
     /// Get a type descriptor for given name.
     /// Returns an empty shared pointer if no type with the given name is found.

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -210,7 +210,7 @@ bool isTransparentShaderGraph(OutputPtr output, const string& target, NodePtr in
             if (nodeDef)
             {
                 const TypeDesc* nodeDefType = TypeDesc::get(nodeDef->getType());
-                if (nodeDefType == Type::BSDF)
+                if (*nodeDefType == *Type::BSDF)
                 {
                     InterfaceElementPtr impl = nodeDef->getImplementation(target);
                     if (impl && impl->isA<NodeGraph>())

--- a/source/MaterialXRender/LightHandler.cpp
+++ b/source/MaterialXRender/LightHandler.cpp
@@ -42,7 +42,7 @@ void LightHandler::findLights(DocumentPtr doc, vector<NodePtr>& lights)
     for (NodePtr node : doc->getNodes())
     {
         const TypeDesc* type = TypeDesc::get(node->getType());
-        if (type == Type::LIGHTSHADER)
+        if (*type == *Type::LIGHTSHADER)
         {
             lights.push_back(node);
         }

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -1038,11 +1038,11 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
 
 int GlslProgram::mapTypeToOpenGLType(const TypeDesc* type)
 {
-    if (type == Type::INTEGER)
+    if (*type == *Type::INTEGER)
         return GL_INT;
-    else if (type == Type::BOOLEAN)
+    else if (*type == *Type::BOOLEAN)
         return GL_BOOL;
-    else if (type == Type::FLOAT)
+    else if (*type == *Type::FLOAT)
         return GL_FLOAT;
     else if (type->isFloat2())
         return GL_FLOAT_VEC2;
@@ -1050,11 +1050,11 @@ int GlslProgram::mapTypeToOpenGLType(const TypeDesc* type)
         return GL_FLOAT_VEC3;
     else if (type->isFloat4())
         return GL_FLOAT_VEC4;
-    else if (type == Type::MATRIX33)
+    else if (*type == *Type::MATRIX33)
         return GL_FLOAT_MAT3;
-    else if (type == Type::MATRIX44)
+    else if (*type == *Type::MATRIX44)
         return GL_FLOAT_MAT4;
-    else if (type == Type::FILENAME)
+    else if (*type == *Type::FILENAME)
     {
         // A "filename" is not indicative of type, so just return a 2d sampler.
         return GL_SAMPLER_2D;


### PR DESCRIPTION
## Issue

Update #1608 

- The globals presets defined for TypeDesc are pointers which may not be shared between shared modules. This occurs for instance  in Python where the pointers are declared locally for each module.
- Any pointer comparison between the same TypeDesc preset  can thus result in a failure status.

## Workaround

The current non API changing patch is to change any existing direct pointer references to to reference compares using new `TypeDesc::operater==` and `TypeDesc::operator!=` method.

This has been tested with RTS:
[rts.pdf](https://github.com/AcademySoftwareFoundation/MaterialX/files/13998018/rts.pdf)
[rts2.pdf](https://github.com/AcademySoftwareFoundation/MaterialX/files/13998017/rts2.pdf)
- 
and separate rendering tests using a renderer written in Python:
- (https://github.com/kwokcb/MaterialX_Learn/blob/main/pymaterialx/mtlxutils/mxrenderer.py)

This workaround has been discussed with @niklasharrysson and @jstone-lucasfilm offline.

## Caveat

This is not a long term fix but is a safe patch. A recommendation is to add  a release note about this so that integrations know about this issue. 