### PR TITLE
Add negative color guards in GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -22,6 +22,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd;
+    vec3 safeTint = max(tint, 0.0);
     if (bsdf.thickness > 0.0)
     { 
         fd = mx_init_fresnel_dielectric_airy(ior, bsdf.thickness, bsdf.ior);
@@ -40,7 +41,7 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
     // Note: NdotL is cancelled out
-    bsdf.response = D * F * G * comp * tint * occlusion * weight / (4.0 * NdotV);
+    bsdf.response = D * F * G * comp * safeTint * occlusion * weight / (4.0 * NdotV);
 }
 
 void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
@@ -54,6 +55,7 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     FresnelData fd;
+    vec3 safeTint = max(tint, 0.0);
     if (bsdf.thickness > 0.0)
     { 
         fd = mx_init_fresnel_dielectric_airy(ior, bsdf.thickness, bsdf.ior);
@@ -74,7 +76,7 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
 
     if (scatter_mode != 0)
     {
-        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, tint) * weight;
+        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, safeTint) * weight;
     }
 }
 
@@ -90,6 +92,7 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     FresnelData fd;
+    vec3 safeTint = max(tint, 0.0);
     if (bsdf.thickness > 0.0)
     { 
         fd = mx_init_fresnel_dielectric_airy(ior, bsdf.thickness, bsdf.ior);
@@ -109,5 +112,5 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
     bsdf.throughput = 1.0 - dirAlbedo * weight;
 
     vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
-    bsdf.response = Li * tint * comp * weight;
+    bsdf.response = Li * safeTint * comp * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -22,20 +22,22 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
     FresnelData fd;
+    vec3 safeColor0 = max(color0, 0.0);
+    vec3 safeColor90 = max(color90, 0.0);
     if (bsdf.thickness > 0.0)
     { 
-        fd = mx_init_fresnel_schlick_airy(color0, color90, exponent, bsdf.thickness, bsdf.ior);
+        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor90, exponent, bsdf.thickness, bsdf.ior);
     }
     else
     {
-        fd = mx_init_fresnel_schlick(color0, color90, exponent);
+        fd = mx_init_fresnel_schlick(safeColor0, safeColor90, exponent);
     }
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(Ht, safeAlpha);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, safeColor0, safeColor90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
@@ -54,13 +56,15 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     FresnelData fd;
+    vec3 safeColor0 = max(color0, 0.0);
+    vec3 safeColor90 = max(color90, 0.0);
     if (bsdf.thickness > 0.0)
     { 
-        fd = mx_init_fresnel_schlick_airy(color0, color90, exponent, bsdf.thickness, bsdf.ior);
+        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor90, exponent, bsdf.thickness, bsdf.ior);
     }
     else
     {
-        fd = mx_init_fresnel_schlick(color0, color90, exponent);
+        fd = mx_init_fresnel_schlick(safeColor0, safeColor90, exponent);
     }
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
@@ -68,15 +72,15 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     float avgAlpha = mx_average_alpha(safeAlpha);
 
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, safeColor0, safeColor90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 
     if (scatter_mode != 0)
     {
-        float avgF0 = dot(color0, vec3(1.0 / 3.0));
+        float avgF0 = dot(safeColor0, vec3(1.0 / 3.0));
         fd.ior = vec3(mx_f0_to_ior(avgF0));
-        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, color0) * weight;
+        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, safeColor0) * weight;
     }
 }
 
@@ -91,20 +95,22 @@ void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     FresnelData fd;
+    vec3 safeColor0 = max(color0, 0.0);
+    vec3 safeColor90 = max(color90, 0.0);
     if (bsdf.thickness > 0.0)
     { 
-        fd = mx_init_fresnel_schlick_airy(color0, color90, exponent, bsdf.thickness, bsdf.ior);
+        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor90, exponent, bsdf.thickness, bsdf.ior);
     }
     else
     {
-        fd = mx_init_fresnel_schlick(color0, color90, exponent);
+        fd = mx_init_fresnel_schlick(safeColor0, safeColor90, exponent);
     }
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
     float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, color0, color90) * comp;
+    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, safeColor0, safeColor90) * comp;
     float avgDirAlbedo = dot(dirAlbedo, vec3(1.0 / 3.0));
     bsdf.throughput = vec3(1.0 - avgDirAlbedo * weight);
 


### PR DESCRIPTION
This changelist adds negative color guards to the GLSL/MSL implementations of dielectric_bsdf and generalized_schlick_bsdf, which were previously susceptible to rendering artifacts from slightly negative color inputs.