### PR TITLE
Support hosting of JsMaterialXCore library

### DIFF
--- a/javascript/MaterialXView/webpack.config.js
+++ b/javascript/MaterialXView/webpack.config.js
@@ -71,6 +71,8 @@ module.exports = {
                 { from: stdSurfaceMaterials, to: stdSurfaceMaterialsBaseURL },
                 { from: usdSurfaceMaterials, to: usdSurfaceMaterialsBaseURL },
                 { from: gltfSurfaceMaterials, to: gltfSurfaceMaterialsBaseURL },
+                { from: "../build/bin/JsMaterialXCore.wasm" },
+                { from: "../build/bin/JsMaterialXCore.js" },
                 { from: "../build/bin/JsMaterialXGenShader.wasm" },
                 { from: "../build/bin/JsMaterialXGenShader.js" },
                 { from: "../build/bin/JsMaterialXGenShader.data" },


### PR DESCRIPTION
## Issue

Update #1692 

- Expose JsMaterialXCore as part of published github pages.
- This allows users to load in the core package only for Web usage without pulling in the much larger shader gen package
(JsMaterialXGenShader) -- which is often undesired.
- These are the current package / data sizes:
  ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/6e0a783c-18da-4456-ab6c-0dfd43fc3430)


## Changes

- Add JsMaterialXCore WASM and JS as part of distribution.

## Example Usage

Basic loading of just core (which includes format).

```html
     <!-- Grab core package -->
    <script src="https://academysoftwarefoundation.github.io/MaterialX/JsMaterialXCore.js" type="text/javascript"></script> 
    <script type="text/javascript">
  
        let mx = null;

        function doStuff(mx) {
            doc = mx.createDocument();
            console.log(mx.prettyPrint(doc));
        }

        function loadMaterialX() {
            return new Promise((resolve, reject) => {
                MaterialX().then((mtlx) => 
                {
                    mx = mtlx;
                    console.log("MaterialX loaded.");
                    resolve();
                }).catch((error) => {
                    reject(error);
                });
            });
        }

        loadMaterialX().then(() => {
            console.log("Performing additional logic with mx:", mx);
            doStuff(mx);
        }).catch((error) => {
            console.error("Error loading MaterialX:", error);
        });
  </script>
```
