### PR TITLE
Improve input filtering in Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -1082,6 +1082,12 @@ export class Material
                     {
                         continue;
                     }
+                    
+                    // Skip non-input types and anything > 2 levels deep 
+                    if (!currentElem.asAInput() || currentElem.getNamePath().split('/').length > 2)
+                    {
+                        continue;
+                    }
 
                     let currentNode = null;
                     if (currentElem.getParent() && currentElem.getParent().getNamePath() != "")
@@ -1169,6 +1175,21 @@ export class Material
                         {
                             path = uiname;
                         }
+                    }
+
+                    // Skip if already added to current folder 
+                    let found = false;
+                    for (let i = 0; i < currentFolder.children.length; ++i)
+                    {
+                        if (currentFolder.children[i]._name == path)
+                        {
+                            found = true;
+                            break;
+                        }
+                    }                        
+                    if (found)
+                    {
+                        continue;
                     }
 
                     switch (variable.getType().getName())
@@ -1390,7 +1411,6 @@ export class Material
                         case 'filename':
                             break;
                         case 'string':
-                            console.log('String: ', name);
                             if (value != null)
                             {
                                 var dummy =


### PR DESCRIPTION
## Issue

There is no current "edit" exposure control for code generation. We thus end up with too many
non-interface inputs and non-inputs being exposed when using "COMPLETE" option.

## Work-around

Add some additional filtering to remove interior inputs, non-inputs.
Also check for repeated inputs.

## Results

| Test | Resulting UI |
| :--: | :--: |
| Procedural Brick Example |  ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/ea799bce-cd1d-4a07-9a2d-06536e07dbd9) |
| Marble Example |  ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/fbccb484-3164-4ffe-91af-e6818d9fdf8c)
 | Top level input |  ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/6a367645-94fa-408e-956d-bd07f19f33ce) |
 | Wood (graph has no interfaces exposed)  |  ![image](https://github.com/AcademySoftwareFoundation/MaterialX/assets/49369885/05f65da2-87be-478f-b45e-061e3deeefad) | 
 
@jstone-lucasfilm , @niklasharrysson . Until we get some new filtering mechanism I'm adding in post filtering to exposed uniforms. 
