### PR TITLE
Add refract node

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2767,7 +2767,7 @@
     The normal vector is assumed to be normalized.
   -->
   <nodedef name="ND_refract_vector3" node="refract" nodegroup="math" doc="Compute the refraction direction of an input vector.">
-    <input name="in" type="vector3" value="1.0,0.0,0.0" doc="Input vector to be reflected."  />
+    <input name="in" type="vector3" value="1.0,0.0,0.0" doc="Input vector to be refracted."  />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Normal vector." />
     <input name="eta" type="float" value="1.0" doc="Ratio of the indices of refraction."/>
     <output name="out" type="vector3" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2761,6 +2761,18 @@
     <output name="out" type="vector3" />
   </nodedef>
 
+  <!--
+    Node: <refract>
+    Compute the refraction direction of an input vector against a normal vector.
+    The normal vector is assumed to be normalized.
+  -->
+  <nodedef name="ND_refract_vector3" node="refract" nodegroup="math" doc="Compute the refraction direction of an input vector.">
+    <input name="in" type="vector3" value="1.0,0.0,0.0" doc="Input vector to be reflected."  />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Normal vector." />
+    <input name="eta" type="float" value="1.0" doc="Ratio of the indices of refraction."/>
+    <output name="out" type="vector3" />
+  </nodedef>
+
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2768,7 +2768,7 @@
   <nodedef name="ND_refract_vector3" node="refract" nodegroup="math" doc="Compute the refraction vector">
     <input name="in" type="vector3" value="1.0, 0.0, 0.0" doc="Incident vector"  />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal" />
-    <input name="eta" type="float" value="1.0" doc="Index of refraction" />
+    <input name="ior" type="float" value="1.0" doc="Index of refraction" />
     <output name="out" type="vector3" />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -2763,13 +2763,12 @@
 
   <!--
     Node: <refract>
-    Compute the refraction direction of an input vector against a normal vector.
-    The normal vector is assumed to be normalized.
+    Compute the refraction vector given an incident vector, unit surface normal, and index of refraction.
   -->
-  <nodedef name="ND_refract_vector3" node="refract" nodegroup="math" doc="Compute the refraction direction of an input vector.">
-    <input name="in" type="vector3" value="1.0,0.0,0.0" doc="Input vector to be refracted."  />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Normal vector." />
-    <input name="eta" type="float" value="1.0" doc="Ratio of the indices of refraction."/>
+  <nodedef name="ND_refract_vector3" node="refract" nodegroup="math" doc="Compute the refraction vector">
+    <input name="in" type="vector3" value="1.0, 0.0, 0.0" doc="Incident vector"  />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal" />
+    <input name="eta" type="float" value="1.0" doc="Index of refraction" />
     <output name="out" type="vector3" />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2741,40 +2741,40 @@
       <input name="in1" type="float" nodename="IdotN"/>
       <input name="in2" type="float" nodename="IdotN"/>
     </multiply>
-    <multiply name="etasq" type="float">
-      <input name="in1" type="float" interfacename="eta"/>
-      <input name="in2" type="float" interfacename="eta"/>
+    <multiply name="iorsq" type="float">
+      <input name="in1" type="float" interfacename="ior"/>
+      <input name="in2" type="float" interfacename="ior"/>
     </multiply>
     <subtract name="one_IdotNsq" type="float">
       <input name="in1" type="float" value="1.0"/>
       <input name="in2" type="float" nodename="IdotNsq"/>
     </subtract>
-    <multiply name="etasq_one_IdotNsq" type="float">
-      <input name="in1" type="float" nodename="etasq"/>
+    <multiply name="iorsq_one_IdotNsq" type="float">
+      <input name="in1" type="float" nodename="iorsq"/>
       <input name="in2" type="float" nodename="one_IdotNsq"/>
     </multiply>
     <subtract name="k" type="float">
       <input name="in1" type="float" value="1.0"/>
-      <input name="in2" type="float" nodename="etasq_one_IdotNsq"/>
+      <input name="in2" type="float" nodename="iorsq_one_IdotNsq"/>
     </subtract>
     <multiply name="I_scaled" type="vector3">
       <input name="in1" type="vector3" interfacename="in"/>
-      <input name="in2" type="float" interfacename="eta"/>
+      <input name="in2" type="float" interfacename="ior"/>
     </multiply>
     <sqrt name="sqrt_k" type="float">
       <input name="in" type="float" nodename="k"/>
     </sqrt>
-    <multiply name="eta_NdotI" type="float">
-      <input name="in1" type="float" interfacename="eta"/>
+    <multiply name="ior_NdotI" type="float">
+      <input name="in1" type="float" interfacename="ior"/>
       <input name="in2" type="float" nodename="IdotN"/>
     </multiply>
-    <add name="eta_NdotI_sqrt_k" type="float">
-      <input name="in1" type="float" nodename="eta_NdotI"/>
+    <add name="ior_NdotI_sqrt_k" type="float">
+      <input name="in1" type="float" nodename="ior_NdotI"/>
       <input name="in2" type="float" nodename="sqrt_k"/>
     </add>
     <multiply name="N_scaled" type="vector3">
       <input name="in1" type="vector3" interfacename="normal"/>
-      <input name="in2" type="float" nodename="eta_NdotI_sqrt_k"/>
+      <input name="in2" type="float" nodename="ior_NdotI_sqrt_k"/>
     </multiply>
     <subtract name="refract_dir" type="vector3">
       <input name="in1" type="vector3" nodename="I_scaled"/>

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2730,8 +2730,7 @@
   
   <!--
     Node: <refract>
-    Compute the refraction direction of an input vector against a normal vector.
-    The normal vector is assumed to be normalized.
+    Compute the refraction vector given an incident vector, unit surface normal, and index of refraction.
   -->
   <nodegraph name="NG_refract_vector3" nodedef="ND_refract_vector3">
     <dotproduct name="IdotN" type="float">

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2728,6 +2728,68 @@
     <output name="out" type="vector3" nodename="reflection_vector" />
   </nodegraph>
   
+  <!--
+    Node: <refract>
+    Compute the refraction direction of an input vector against a normal vector.
+    The normal vector is assumed to be normalized.
+  -->
+  <nodegraph name="NG_refract_vector3" nodedef="ND_refract_vector3">
+    <dotproduct name="IdotN" type="float">
+      <input name="in1" type="vector3" interfacename="in"/>
+      <input name="in2" type="vector3" interfacename="normal"/>
+    </dotproduct>
+    <multiply name="IdotNsq" type="float">
+      <input name="in1" type="float" nodename="IdotN"/>
+      <input name="in2" type="float" nodename="IdotN"/>
+    </multiply>
+    <multiply name="etasq" type="float">
+      <input name="in1" type="float" interfacename="eta"/>
+      <input name="in2" type="float" interfacename="eta"/>
+    </multiply>
+    <subtract name="one_IdotNsq" type="float">
+      <input name="in1" type="float" value="1.0"/>
+      <input name="in2" type="float" nodename="IdotNsq"/>
+    </subtract>
+    <multiply name="etasq_one_IdotNsq" type="float">
+      <input name="in1" type="float" nodename="etasq"/>
+      <input name="in2" type="float" nodename="one_IdotNsq"/>
+    </multiply>
+    <subtract name="k" type="float">
+      <input name="in1" type="float" value="1.0"/>
+      <input name="in2" type="float" nodename="etasq_one_IdotNsq"/>
+    </subtract>
+    <multiply name="I_scaled" type="vector3">
+      <input name="in1" type="vector3" interfacename="in"/>
+      <input name="in2" type="float" interfacename="eta"/>
+    </multiply>
+    <sqrt name="sqrt_k" type="float">
+      <input name="in" type="float" nodename="k"/>
+    </sqrt>
+    <multiply name="eta_NdotI" type="float">
+      <input name="in1" type="float" interfacename="eta"/>
+      <input name="in2" type="float" nodename="IdotN"/>
+    </multiply>
+    <add name="eta_NdotI_sqrt_k" type="float">
+      <input name="in1" type="float" nodename="eta_NdotI"/>
+      <input name="in2" type="float" nodename="sqrt_k"/>
+    </add>
+    <multiply name="N_scaled" type="vector3">
+      <input name="in1" type="vector3" interfacename="normal"/>
+      <input name="in2" type="float" nodename="eta_NdotI_sqrt_k"/>
+    </multiply>
+    <subtract name="refract_dir" type="vector3">
+      <input name="in1" type="vector3" nodename="I_scaled"/>
+      <input name="in2" type="vector3" nodename="N_scaled"/>
+    </subtract>
+    <ifgreater name="result" type="vector3">
+      <input name="value1" type="float" value="0.0"/>
+      <input name="value2" type="float" nodename="k"/>
+      <input name="in1" type="vector3" value="0.0, 0.0, 0.0"/>
+      <input name="in2" type="vector3" nodename="refract_dir"/>
+    </ifgreater>
+    <output name="out" type="vector3" nodename="result"/>
+  </nodegraph>
+
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
   <!-- ======================================================================== -->


### PR DESCRIPTION
Adding `refract` node to partner with the `reflect` node, with a similar named interface, and implementation as a nodegraph taken from the OSL spec 
```
vector refract (vector I, vector N, float eta)
{
         float IdotN = dot (I, N);
         float k = 1 - eta*eta * (1 - IdotN*IdotN);
         return (k < 0) ? vector(0,0,0) : (eta*I - N * (eta*IdotN + sqrt(k)));
}
```
which also lines up with the [Kronos implementation](https://registry.khronos.org/OpenGL-Refpages/gl4/html/refract.xhtml) here too.