### PR TITLE
Remove 'baked' suffix from TextureBaker names

### DIFF
--- a/source/MaterialXRender/TextureBaker.inl
+++ b/source/MaterialXRender/TextureBaker.inl
@@ -18,7 +18,6 @@ namespace
 
 const string SRGB_TEXTURE = "srgb_texture";
 const string LIN_REC709 = "lin_rec709";
-const string BAKED_POSTFIX = "_baked";
 const string SHADER_PREFIX = "SR_";
 const string DEFAULT_UDIM_PREFIX = "_";
 
@@ -352,13 +351,13 @@ DocumentPtr TextureBaker<Renderer, ShaderGen>::generateNewDocumentFromShader(Nod
     }
 
     // Create a shader node.
-    NodePtr bakedShader = _bakedTextureDoc->addNode(shader->getCategory(), shader->getName() + BAKED_POSTFIX, shader->getType());
+    NodePtr bakedShader = _bakedTextureDoc->addNode(shader->getCategory(), shader->getName(), shader->getType());
 
     // Optionally create a material node, connecting it to the new shader node.
     if (_material)
     {
         string materialName = (_texTemplateOverrides.count("$MATERIAL")) ? _texTemplateOverrides["$MATERIAL"] : _material->getName();
-        NodePtr bakedMaterial = _bakedTextureDoc->addNode(_material->getCategory(), materialName + BAKED_POSTFIX, _material->getType());
+        NodePtr bakedMaterial = _bakedTextureDoc->addNode(_material->getCategory(), materialName, _material->getType());
         for (auto sourceMaterialInput : _material->getInputs())
         {
             const string& sourceMaterialInputName = sourceMaterialInput->getName();
@@ -421,7 +420,7 @@ DocumentPtr TextureBaker<Renderer, ShaderGen>::generateNewDocumentFromShader(Nod
             if (!_bakedImageMap.empty())
             {
                 // Add the image node.
-                NodePtr bakedImage = bakedNodeGraph->addNode("image", sourceName + BAKED_POSTFIX, sourceType);
+                NodePtr bakedImage = bakedNodeGraph->addNode("image", sourceName, sourceType);
                 InputPtr input = bakedImage->addInput("file", "filename");
                 StringMap filenameTemplateMap = initializeFileTemplateMap(bakedInput, shader, udimSet.empty() ? EMPTY_STRING : UDIM_TOKEN);
                 input->setValueString(generateTextureFilename(filenameTemplateMap));
@@ -433,7 +432,7 @@ DocumentPtr TextureBaker<Renderer, ShaderGen>::generateNewDocumentFromShader(Nod
                     NodePtr origWorldSpaceNode = worldSpacePair->second;
                     if (origWorldSpaceNode)
                     {
-                        NodePtr newWorldSpaceNode = bakedNodeGraph->addNode(origWorldSpaceNode->getCategory(), sourceName + BAKED_POSTFIX + "_map", sourceType);
+                        NodePtr newWorldSpaceNode = bakedNodeGraph->addNode(origWorldSpaceNode->getCategory(), sourceName + "_map", sourceType);
                         newWorldSpaceNode->copyContentFrom(origWorldSpaceNode);
                         InputPtr mapInput = newWorldSpaceNode->getInput("in");
                         if (mapInput)


### PR DESCRIPTION
The texturebaker appended a "_baked" token suffix to the generated material names that changed material name. Some pipelines get impacted by this rename, since the original material name is lost. Removing the suffix to retain original material name.
