### PR TITLE
Use framework linkage for OpenGL on macOS

### DIFF
--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -70,7 +70,7 @@ if(WIN32)
 elseif(APPLE)
     target_link_libraries(
         ${MATERIALX_MODULE_NAME}
-        OpenGL::GL
+        "-framework OpenGL"
         "-framework Foundation"
         "-framework Cocoa"
         "-framework Metal")

--- a/source/MaterialXRenderMsl/CMakeLists.txt
+++ b/source/MaterialXRenderMsl/CMakeLists.txt
@@ -57,7 +57,7 @@ elseif(APPLE)
         target_link_libraries(
             ${MATERIALX_MODULE_NAME}
             "-framework Cocoa"
-            OpenGL::GL)
+            "-framework OpenGL")
     endif()
     target_link_libraries(
         ${MATERIALX_MODULE_NAME}


### PR DESCRIPTION
Backporting https://github.com/AcademySoftwareFoundation/MaterialX/pull/1741 to Main for 1.38.10