### PR TITLE
Draft : Implementing structures.

### DIFF
--- a/documents/Specification/MaterialX.Specification.md
+++ b/documents/Specification/MaterialX.Specification.md
@@ -255,7 +255,7 @@ While color<em>N</em> and vector<em>N</em> types both describe vectors of floati
 
 ## Custom Data Types
 
-In addition to the standard data types, MaterialX supports the specification of custom data types for the inputs and outputs of shaders and custom nodes.  This allows documents to describe data streams of any complex type an application may require; examples might include spectral color samples or compound geometric data.
+In addition to the standard data types, MaterialX supports the specification of custom data types for the inputs and outputs of shaders and custom nodes.  This allows documents to describe data streams of any complex type an application may require; examples might include spectral color samples or compound geometric data.  The structure of a custom type's contents is described using a number of &lt;member> elements.
 
 Types can be declared to have a specific semantic, which can be used to determine how values of that type should be interpreted, and how nodes outputting that type can be connected.  Currently, MaterialX defines three semantics:
 
@@ -268,8 +268,12 @@ Types not defined with a specific semantic are assumed to have semantic="default
 Custom types are defined using the &lt;typedef> element:
 
 ```xml
-  <typedef name="spectrum" semantic="color"/>
-  <typedef name="manifold"/>
+  <typedef name="manifold">
+    <member name="P" type="vector3"/>
+    <member name="N" type="vector3"/>
+    <member name="du" type="vector3"/>
+    <member name="dv" type="vector3"/>
+  </typedef>
 ```
 
 Attributes for &lt;typedef> elements:
@@ -282,10 +286,35 @@ Attributes for &lt;typedef> elements:
     * "halfprecision": the values within this type are half-precision
     * "doubleprecision: the values within this type are double-precision
 
-Once a custom type is defined by a &lt;typedef>, it can then be used in any MaterialX element that allows "any MaterialX type"; the list of MaterialX types is effectively expanded to include the new custom type.  It should be noted however that the &lt;typedef> is only declaring the existence of the type and perhaps some hints about its intended definition, but it is up to each application and code generator to provide its own precise definition for any type.
+Attributes for &lt;member> elements:
+
+* `name` (string, required): the name of the member variable.
+* `type` (string, required): the type of the member variable; can be any built-in MaterialX type; using custom types for &lt;member> types is not supported. 
+* `defaultvalue` (string, optional): the value the member variable will be initialized to if not explicitly set on a node.
+
+**(Discussion point : We might be able to support custom types as members as well?  Given the initializers are now wrapped in braces, its possible to accurately define nested initializers, and potentially also allow for some members to not be initialized)**
+
+If a number of &lt;member> elements are provided, then a MaterialX file can specify a value for that type any place it is used, using an aggregated initializer, a semicolon-separated list of numbers and strings surrounded by braced.  The expectation is that the numbers and strings between semicolons exactly line up with the expected &lt;member> types in order. For example, if the following &lt;typedef> was declared:
+
+```xml
+  <typedef name="exampletype">
+    <member name="id" type="integer"/>
+    <member name="compclr" type="color3"/> 
+    <member name="objects" type="stringarray"/> 
+    <member name="minvec" type="vector2"/> 
+    <member name="maxvec" type="vector2"/>
+  </typedef>
+```
+
+Then a permissible input declaration in a custom node using that type could be:
+
+```xml
+  <input name="in2" type="exampletype" value="{3; 0.18,0.2,0.11; foo,bar; 0.0,1.0; 3.4,5.1}"/>
+```
+
+Once a custom type is defined by a &lt;typedef>, it can then be used in any MaterialX element that allows "any MaterialX type"; the list of MaterialX types is effectively expanded to include the new custom type.
 
 The standard MaterialX distribution includes definitions for four "shader"-semantic data types: **surfaceshader**, **displacementshader**, **volumeshader**, and **lightshader**.  These types are discussed in more detail in the [Shader Nodes](#shader-nodes) section below.
-
 
 
 ## MTLX File Format Definition

--- a/libraries/experimental/experimental_defs.mtlx
+++ b/libraries/experimental/experimental_defs.mtlx
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <!--
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
+
+    Declarations of experimental data types and nodes
+  -->
+
+    <typedef name="texcoord">
+        <member name="ss" type="float"/>
+        <member name="tt" type="float"/>
+    </typedef>
+
+    <nodedef name="ND_extract_s_texcoord" node="extracts" nodegroup="shader" >
+        <input name="in" type="struct:texcoord" value="0.0;0.0" />
+        <output name="out" type="float" value="0.0" />
+    </nodedef>
+
+</materialx>

--- a/libraries/experimental/experimental_ng.mtlx
+++ b/libraries/experimental/experimental_ng.mtlx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+    <!--
+      Copyright Contributors to the MaterialX Project
+      SPDX-License-Identifier: Apache-2.0
+
+      Nodegraph Implementations of experimental nodes
+    -->
+
+</materialx>

--- a/libraries/experimental/genglsl/experimental_genglsl_impl.mtlx
+++ b/libraries/experimental/genglsl/experimental_genglsl_impl.mtlx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+    <!--
+      Copyright Contributors to the MaterialX Project
+      SPDX-License-Identifier: Apache-2.0
+
+      GLSL Implementations of experimental nodes
+    -->
+
+    <implementation name="IM_extract_s_texcoord" nodedef="ND_extract_s_texcoord" target="genglsl" sourcecode="{{in__I__ss}}" />
+
+</materialx>

--- a/libraries/experimental/genmsl/experimental_genmsl_impl.mtlx
+++ b/libraries/experimental/genmsl/experimental_genmsl_impl.mtlx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+    <!--
+      Copyright Contributors to the MaterialX Project
+      SPDX-License-Identifier: Apache-2.0
+
+      MSL Implementations of experimental nodes
+    -->
+
+    <implementation name="IM_extract_s_texcoord" nodedef="ND_extract_s_texcoord" target="genmsl" sourcecode="{{in__I__ss}}" />
+
+</materialx>

--- a/resources/Materials/TestSuite/experimental/struct/struct_texcoord.mtlx
+++ b/resources/Materials/TestSuite/experimental/struct/struct_texcoord.mtlx
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+    <nodegraph name="test_struct_texcoord">
+
+        <extracts name="extracts" type="float">
+            <input name="in" type="struct:texcoord" value="0.3;0.2"/>
+        </extracts>
+
+        <convert name="float_to_color3" type="color3">
+            <input name="in" type="float" nodename="extracts"/>
+        </convert>
+        <oren_nayar_diffuse_bsdf name="diffuse_brdf1" type="BSDF">
+            <input name="color" type="color3" nodename="float_to_color3" />
+        </oren_nayar_diffuse_bsdf>
+        <surface name="surface1" type="surfaceshader">
+            <input name="bsdf" type="BSDF" nodename="diffuse_brdf1" />
+            <input name="opacity" type="float" value="1.0" />
+        </surface>
+        <output name="out" type="surfaceshader" nodename="surface1" />
+    </nodegraph>
+</materialx>

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -831,6 +831,11 @@ ShaderNode* ShaderGraph::createNode(const Node& node, GenContext& context)
         ShaderInput* input = newNode->getInput(nodeDefInput->getName());
         InputPtr nodeInput = node.getInput(nodeDefInput->getName());
 
+        // 'input' is null_ptr if the input is a struct - a fully formed struct implementation likely needs to handle some of these
+        // additional cases more gracefully and completely.
+        if (!input)
+            continue;
+
         const string& connection = nodeInput ? nodeInput->getNodeName() : EMPTY_STRING;
         if (connection.empty() && !input->getConnection())
         {

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -73,7 +73,11 @@ int TypeDesc::getChannelIndex(char channel) const
 const TypeDesc* TypeDesc::get(const string& name)
 {
     const TypeDescMap& map = typeMap();
-    auto it = map.find(name);
+    std::string localName = name;
+    if (localName.substr(0, 7) == "struct:") {
+        localName = "struct";
+    }
+    auto it = map.find(localName);
     return it != map.end() ? it->second.get() : nullptr;
 }
 
@@ -97,6 +101,7 @@ const TypeDesc* COLOR4              = TypeDesc::registerType("color4", TypeDesc:
 const TypeDesc* MATRIX33            = TypeDesc::registerType("matrix33", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_MATRIX, 9);
 const TypeDesc* MATRIX44            = TypeDesc::registerType("matrix44", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_MATRIX, 16);
 const TypeDesc* STRING              = TypeDesc::registerType("string", TypeDesc::BASETYPE_STRING);
+const TypeDesc* STRUCT              = TypeDesc::registerType("struct", TypeDesc::BASETYPE_STRUCT);
 const TypeDesc* FILENAME            = TypeDesc::registerType("filename", TypeDesc::BASETYPE_STRING, TypeDesc::SEMANTIC_FILENAME);
 const TypeDesc* BSDF                = TypeDesc::registerType("BSDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);
 const TypeDesc* EDF                 = TypeDesc::registerType("EDF", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_CLOSURE, 1, false);

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -146,6 +146,7 @@ extern MX_GENSHADER_API const TypeDesc* COLOR4;
 extern MX_GENSHADER_API const TypeDesc* MATRIX33;
 extern MX_GENSHADER_API const TypeDesc* MATRIX44;
 extern MX_GENSHADER_API const TypeDesc* STRING;
+extern MX_GENSHADER_API const TypeDesc* STRUCT;
 extern MX_GENSHADER_API const TypeDesc* FILENAME;
 extern MX_GENSHADER_API const TypeDesc* BSDF;
 extern MX_GENSHADER_API const TypeDesc* EDF;


### PR DESCRIPTION
# Struct support in MaterialX

## Introduction

The [MaterialX (1.38) specification document](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/v1.38/MaterialX.v1.38.Spec.pdf) allows for “Custom Data Types” (see page 8).  Custom data types can specify `<member>`  elements, effectively defining a custom structure.  Once defined these custom structs can be used as types for `input` and `output` elements in a node or node definition in MaterialX documents.  
Parsing the document is currently supported, but nothing else is.  None of the MaterialX shader generation code provides any support for these custom types. 

## Proposal

Inspired by how [OpenShadingLanguage](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage) deals with structs, I believe there is a reasonably easy path to adding support to MaterialX shader generation, in a language agnostic way. (Previously the project struggled to find a way to peformantly support this idea across all destination shader languages).

Effectively the idea boils down to implictly namespaced shader parameters being generated dynamically at shader generation time.  Instead of a node generating a function where the parameters are one-to-one with the input ports on the corresponding node definition, when we encounter a custom struct type we expand that parameter out to a set of parameters prefixed with the struct name.

For example, the following custom type and node definition

```
<typedef name="myTexCoord">
  <member name="ss" type="float"/>
  <member name="tt" type="float"/>
</typedef>
  
<nodedef name=“ND_extractMyTexCoordS_float” type=float“>
  <input name="in" type="myTexCoord" value="{0.5,0.5}"/>
  <output name="out" type="float" defaultvalue="0.5"/>
</nodedef>
```

would generate something similar to the following psuedo-code, note the namespaced input parameters to the function.  Note, the separator string here (`__I__`) is certainly a subject for discussion.

```
float extractMyTexCoordS(
  float in__I__ss = 0.5,
  float in__I__tt = 0.5
) 
{
   // implementation
} 
```

The shader generation code can be updated in a shader language agnostic way.  Each time a struct is discovered when traversing the nodegraph each operation (connecting nodes, setting local values, etc) is just applied for each child `<member>` of the custom struct.


## Rationale

This might not be the most obvious approach, but the reason we choose to take it anyway, is primarily that it allows the nodegraph to give the illusion of using structs, without imposing any potential performance penalty on the destination shader language by actually using structs.  It also allows a potential future shader language to be adopted if it doesn’t support the concept at all.  There is strong precedent for this approach in OSL, which is a production proven shading language used on 100’s of feature films.


## Considerations

A few subtleties that are open for discussion.

* Do we allow support structs that contain other structs?
    * I think technically we could support this (OSL does), the namespace for the parameter names could just contain multiple scopes.
* Do we allow partially initialized structs when setting values on input ports?
    * In OSL it is legal to provide an initializer list where the number of members in the list is not complete to the number of member in the struct, in that case the later members just remain unset (or default).
* Do we want to extend the specification to mandate that `<member>` elements contain a `defaultvalue` element to ensure nothing is ever uninitialized?

## Proposed Specification

I’ve written what I would like to propose to the ASWF project as the update to the MaterialX specification for 1.39.

* * *

## Custom Data Types

In addition to the standard data types, MaterialX supports the specification of custom data types for the inputs and outputs of shaders and custom nodes.  This allows documents to describe data streams of any complex type an application may require; examples might include spectral color samples or compound geometric data.  The structure of a custom type's contents is described using a number of `<member>` elements.

Types can be declared to have a specific semantic, which can be used to determine how values of that type should be interpreted, and how nodes outputting that type can be connected.  Currently, MaterialX defines three semantics:

* "`color`": the type is interpreted to represent or contain a color, and thus should be color-managed as described in the Color Spaces and Color Management Systems section.
* "`shader`": the type is interpreted as a shader output type; nodes or nodegraphs which output a type with a "shader" semantic can be used to define a shader-type node, which can be connected to inputs of "material"-type nodes.
* "`material`": the type is interpreted as a material output type; nodes or nodegraphs which output a type with a "material" semantic can be referenced by a <materialassign> in a <look>.

Types not defined with a specific semantic are assumed to have semantic="default".


Custom types are defined using the `<typedef>` element:

```
  <typedef name="manifold">
    <member name="P" type="vector3"/>
    <member name="N" type="vector3"/>
    <member name="du" type="vector3"/>
    <member name="dv" type="vector3"/>
  </typedef>
```

Attributes for `<typedef>` elements:

* `name` (string, required): the name of this type.  Cannot be the same as a built-in MaterialX type.
* `semantic` (string, optional): the semantic for this type (see above); the default semantic is "default".
* `context` (string, optional): a semantic-specific context in which this type should be applied.  For "shader" semantic types, `context` defines the rendering context in which the shader output is interpreted; please see the Shader Nodes section for details.
* `inherit` (string, optional): the name of another type that this type inherits from, which can be either a built-in type or a custom type.  Applications that do not have a definition for this type can use the inherited type as a "fallback" type.
* `hint` (string, optional): A hint to help those creating code generators understand how the type might be defined.  The following hints for typedefs are currently defined:
    * "halfprecision": the values within this type are half-precision
    * "doubleprecision: the values within this type are double-precision

Attributes for `<member>` elements:

* `name` (string, required): the name of the member variable.
* `type` (string, required): the type of the member variable; can be any built-in MaterialX type; using custom types for `<member>` types is not supported.
* `defaultvalue` (string, optional): the value the member variable will be initialized to if not explicitly set on a node.

If a number of `<member>` elements are provided, then a MaterialX file can specify a value for that type any place it is used, using an aggregated initializer, a semicolon-separated list of numbers and strings surrounded by braced.  The expectation is that the numbers and strings between semicolons exactly line up with the expected &lt;member> types in order. For example, if the following &lt;typedef> was declared:

```
  <typedef name="exampletype">
    <member name="id" type="integer"/>
    <member name="compclr" type="color3"/> 
    <member name="objects" type="stringarray"/> 
    <member name="minvec" type="vector2"/> 
    <member name="maxvec" type="vector2"/>
  </typedef>
```

Then a permissible input declaration in a custom node using that type could be:

```

<input name="in2" type="exampletype" value="{3; 0.18,0.2,0.11; foo,bar; 0.0,1.0; 3.4,5.1}"/>
  
```

Once a custom type is defined by a `<typedef>`, it can then be used in any MaterialX element that allows "any MaterialX type"; the list of MaterialX types is effectively expanded to include the new custom type.

The standard MaterialX distribution includes definitions for four "shader"-semantic data types: **surfaceshader**, **displacementshader**, **volumeshader**, and **lightshader**.  These types are discussed in more detail in the Shader Nodes.
