### PR TITLE
Add missing vertex data prefix to Vulkan ShaderGen

### DIFF
--- a/source/MaterialXGenGlsl/VkShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/VkShaderGenerator.cpp
@@ -69,9 +69,9 @@ void VkShaderGenerator::emitInputs(GenContext& context, ShaderStage& stage) cons
     }
 }
 
-string VkShaderGenerator::getVertexDataPrefix(const VariableBlock&) const
+string VkShaderGenerator::getVertexDataPrefix(const VariableBlock& vertexData) const
 {
-    return EMPTY_STRING;
+    return vertexData.getInstance() + ".";
 }
 
 void VkShaderGenerator::emitOutputs(GenContext& context, ShaderStage& stage) const


### PR DESCRIPTION
@clach found that the VkShaderGenerator::getVertexDataPrefix() is returning the empty string when it seems like it should be returning vertexData.GetInstance() + "." similar to the glsl and metal shader gens do.