### PR TITLE
Fix the 'creatematrix' shader default output value

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -4539,7 +4539,7 @@
     <input name="in2" type="vector3" value="0.0, 1.0, 0.0" />
     <input name="in3" type="vector3" value="0.0, 0.0, 1.0" />
     <input name="in4" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="matrix44" default="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  1.0, 0.0, 0.0, 0.0" />
+    <output name="out" type="matrix44" default="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
   </nodedef>
 
   <nodedef name="ND_creatematrix_vector4_matrix44" node="creatematrix" nodegroup="math">
@@ -4547,7 +4547,7 @@
     <input name="in2" type="vector4" value="0.0, 1.0, 0.0, 0.0" />
     <input name="in3" type="vector4" value="0.0, 0.0, 1.0, 0.0" />
     <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 1.0" />
-    <output name="out" type="matrix44" default="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  1.0, 0.0, 0.0, 0.0" />
+    <output name="out" type="matrix44" default="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
   </nodedef>
 
   <!--


### PR DESCRIPTION
The 'nodedef' elements for the ND_creatematrix_vector3_matrix44 and ND_creatematrix_vector4_matrix44 shader definitions have a typo in their default value for the "out" output. The last vector currently is (1,0,0,0) but should be (0,0,0,1), to form an identity matrix. This pull request fixes that.