### PR TITLE
Add round node to data libraries

### DIFF
--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -302,6 +302,15 @@
   <implementation name="IM_ceil_vector4_genglsl" nodedef="ND_ceil_vector4" target="genglsl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_integer_genglsl" nodedef="ND_ceil_integer" target="genglsl" sourcecode="int(ceil({{in}}))" />
 
+  <!-- <round> -->
+  <implementation name="IM_round_float_genglsl" nodedef="ND_round_float" target="genglsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_color3_genglsl" nodedef="ND_round_color3" target="genglsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_color4_genglsl" nodedef="ND_round_color4" target="genglsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector2_genglsl" nodedef="ND_round_vector2" target="genglsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector3_genglsl" nodedef="ND_round_vector3" target="genglsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector4_genglsl" nodedef="ND_round_vector4" target="genglsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_integer_genglsl" nodedef="ND_round_integer" target="genglsl" sourcecode="int(round({{in}}))" />
+
   <!-- <power> -->
   <implementation name="IM_power_float_genglsl" nodedef="ND_power_float" target="genglsl" sourcecode="pow({{in1}}, {{in2}})" />
   <implementation name="IM_power_color3_genglsl" nodedef="ND_power_color3" target="genglsl" sourcecode="pow({{in1}}, {{in2}})" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -304,6 +304,15 @@
   <implementation name="IM_ceil_vector4_genmdl" nodedef="ND_ceil_vector4" sourcecode="math::ceil({{in}})" target="genmdl" />
   <implementation name="IM_ceil_integer_genmdl" nodedef="ND_ceil_integer" sourcecode="int(math::ceil({{in}}))" target="genmdl" />
 
+  <!-- <round> -->
+  <implementation name="IM_round_float_genmdl" nodedef="ND_round_float" sourcecode="math::round({{in}})" target="genmdl" />
+  <implementation name="IM_round_color3_genmdl" nodedef="ND_round_color3" sourcecode="mx::stdlib::mx_round_color3({{in}})" target="genmdl" />
+  <implementation name="IM_round_color4_genmdl" nodedef="ND_round_color4" sourcecode="mx::stdlib::mx_round_color4({{in}})" target="genmdl" />
+  <implementation name="IM_round_vector2_genmdl" nodedef="ND_round_vector2" sourcecode="math::round({{in}})" target="genmdl" />
+  <implementation name="IM_round_vector3_genmdl" nodedef="ND_round_vector3" sourcecode="math::round({{in}})" target="genmdl" />
+  <implementation name="IM_round_vector4_genmdl" nodedef="ND_round_vector4" sourcecode="math::round({{in}})" target="genmdl" />
+  <implementation name="IM_round_integer_genmdl" nodedef="ND_round_integer" sourcecode="int(math::round({{in}}))" target="genmdl" />
+
   <!-- <power> -->
   <implementation name="IM_power_float_genmdl" nodedef="ND_power_float" sourcecode="math::pow({{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_power_color3_genmdl" nodedef="ND_power_color3" sourcecode="math::pow({{in1}}, {{in2}})" target="genmdl" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -302,6 +302,15 @@
   <implementation name="IM_ceil_vector4_genmsl" nodedef="ND_ceil_vector4" target="genmsl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_integer_genmsl" nodedef="ND_ceil_integer" target="genmsl" sourcecode="int(ceil({{in}}))" />
 
+  <!-- <round> -->
+  <implementation name="IM_round_float_genmsl" nodedef="ND_round_float" target="genmsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_color3_genmsl" nodedef="ND_round_color3" target="genmsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_color4_genmsl" nodedef="ND_round_color4" target="genmsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector2_genmsl" nodedef="ND_round_vector2" target="genmsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector3_genmsl" nodedef="ND_round_vector3" target="genmsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector4_genmsl" nodedef="ND_round_vector4" target="genmsl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_integer_genmsl" nodedef="ND_round_integer" target="genmsl" sourcecode="int(round({{in}}))" />
+
   <!-- <power> -->
   <implementation name="IM_power_float_genmsl" nodedef="ND_power_float" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
   <implementation name="IM_power_color3_genmsl" nodedef="ND_power_color3" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />

--- a/libraries/stdlib/genosl/include/color4.h
+++ b/libraries/stdlib/genosl/include/color4.h
@@ -151,6 +151,11 @@ color4 ceil(color4 a)
     return color4(ceil(a.rgb), ceil(a.a));
 }
 
+color4 round(color4 a)
+{
+    return color4(round(a.rgb), round(a.a));
+}
+
 color4 floor(color4 a)
 {
     return color4(floor(a.rgb), floor(a.a));

--- a/libraries/stdlib/genosl/include/vector2.h
+++ b/libraries/stdlib/genosl/include/vector2.h
@@ -151,6 +151,11 @@ vector2 ceil(vector2 a)
     return vector2 (ceil(a.x), ceil(a.y));
 }
 
+vector2 round(vector2 a)
+{
+    return vector2 (round(a.x), round(a.y));
+}
+
 vector2 floor(vector2 a)
 {
     return vector2 (floor(a.x), floor(a.y));

--- a/libraries/stdlib/genosl/include/vector4.h
+++ b/libraries/stdlib/genosl/include/vector4.h
@@ -160,6 +160,14 @@ vector4 ceil(vector4 in)
                     ceil(in.w));
 }
 
+vector4 round(vector4 in)
+{
+    return vector4 (round(in.x),
+                    round(in.y),
+                    round(in.z),
+                    round(in.w));
+}
+
 vector4 floor(vector4 in)
 {
     return vector4 (floor(in.x),

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -304,6 +304,15 @@
   <implementation name="IM_ceil_vector4_genosl" nodedef="ND_ceil_vector4" target="genosl" sourcecode="ceil({{in}})" />
   <implementation name="IM_ceil_integer_genosl" nodedef="ND_ceil_integer" target="genosl" sourcecode="int(ceil({{in}}))" />
 
+  <!-- <round> -->
+  <implementation name="IM_round_float_genosl" nodedef="ND_round_float" target="genosl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_color3_genosl" nodedef="ND_round_color3" target="genosl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_color4_genosl" nodedef="ND_round_color4" target="genosl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector2_genosl" nodedef="ND_round_vector2" target="genosl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector3_genosl" nodedef="ND_round_vector3" target="genosl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_vector4_genosl" nodedef="ND_round_vector4" target="genosl" sourcecode="round({{in}})" />
+  <implementation name="IM_round_integer_genosl" nodedef="ND_round_integer" target="genosl" sourcecode="int(round({{in}}))" />
+
   <!-- <power> -->
   <implementation name="IM_power_float_genosl" nodedef="ND_power_float" target="genosl" sourcecode="pow({{in1}}, {{in2}})" />
   <implementation name="IM_power_color3_genosl" nodedef="ND_power_color3" target="genosl" sourcecode="pow({{in1}}, {{in2}})" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1915,6 +1915,39 @@
   </nodedef>
 
   <!--
+    Node: <round>
+    Round incoming float/color/vector values.
+  -->
+  <nodedef name="ND_round_float" node="round" nodegroup="math">
+    <input name="in" type="float" value="0.0" />
+    <output name="out" type="float" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_round_color3" node="round" nodegroup="math">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_round_color4" node="round" nodegroup="math">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <output name="out" type="color4" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_round_vector2" node="round" nodegroup="math">
+    <input name="in" type="vector2" value="0.0, 0.0" />
+    <output name="out" type="vector2" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_round_vector3" node="round" nodegroup="math">
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="vector3" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_round_vector4" node="round" nodegroup="math">
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <output name="out" type="vector4" defaultinput="in" />
+  </nodedef>
+  <nodedef name="ND_round_integer" node="round" nodegroup="math">
+    <input name="in" type="float" value="0.0" />
+    <output name="out" type="integer" defaultinput="in" />
+  </nodedef>
+
+  <!--
     Node: <power>
     Raise incoming float/color/vector values to the "in2" power.
   -->

--- a/python/Scripts/genmdl.py
+++ b/python/Scripts/genmdl.py
@@ -644,6 +644,9 @@ def main():
                 elif nodeCategory == 'ceil':
                     _writeOneArgumentFunc(file, outputType, '::math::'+nodeCategory)
                     wroteImplementation = True
+                elif nodeCategory == 'round':
+                    _writeOneArgumentFunc(file, outputType, '::math::'+nodeCategory)
+                    wroteImplementation = True
                 elif nodeCategory == 'floor':
                     _writeOneArgumentFunc(file, outputType, '::math::'+nodeCategory)
                     wroteImplementation = True

--- a/resources/Materials/TestSuite/stdlib/math/math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math.mtlx
@@ -234,6 +234,69 @@
     </constant>
     <output name="out" type="integer" nodename="ceil1" />
   </nodegraph>
+  <nodegraph name="round_float_nodegraph">
+    <round name="round1" type="float">
+      <input name="in" type="float" nodename="constant1" />
+    </round>
+    <constant name="constant1" type="float">
+      <input name="value" type="float" value="0.5000" />
+    </constant>
+    <output name="out" type="float" nodename="round1" />
+  </nodegraph>
+  <nodegraph name="round_vector2_nodegraph">
+    <round name="round1" type="vector2">
+      <input name="in" type="vector2" nodename="constant1" />
+    </round>
+    <constant name="constant1" type="vector2">
+      <input name="value" type="vector2" value="-0.5000, 0.5000" />
+    </constant>
+    <output name="out" type="vector2" nodename="round1" />
+  </nodegraph>
+  <nodegraph name="round_vector3_nodegraph">
+    <constant name="constant1" type="vector3">
+      <input name="value" type="vector3" value="-0.5000, 0.5000, 0.0000" />
+    </constant>
+    <output name="out" type="vector3" nodename="round1" />
+    <round name="round1" type="vector3">
+      <input name="in" type="vector3" nodename="constant1" />
+    </round>
+  </nodegraph>
+  <nodegraph name="round_vector4_nodegraph">
+    <round name="round1" type="vector4">
+      <input name="in" type="vector4" nodename="constant1" />
+    </round>
+    <constant name="constant1" type="vector4">
+      <input name="value" type="vector4" value="-0.5000, 0.5000, 0.0, 1.0" />
+    </constant>
+    <output name="out" type="vector4" nodename="round1" />
+  </nodegraph>
+  <nodegraph name="round_color3_nodegraph">
+    <constant name="constant1" type="color3">
+      <input name="value" type="color3" value="-0.5000, 0.5000, 0.0" />
+    </constant>
+    <round name="round1" type="color3">
+      <input name="in" type="color3" nodename="constant1" />
+    </round>
+    <output name="out" type="color3" nodename="round1" />
+  </nodegraph>
+  <nodegraph name="round_color4_nodegraph">
+    <constant name="constant1" type="color4">
+      <input name="value" type="color4" value="-0.5000, 0.5000, 0.0, 1.0" />
+    </constant>
+    <round name="round1" type="color4">
+      <input name="in" type="color4" nodename="constant1" />
+    </round>
+    <output name="out" type="color4" nodename="round1" />
+  </nodegraph>
+  <nodegraph name="round_integer_nodegraph">
+    <round name="round1" type="integer">
+      <input name="in" type="float" nodename="constant1" />
+    </round>
+    <constant name="constant1" type="float">
+      <input name="value" type="float" value="0.5000" />
+    </constant>
+    <output name="out" type="integer" nodename="round1" />
+  </nodegraph>
   <nodegraph name="sign_float">
     <constant name="constant1" type="float">
       <input name="value" type="float" value="1.0000" />

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -1498,6 +1498,26 @@ export core::color4 mx_ceil_color4(
 	return core::mk_color4(::math::ceil(core::mk_float4(mxp_in)));
 }
 
+export color mx_round_color3(
+	color mxp_in = color(0.0, 0.0, 0.0)
+)
+	[[
+		anno::description("Node Group: math")
+	]]
+{
+	return color(::math::round(float3(mxp_in)));
+}
+
+export color4 mx_round_color4(
+	color4 mxp_in = mk_color4(0.0, 0.0, 0.0, 0.0)
+)
+	[[
+		anno::description("Node Group: math")
+	]]
+{
+	return mk_color4(::math::round(mk_float4(mxp_in)));
+}
+
 export core::color4 mx_power_color4(
 	core::color4 mxp_in1 = core::mk_color4(0.0, 0.0, 0.0, 0.0),
 	core::color4 mxp_in2 = core::mk_color4(1.0, 1.0, 1.0, 1.0)

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -1508,14 +1508,14 @@ export color mx_round_color3(
 	return color(::math::round(float3(mxp_in)));
 }
 
-export color4 mx_round_color4(
-	color4 mxp_in = mk_color4(0.0, 0.0, 0.0, 0.0)
+export core::color4 mx_round_color4(
+	core::color4 mxp_in = core::mk_color4(0.0, 0.0, 0.0, 0.0)
 )
 	[[
 		anno::description("Node Group: math")
 	]]
 {
-	return mk_color4(::math::round(mk_float4(mxp_in)));
+	return core::mk_color4(::math::round(core::mk_float4(mxp_in)));
 }
 
 export core::color4 mx_power_color4(

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_8.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_8.mdl
@@ -95,6 +95,8 @@ export using .::stdlib_1_7 import mx_floor_color3;
 export using .::stdlib_1_7 import mx_floor_color4;
 export using .::stdlib_1_7 import mx_ceil_color3;
 export using .::stdlib_1_7 import mx_ceil_color4;
+export using .::stdlib_1_7 import mx_round_color3;
+export using .::stdlib_1_7 import mx_round_color4;
 export using .::stdlib_1_7 import mx_power_color4;
 export using .::stdlib_1_7 import mx_power_color4FA;
 export using .::stdlib_1_7 import mx_sin_float;


### PR DESCRIPTION
Mirror the existing ceil node definition.

This is now being submitted for inclusion in `main` - previous PR (#1661) closed