### PR TITLE
Improvements to GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
           python: 3.7
 
         - name: MacOS_Xcode_14_Python311
-          os: macos-13
+          os: macos-14
           compiler: xcode
           compiler_version: "14.3"
           python: 3.11
@@ -128,7 +128,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install xorg-dev mesa-utils
+        sudo apt-get install xorg-dev
         if [ "${{ matrix.compiler_version }}" != 'None' ]; then
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             sudo apt-get install -y g++-${{ matrix.compiler_version }} g++-${{ matrix.compiler_version }}-multilib
@@ -255,7 +255,6 @@ jobs:
         Xvfb :1 -screen 0 1280x960x24 &
         echo "DISPLAY=:1" >> $GITHUB_ENV
         echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
-        echo "GALLIUM_DRIVER=llvmpipe" >> $GITHUB_ENV
 
     - name: Render Script Tests
       if: matrix.test_render == 'ON'
@@ -344,7 +343,6 @@ jobs:
       with:
         name: MaterialX_JavaScript
         path: javascript/build/installed/JavaScript/MaterialX        
-        if-no-files-found: ignore   
 
   sdist:
     name: Python SDist


### PR DESCRIPTION
- Upgrade the MacOS_Xcode_14_Python311 build to the MacOS 14 environment.
- Remove unneeded steps in virtual framebuffer setup and JavaScript uploads.