### PR TITLE
Align vector spaces for npr nodes

### DIFF
--- a/libraries/nprlib/nprlib_ng.mtlx
+++ b/libraries/nprlib/nprlib_ng.mtlx
@@ -48,8 +48,12 @@
     Node: <gooch_shade>
   -->
   <nodegraph name="NG_gooch_shade" type="color3" nodedef="ND_gooch_shade">
-    <normal name="normal" type="vector3" />
-    <viewdirection name="viewdir" type="vector3" />
+    <normal name="normal" type="vector3" >
+      <input name="space" type="string" value="world" />
+    </normal>
+    <viewdirection name="viewdir" type="vector3" >
+      <input name="space" type="string" value="world" />
+    </viewdirection>
     <normalize name="unit_normal" type="vector3">
       <input name="in" type="vector3" nodename="normal" />
     </normalize>

--- a/resources/Materials/TestSuite/nprlib/toon_shade.mtlx
+++ b/resources/Materials/TestSuite/nprlib/toon_shade.mtlx
@@ -27,7 +27,9 @@
   </npr_test:toon_shade>
   <nodegraph name="NG_toon_sample" namespace="npr_test" nodedef="ND_toon_sample">
     <output name="output_color3" type="color3" nodename="multiply_color3" />
-    <normal name="normal" type="vector3" />
+    <normal name="normal" type="vector3" >
+      <input name="space" type="string" value="world" />
+    </normal>
     <dotproduct name="NdotL" type="float">
       <input name="in1" type="vector3" nodename="unit_normal" />
       <input name="in2" type="vector3" nodename="multiply_vector4" />
@@ -47,7 +49,9 @@
       <input name="in" type="float" nodename="NdotL" />
       <input name="high" type="float" value="0.001" />
     </smoothstep>
-    <viewdirection name="viewdirection_vector3" type="vector3" />
+    <viewdirection name="viewdirection_vector3" type="vector3" >
+      <input name="space" type="string" value="world" />
+    </viewdirection>
     <normalize name="unit_viewdirection" type="vector3">
       <input name="in" type="vector3" nodename="viewdirection_vector3" />
     </normalize>


### PR DESCRIPTION
## Issue

- Gooch was using `<normal>` in "object" space and `<viewdirection>` in "world" space.
This causes incorrect rendering when the geometric transform is not identity.
- The toon example was also doing this.

## Fix

- Correct to consistently use "world" space.