### PR TITLE
Remove legacy copy of OIIO for viewer

### DIFF
--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -40,8 +40,6 @@ if(MATERIALX_BUILD_OIIO)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/External/OpenImageIO")
     find_package(OpenImageIO CONFIG REQUIRED)
     target_link_libraries(${MATERIALX_MODULE_NAME} OpenImageIO::OpenImageIO OpenImageIO::OpenImageIO_Util)
-    # Also needed by MaterialXView:
-    set(OPENIMAGEIO_ROOT_DIR "${OpenImageIO_INCLUDE_DIR}/../" PARENT_SCOPE)
 endif()
 
 set_target_properties(

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -143,12 +143,6 @@ target_include_directories(
     ${NANOGUI_INCLUDE_DIRS}
     ${NANOGUI_EXTRA_INCS})
 
-if(MATERIALX_BUILD_OIIO AND OPENIMAGEIO_ROOT_DIR)
-    add_custom_command(TARGET MaterialXView POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${OPENIMAGEIO_ROOT_DIR}/bin ${CMAKE_BINARY_DIR}/bin)
-endif()
-
 set_target_properties(
     MaterialXView PROPERTIES
     INSTALL_RPATH "${MATERIALX_UP_ONE_RPATH}")


### PR DESCRIPTION
This changelist removes a legacy copy of the OpenImageIO folder that was generated in builds of the MaterialX Viewer.