### PR TITLE
Add facingratio node to nprlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added a [non-photorealistic rendering](https://github.com/AcademySoftwareFoundation/MaterialX/pull/1631) data library to MaterialX, initially consisting of a single 'viewdirection' node.
+- Added a [non-photorealistic rendering](https://github.com/AcademySoftwareFoundation/MaterialX/pull/1631) data library to MaterialX, initially supporting the 'viewdirection' and 'facingratio' nodes.
 - Added support for the generation of [pre-filtered environment maps](https://github.com/AcademySoftwareFoundation/MaterialX/pull/1420) in MaterialX GLSL and MSL.
 - Added support for the [creatematrix node](https://github.com/AcademySoftwareFoundation/MaterialX/pull/1553) in shader generation.
 - Added [floating popups](https://github.com/AcademySoftwareFoundation/MaterialX/pull/1565) for hovered pins in the MaterialX Graph Editor.

--- a/libraries/nprlib/nprlib_defs.mtlx
+++ b/libraries/nprlib/nprlib_defs.mtlx
@@ -8,6 +8,12 @@
   -->
 
   <!-- ======================================================================== -->
+  <!-- View-dependent properties                                                -->
+  <!-- ======================================================================== -->
+
+  <geompropdef name="Vworld" type="vector3" geomprop="viewdirection" space="world" />
+
+  <!-- ======================================================================== -->
   <!-- View-dependent nodes                                                     -->
   <!-- ======================================================================== -->
 
@@ -18,6 +24,19 @@
   <nodedef name="ND_viewdirection_vector3" node="viewdirection" nodegroup="npr">
     <input name="space" type="string" value="world" enum="model,object,world" uniform="true" />
     <output name="out" type="vector3" default="0.0, 0.0, 1.0" />
+  </nodedef>
+
+  <!--
+    Node: <facingratio>
+    Return the geometric facing ratio, computed as the dot product between the
+    view direction and geometric normal.
+  -->
+  <nodedef name="ND_facingratio_float" node="facingratio" nodegroup="npr">
+    <input name="viewdirection" type="vector3" defaultgeomprop="Vworld" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" />
+    <input name="faceforward" type="boolean" default="true" />
+    <input name="invert" type="boolean" default="false" />
+    <output name="out" type="float" default="0.0" />
   </nodedef>
 
 </materialx>

--- a/libraries/nprlib/nprlib_ng.mtlx
+++ b/libraries/nprlib/nprlib_ng.mtlx
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <!--
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
+
+    Graph definitions of standard nodes included in the MaterialX specification.
+  -->
+
+  <!-- ======================================================================== -->
+  <!-- View-dependent nodes                                                     -->
+  <!-- ======================================================================== -->
+
+  <!--
+    Node: <facingratio>
+  -->
+  <nodegraph name="NG_facingratio_float" nodedef="ND_facingratio_float">
+    <dotproduct name="N_dotproduct" type="float">
+      <input name="in1" type="vector3" interfacename="viewdirection" />
+      <input name="in2" type="vector3" interfacename="normal" />
+    </dotproduct>
+    <multiply name="N_scale" type="float">
+      <input name="in1" type="float" nodename="N_dotproduct" />
+      <input name="in2" type="float" value="-1" />
+    </multiply>
+    <absval name="N_absval" type="float">
+      <input name="in" type="float" nodename="N_dotproduct" />
+    </absval>
+    <ifequal name="N_facing" type="float">
+      <input name="value1" type="boolean" interfacename="faceforward" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in1" type="float" nodename="N_absval" />
+      <input name="in2" type="float" nodename="N_scale" />
+    </ifequal>
+    <subtract name="N_invert" type="float">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" nodename="N_facing" />
+    </subtract>
+    <ifequal name="N_result" type="float">
+      <input name="value1" type="boolean" interfacename="invert" />
+      <input name="value2" type="boolean" value="true" />
+      <input name="in1" type="float" nodename="N_invert" />
+      <input name="in2" type="float" nodename="N_facing" />
+    </ifequal>
+    <output name="out" type="float" nodename="N_result" />
+  </nodegraph>
+
+</materialx>

--- a/resources/Materials/TestSuite/nprlib/edge_brighten.mtlx
+++ b/resources/Materials/TestSuite/nprlib/edge_brighten.mtlx
@@ -1,18 +1,9 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="lin_rec709">
   <nodegraph name="edge_brighten">
-    <viewdirection name="viewdirection_vector3" type="vector3" />
-    <normal name="normal_vector3" type="vector3" />
-    <multiply name="multiply_vector3" type="vector3">
-      <input name="in1" type="vector3" nodename="viewdirection_vector3" />
-      <input name="in2" type="float" value="-1" />
-    </multiply>
-    <dotproduct name="dotproduct_vector3" type="float">
-      <input name="in1" type="vector3" nodename="multiply_vector3" />
-      <input name="in2" type="vector3" nodename="normal_vector3" />
-    </dotproduct>
+    <facingratio name="facingratio_float" type="float" />
     <clamp name="clamp_float" type="float">
-      <input name="in" type="float" nodename="dotproduct_vector3" />
+      <input name="in" type="float" nodename="facingratio_float" />
     </clamp>
     <power name="power_float" type="float">
       <input name="in1" type="float" nodename="clamp_float" />


### PR DESCRIPTION
This changelist adds a `facingratio` node to the NPR data library, providing an additional intermediate node for building NPR graphs.