### PR TITLE
Optimizations to GLSL FresnelData

### DIFF
--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -23,12 +23,7 @@ void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float
     float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
-    FresnelData fd;
-    if (thinfilm_thickness > 0.0)
-        fd = mx_init_fresnel_conductor_airy(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
-    else
-        fd = mx_init_fresnel_conductor(ior_n, ior_k);
-
+    FresnelData fd = mx_init_fresnel_conductor(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
     vec3 F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(Ht, safeAlpha);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
@@ -52,12 +47,7 @@ void mx_conductor_bsdf_indirect(vec3 V, float weight, vec3 ior_n, vec3 ior_k, ve
 
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    FresnelData fd;
-    if (thinfilm_thickness > 0.0)
-        fd = mx_init_fresnel_conductor_airy(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
-    else
-        fd = mx_init_fresnel_conductor(ior_n, ior_k);
-
+    FresnelData fd = mx_init_fresnel_conductor(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -21,16 +21,8 @@ void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, floa
     float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
-    FresnelData fd;
     vec3 safeTint = max(tint, 0.0);
-    if (thinfilm_thickness > 0.0)
-    { 
-        fd = mx_init_fresnel_dielectric_airy(ior, thinfilm_thickness, thinfilm_ior);
-    }
-    else
-    {
-        fd = mx_init_fresnel_dielectric(ior);
-    }
+    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(Ht, safeAlpha);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
@@ -54,16 +46,8 @@ void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior,
     N = mx_forward_facing_normal(N, V);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    FresnelData fd;
     vec3 safeTint = max(tint, 0.0);
-    if (thinfilm_thickness > 0.0)
-    { 
-        fd = mx_init_fresnel_dielectric_airy(ior, thinfilm_thickness, thinfilm_ior);
-    }
-    else
-    {
-        fd = mx_init_fresnel_dielectric(ior);
-    }
+    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
@@ -91,16 +75,8 @@ void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec
 
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    FresnelData fd;
     vec3 safeTint = max(tint, 0.0);
-    if (thinfilm_thickness > 0.0)
-    { 
-        fd = mx_init_fresnel_dielectric_airy(ior, thinfilm_thickness, thinfilm_ior);
-    }
-    else
-    {
-        fd = mx_init_fresnel_dielectric(ior);
-    }
+    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -21,18 +21,10 @@ void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlus
     float avgAlpha = mx_average_alpha(safeAlpha);
     vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
 
-    FresnelData fd;
     vec3 safeColor0 = max(color0, 0.0);
     vec3 safeColor82 = max(color82, 0.0);
     vec3 safeColor90 = max(color90, 0.0);
-    if (thinfilm_thickness > 0.0)
-    { 
-        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
-    }
-    else
-    {
-        fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent);
-    }
+    FresnelData fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
     vec3  F = mx_compute_fresnel(VdotH, fd);
     float D = mx_ggx_NDF(Ht, safeAlpha);
     float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
@@ -56,18 +48,10 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     N = mx_forward_facing_normal(N, V);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    FresnelData fd;
     vec3 safeColor0 = max(color0, 0.0);
     vec3 safeColor82 = max(color82, 0.0);
     vec3 safeColor90 = max(color90, 0.0);
-    if (thinfilm_thickness > 0.0)
-    { 
-        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_thickness);
-    }
-    else
-    {
-        fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent);
-    }
+    FresnelData fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
@@ -96,18 +80,10 @@ void mx_generalized_schlick_bsdf_indirect(vec3 V, float weight, vec3 color0, vec
     N = mx_forward_facing_normal(N, V);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    FresnelData fd;
     vec3 safeColor0 = max(color0, 0.0);
     vec3 safeColor82 = max(color82, 0.0);
     vec3 safeColor90 = max(color90, 0.0);
-    if (thinfilm_thickness > 0.0)
-    { 
-        fd = mx_init_fresnel_schlick_airy(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
-    }
-    else
-    {
-        fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent);
-    }
+    FresnelData fd = mx_init_fresnel_schlick(safeColor0, safeColor82, safeColor90, exponent, thinfilm_thickness, thinfilm_ior);
     vec3 F = mx_compute_fresnel(NdotV, fd);
 
     vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);


### PR DESCRIPTION
- Simplify mode selection and initialization for the FresnelData struct in GLSL.
- Remove an unneeded dynamic branch in mx_fresnel_dielectric_polarized.
- Remove unused temporaries in mx_fresnel_airy.