### PR TITLE
Update to Clang 18 in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,10 +55,10 @@ jobs:
           python: 3.7
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_Clang_15_Python312
+        - name: Linux_Clang_18_Python312
           os: ubuntu-24.04
           compiler: clang
-          compiler_version: "15"
+          compiler_version: "18"
           python: 3.12
           test_render: ON
           clang_format: ON


### PR DESCRIPTION
This changelist updates the highest Clang target to Clang 18 in GitHub Actions, leveraging the support for more recent compiler versions in Ubuntu 24.04.