### PR TITLE
Move prefilter functions to referencing GLSL files

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -1,5 +1,12 @@
 #include "mx_microfacet_specular.glsl"
 
+// Return the mip level associated with the given alpha in a prefiltered environment.
+float mx_latlong_alpha_to_lod(float alpha)
+{
+    float lodBias = (alpha < 0.25) ? sqrt(alpha) : 0.5 * alpha + 0.375;
+    return lodBias * float($envRadianceMips - 1);
+}
+
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
     N = mx_forward_facing_normal(N, V);

--- a/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
@@ -12,6 +12,13 @@ mat3 mx_orthonormal_basis(vec3 N)
     return mat3(X, Y, N);
 }
 
+// Return the alpha associated with the given mip level in a prefiltered environment.
+float mx_latlong_lod_to_alpha(float lod)
+{
+    float lodBias = lod / float($envRadianceMips - 1);
+    return (lodBias < 0.5) ? mx_square(lodBias) : 2.0 * (lodBias - 0.375);
+}
+
 // The inverse of mx_latlong_projection.
 vec3 mx_latlong_map_projection_inverse(vec2 uv)
 {

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -604,17 +604,3 @@ float mx_latlong_compute_lod(vec3 dir, float pdf, float maxMipLevel, int envSamp
     float distortion = sqrt(1.0 - mx_square(dir.y));
     return max(effectiveMaxMipLevel - 0.5 * log2(float(envSamples) * pdf * distortion), 0.0);
 }
-
-// Return the mip level associated with the given alpha in a prefiltered environment.
-float mx_latlong_alpha_to_lod(float alpha)
-{
-    float lodBias = (alpha < 0.25) ? sqrt(alpha) : 0.5 * alpha + 0.375;
-    return lodBias * float($envRadianceMips - 1);
-}
-
-// Return the alpha associated with the given mip level in a prefiltered environment.
-float mx_latlong_lod_to_alpha(float lod)
-{
-    float lodBias = lod / float($envRadianceMips - 1);
-    return (lodBias < 0.5) ? mx_square(lodBias) : 2.0 * (lodBias - 0.375);
-}


### PR DESCRIPTION
This changelist moves environment prefilter functions into the GLSL files that reference them, addressing shader compilation errors when GenOptions::hwDirectionalAlbedoMethod is set to DIRECTIONAL_ALBEDO_TABLE or DIRECTIONAL_ALBEDO_MONTE_CARLO by the client.