### PR TITLE
Enable color and unit transforms on root nodes

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -92,6 +92,9 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     const vector<ShaderGraphInputSocket*>& getInputSockets() const { return _outputOrder; }
     const vector<ShaderGraphOutputSocket*>& getOutputSockets() const { return _inputOrder; }
 
+    /// Apply color and unit transforms to each input of a node.
+    void applyInputTransforms(ConstNodePtr node, ShaderNodePtr shaderNode, GenContext& context);
+
     /// Create a new node in the graph
     ShaderNode* createNode(ConstNodePtr node, GenContext& context);
 


### PR DESCRIPTION
This changelist adds support for color and unit transforms on the root nodes that are passed into shader generation, where previously they were only supported on non-root nodes in the material graph.

In MaterialX 1.38.9, a special-case pathway for root surface shader nodes was merged into the main logic, causing color transforms in some USD/MaterialX contexts to be omitted, and this changelist restores and generalizes the original approach to handle all root nodes.