### PR TITLE
Add TypedElement::isColorType method

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -869,6 +869,12 @@ class MX_CORE_API TypedElement : public Element
         return getAttribute(TYPE_ATTRIBUTE);
     }
 
+    /// Return true if the element is of color type.
+    bool isColorType() const
+    {
+        return getType() == "color3" || getType() == "color4";
+    }
+
     /// Return true if the element is of multi-output type.
     bool isMultiOutputType() const
     {

--- a/source/MaterialXRender/TextureBaker.inl
+++ b/source/MaterialXRender/TextureBaker.inl
@@ -223,8 +223,7 @@ void TextureBaker<Renderer, ShaderGen>::bakeGraphOutput(OutputPtr output, GenCon
         return;
     }
 
-    bool encodeSrgb = _colorSpace == SRGB_TEXTURE &&
-                      (output->getType() == "color3" || output->getType() == "color4");
+    bool encodeSrgb = _colorSpace == SRGB_TEXTURE && output->isColorType();
     Renderer::getFramebuffer()->setEncodeSrgb(encodeSrgb);
 
     ShaderPtr shader = _generator->generate("BakingShader", output, context);
@@ -412,7 +411,7 @@ DocumentPtr TextureBaker<Renderer, ShaderGen>::generateNewDocumentFromShader(Nod
                 Color4 uniformColor = _bakedConstantMap[output].color;
                 string uniformColorString = getValueStringFromColor(uniformColor, bakedInput->getType());
                 bakedInput->setValueString(uniformColorString);
-                if (bakedInput->getType() == "color3" || bakedInput->getType() == "color4")
+                if (bakedInput->isColorType())
                 {
                     bakedInput->setColorSpace(_colorSpace);
                 }

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Document", "[document]")
     constant->setInputValue("value", mx::Color3(0.5f));
     mx::OutputPtr output = nodeGraph->addOutput();
     output->setConnectedNode(constant);
+    REQUIRE(output->isColorType());
     REQUIRE(doc->validate());
 
     // Create and test a type mismatch in a connection.

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -124,6 +124,7 @@ void bindPyElement(py::module& mod)
         .def("setType", &mx::TypedElement::setType)
         .def("hasType", &mx::TypedElement::hasType)
         .def("getType", &mx::TypedElement::getType)
+        .def("isColorType", &mx::TypedElement::isColorType)
         .def("isMultiOutputType", &mx::TypedElement::isMultiOutputType)
         .def("getTypeDef", &mx::TypedElement::getTypeDef)
         .def_readonly_static("TYPE_ATTRIBUTE", &mx::TypedElement::TYPE_ATTRIBUTE);


### PR DESCRIPTION
This changelist adds a TypedElement::isColorType helper method, allowing color logic to be written more clearly through the MaterialX API.