### PR TITLE
MDL implementation for viewdirection

### DIFF
--- a/libraries/nprlib/genmdl/nprlib_genmdl_impl.mtlx
+++ b/libraries/nprlib/genmdl/nprlib_genmdl_impl.mtlx
@@ -12,6 +12,6 @@
   <!-- ======================================================================== -->
 
   <!-- <viewdirection> -->
-  <implementation name="IM_viewdirection_vector3_genmdl" nodedef="ND_viewdirection_vector3" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_viewdirection_vector3()" target="genmdl" />
+  <implementation name="IM_viewdirection_vector3_genmdl" nodedef="ND_viewdirection_vector3" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_viewdirection_vector3(mxp_space:{{space}})" target="genmdl" />
 
 </materialx>

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_8.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_8.mdl
@@ -419,3 +419,29 @@ export float4 mx_geompropvalue_vector4(
 {
     return scene::data_lookup_float4(mxp_geomprop, mxp_default);
 }
+
+export float3 mx_viewdirection_vector3(
+	uniform core::mx_coordinatespace_type mxp_space = core::mx_coordinatespace_type_world
+	[[
+		anno::description("Enumeration {model,object,world}."),
+		anno::unused()
+	]]
+)
+	[[
+		anno::description("Node Group: nprlib")
+	]]
+{
+	float3 internal_space_direction =
+		state::position() - scene::data_lookup_float3("CAMERA_POSITION", float3(0.0, 0.0, 0.0));
+
+	if (mxp_space == core::mx_coordinatespace_type_world)
+		return math::normalize(state::transform_vector(
+			::state::coordinate_internal,
+			::state::coordinate_world,
+			internal_space_direction));
+	else
+		return math::normalize(state::transform_vector(
+			::state::coordinate_internal,
+			::state::coordinate_object,
+			internal_space_direction));
+}


### PR DESCRIPTION
Draft of an MDL implemention for mx_viewdirection.
This assumes that the viewdirection is defined by direction from camera position to shading point.
In the context of a path tracer, the camera position is used as well and NOT the ray origin of the current path segment.