### PR TITLE
Add core utility unit tests

### DIFF
--- a/source/MaterialXTest/MaterialXCore/CoreUtil.cpp
+++ b/source/MaterialXTest/MaterialXCore/CoreUtil.cpp
@@ -28,6 +28,14 @@ TEST_CASE("String utilities", "[coreutil]")
 
     REQUIRE(mx::splitString("robot1, robot2", ", ") == (std::vector<std::string>{"robot1", "robot2"}));
     REQUIRE(mx::splitString("[one...two...three]", "[.]") == (std::vector<std::string>{"one", "two", "three"}));
+
+    REQUIRE(mx::stringToLower("testName") == "testname");
+    REQUIRE(mx::stringToLower("testName1") == "testname1");
+
+    REQUIRE(mx::stringStartsWith("testName", "test"));
+    REQUIRE(!mx::stringStartsWith("testName", "Name"));
+    REQUIRE(mx::stringEndsWith("testName", "Name"));
+    REQUIRE(!mx::stringEndsWith("testName", "test"));
 }
 
 TEST_CASE("Print utilities", "[coreutil]")

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -17,6 +17,13 @@ TEST_CASE("Document", "[document]")
     // Create a document.
     mx::DocumentPtr doc = mx::createDocument();
 
+    // Test version strings.
+    REQUIRE(mx::stringStartsWith(mx::getVersionString(), doc->getVersionString()));
+
+    // Test version integers.
+    REQUIRE(doc->getVersionIntegers().first == std::get<0>(mx::getVersionIntegers()));
+    REQUIRE(doc->getVersionIntegers().second == std::get<1>(mx::getVersionIntegers()));
+
     // Create a node graph with a constant color output.
     mx::NodeGraphPtr nodeGraph = doc->addNodeGraph();
     mx::NodePtr constant = nodeGraph->addNode("constant");


### PR DESCRIPTION
This changelist adds a handful of new unit tests for core utilities, bringing the measured code coverage of MaterialX unit tests to 88.4%.