### PR TITLE
Add Python 3.12 to Python wheels generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -383,7 +383,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-minor: ['7', '8', '9', '10', '11']
+        python-minor: ['7', '8', '9', '10', '11', '12']
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
 
     steps:


### PR DESCRIPTION
The highest version of Python for generating wheels in the Github workflow is currently 3.11. However, Python 3.12 is now quite widespread (Ubuntu 24.04, Arch Linux, Windows etc.). On a platform with Python 3.12, `pip install` results in recompilation from source, which is quite tedious.
The proposal is therefore simply to extend the generation of wheels in the Github workflow to Python 3.12, to feed PyPI.

Thank you in advance!