### PR TITLE
Extend web deployment to branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -331,7 +331,7 @@ jobs:
       working-directory: javascript/MaterialXView
 
     - name: Deploy Web Viewer
-      if: matrix.build_javascript == 'ON' && github.ref == 'refs/heads/main'
+      if: matrix.build_javascript == 'ON' && github.event_name != 'pull_request'
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages


### PR DESCRIPTION
This changelist extends web deployment to GitHub branches, allowing upcoming development in the dev_1.39 branch to be validated in the MaterialX Web Viewer.