### PR TITLE
Simplify extract and separateN nodes

### DIFF
--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -4150,112 +4150,48 @@
     Node: <extract>
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
-  <nodegraph name="NG_extract_vector2" nodedef="ND_extract_vector2">
-    <swizzle name="N_x_vector2" type="float">
-      <input name="in" type="vector2" interfacename="in" />
-      <input name="channels" type="string" value="x" />
-    </swizzle>
-    <swizzle name="N_y_vector2" type="float">
-      <input name="in" type="vector2" interfacename="in" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <switch name="N_sw_vector2" type="float">
-      <input name="in1" type="float" nodename="N_x_vector2" />
-      <input name="in2" type="float" nodename="N_y_vector2" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_vector2" />
-  </nodegraph>
   <nodegraph name="NG_extract_color3" nodedef="ND_extract_color3">
-    <swizzle name="N_r_color3" type="float">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="channels" type="string" value="r" />
-    </swizzle>
-    <swizzle name="N_g_color3" type="float">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="channels" type="string" value="g" />
-    </swizzle>
-    <swizzle name="N_b_color3" type="float">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="channels" type="string" value="b" />
-    </swizzle>
     <switch name="N_sw_color3" type="float">
-      <input name="in1" type="float" nodename="N_r_color3" />
-      <input name="in2" type="float" nodename="N_g_color3" />
-      <input name="in3" type="float" nodename="N_b_color3" />
+      <input name="in1" type="float" interfacename="in" channels="r" />
+      <input name="in2" type="float" interfacename="in" channels="g" />
+      <input name="in3" type="float" interfacename="in" channels="b" />
       <input name="which" type="integer" interfacename="index" />
     </switch>
     <output name="out" type="float" nodename="N_sw_color3" />
   </nodegraph>
-  <nodegraph name="NG_extract_vector3" nodedef="ND_extract_vector3">
-    <swizzle name="N_x_vector3" type="float">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="channels" type="string" value="x" />
-    </swizzle>
-    <swizzle name="N_y_vector3" type="float">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <swizzle name="N_z_vector3" type="float">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="channels" type="string" value="z" />
-    </swizzle>
-    <switch name="N_sw_vector3" type="float">
-      <input name="in1" type="float" nodename="N_x_vector3" />
-      <input name="in2" type="float" nodename="N_y_vector3" />
-      <input name="in3" type="float" nodename="N_z_vector3" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_vector3" />
-  </nodegraph>
   <nodegraph name="NG_extract_color4" nodedef="ND_extract_color4">
-    <swizzle name="N_r_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="r" />
-    </swizzle>
-    <swizzle name="N_g_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="g" />
-    </swizzle>
-    <swizzle name="N_b_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="b" />
-    </swizzle>
-    <swizzle name="N_a_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="a" />
-    </swizzle>
     <switch name="N_sw_color4" type="float">
-      <input name="in1" type="float" nodename="N_r_color4" />
-      <input name="in2" type="float" nodename="N_g_color4" />
-      <input name="in3" type="float" nodename="N_b_color4" />
-      <input name="in4" type="float" nodename="N_a_color4" />
+      <input name="in1" type="float" interfacename="in" channels="r" />
+      <input name="in2" type="float" interfacename="in" channels="g" />
+      <input name="in3" type="float" interfacename="in" channels="b" />
+      <input name="in4" type="float" interfacename="in" channels="a" />
       <input name="which" type="integer" interfacename="index" />
     </switch>
     <output name="out" type="float" nodename="N_sw_color4" />
   </nodegraph>
+  <nodegraph name="NG_extract_vector2" nodedef="ND_extract_vector2">
+    <switch name="N_sw_vector2" type="float">
+      <input name="in1" type="float" interfacename="in" channels="x" />
+      <input name="in2" type="float" interfacename="in" channels="y" />
+      <input name="which" type="integer" interfacename="index" />
+    </switch>
+    <output name="out" type="float" nodename="N_sw_vector2" />
+  </nodegraph>
+  <nodegraph name="NG_extract_vector3" nodedef="ND_extract_vector3">
+    <switch name="N_sw_vector3" type="float">
+      <input name="in1" type="float" interfacename="in" channels="x" />
+      <input name="in2" type="float" interfacename="in" channels="y" />
+      <input name="in3" type="float" interfacename="in" channels="z" />
+      <input name="which" type="integer" interfacename="index" />
+    </switch>
+    <output name="out" type="float" nodename="N_sw_vector3" />
+  </nodegraph>
   <nodegraph name="NG_extract_vector4" nodedef="ND_extract_vector4">
-    <swizzle name="N_x_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="x" />
-    </swizzle>
-    <swizzle name="N_y_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <swizzle name="N_z_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="z" />
-    </swizzle>
-    <swizzle name="N_w_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="w" />
-    </swizzle>
     <switch name="N_sw_vector4" type="float">
-      <input name="in1" type="float" nodename="N_x_vector4" />
-      <input name="in2" type="float" nodename="N_y_vector4" />
-      <input name="in3" type="float" nodename="N_z_vector4" />
-      <input name="in4" type="float" nodename="N_w_vector4" />
+      <input name="in1" type="float" interfacename="in" channels="x" />
+      <input name="in2" type="float" interfacename="in" channels="y" />
+      <input name="in3" type="float" interfacename="in" channels="z" />
+      <input name="in4" type="float" interfacename="in" channels="w" />
       <input name="which" type="integer" interfacename="index" />
     </switch>
     <output name="out" type="float" nodename="N_sw_vector4" />
@@ -4265,95 +4201,46 @@
     Nodes: <separate2>, <separate3>, <separate4>
     Output each of the channels of a color/vector stream as a separate float output.
   -->
-  <nodegraph name="NG_separate2_vector2" nodedef="ND_separate2_vector2">
-    <swizzle name="N_x_vector2" type="float">
-      <input name="in" type="vector2" interfacename="in" />
-      <input name="channels" type="string" value="x" />
-    </swizzle>
-    <swizzle name="N_y_vector2" type="float">
-      <input name="in" type="vector2" interfacename="in" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <output name="outx" type="float" nodename="N_x_vector2" />
-    <output name="outy" type="float" nodename="N_y_vector2" />
-  </nodegraph>
   <nodegraph name="NG_separate3_color3" nodedef="ND_separate3_color3">
-    <swizzle name="N_r_color3" type="float">
+    <dot name="N_dot_color3" type="color3">
       <input name="in" type="color3" interfacename="in" />
-      <input name="channels" type="string" value="r" />
-    </swizzle>
-    <swizzle name="N_g_color3" type="float">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="channels" type="string" value="g" />
-    </swizzle>
-    <swizzle name="N_b_color3" type="float">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="channels" type="string" value="b" />
-    </swizzle>
-    <output name="outr" type="float" nodename="N_r_color3" />
-    <output name="outg" type="float" nodename="N_g_color3" />
-    <output name="outb" type="float" nodename="N_b_color3" />
-  </nodegraph>
-  <nodegraph name="NG_separate3_vector3" nodedef="ND_separate3_vector3">
-    <swizzle name="N_x_vector3" type="float">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="channels" type="string" value="x" />
-    </swizzle>
-    <swizzle name="N_y_vector3" type="float">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <swizzle name="N_z_vector3" type="float">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="channels" type="string" value="z" />
-    </swizzle>
-    <output name="outx" type="float" nodename="N_x_vector3" />
-    <output name="outy" type="float" nodename="N_y_vector3" />
-    <output name="outz" type="float" nodename="N_z_vector3" />
+    </dot>
+    <output name="outr" type="float" nodename="N_dot_color3" channels="r" />
+    <output name="outg" type="float" nodename="N_dot_color3" channels="g" />
+    <output name="outb" type="float" nodename="N_dot_color3" channels="b" />
   </nodegraph>
   <nodegraph name="NG_separate4_color4" nodedef="ND_separate4_color4">
-    <swizzle name="N_r_color4" type="float">
+    <dot name="N_dot_color4" type="color4">
       <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="r" />
-    </swizzle>
-    <swizzle name="N_g_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="g" />
-    </swizzle>
-    <swizzle name="N_b_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="b" />
-    </swizzle>
-    <swizzle name="N_a_color4" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="channels" type="string" value="a" />
-    </swizzle>
-    <output name="outr" type="float" nodename="N_r_color4" />
-    <output name="outg" type="float" nodename="N_g_color4" />
-    <output name="outb" type="float" nodename="N_b_color4" />
-    <output name="outa" type="float" nodename="N_a_color4" />
+    </dot>
+    <output name="outr" type="float" nodename="N_dot_color4" channels="r" />
+    <output name="outg" type="float" nodename="N_dot_color4" channels="g" />
+    <output name="outb" type="float" nodename="N_dot_color4" channels="b" />
+    <output name="outa" type="float" nodename="N_dot_color4" channels="a" />
+  </nodegraph>
+  <nodegraph name="NG_separate2_vector2" nodedef="ND_separate2_vector2">
+    <dot name="N_dot_vector2" type="vector2">
+      <input name="in" type="vector2" interfacename="in" />
+    </dot>
+    <output name="outx" type="float" nodename="N_dot_vector2" channels="x" />
+    <output name="outy" type="float" nodename="N_dot_vector2" channels="y" />
+  </nodegraph>
+  <nodegraph name="NG_separate3_vector3" nodedef="ND_separate3_vector3">
+    <dot name="N_dot_vector3" type="vector3">
+      <input name="in" type="vector3" interfacename="in" />
+    </dot>
+    <output name="outx" type="float" nodename="N_dot_vector3" channels="x" />
+    <output name="outy" type="float" nodename="N_dot_vector3" channels="y" />
+    <output name="outz" type="float" nodename="N_dot_vector3" channels="z" />
   </nodegraph>
   <nodegraph name="NG_separate4_vector4" nodedef="ND_separate4_vector4">
-    <swizzle name="N_x_vector4" type="float">
+    <dot name="N_dot_vector4" type="vector4">
       <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="x" />
-    </swizzle>
-    <swizzle name="N_y_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="y" />
-    </swizzle>
-    <swizzle name="N_z_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="z" />
-    </swizzle>
-    <swizzle name="N_w_vector4" type="float">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="channels" type="string" value="w" />
-    </swizzle>
-    <output name="outx" type="float" nodename="N_x_vector4" />
-    <output name="outy" type="float" nodename="N_y_vector4" />
-    <output name="outz" type="float" nodename="N_z_vector4" />
-    <output name="outw" type="float" nodename="N_w_vector4" />
+    </dot>
+    <output name="outx" type="float" nodename="N_dot_vector4" channels="x" />
+    <output name="outy" type="float" nodename="N_dot_vector4" channels="y" />
+    <output name="outz" type="float" nodename="N_dot_vector4" channels="z" />
+    <output name="outw" type="float" nodename="N_dot_vector4" channels="w" />
   </nodegraph>
 
   <!-- ======================================================================== -->


### PR DESCRIPTION
This changelist simplifies the graph definitions for the extract and separateN nodes, replacing the use of swizzle nodes with channels strings.  This is a very first step towards a refactoring of these features in MaterialX 1.39.