### PR TITLE
Add color82 to generalized_schlick_bsdf

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
@@ -6,6 +6,12 @@ float mx_pow5(float x)
     return mx_square(mx_square(x)) * x;
 }
 
+float mx_pow6(float x)
+{
+    float x2 = mx_square(x);
+    return mx_square(x2) * x2;
+}
+
 // Standard Schlick Fresnel
 float mx_fresnel_schlick(float cosTheta, float F0)
 {

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -1,6 +1,6 @@
 #include "lib/mx_microfacet_specular.glsl"
 
-void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
+void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -23,14 +23,15 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
 
     FresnelData fd;
     vec3 safeColor0 = max(color0, 0.0);
+    vec3 safeColor82 = max(color82, 0.0);
     vec3 safeColor90 = max(color90, 0.0);
     if (thinfilm_thickness > 0.0)
     { 
-        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
+        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
     }
     else
     {
-        fd = mx_init_fresnel_schlick(safeColor0, safeColor90, exponent);
+        fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent);
     }
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(Ht, safeAlpha);
@@ -45,7 +46,7 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     bsdf.response = D * F * G * comp * occlusion * weight / (4.0 * NdotV);
 }
 
-void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
+void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -57,14 +58,15 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
 
     FresnelData fd;
     vec3 safeColor0 = max(color0, 0.0);
+    vec3 safeColor82 = max(color82, 0.0);
     vec3 safeColor90 = max(color90, 0.0);
     if (thinfilm_thickness > 0.0)
     { 
-        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor90, exponent, thinfilm_thickness, thinfilm_thickness);
+        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_thickness);
     }
     else
     {
-        fd = mx_init_fresnel_schlick(safeColor0, safeColor90, exponent);
+        fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent);
     }
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
@@ -84,7 +86,7 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     }
 }
 
-void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
+void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -96,14 +98,15 @@ void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec
 
     FresnelData fd;
     vec3 safeColor0 = max(color0, 0.0);
+    vec3 safeColor82 = max(color82, 0.0);
     vec3 safeColor90 = max(color90, 0.0);
     if (thinfilm_thickness > 0.0)
     { 
-        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
+        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
     }
     else
     {
-        fd = mx_init_fresnel_schlick(safeColor0, safeColor90, exponent);
+        fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent);
     }
     vec3 F = mx_compute_fresnel(NdotV, fd);
 

--- a/libraries/pbrlib/genosl/legacy/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/legacy/mx_generalized_schlick_bsdf.osl
@@ -1,6 +1,6 @@
 #include "../lib/mx_microfacet_specular.osl"
 
-void mx_generalized_schlick_bsdf(float weight, color color0, color color90, float exponent, vector2 roughness, float thinfilm_thickness, float thinfilm_ior, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
+void mx_generalized_schlick_bsdf(float weight, color color0, color color82, color color90, float exponent, vector2 roughness, float thinfilm_thickness, float thinfilm_ior, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {
     float avgF0 = dot(color0, color(1.0 / 3.0));
     float ior = mx_f0_to_ior(avgF0);

--- a/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
@@ -1,4 +1,4 @@
-void mx_generalized_schlick_bsdf(float weight, color color0, color color90, float exponent, vector2 roughness, float thinfilm_thickness, float thinfilm_ior, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
+void mx_generalized_schlick_bsdf(float weight, color color0, color color82, color color90, float exponent, vector2 roughness, float thinfilm_thickness, float thinfilm_ior, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {
     if (scatter_mode == "R")
     {

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -96,6 +96,7 @@
   <nodedef name="ND_generalized_schlick_bsdf" node="generalized_schlick_bsdf" nodegroup="pbr" doc="A reflection/transmission BSDF node based on a microfacet model and a generalized Schlick Fresnel curve.">
     <input name="weight" type="float" value="1.0" uimin="0.0" uimax="1.0" />
     <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
     <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
     <input name="exponent" type="float" value="5.0" />
     <input name="roughness" type="vector2" value="0.05, 0.05" />

--- a/resources/Materials/TestSuite/pbrlib/bsdf/generalized_schlick.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/generalized_schlick.mtlx
@@ -4,6 +4,7 @@
     <generalized_schlick_bsdf name="schlick_R" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="scatter_mode" type="string" value="R" />
@@ -16,6 +17,7 @@
     <generalized_schlick_bsdf name="schlick_T" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="scatter_mode" type="string" value="T" />
@@ -28,6 +30,7 @@
     <generalized_schlick_bsdf name="schlick_RT" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
+      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="scatter_mode" type="string" value="RT" />
@@ -49,6 +52,7 @@
     <generalized_schlick_bsdf name="schlick_R2" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="0.5, 0.0, 0.0" />
+      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="0.0, 1.0, 0.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="scatter_mode" type="string" value="R" />
@@ -61,6 +65,7 @@
     <generalized_schlick_bsdf name="schlick_T2" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="0.5, 0.0, 0.0" />
+      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="0.0, 1.0, 0.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="scatter_mode" type="string" value="T" />
@@ -73,6 +78,7 @@
     <generalized_schlick_bsdf name="schlick_RT2" type="BSDF">
       <input name="weight" type="float" value="1.0" />
       <input name="color0" type="color3" value="0.5, 0.0, 0.0" />
+      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
       <input name="color90" type="color3" value="0.0, 1.0, 0.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="scatter_mode" type="string" value="RT" />
@@ -90,6 +96,19 @@
       <input name="bsdf" type="BSDF" nodename="layer_RT2" />
     </surface>
     <output name="layer_RT2_out" type="surfaceshader" nodename="surface_layer_RT2" />
+
+    <generalized_schlick_bsdf name="schlick_R3" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="color82" type="color3" value="0.0, 0.0, 1.0" />
+      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="scatter_mode" type="string" value="R" />
+    </generalized_schlick_bsdf>
+    <surface name="surface_R3" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="schlick_R3" />
+    </surface>
+    <output name="R3_out" type="surfaceshader" nodename="surface_R3" />
 
   </nodegraph>
 </materialx>


### PR DESCRIPTION
This changelist adds a color82 input to the generalized_schlick_bsdf node in MaterialX, with a full implementation in hardware shading languages (GLSL/MSL/ESSL) and simple fallback behavior in closure-based shading languages (OSL/MDL).

The real-time implementation is based on Naty Hoffman's generalization of Adobe Fresnel (https://renderwonk.com/publications/wp-generalization-adobe/gen-adobe.pdf), which is visually consistent with previous versions of generalized_schlick_bsdf when color82 is left at its default setting.