### PR TITLE
Improvements to facingratio

### DIFF
--- a/libraries/nprlib/nprlib_defs.mtlx
+++ b/libraries/nprlib/nprlib_defs.mtlx
@@ -34,8 +34,8 @@
   <nodedef name="ND_facingratio_float" node="facingratio" nodegroup="npr">
     <input name="viewdirection" type="vector3" defaultgeomprop="Vworld" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
-    <input name="faceforward" type="boolean" default="true" />
-    <input name="invert" type="boolean" default="false" />
+    <input name="faceforward" type="boolean" value="true" />
+    <input name="invert" type="boolean" value="false" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 

--- a/libraries/nprlib/nprlib_ng.mtlx
+++ b/libraries/nprlib/nprlib_ng.mtlx
@@ -32,10 +32,9 @@
       <input name="in1" type="float" nodename="N_absval" />
       <input name="in2" type="float" nodename="N_scale" />
     </ifequal>
-    <subtract name="N_invert" type="float">
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" nodename="N_facing" />
-    </subtract>
+    <invert name="N_invert" type="float">
+      <input name="in" type="float" nodename="N_facing" />
+    </invert>
     <ifequal name="N_result" type="float">
       <input name="value1" type="boolean" interfacename="invert" />
       <input name="value2" type="boolean" value="true" />

--- a/resources/Materials/TestSuite/nprlib/edge_brighten.mtlx
+++ b/resources/Materials/TestSuite/nprlib/edge_brighten.mtlx
@@ -1,17 +1,16 @@
 <?xml version="1.0"?>
 <materialx version="1.38" colorspace="lin_rec709">
   <nodegraph name="edge_brighten">
-    <facingratio name="facingratio_float" type="float" />
-    <clamp name="clamp_float" type="float">
-      <input name="in" type="float" nodename="facingratio_float" />
-    </clamp>
+    <facingratio name="facingratio_float" type="float">
+      <input name="invert" type="boolean" value="true" />
+    </facingratio>
     <power name="power_float" type="float">
-      <input name="in1" type="float" nodename="clamp_float" />
-      <input name="in2" type="float" value="0.2" />
+      <input name="in1" type="float" nodename="facingratio_float" />
+      <input name="in2" type="float" value="3.0" />
     </power>
     <mix name="mix_color3" type="color3">
-      <input name="fg" type="color3" value="0, 0.0986187, 0.186275" />
-      <input name="bg" type="color3" value="0.735294, 0.735294, 0.735294" />
+      <input name="bg" type="color3" value="0, 0.0986187, 0.186275" />
+      <input name="fg" type="color3" value="0.735294, 0.735294, 0.735294" />
       <input name="mix" type="float" nodename="power_float" />
     </mix>
     <output name="out" type="color3" nodename="mix_color3" />


### PR DESCRIPTION
- Fix syntax of input default values.
- Use the invert node in facingratio for compactness.
- Clarify the edge brighten example material.