### PR TITLE
Always build GLFW as a static library

### DIFF
--- a/source/MaterialXGraphEditor/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(
     MaterialXGraphEditor
     PRIVATE
     ${MATERIALX_LIBRARIES}
- 	glfw)
+ 	glfw_minimal)
 
 install(TARGETS MaterialXGraphEditor
     EXPORT MaterialX

--- a/source/MaterialXGraphEditor/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/CMakeLists.txt
@@ -60,6 +60,12 @@ set(GLFW_BUILD_TESTS OFF)
 set(GLFW_BUILD_DOCS OFF)
 set(GLFW_INSTALL OFF)
 
+# we explicitly force glfw to build static libraries, as we don't install them.
+# we don't need to restore the state after we call add_subdirectory here because
+# we're not adding any new targets after this, and the state is unmodified at a higher
+# cmake level.
+set(BUILD_SHARED_LIBS OFF)
+
 add_subdirectory(External/Glfw)
 
 if(MSVC)

--- a/source/MaterialXGraphEditor/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/CMakeLists.txt
@@ -94,7 +94,7 @@ target_link_libraries(
     MaterialXGraphEditor
     PRIVATE
     ${MATERIALX_LIBRARIES}
- 	glfw_minimal)
+ 	glfw)
 
 install(TARGETS MaterialXGraphEditor
     EXPORT MaterialX

--- a/source/MaterialXGraphEditor/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/CMakeLists.txt
@@ -60,10 +60,7 @@ set(GLFW_BUILD_TESTS OFF)
 set(GLFW_BUILD_DOCS OFF)
 set(GLFW_INSTALL OFF)
 
-# we explicitly force glfw to build static libraries, as we don't install them.
-# we don't need to restore the state after we call add_subdirectory here because
-# we're not adding any new targets after this, and the state is unmodified at a higher
-# cmake level.
+# Explicitly build GLFW with static libraries, independent of the broader build settings.
 set(BUILD_SHARED_LIBS OFF)
 
 add_subdirectory(External/Glfw)


### PR DESCRIPTION
Currently the embedded glfw build for MaterialXGraphEditor inherits the value of `BUILD_SHARED_LIBS` from `MATERIALX_BUILD_SHARED_LIBS`, but we're not installing `libglfw`, per #1245 the intention was to statically link.

closes #1245 