### PR TITLE
Update Linux builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
         - name: Linux_GCC_12_Python311
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           compiler: gcc
           compiler_version: "12"
           python: 3.11
           build_javascript: ON
 
         - name: Linux_GCC_13_Python312
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           compiler: gcc
           compiler_version: "13"
           python: 3.12
@@ -41,7 +41,7 @@ jobs:
           cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
         - name: Linux_GCC_CoverageAnalysis
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           compiler: gcc
           compiler_version: "None"
           python: None
@@ -56,7 +56,7 @@ jobs:
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
         - name: Linux_Clang_15_Python312
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           compiler: clang
           compiler_version: "15"
           python: 3.12


### PR DESCRIPTION
This changelist updates Linux builds from Ubuntu 22.04 to 24.04 in GitHub Actions, providing access to a wider set of recent GCC versions.