### PR TITLE
Update implementations of extract and separate

### DIFF
--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -705,6 +705,13 @@
   <implementation name="IM_creatematrix_vector3_matrix44_genglsl" nodedef="ND_creatematrix_vector3_matrix44" file="mx_creatematrix_vector3_matrix44.glsl" function="mx_creatematrix_vector3_matrix44" target="genglsl" />
   <implementation name="IM_creatematrix_vector4_matrix44_genglsl" nodedef="ND_creatematrix_vector4_matrix44" file="mx_creatematrix_vector4_matrix44.glsl" function="mx_creatematrix_vector4_matrix44" target="genglsl" />
 
+  <!-- <extract> -->
+  <implementation name="IM_extract_color3_genglsl" nodedef="ND_extract_color3" sourcecode="{{in}}[{{index}}]" target="genglsl" />
+  <implementation name="IM_extract_color4_genglsl" nodedef="ND_extract_color4" sourcecode="{{in}}[{{index}}]" target="genglsl" />
+  <implementation name="IM_extract_vector2_genglsl" nodedef="ND_extract_vector2" sourcecode="{{in}}[{{index}}]" target="genglsl" />
+  <implementation name="IM_extract_vector3_genglsl" nodedef="ND_extract_vector3" sourcecode="{{in}}[{{index}}]" target="genglsl" />
+  <implementation name="IM_extract_vector4_genglsl" nodedef="ND_extract_vector4" sourcecode="{{in}}[{{index}}]" target="genglsl" />
+
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -717,6 +717,13 @@
   <implementation name="IM_creatematrix_vector3_matrix44_genmdl" nodedef="ND_creatematrix_vector3_matrix44" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_creatematrix_vector3_matrix44({{in1}}, {{in2}}, {{in3}}, {{in4}})" target="genmdl" />
   <implementation name="IM_creatematrix_vector4_matrix44_genmdl" nodedef="ND_creatematrix_vector4_matrix44" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_creatematrix_vector4_matrix44({{in1}}, {{in2}}, {{in3}}, {{in4}})" target="genmdl" />
 
+  <!-- <extract> -->
+  <implementation name="IM_extract_color3_genmdl" nodedef="ND_extract_color3" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_extract_color3({{in}}, {{index}})" target="genmdl" />
+  <implementation name="IM_extract_color4_genmdl" nodedef="ND_extract_color4" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_extract_color4({{in}}, {{index}})" target="genmdl" />
+  <implementation name="IM_extract_vector2_genmdl" nodedef="ND_extract_vector2" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_extract_vector2({{in}}, {{index}})" target="genmdl" />
+  <implementation name="IM_extract_vector3_genmdl" nodedef="ND_extract_vector3" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_extract_vector3({{in}}, {{index}})" target="genmdl" />
+  <implementation name="IM_extract_vector4_genmdl" nodedef="ND_extract_vector4" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_extract_vector4({{in}}, {{index}})" target="genmdl" />
+
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -705,6 +705,13 @@
   <implementation name="IM_creatematrix_vector3_matrix44_genmsl" nodedef="ND_creatematrix_vector3_matrix44" file="../genglsl/mx_creatematrix_vector3_matrix44.glsl" function="mx_creatematrix_vector3_matrix44" target="genmsl" />
   <implementation name="IM_creatematrix_vector4_matrix44_genmsl" nodedef="ND_creatematrix_vector4_matrix44" file="../genglsl/mx_creatematrix_vector4_matrix44.glsl" function="mx_creatematrix_vector4_matrix44" target="genmsl" />
 
+  <!-- <extract> -->
+  <implementation name="IM_extract_color3_genmsl" nodedef="ND_extract_color3" sourcecode="{{in}}[{{index}}]" target="genmsl" />
+  <implementation name="IM_extract_color4_genmsl" nodedef="ND_extract_color4" sourcecode="{{in}}[{{index}}]" target="genmsl" />
+  <implementation name="IM_extract_vector2_genmsl" nodedef="ND_extract_vector2" sourcecode="{{in}}[{{index}}]" target="genmsl" />
+  <implementation name="IM_extract_vector3_genmsl" nodedef="ND_extract_vector3" sourcecode="{{in}}[{{index}}]" target="genmsl" />
+  <implementation name="IM_extract_vector4_genmsl" nodedef="ND_extract_vector4" sourcecode="{{in}}[{{index}}]" target="genmsl" />
+
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/genosl/include/mx_funcs.h
+++ b/libraries/stdlib/genosl/include/mx_funcs.h
@@ -16,6 +16,7 @@
 //
 
 float mx_ternary(int expr, float v1, float v2) { if (expr) return v1; else return v2; }
+int mx_ternary(int expr, int v1, int v2) { if (expr) return v1; else return v2; }
 color mx_ternary(int expr, color v1, color v2) { if (expr) return v1; else return v2; }
 color4 mx_ternary(int expr, color4 v1, color4 v2) { if (expr) return v1; else return v2; }
 vector mx_ternary(int expr, vector v1, vector v2) { if (expr) return v1; else return v2; }
@@ -96,6 +97,39 @@ matrix mx_subtract(matrix a, float b)
         a[1][0]-b, a[1][1]-b, a[1][2]-b, a[1][3]-b,
         a[2][0]-b, a[2][1]-b, a[2][2]-b, a[2][3]-b,
         a[3][0]-b, a[3][1]-b, a[3][2]-b, a[3][3]-b);
+}
+
+
+float mx_extract(color in, int index)
+{
+    return in[index];
+}
+
+float mx_extract(color4 in, int index)
+{
+    if (index == 0) return in.rgb.r;
+    else if (index == 1) return in.rgb.g;
+    else if (index == 2) return in.rgb.b;
+    else return in.a;
+}
+
+float mx_extract(vector2 in, int index)
+{
+    if (index == 0) return in.x;
+    else return in.y;
+}
+
+float mx_extract(vector in, int index)
+{
+    return in[index];
+}
+
+float mx_extract(vector4 in, int index)
+{
+    if (index == 0) return in.x;
+    else if (index == 1) return in.y;
+    else if (index == 2) return in.z;
+    else return in.w;
 }
 
 

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -708,6 +708,13 @@
   <implementation name="IM_creatematrix_vector3_matrix44_genosl" nodedef="ND_creatematrix_vector3_matrix44" file="mx_creatematrix.osl" function="mx_creatematrix_vector3_matrix44" target="genosl" />
   <implementation name="IM_creatematrix_vector4_matrix44_genosl" nodedef="ND_creatematrix_vector4_matrix44" file="mx_creatematrix.osl" function="mx_creatematrix_vector4_matrix44" target="genosl" />
 
+  <!-- <extract> -->
+  <implementation name="IM_extract_color3_genosl" nodedef="ND_extract_color3" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
+  <implementation name="IM_extract_color4_genosl" nodedef="ND_extract_color4" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
+  <implementation name="IM_extract_vector2_genosl" nodedef="ND_extract_vector2" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
+  <implementation name="IM_extract_vector3_genosl" nodedef="ND_extract_vector3" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
+  <implementation name="IM_extract_vector4_genosl" nodedef="ND_extract_vector4" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
+
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->
   <!-- ======================================================================== -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -4412,7 +4412,7 @@
   </nodedef>
 
   <!--
-    Node: <extract> Supplemental Node
+    Node: <extract>
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
   <nodedef name="ND_extract_color3" node="extract" nodegroup="channel">

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -3977,10 +3977,10 @@
   </nodegraph>
   <nodegraph name="NG_overlay_color3" nodedef="ND_overlay_color3">
     <output name="out" type="color3" nodename="N_combine" />
-    <separate3 name="N_split_color3_fg" type="multioutput" nodedef="ND_separate3_color3">
+    <separate3 name="N_split_color3_fg" type="multioutput">
       <input name="in" type="color3" interfacename="fg" />
     </separate3>
-    <separate3 name="N_split_color3_bg" type="multioutput" nodedef="ND_separate3_color3">
+    <separate3 name="N_split_color3_bg" type="multioutput">
       <input name="in" type="color3" interfacename="bg" />
     </separate3>
     <combine3 name="N_combine" type="color3" nodedef="ND_combine3_color3">
@@ -4006,10 +4006,10 @@
   </nodegraph>
   <nodegraph name="NG_overlay_color4" nodedef="ND_overlay_color4">
     <output name="out" type="color4" nodename="N_combine" />
-    <separate4 name="N_split_fg" type="multioutput" nodedef="ND_separate4_color4">
+    <separate4 name="N_split_fg" type="multioutput">
       <input name="in" type="color4" interfacename="fg" />
     </separate4>
-    <separate4 name="N_split_bg" type="multioutput" nodedef="ND_separate4_color4">
+    <separate4 name="N_split_bg" type="multioutput">
       <input name="in" type="color4" interfacename="bg" />
     </separate4>
     <overlay name="N_overlay_r" type="float" nodedef="ND_overlay_float">
@@ -4147,100 +4147,98 @@
   </nodegraph>
 
   <!--
-    Node: <extract>
-    Extract a single channel from a colorN or vectorN stream, outputting a float.
-  -->
-  <nodegraph name="NG_extract_color3" nodedef="ND_extract_color3">
-    <switch name="N_sw_color3" type="float">
-      <input name="in1" type="float" interfacename="in" channels="r" />
-      <input name="in2" type="float" interfacename="in" channels="g" />
-      <input name="in3" type="float" interfacename="in" channels="b" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_color3" />
-  </nodegraph>
-  <nodegraph name="NG_extract_color4" nodedef="ND_extract_color4">
-    <switch name="N_sw_color4" type="float">
-      <input name="in1" type="float" interfacename="in" channels="r" />
-      <input name="in2" type="float" interfacename="in" channels="g" />
-      <input name="in3" type="float" interfacename="in" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_color4" />
-  </nodegraph>
-  <nodegraph name="NG_extract_vector2" nodedef="ND_extract_vector2">
-    <switch name="N_sw_vector2" type="float">
-      <input name="in1" type="float" interfacename="in" channels="x" />
-      <input name="in2" type="float" interfacename="in" channels="y" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_vector2" />
-  </nodegraph>
-  <nodegraph name="NG_extract_vector3" nodedef="ND_extract_vector3">
-    <switch name="N_sw_vector3" type="float">
-      <input name="in1" type="float" interfacename="in" channels="x" />
-      <input name="in2" type="float" interfacename="in" channels="y" />
-      <input name="in3" type="float" interfacename="in" channels="z" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_vector3" />
-  </nodegraph>
-  <nodegraph name="NG_extract_vector4" nodedef="ND_extract_vector4">
-    <switch name="N_sw_vector4" type="float">
-      <input name="in1" type="float" interfacename="in" channels="x" />
-      <input name="in2" type="float" interfacename="in" channels="y" />
-      <input name="in3" type="float" interfacename="in" channels="z" />
-      <input name="in4" type="float" interfacename="in" channels="w" />
-      <input name="which" type="integer" interfacename="index" />
-    </switch>
-    <output name="out" type="float" nodename="N_sw_vector4" />
-  </nodegraph>
-
-  <!--
     Nodes: <separate2>, <separate3>, <separate4>
     Output each of the channels of a color/vector stream as a separate float output.
   -->
   <nodegraph name="NG_separate3_color3" nodedef="ND_separate3_color3">
-    <dot name="N_dot_color3" type="color3">
+    <extract name="N_extract_0" type="float">
       <input name="in" type="color3" interfacename="in" />
-    </dot>
-    <output name="outr" type="float" nodename="N_dot_color3" channels="r" />
-    <output name="outg" type="float" nodename="N_dot_color3" channels="g" />
-    <output name="outb" type="float" nodename="N_dot_color3" channels="b" />
+      <input name="index" type="integer" value="0" />
+    </extract>
+    <extract name="N_extract_1" type="float">
+      <input name="in" type="color3" interfacename="in" />
+      <input name="index" type="integer" value="1" />
+    </extract>
+    <extract name="N_extract_2" type="float">
+      <input name="in" type="color3" interfacename="in" />
+      <input name="index" type="integer" value="2" />
+    </extract>
+    <output name="outr" type="float" nodename="N_extract_0" />
+    <output name="outg" type="float" nodename="N_extract_1" />
+    <output name="outb" type="float" nodename="N_extract_2" />
   </nodegraph>
   <nodegraph name="NG_separate4_color4" nodedef="ND_separate4_color4">
-    <dot name="N_dot_color4" type="color4">
+     <extract name="N_extract_0" type="float">
       <input name="in" type="color4" interfacename="in" />
-    </dot>
-    <output name="outr" type="float" nodename="N_dot_color4" channels="r" />
-    <output name="outg" type="float" nodename="N_dot_color4" channels="g" />
-    <output name="outb" type="float" nodename="N_dot_color4" channels="b" />
-    <output name="outa" type="float" nodename="N_dot_color4" channels="a" />
+      <input name="index" type="integer" value="0" />
+    </extract>
+    <extract name="N_extract_1" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="1" />
+    </extract>
+    <extract name="N_extract_2" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="2" />
+    </extract>
+    <extract name="N_extract_3" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <output name="outr" type="float" nodename="N_extract_0" />
+    <output name="outg" type="float" nodename="N_extract_1" />
+    <output name="outb" type="float" nodename="N_extract_2" />
+    <output name="outa" type="float" nodename="N_extract_3" />
   </nodegraph>
   <nodegraph name="NG_separate2_vector2" nodedef="ND_separate2_vector2">
-    <dot name="N_dot_vector2" type="vector2">
+     <extract name="N_extract_0" type="float">
       <input name="in" type="vector2" interfacename="in" />
-    </dot>
-    <output name="outx" type="float" nodename="N_dot_vector2" channels="x" />
-    <output name="outy" type="float" nodename="N_dot_vector2" channels="y" />
+      <input name="index" type="integer" value="0" />
+    </extract>
+    <extract name="N_extract_1" type="float">
+      <input name="in" type="vector2" interfacename="in" />
+      <input name="index" type="integer" value="1" />
+    </extract>
+    <output name="outx" type="float" nodename="N_extract_0" />
+    <output name="outy" type="float" nodename="N_extract_1" />
   </nodegraph>
   <nodegraph name="NG_separate3_vector3" nodedef="ND_separate3_vector3">
-    <dot name="N_dot_vector3" type="vector3">
+     <extract name="N_extract_0" type="float">
       <input name="in" type="vector3" interfacename="in" />
-    </dot>
-    <output name="outx" type="float" nodename="N_dot_vector3" channels="x" />
-    <output name="outy" type="float" nodename="N_dot_vector3" channels="y" />
-    <output name="outz" type="float" nodename="N_dot_vector3" channels="z" />
+      <input name="index" type="integer" value="0" />
+    </extract>
+    <extract name="N_extract_1" type="float">
+      <input name="in" type="vector3" interfacename="in" />
+      <input name="index" type="integer" value="1" />
+    </extract>
+    <extract name="N_extract_2" type="float">
+      <input name="in" type="vector3" interfacename="in" />
+      <input name="index" type="integer" value="2" />
+    </extract>
+    <output name="outx" type="float" nodename="N_extract_0" />
+    <output name="outy" type="float" nodename="N_extract_1" />
+    <output name="outz" type="float" nodename="N_extract_2" />
   </nodegraph>
   <nodegraph name="NG_separate4_vector4" nodedef="ND_separate4_vector4">
-    <dot name="N_dot_vector4" type="vector4">
+    <extract name="N_extract_0" type="float">
       <input name="in" type="vector4" interfacename="in" />
-    </dot>
-    <output name="outx" type="float" nodename="N_dot_vector4" channels="x" />
-    <output name="outy" type="float" nodename="N_dot_vector4" channels="y" />
-    <output name="outz" type="float" nodename="N_dot_vector4" channels="z" />
-    <output name="outw" type="float" nodename="N_dot_vector4" channels="w" />
+      <input name="index" type="integer" value="0" />
+    </extract>
+    <extract name="N_extract_1" type="float">
+      <input name="in" type="vector4" interfacename="in" />
+      <input name="index" type="integer" value="1" />
+    </extract>
+    <extract name="N_extract_2" type="float">
+      <input name="in" type="vector4" interfacename="in" />
+      <input name="index" type="integer" value="2" />
+    </extract>
+    <extract name="N_extract_3" type="float">
+      <input name="in" type="vector4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <output name="outx" type="float" nodename="N_extract_0" />
+    <output name="outy" type="float" nodename="N_extract_1" />
+    <output name="outz" type="float" nodename="N_extract_2" />
+    <output name="outw" type="float" nodename="N_extract_3" />
   </nodegraph>
 
   <!-- ======================================================================== -->

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -4461,11 +4461,87 @@ export float4x4 mx_creatematrix_vector4_matrix44(
 		mxp_in4[0], mxp_in4[1], mxp_in4[2], mxp_in4[3]);
 }
 
-// Nodedef: ND_extract_color3 is represented by a nodegraph: NG_extract_color3
-// Nodedef: ND_extract_color4 is represented by a nodegraph: NG_extract_color4
-// Nodedef: ND_extract_vector2 is represented by a nodegraph: NG_extract_vector2
-// Nodedef: ND_extract_vector3 is represented by a nodegraph: NG_extract_vector3
-// Nodedef: ND_extract_vector4 is represented by a nodegraph: NG_extract_vector4
+export float mx_extract_color3(
+	color mxp_in = color(0.0, 0.0, 0.0),
+	float mxp_index = int(0)
+)
+	[[
+		anno::description("Node Group: channel")
+	]]
+{
+	switch (mxp_index)
+	{
+		case 0: return float3(mxp_in).r;
+		case 1: return float3(mxp_in).g;
+		default: return float3(mxp_in).b;
+	}
+}
+
+export float mx_extract_color4(
+	core::mk_color4 mxp_in = core::mk_color4(0.0, 0.0, 0.0, 0.0),
+	float mxp_index = int(0)
+)
+	[[
+		anno::description("Node Group: channel")
+	]]
+{
+	switch (mxp_index)
+	{
+		case 0: return float3(mxp_in.rgb).r;
+		case 1: return float3(mxp_in.rgb).g;
+		case 2: return float3(mxp_in.rgb).b;
+		default: return mxp_in.a;
+	}
+}
+
+export float mx_extract_vector2(
+	float2 mxp_in = float2(0.0, 0.0),
+	float mxp_index = int(0)
+)
+	[[
+		anno::description("Node Group: channel")
+	]]
+{
+	switch (mxp_index)
+	{
+		case 0: return mxp_in.x;
+		default: return mxp_in.y;
+	}
+}
+
+export float mx_extract_vector3(
+	float3 mxp_in = float3(0.0, 0.0, 0.0),
+	float mxp_index = int(0)
+)
+	[[
+		anno::description("Node Group: channel")
+	]]
+{
+	switch (mxp_index)
+	{
+		case 0: return mxp_in.x;
+		case 1: return mxp_in.y;
+		default: return mxp_in.z;
+	}
+}
+
+export float mx_extract_vector4(
+	float4 mxp_in = float4(0.0, 0.0, 0.0, 0.0),
+	float mxp_index = int(0)
+)
+	[[
+		anno::description("Node Group: channel")
+	]]
+{
+	switch (mxp_index)
+	{
+		case 0: return mxp_in.x;
+		case 1: return mxp_in.y;
+		case 2: return mxp_in.z;
+		default: return mxp_in.w;
+	}
+}
+
 // Nodedef: ND_separate2_vector2 is represented by a nodegraph: NG_separate2_vector2
 // Nodedef: ND_separate3_color3 is represented by a nodegraph: NG_separate3_color3
 // Nodedef: ND_separate3_vector3 is represented by a nodegraph: NG_separate3_vector3


### PR DESCRIPTION
This changelist updates the implementations of the extract and separate nodes, removing their dependence on channels attributes.

This is a first step towards converting channels attributes to nodes in the upgrade logic for MaterialX 1.39.