### PR TITLE
Rename ND_normalmap to ND_normalmap_float in 1.39

### DIFF
--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -42,9 +42,8 @@
   </implementation>
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_float_genglsl" nodedef="ND_normalmap" file="mx_normalmap.glsl" function="mx_normalmap_float" target="genglsl" />
+  <implementation name="IM_normalmap_float_genglsl" nodedef="ND_normalmap_float" file="mx_normalmap.glsl" function="mx_normalmap_float" target="genglsl" />
   <implementation name="IM_normalmap_vector2_genglsl" nodedef="ND_normalmap_vector2" file="mx_normalmap.glsl" function="mx_normalmap_vector2" target="genglsl" />
-
 
   <!-- ======================================================================== -->
   <!-- Procedural nodes                                                         -->

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -44,7 +44,7 @@
   <!-- <triplanarprojection> -->
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_float_genmdl" nodedef="ND_normalmap" sourcecode="mx::stdlib::mx_normalmap_float(mxp_in:{{in}}, mxp_space:{{space}}, mxp_scale:{{scale}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}})" target="genmdl" />
+  <implementation name="IM_normalmap_float_genmdl" nodedef="ND_normalmap_float" sourcecode="mx::stdlib::mx_normalmap_float(mxp_in:{{in}}, mxp_space:{{space}}, mxp_scale:{{scale}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}})" target="genmdl" />
   <implementation name="IM_normalmap_vector2_genmdl" nodedef="ND_normalmap_vector2" sourcecode="mx::stdlib::mx_normalmap_vector2(mxp_in:{{in}}, mxp_space:{{space}}, mxp_scale:{{scale}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}})" target="genmdl" />
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -42,7 +42,7 @@
   </implementation>
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_float_genmsl" nodedef="ND_normalmap" file="mx_normalmap.metal" function="mx_normalmap_float" target="genmsl" />
+  <implementation name="IM_normalmap_float_genmsl" nodedef="ND_normalmap_float" file="mx_normalmap.metal" function="mx_normalmap_float" target="genmsl" />
   <implementation name="IM_normalmap_vector2_genmsl" nodedef="ND_normalmap_vector2" file="mx_normalmap.metal" function="mx_normalmap_vector2" target="genmsl" />
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -44,7 +44,7 @@
   <!-- <triplanarprojection> -->
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_float_genosl" nodedef="ND_normalmap" file="mx_normalmap.osl" function="mx_normalmap_float" target="genosl" />
+  <implementation name="IM_normalmap_float_genosl" nodedef="ND_normalmap_float" file="mx_normalmap.osl" function="mx_normalmap_float" target="genosl" />
   <implementation name="IM_normalmap_vector2_genosl" nodedef="ND_normalmap_vector2" file="mx_normalmap.osl" function="mx_normalmap_vector2" target="genosl" />
 
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2497,7 +2497,7 @@
     Node: <normalmap>
     Transform a normal vector from object or tangent space into "world" space.
   -->
-  <nodedef name="ND_normalmap" node="normalmap" nodegroup="math">
+  <nodedef name="ND_normalmap_float" node="normalmap" nodegroup="math">
     <input name="in" type="vector3" value="0.5, 0.5, 1.0" />
     <input name="space" type="string" value="tangent" enum="tangent, object" uniform="true" />
     <input name="scale" type="float" value="1.0" />

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1443,7 +1443,8 @@ void Document::upgradeVersion()
                 {
                     input2->setName("inx");
                 }
-            } else if (nodeDef == "ND_normalmap")
+            }
+            else if (nodeDef == "ND_normalmap")
             {
                 // ND_normalmap was renamed to ND_normalmap_float
                 node->setNodeDefString("ND_normalmap_float");

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -1426,6 +1426,7 @@ void Document::upgradeVersion()
                 continue;
             }
             const string& nodeCategory = node->getCategory();
+            const string& nodeDef = node->getNodeDefString();
             if (nodeCategory == "atan2")
             {
                 // rename input ports
@@ -1442,6 +1443,10 @@ void Document::upgradeVersion()
                 {
                     input2->setName("inx");
                 }
+            } else if (nodeDef == "ND_normalmap")
+            {
+                // ND_normalmap was renamed to ND_normalmap_float
+                node->setNodeDefString("ND_normalmap_float");
             }
         }
 


### PR DESCRIPTION
Renaming `ND_normalmap` -> `ND_normalmap_float`

Added upgrade mechanism to handle the node definition rename.