### PR TITLE
Remove unused thin-film logic

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -218,9 +218,6 @@ GlslShaderGenerator::GlslShaderGenerator() :
     };
     registerImplementation(elementNames, ClosureMultiplyNode::create);
 
-    // <!-- <thin_film> -->
-    registerImplementation("IM_thin_film_bsdf_" + GlslShaderGenerator::TARGET, NopNode::create);
-
     // <!-- <surfacematerial> -->
     registerImplementation("IM_surfacematerial_" + GlslShaderGenerator::TARGET, MaterialNode::create);
 

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -222,9 +222,6 @@ MslShaderGenerator::MslShaderGenerator() :
     };
     registerImplementation(elementNames, ClosureMultiplyNode::create);
 
-    // <!-- <thin_film> -->
-    registerImplementation("IM_thin_film_bsdf_" + MslShaderGenerator::TARGET, NopNode::create);
-
     // <!-- <surfacematerial> -->
     registerImplementation("IM_surfacematerial_" + MslShaderGenerator::TARGET, MaterialNode::create);
 

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -112,9 +112,6 @@ OslShaderGenerator::OslShaderGenerator() :
 
 #endif // MATERIALX_OSL_LEGACY_CLOSURES
 
-    // <!-- <thin_film> -->
-    registerImplementation("IM_thin_film_bsdf_" + OslShaderGenerator::TARGET, NopNode::create);
-
     // <!-- <surface> -->
     registerImplementation("IM_surface_" + OslShaderGenerator::TARGET, SurfaceNodeOsl::create);
 

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -276,11 +276,6 @@ ShaderNodePtr ShaderNode::create(const ShaderGraph* parent, const string& name, 
         {
             newNode->_classification |= Classification::LAYER;
         }
-        // Check specifically for the thin-film node
-        else if (nodeDefName == "ND_thin_film_bsdf")
-        {
-            newNode->_classification |= Classification::THINFILM;
-        }
     }
     else if (primaryOutput->getType() == Type::EDF)
     {

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -341,17 +341,16 @@ class MX_GENSHADER_API ShaderNode
         static const uint32_t EDF           = 1 << 10; /// A EDF node
         static const uint32_t VDF           = 1 << 11; /// A VDF node
         static const uint32_t LAYER         = 1 << 12; /// A node for vertical layering of other closure nodes
-        static const uint32_t THINFILM      = 1 << 13; /// A node for adding thin-film over microfacet BSDF nodes
         // Specific shader types
-        static const uint32_t SURFACE       = 1 << 14; /// A surface shader node
-        static const uint32_t VOLUME        = 1 << 15; /// A volume shader node
-        static const uint32_t LIGHT         = 1 << 16; /// A light shader node
-        static const uint32_t UNLIT         = 1 << 17; /// An unlit surface shader node
+        static const uint32_t SURFACE       = 1 << 13; /// A surface shader node
+        static const uint32_t VOLUME        = 1 << 14; /// A volume shader node
+        static const uint32_t LIGHT         = 1 << 15; /// A light shader node
+        static const uint32_t UNLIT         = 1 << 16; /// An unlit surface shader node
         // Types based on nodegroup
-        static const uint32_t SAMPLE2D      = 1 << 18; /// Can be sampled in 2D (uv space)
-        static const uint32_t SAMPLE3D      = 1 << 19; /// Can be sampled in 3D (position)
-        static const uint32_t GEOMETRIC     = 1 << 20; /// Geometric input
-        static const uint32_t DOT           = 1 << 21; /// A dot node
+        static const uint32_t SAMPLE2D      = 1 << 17; /// Can be sampled in 2D (uv space)
+        static const uint32_t SAMPLE3D      = 1 << 18; /// Can be sampled in 3D (position)
+        static const uint32_t GEOMETRIC     = 1 << 19; /// Geometric input
+        static const uint32_t DOT           = 1 << 20; /// A dot node
     };
 
     static const ShaderNodePtr NONE;


### PR DESCRIPTION
This changelist removes unused thin-film logic for MaterialX 1.39, where the original thin_film_bsdf node has been replaced with thin-film inputs on reflective BSDF nodes.