### PR TITLE
Initial support for signed integer textures

### DIFF
--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -112,11 +112,13 @@ unsigned int Image::getBaseStride() const
         return 4;
     }
     if (_baseType == BaseType::HALF ||
-        _baseType == BaseType::UINT16)
+        _baseType == BaseType::UINT16 ||
+        _baseType == BaseType::INT16)
     {
         return 2;
     }
-    if (_baseType == BaseType::UINT8)
+    if (_baseType == BaseType::UINT8 ||
+        _baseType == BaseType::INT8)
     {
         return 1;
     }
@@ -164,12 +166,28 @@ void Image::setTexelColor(unsigned int x, unsigned int y, const Color4& color)
             data[c] = (uint16_t) std::round(color[c] * (float) std::numeric_limits<uint16_t>::max());
         }
     }
+    else if (_baseType == BaseType::INT16)
+    {
+        int16_t* data = static_cast<int16_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        for (unsigned int c = 0; c < writeChannels; c++)
+        {
+            data[c] = (int16_t) std::round(color[c] * (float) std::numeric_limits<int16_t>::max());
+        }
+    }
     else if (_baseType == BaseType::UINT8)
     {
         uint8_t* data = static_cast<uint8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
         for (unsigned int c = 0; c < writeChannels; c++)
         {
             data[c] = (uint8_t) std::round(color[c] * (float) std::numeric_limits<uint8_t>::max());
+        }
+    }
+    else if (_baseType == BaseType::INT8)
+    {
+        int8_t* data = static_cast<int8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        for (unsigned int c = 0; c < writeChannels; c++)
+        {
+            data[c] = (int8_t) std::round(color[c] * (float) std::numeric_limits<int8_t>::max());
         }
     }
     else
@@ -263,10 +281,62 @@ Color4 Image::getTexelColor(unsigned int x, unsigned int y) const
             throw Exception("Unsupported channel count in getTexelColor");
         }
     }
+    else if (_baseType == BaseType::INT16)
+    {
+        int16_t* data = static_cast<int16_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        const float MAX_VALUE = (float) std::numeric_limits<int16_t>::max();
+        if (_channelCount == 4)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, data[3] / MAX_VALUE);
+        }
+        else if (_channelCount == 3)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, 1.0f);
+        }
+        else if (_channelCount == 2)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, 0.0f, 1.0f);
+        }
+        else if (_channelCount == 1)
+        {
+            float scalar = data[0] / MAX_VALUE;
+            return Color4(scalar, scalar, scalar, 1.0f);
+        }
+        else
+        {
+            throw Exception("Unsupported channel count in getTexelColor");
+        }
+    }
     else if (_baseType == BaseType::UINT8)
     {
         uint8_t* data = static_cast<uint8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
         const float MAX_VALUE = (float) std::numeric_limits<uint8_t>::max();
+        if (_channelCount == 4)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, data[3] / MAX_VALUE);
+        }
+        else if (_channelCount == 3)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, 1.0f);
+        }
+        else if (_channelCount == 2)
+        {
+            return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, 0.0f, 1.0f);
+        }
+        else if (_channelCount == 1)
+        {
+            float scalar = data[0] / MAX_VALUE;
+            return Color4(scalar, scalar, scalar, 1.0f);
+        }
+        else
+        {
+            throw Exception("Unsupported channel count in getTexelColor");
+        }
+    }
+    else if (_baseType == BaseType::INT8)
+    {
+        int8_t* data = static_cast<int8_t*>(_resourceBuffer) + (y * _width + x) * _channelCount;
+        const float MAX_VALUE = (float) std::numeric_limits<int8_t>::max();
         if (_channelCount == 4)
         {
             return Color4(data[0] / MAX_VALUE, data[1] / MAX_VALUE, data[2] / MAX_VALUE, data[3] / MAX_VALUE);

--- a/source/MaterialXRender/Image.h
+++ b/source/MaterialXRender/Image.h
@@ -47,10 +47,12 @@ class MX_RENDER_API Image
   public:
     enum class BaseType
     {
-        UINT8 = 0,
-        UINT16 = 1,
-        HALF = 2,
-        FLOAT = 3
+        UINT8,
+        INT8,
+        UINT16,
+        INT16,
+        HALF,
+        FLOAT
     };
 
   public:

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -184,11 +184,10 @@ ImageVec ImageHandler::getReferencedImages(ConstDocumentPtr doc)
             continue;
         }
 
-        NodePtr node = elem->asA<Node>();
-        InputPtr file = node ? node->getInput("file") : nullptr;
-        if (file)
+        InputPtr input = elem->asA<Input>();
+        if (input && input->getType() == FILENAME_TYPE_STRING)
         {
-            ImagePtr image = acquireImage(file->getResolvedValueString());
+            ImagePtr image = acquireImage(input->getResolvedValueString());
             if (image)
             {
                 imageVec.push_back(image);

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -31,8 +31,14 @@ bool OiioImageLoader::saveImage(const FilePath& filePath,
         case Image::BaseType::UINT8:
             format = OIIO::TypeDesc::UINT8;
             break;
+        case Image::BaseType::INT8:
+            format = OIIO::TypeDesc::INT8;
+            break;
         case Image::BaseType::UINT16:
             format = OIIO::TypeDesc::UINT16;
+            break;
+        case Image::BaseType::INT16:
+            format = OIIO::TypeDesc::INT16;
             break;
         case Image::BaseType::HALF:
             format = OIIO::TypeDesc::HALF;
@@ -90,8 +96,14 @@ ImagePtr OiioImageLoader::loadImage(const FilePath& filePath)
         case OIIO::TypeDesc::UINT8:
             baseType = Image::BaseType::UINT8;
             break;
+        case OIIO::TypeDesc::INT8:
+            baseType = Image::BaseType::INT8;
+            break;
         case OIIO::TypeDesc::UINT16:
             baseType = Image::BaseType::UINT16;
+            break;
+        case OIIO::TypeDesc::INT16:
+            baseType = Image::BaseType::INT16;
             break;
         case OIIO::TypeDesc::HALF:
             baseType = Image::BaseType::HALF;

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -230,9 +230,9 @@ void GLTextureHandler::mapTextureFormatToGL(Image::BaseType baseType, unsigned i
         default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
     }
 
-    if (baseType == Image::BaseType::UINT8)
+    if (baseType == Image::BaseType::UINT8 || baseType == Image::BaseType::INT8)
     {
-        glType = GL_UNSIGNED_BYTE;
+        glType = baseType == Image::BaseType::UINT8 ? GL_UNSIGNED_BYTE : GL_BYTE;
         switch (channelCount)
         {
             case 4: glInternalFormat = srgb ? GL_SRGB8_ALPHA8 : GL_RGBA8; break;
@@ -242,9 +242,9 @@ void GLTextureHandler::mapTextureFormatToGL(Image::BaseType baseType, unsigned i
             default: throw Exception("Unsupported channel count in mapTextureFormatToGL");
         }
     }
-    else if (baseType == Image::BaseType::UINT16)
+    else if (baseType == Image::BaseType::UINT16 || baseType == Image::BaseType::INT16)
     {
-        glType = GL_UNSIGNED_SHORT;
+        glType = baseType == Image::BaseType::UINT16 ? GL_UNSIGNED_SHORT : GL_SHORT;
         switch (channelCount)
         {
             case 4: glInternalFormat = GL_RGBA16; break;


### PR DESCRIPTION
This changelist adds initial support for signed integer textures (e.g. INT8 and INT16) in MaterialXRender and MaterialXRenderGlsl, allowing these textures to be leveraged in MaterialXView, MaterialXGraphEditor, and Shader Translation Graphs.