### PR TITLE
Add ESSL unit tests

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -21,7 +21,7 @@
 
     <!-- Comma separated list of target" specifiers to indicate which
          code generators to use. -->
-    <input name="targets" type="string" value="genglsl,genosl,genmdl,genmsl" />
+    <input name="targets" type="string" value="genglsl,genosl,genmdl,genessl,genmsl" />
 
     <!-- Check the count of number of implementations used for a given generator -->
     <input name="checkImplCount" type="boolean" value="true" />

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -4,15 +4,11 @@
 //
 
 #include <MaterialXTest/External/Catch/catch.hpp>
-#include <MaterialXTest/MaterialXGenShader/GenShaderUtil.h>
+
 #include <MaterialXTest/MaterialXGenGlsl/GenGlsl.h>
 
-#include <MaterialXCore/Document.h>
-
-#include <MaterialXFormat/File.h>
-
-#include <MaterialXGenShader/TypeDesc.h>
-
+#include <MaterialXGenGlsl/EsslShaderGenerator.h>
+#include <MaterialXGenGlsl/EsslSyntax.h>
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 #include <MaterialXGenGlsl/GlslSyntax.h>
 #include <MaterialXGenGlsl/GlslResourceBindingContext.h>
@@ -95,7 +91,7 @@ TEST_CASE("GenShader: GLSL Unique Names", "[genglsl]")
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
-TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
+TEST_CASE("GenShader: GLSL Light Shaders", "[genglsl]")
 {
     mx::DocumentPtr doc = mx::createDocument();
 
@@ -120,7 +116,7 @@ TEST_CASE("GenShader: Bind Light Shaders", "[genglsl]")
 }
 
 #ifdef MATERIALX_BUILD_BENCHMARK_TESTS
-TEST_CASE("GenShader: Performance Test", "[genglsl]")
+TEST_CASE("GenShader: GLSL Performance Test", "[genglsl]")
 {
     mx::GenContext context(mx::GlslShaderGenerator::create());
     BENCHMARK("Load documents, validate and generate shader") 
@@ -132,26 +128,13 @@ TEST_CASE("GenShader: Performance Test", "[genglsl]")
 
 enum class GlslType
 {
-    Glsl400,
-    Glsl420,
+    Essl,
+    Glsl,
+    GlslLayout,
     GlslVulkan
 };
 
-const std::string GlslTypeToString(GlslType e) throw()
-{
-    switch (e)
-    {
-        case GlslType::Glsl420:
-            return "glsl420_layout";
-        case GlslType::GlslVulkan:
-            return "glsl420_vulkan";
-        case GlslType::Glsl400:
-        default:
-            return "glsl400";
-    }
-}
-
-static void generateGlslCode(GlslType type = GlslType::Glsl400)
+static void generateGlslCode(GlslType type)
 {
     mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
@@ -159,16 +142,34 @@ static void generateGlslCode(GlslType type = GlslType::Glsl400)
     testRootPaths.push_back(searchPath.find("resources/Materials/TestSuite"));
     testRootPaths.push_back(searchPath.find("resources/Materials/Examples/StandardSurface"));
 
-    const mx::FilePath logPath("genglsl_" + GlslTypeToString(type) + "_generate_test.txt");
-
-    bool writeShadersToDisk = false;
-    GlslShaderGeneratorTester tester((type == GlslType::GlslVulkan) ? mx::VkShaderGenerator::create() : mx::GlslShaderGenerator::create(),
-                                     testRootPaths, searchPath, logPath, writeShadersToDisk);
-
-    // Add resource binding context for glsl 4.20
-    if (type == GlslType::Glsl420)
+    // Create the requested shader generator.
+    mx::ShaderGeneratorPtr generator;
+    if (type == GlslType::Essl)
     {
-        // Set binding context to handle resource binding layouts
+        generator = mx::EsslShaderGenerator::create();
+    }
+    else if (type == GlslType::GlslVulkan)
+    {
+        generator = mx::VkShaderGenerator::create();
+    }
+    else
+    {
+        generator = mx::GlslShaderGenerator::create();
+    }
+
+    const std::unordered_map<GlslType, std::string> TYPE_NAME_MAP =
+    {
+        { GlslType::Essl, "essl" },
+        { GlslType::Glsl, "glsl" },
+        { GlslType::GlslLayout, "glsl_layout" },
+        { GlslType::GlslVulkan, "glsl_vulkan" }
+    };
+    const mx::FilePath logPath("genglsl_" + TYPE_NAME_MAP.at(type) + "_generate_test.txt");
+    GlslShaderGeneratorTester tester(generator, testRootPaths, searchPath, logPath, false);
+
+    // Handle resource binding layouts if requested.
+    if (type == GlslType::GlslLayout)
+    {
         mx::GlslResourceBindingContextPtr glslresourceBinding(mx::GlslResourceBindingContext::create());
         glslresourceBinding->enableSeparateBindingLocations(true);
         tester.addUserData(mx::HW::USER_DATA_BINDING_CONTEXT, glslresourceBinding);
@@ -179,20 +180,22 @@ static void generateGlslCode(GlslType type = GlslType::Glsl400)
     tester.validate(genOptions, optionsFilePath);
 }
 
+TEST_CASE("GenShader: ESSL Shader Generation", "[genglsl]")
+{
+    generateGlslCode(GlslType::Essl);
+}
+
 TEST_CASE("GenShader: GLSL Shader Generation", "[genglsl]")
 {
-    // Generate with standard GLSL i.e version 400
-    generateGlslCode(GlslType::Glsl400);
+    generateGlslCode(GlslType::Glsl);
 }
 
-TEST_CASE("GenShader: GLSL Shader with Layout Generation", "[genglsl]")
+TEST_CASE("GenShader: GLSL Shader Generation with Layout", "[genglsl]")
 {
-    // Generate GLSL with layout i.e version 400 + layout extension
-    generateGlslCode(GlslType::Glsl420);
+    generateGlslCode(GlslType::GlslLayout);
 }
 
-TEST_CASE("GenShader: Vulkan GLSL Shader", "[genglsl]")
+TEST_CASE("GenShader: Vulkan GLSL Shader Generation", "[genglsl]")
 {
-    // Generate with GLSL for Vulkan i.e. version 450
     generateGlslCode(GlslType::GlslVulkan);
 }


### PR DESCRIPTION
This changelist adds initial unit tests for ESSL shader generation, bringing the measured code coverage of MaterialX unit tests to 88.7%.