### PR TITLE
Fix nodegraph to nodegraph linking in graph editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -307,8 +307,8 @@ ed::PinId Graph::getOutputPin(UiNodePtr node, UiNodePtr upNode, UiPinPtr input)
 {
     if (upNode->getNodeGraph() != nullptr)
     {
-        // For nodegraph need to get the correct ouput pin accorinding to the names of the output nodes
-        mx::OutputPtr output = nullptr;
+        // For nodegraph need to get the correct ouput pin according to the names of the output nodes
+        mx::OutputPtr output;
         if (input->_pinNode->getNode())
         {
             output = input->_pinNode->getNode()->getConnectedOutput(input->_name);

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -308,7 +308,16 @@ ed::PinId Graph::getOutputPin(UiNodePtr node, UiNodePtr upNode, UiPinPtr input)
     if (upNode->getNodeGraph() != nullptr)
     {
         // For nodegraph need to get the correct ouput pin accorinding to the names of the output nodes
-        mx::OutputPtr output = input->_pinNode->getNode() ? input->_pinNode->getNode()->getConnectedOutput(input->_name) : nullptr;
+        mx::OutputPtr output = nullptr;
+        if (input->_pinNode->getNode())
+        {
+            output = input->_pinNode->getNode()->getConnectedOutput(input->_name);
+        }
+        else if (input->_pinNode->getNodeGraph())
+        {
+            output = input->_pinNode->getNodeGraph()->getConnectedOutput(input->_name);
+        }
+
         if (output)
         {
             std::string outName = output->getName();
@@ -1342,21 +1351,28 @@ void Graph::buildUiBaseGraph(mx::DocumentPtr doc)
         {
             int downNum = -1;
             int upNum = -1;
+            mx::string nodeGraphName = input->getNodeGraphString();
             mx::NodePtr connectedNode = input->getConnectedNode();
-            if (connectedNode)
+            if (!nodeGraphName.empty())
+            {
+                downNum = findNode(graph->getName(), "nodegraph");
+                upNum = findNode(nodeGraphName, "nodegraph");
+            }
+            else if (connectedNode)
             {
                 downNum = findNode(graph->getName(), "nodegraph");
                 upNum = findNode(connectedNode->getName(), "node");
-                if (upNum > -1)
+            }
+
+            if (upNum > -1)
+            {
+                UiEdge newEdge = UiEdge(_graphNodes[upNum], _graphNodes[downNum], input);
+                if (!edgeExists(newEdge))
                 {
-                    UiEdge newEdge = UiEdge(_graphNodes[upNum], _graphNodes[downNum], input);
-                    if (!edgeExists(newEdge))
-                    {
-                        _graphNodes[downNum]->edges.push_back(newEdge);
-                        _graphNodes[downNum]->setInputNodeNum(1);
-                        _graphNodes[upNum]->setOutputConnection(_graphNodes[downNum]);
-                        _currEdge.push_back(newEdge);
-                    }
+                    _graphNodes[downNum]->edges.push_back(newEdge);
+                    _graphNodes[downNum]->setInputNodeNum(1);
+                    _graphNodes[upNum]->setOutputConnection(_graphNodes[downNum]);
+                    _currEdge.push_back(newEdge);
                 }
             }
         }


### PR DESCRIPTION
Closes #1484

The fix comes in two parts:

1. In `Graph::buildUiBaseGraph` called during material load, edges between nodegraphs and nodes are created, but not between nodegraphs and nodegraphs. Fixing this partially solves the issue as the down node now knows about the connection. However the actual link still doesn't exist
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/24794294/723fab4d-293f-401d-927b-2053f6e15f37)

2. When building links in `Graph::linkGraph`, the call to `getOutputPin` fails to return an ID when both nodes are nodegraphs. Modifying `getOutputPin` to handle this case solves the issue. 
![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/24794294/35b821d9-8c22-4895-bed2-a238d6e0c7d2)

It also fixes issues happening on other contexts involving calls to `linkGraph` (e.g. adding a new node was breaking nodegraph to nodegraph links).