### PR TITLE
Move light uniforms into referencing GLSL files

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -59,10 +59,11 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
     radiance /= G1V * float(envRadianceSamples);
 
     // Return the final radiance.
-    return radiance;
+    return radiance * $envLightIntensity;
 }
 
 vec3 mx_environment_irradiance(vec3 N)
 {
-    return mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance);
+    vec3 Li = mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance);
+    return Li * $envLightIntensity;
 }

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -20,10 +20,11 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
     vec3 FG = fd.refraction ? vec3(1.0) - (F * G) : F * G;
 
     vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_alpha_to_lod(avgAlpha), $envRadiance);
-    return Li * FG;
+    return Li * FG * $envLightIntensity;
 }
 
 vec3 mx_environment_irradiance(vec3 N)
 {
-    return mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance);
+    vec3 Li = mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance);
+    return Li * $envLightIntensity;
 }

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -495,7 +495,7 @@ vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D envSam
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(envSampler, uv, lod).rgb * $envLightIntensity;
+    return textureLod(envSampler, uv, lod).rgb;
 }
 
 // Return the mip level with the appropriate coverage for a filtered importance sample.

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -28,6 +28,7 @@ const std::string options =
     "    --envRad [FILENAME]            Specify the filename of the environment light to display, stored as HDR environment radiance in the latitude-longitude format\n"
     "    --envMethod [INTEGER]          Specify the environment lighting method (0 = filtered importance sampling, 1 = prefiltered environment maps, defaults to 0)\n"
     "    --envSampleCount [INTEGER]     Specify the environment sample count (defaults to 16)\n"
+    "    --envLightIntensity [FLOAT]    Specify the environment light intensity (defaults to 1)\n"
     "    --lightRotation [FLOAT]        Specify the rotation in degrees of the lighting environment about the Y axis (defaults to 0)\n"
     "    --shadowMap [BOOLEAN]          Specify whether shadow mapping is enabled (defaults to true)\n"
     "    --path [FILEPATH]              Specify an additional data search path location (e.g. '/projects/MaterialX').  This absolute path will be queried when locating data libraries, XInclude references, and referenced images.\n"
@@ -88,6 +89,7 @@ int main(int argc, char* const argv[])
     float cameraZoom(DEFAULT_CAMERA_ZOOM);
     mx::HwSpecularEnvironmentMethod specularEnvironmentMethod = mx::SPECULAR_ENVIRONMENT_FIS;
     int envSampleCount = mx::DEFAULT_ENV_SAMPLE_COUNT;
+    float envLightIntensity = 1.0f;
     float lightRotation = 0.0f;
     bool shadowMap = true;
     DocumentModifiers modifiers;
@@ -161,6 +163,10 @@ int main(int argc, char* const argv[])
         else if (token == "--envSampleCount")
         {
             parseToken(nextToken, "integer", envSampleCount);
+        }
+        else if (token == "--envLightIntensity")
+        {
+            parseToken(nextToken, "float", envLightIntensity);
         }
         else if (token == "--lightRotation")
         {
@@ -288,6 +294,7 @@ int main(int argc, char* const argv[])
         viewer->setCameraZoom(cameraZoom);
         viewer->setSpecularEnvironmentMethod(specularEnvironmentMethod);
         viewer->setEnvSampleCount(envSampleCount);
+        viewer->setEnvLightIntensity(envLightIntensity);
         viewer->setLightRotation(lightRotation);
         viewer->setShadowMapEnable(shadowMap);
         viewer->setDrawEnvironment(drawEnvironment);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -172,7 +172,6 @@ Viewer::Viewer(const std::string& materialFilename,
     _userCameraEnabled(true),
     _userTranslationActive(false),
     _lightRotation(0.0f),
-    _intensityMultiplier(1.0f),
     _normalizeEnvironment(false),
     _splitDirectLight(false),
     _generateReferenceIrradiance(false),
@@ -766,7 +765,24 @@ void Viewer::createAdvancedSettings(Widget* parent)
     {
         _genContext.getOptions().hwDirectionalAlbedoMethod = (mx::HwDirectionalAlbedoMethod) index;
         reloadShaders();
-        _renderPipeline->updateAlbedoTable(ALBEDO_TABLE_SIZE);
+        try
+        {
+            _renderPipeline->updateAlbedoTable(ALBEDO_TABLE_SIZE);
+        }
+        catch (mx::ExceptionRenderError& e)
+        {
+            for (const std::string& error : e.errorLog())
+            {
+                std::cerr << error << std::endl;
+            }
+            new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Shader generation error", e.what());
+            _materialAssignments.clear();
+        }
+        catch (std::exception& e)
+        {
+            new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Failed to update albedo table", e.what());
+            _materialAssignments.clear();
+        }
     });
 
     Widget* sampleGroup = new Widget(advancedPopup);
@@ -817,22 +833,6 @@ void Viewer::createAdvancedSettings(Widget* parent)
         invalidateShadowMap();
     });
     lightRotationBox->set_editable(true);
-
-    Widget* envLightIntensityRow = new Widget(advancedPopup);
-    envLightIntensityRow->set_layout(new ng::BoxLayout(ng::Orientation::Horizontal));
-    mx::UIProperties intensityUI;
-    intensityUI.uiSoftMin = mx::Value::createValue(0.0f);
-    intensityUI.uiSoftMax = mx::Value::createValue(10.0f);
-    intensityUI.uiStep = mx::Value::createValue(0.1f);
-
-    ng::FloatBox<float>* envIntensity = createFloatWidget(envLightIntensityRow, "Light Intensity:",
-        _intensityMultiplier, &intensityUI, [this](float value)
-    {
-        _intensityMultiplier = value;
-        _lightHandler->setEnvLightIntensity(_intensityMultiplier);
-    });
-    envIntensity->set_value(1.0);
-    envIntensity->set_editable(true);
 
     ng::Label* shadowingLabel = new ng::Label(advancedPopup, "Shadowing Options");
     shadowingLabel->set_font_size(20);

--- a/source/MaterialXView/Viewer.h
+++ b/source/MaterialXView/Viewer.h
@@ -109,6 +109,12 @@ class Viewer : public ng::Screen
         _lightHandler->setEnvSampleCount(count);
     }
 
+    // Set the environment light intensity.
+    void setEnvLightIntensity(float intensity)
+    {
+        _lightHandler->setEnvLightIntensity(intensity);
+    }
+
     // Set the rotation of the lighting environment about the Y axis.
     void setLightRotation(float rotation)
     {
@@ -355,7 +361,6 @@ class Viewer : public ng::Screen
     mx::FilePath _lightRigFilename;
     mx::DocumentPtr _lightRigDoc;
     float _lightRotation;
-    float _intensityMultiplier;
 
     // Light processing options
     bool _normalizeEnvironment;


### PR DESCRIPTION
This change moves the new environment light intensity uniforms into their referencing GLSL files, addressing shader compilation errors when GenOptions::hwDirectionalAlbedoMethod is set to DIRECTIONAL_ALBEDO_TABLE or DIRECTIONAL_ALBEDO_MONTE_CARLO by the client.

Additionally, the change moves the environment light intensity option from the UI to the command line of the viewer, since isolated adjustments of the indirect lighting term are an unintuitive rendering control for most users.