### PR TITLE
Add safepower node to data libraries

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1975,6 +1975,67 @@
   </nodedef>
 
   <!--
+    Node: <safepower>
+    Raise incoming float/color/vector values to the "in2" power.
+      Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
+  -->
+  <nodedef name="ND_safepower_float" node="safepower" nodegroup="math">
+    <input name="in1" type="float" value="0.0" />
+    <input name="in2" type="float" value="1.0" />
+    <output name="out" type="float" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_color3" node="safepower" nodegroup="math">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <output name="out" type="color3" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_color4" node="safepower" nodegroup="math">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <output name="out" type="color4" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_vector2" node="safepower" nodegroup="math">
+    <input name="in1" type="vector2" value="0.0, 0.0" />
+    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <output name="out" type="vector2" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_vector3" node="safepower" nodegroup="math">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <output name="out" type="vector3" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_vector4" node="safepower" nodegroup="math">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <output name="out" type="vector4" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_color3FA" node="safepower" nodegroup="math">
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in2" type="float" value="1.0" />
+    <output name="out" type="color3" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_color4FA" node="safepower" nodegroup="math">
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in2" type="float" value="1.0" />
+    <output name="out" type="color4" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_vector2FA" node="safepower" nodegroup="math">
+    <input name="in1" type="vector2" value="0.0, 0.0" />
+    <input name="in2" type="float" value="1.0" />
+    <output name="out" type="vector2" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_vector3FA" node="safepower" nodegroup="math">
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in2" type="float" value="1.0" />
+    <output name="out" type="vector3" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_safepower_vector4FA" node="safepower" nodegroup="math">
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in2" type="float" value="1.0" />
+    <output name="out" type="vector4" defaultinput="in1" />
+  </nodedef>
+
+  <!--
     Nodes: <sin>, <cos>, <tan>, <asin>, <acos>, <atan2>
     Standard trigonometric functions; angles are given in radians.
   -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1977,7 +1977,7 @@
   <!--
     Node: <safepower>
     Raise incoming float/color/vector values to the "in2" power.
-      Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
+    Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
   -->
   <nodedef name="ND_safepower_float" node="safepower" nodegroup="math">
     <input name="in1" type="float" value="0.0" />

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2770,6 +2770,199 @@
   </nodegraph>
 
   <!--
+    Node: <safepower>
+    Raise incoming half/float/color/vector values to the "in2" power.
+      Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
+  -->
+  <nodegraph name="NG_safepower_float" nodedef="ND_safepower_float">
+    <sign name="sign_in1" type="float">
+      <input name="in" type="float" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="float">
+      <input name="in" type="float" interfacename="in1"/>
+    </absval>
+    <power name="power" type="float">
+      <input name="in1" type="float" nodename="abs_in1"/>
+      <input name="in2" type="float" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="float">
+      <input name="in1" type="float" nodename="sign_in1"/>
+      <input name="in2" type="float" nodename="power"/>
+    </multiply>
+    <output name="out" type="float" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_color3" nodedef="ND_safepower_color3">
+    <sign name="sign_in1" type="color3">
+      <input name="in" type="color3" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="color3">
+      <input name="in" type="color3" interfacename="in1"/>
+    </absval>
+    <power name="power" type="color3">
+      <input name="in1" type="color3" nodename="abs_in1"/>
+      <input name="in2" type="color3" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="color3">
+      <input name="in1" type="color3" nodename="sign_in1"/>
+      <input name="in2" type="color3" nodename="power"/>
+    </multiply>
+    <output name="out" type="color3" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_color4" nodedef="ND_safepower_color4">
+    <sign name="sign_in1" type="color4">
+      <input name="in" type="color4" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="color4">
+      <input name="in" type="color4" interfacename="in1"/>
+    </absval>
+    <power name="power" type="color4">
+      <input name="in1" type="color4" nodename="abs_in1"/>
+      <input name="in2" type="color4" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="color4">
+      <input name="in1" type="color4" nodename="sign_in1"/>
+      <input name="in2" type="color4" nodename="power"/>
+    </multiply>
+    <output name="out" type="color4" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_vector2" nodedef="ND_safepower_vector2">
+    <sign name="sign_in1" type="vector2">
+      <input name="in" type="vector2" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="vector2">
+      <input name="in" type="vector2" interfacename="in1"/>
+    </absval>
+    <power name="power" type="vector2">
+      <input name="in1" type="vector2" nodename="abs_in1"/>
+      <input name="in2" type="vector2" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="vector2">
+      <input name="in1" type="vector2" nodename="sign_in1"/>
+      <input name="in2" type="vector2" nodename="power"/>
+    </multiply>
+    <output name="out" type="vector2" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_vector3" nodedef="ND_safepower_vector3">
+    <sign name="sign_in1" type="vector3">
+      <input name="in" type="vector3" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="vector3">
+      <input name="in" type="vector3" interfacename="in1"/>
+    </absval>
+    <power name="power" type="vector3">
+      <input name="in1" type="vector3" nodename="abs_in1"/>
+      <input name="in2" type="vector3" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="vector3">
+      <input name="in1" type="vector3" nodename="sign_in1"/>
+      <input name="in2" type="vector3" nodename="power"/>
+    </multiply>
+    <output name="out" type="vector3" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_vector4" nodedef="ND_safepower_vector4">
+    <sign name="sign_in1" type="vector4">
+      <input name="in" type="vector4" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="vector4">
+      <input name="in" type="vector4" interfacename="in1"/>
+    </absval>
+    <power name="power" type="vector4">
+      <input name="in1" type="vector4" nodename="abs_in1"/>
+      <input name="in2" type="vector4" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="vector4">
+      <input name="in1" type="vector4" nodename="sign_in1"/>
+      <input name="in2" type="vector4" nodename="power"/>
+    </multiply>
+    <output name="out" type="vector4" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_color3FA" nodedef="ND_safepower_color3FA">
+    <sign name="sign_in1" type="color3">
+      <input name="in" type="color3" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="color3">
+      <input name="in" type="color3" interfacename="in1"/>
+    </absval>
+    <power name="power" type="color3">
+      <input name="in1" type="color3" nodename="abs_in1"/>
+      <input name="in2" type="float" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="color3">
+      <input name="in1" type="color3" nodename="sign_in1"/>
+      <input name="in2" type="color3" nodename="power"/>
+    </multiply>
+    <output name="out" type="color3" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_color4FA" nodedef="ND_safepower_color4FA">
+    <sign name="sign_in1" type="color4">
+      <input name="in" type="color4" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="color4">
+      <input name="in" type="color4" interfacename="in1"/>
+    </absval>
+    <power name="power" type="color4">
+      <input name="in1" type="color4" nodename="abs_in1"/>
+      <input name="in2" type="float" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="color4">
+      <input name="in1" type="color4" nodename="sign_in1"/>
+      <input name="in2" type="color4" nodename="power"/>
+    </multiply>
+    <output name="out" type="color4" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_vector2FA" nodedef="ND_safepower_vector2FA">
+    <sign name="sign_in1" type="vector2">
+      <input name="in" type="vector2" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="vector2">
+      <input name="in" type="vector2" interfacename="in1"/>
+    </absval>
+    <power name="power" type="vector2">
+      <input name="in1" type="vector2" nodename="abs_in1"/>
+      <input name="in2" type="float" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="vector2">
+      <input name="in1" type="vector2" nodename="sign_in1"/>
+      <input name="in2" type="vector2" nodename="power"/>
+    </multiply>
+    <output name="out" type="vector2" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_vector3FA" nodedef="ND_safepower_vector3FA">
+    <sign name="sign_in1" type="vector3">
+      <input name="in" type="vector3" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="vector3">
+      <input name="in" type="vector3" interfacename="in1"/>
+    </absval>
+    <power name="power" type="vector3">
+      <input name="in1" type="vector3" nodename="abs_in1"/>
+      <input name="in2" type="float" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="vector3">
+      <input name="in1" type="vector3" nodename="sign_in1"/>
+      <input name="in2" type="vector3" nodename="power"/>
+    </multiply>
+    <output name="out" type="vector3" nodename="safepower"/>
+  </nodegraph>
+  <nodegraph name="NG_safepower_vector4FA" nodedef="ND_safepower_vector4FA">
+    <sign name="sign_in1" type="vector4">
+      <input name="in" type="vector4" interfacename="in1"/>
+    </sign>
+    <absval name="abs_in1" type="vector4">
+      <input name="in" type="vector4" interfacename="in1"/>
+    </absval>
+    <power name="power" type="vector4">
+      <input name="in1" type="vector4" nodename="abs_in1"/>
+      <input name="in2" type="float" interfacename="in2"/>
+    </power>
+    <multiply name="safepower" type="vector4">
+      <input name="in1" type="vector4" nodename="sign_in1"/>
+      <input name="in2" type="vector4" nodename="power"/>
+    </multiply>
+    <output name="out" type="vector4" nodename="safepower"/>
+  </nodegraph>
+
+  <!--
     Node: <contrast>
     Increase or decrease contrast of a float/color value using a linear slope multiplier.
   -->

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2772,7 +2772,7 @@
   <!--
     Node: <safepower>
     Raise incoming half/float/color/vector values to the "in2" power.
-      Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
+    Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
   -->
   <nodegraph name="NG_safepower_float" nodedef="ND_safepower_float">
     <sign name="sign_in1" type="float">

--- a/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
@@ -462,6 +462,83 @@
     </power>
     <output name="out" type="vector4" nodename="power1" />
   </nodegraph>
+  <nodegraph name="safepower_float">
+    <safepower name="safepower1" type="float">
+      <input name="in1" type="float" value="0.5000" />
+      <input name="in2" type="float" value="2.0000" />
+    </safepower>
+    <output name="out" type="float" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_color3">
+    <safepower name="safepower1" type="color3">
+      <input name="in1" type="color3" value="0.5000, 1.0000, -1.0000" />
+      <input name="in2" type="color3" value="2.0000, 1.0000, 0.0" />
+    </safepower>
+    <output name="out" type="color3" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_color3FA">
+    <safepower name="safepower1" type="color3">
+      <input name="in1" type="color3" value="-0.5000, 1.0000, 0.0000" />
+      <input name="in2" type="float" value="2.0000" />
+    </safepower>
+    <output name="out" type="color3" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_color4">
+    <safepower name="safepower1" type="color4">
+      <input name="in1" type="color4" value="0.5000, 1.0000, -1.0000, 1.0000" />
+      <input name="in2" type="color4" value="2.0000, 1.0000, 0.0000, 3.0000" />
+    </safepower>
+    <output name="out" type="color4" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_color4FA">
+    <safepower name="safepower1" type="color4">
+      <input name="in1" type="color4" value="0.5000, 1.0000, 0.0, 1.0000" />
+      <input name="in2" type="float" value="2.0000" />
+    </safepower>
+    <output name="out" type="color4" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_vector2">
+    <safepower name="safepower1" type="vector2">
+      <input name="in1" type="vector2" value="-0.5000, 1.0000" />
+      <input name="in2" type="vector2" value="2.0000, 1.0000" />
+    </safepower>
+    <output name="out" type="vector2" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_vector2FA">
+    <safepower name="safepower1" type="vector2">
+      <input name="in1" type="vector2" value="0.5000, 1.0000" />
+      <input name="in2" type="float" value="2.0000" />
+    </safepower>
+    <output name="out" type="vector2" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_vector3">
+    <safepower name="safepower1" type="vector3">
+      <input name="in1" type="vector3" value="0.5000, 1.0000, -1.0000" />
+      <input name="in2" type="vector3" value="2.0000, 1.0000, 0.0" />
+    </safepower>
+    <output name="out" type="vector3" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_vector3FA">
+    <safepower name="safepower1" type="vector3">
+      <input name="in1" type="vector3" value="0.5000, 1.0000, 0.0" />
+      <input name="in2" type="float" value="2.0000" />
+    </safepower>
+    <output name="out" type="vector3" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_vector4">
+    <safepower name="safepower1" type="vector4">
+      <input name="in1" type="vector4" value="0.5000, -1.0000, 1.0000, 1.0" />
+      <input name="in2" type="vector4" value="2.0000, 1.0000, 0.0, 3.0000" />
+    </safepower>
+    <output name="out" type="vector4" nodename="safepower1" />
+  </nodegraph>
+  <nodegraph name="safepower_vector4FA">
+    <safepower name="safepower1" type="vector4">
+      <input name="in1" type="vector4" value="0.5000, 1.0000, 0.0, 1.0000" />
+      <input name="in2" type="float" value="2.0000" />
+    </safepower>
+    <output name="out" type="vector4" nodename="safepower1" />
+  </nodegraph>
   <nodegraph name="add_matrix33">
     <add name="add1" type="matrix33">
       <input name="in1" type="matrix33" value="0.5, 0.0, 0.0,  0.0, 0.5, 0.0,  0.0, 0.0, 0.5" />


### PR DESCRIPTION
Add node definition and nodegraph for `safepower` which is already in the v1.39 specification, but currently missing in the source code.

As this is an additive change we can safely add this to `main` for inclusion in any v.138 release.