### PR TITLE
Fix Python binding of setUnitType

### DIFF
--- a/source/PyMaterialX/PyMaterialXCore/PyDefinition.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyDefinition.cpp
@@ -73,7 +73,7 @@ void bindPyDefinition(py::module& mod)
         .def_readonly_static("CATEGORY", &mx::Unit::CATEGORY);
 
     py::class_<mx::UnitDef, mx::UnitDefPtr, mx::Element>(mod, "UnitDef")
-        .def("setUnitType", &mx::UnitDef::hasUnitType)
+        .def("setUnitType", &mx::UnitDef::setUnitType)
         .def("hasUnitType", &mx::UnitDef::hasUnitType)
         .def("getUnitType", &mx::UnitDef::getUnitType)
         .def("addUnit", &mx::UnitDef::addUnit)


### PR DESCRIPTION
Fix Python API `setUnitType()` was bound to C++ `hasUnitType()`.

This issue was initially reported here:
https://academysoftwarefdn.slack.com/archives/C0230LWBE2X/p1702146955156999
