### PR TITLE
Fix handling of image default values in MDL

### DIFF
--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -155,6 +155,8 @@ export float mx_image_float(
 	if ( mxp_vaddressmode == core::mx_addressmode_type_constant
 	     && ( mxp_texcoord.y < 0.0 || mxp_texcoord.y > 1.0))
 		return mxp_default;
+	if (::tex::texture_isvalid(mxp_file) == false)
+		return mxp_default;
 
 	float returnValue = ::tex::lookup_float(tex: mxp_file, 
 						coord: mxp_flip_v
@@ -229,6 +231,8 @@ export color mx_image_color3(
 		return mxp_default;
 	if ( mxp_vaddressmode == core::mx_addressmode_type_constant
 	     && ( mxp_texcoord.y < 0.0 || mxp_texcoord.y > 1.0))
+		return mxp_default;
+	if (::tex::texture_isvalid(mxp_file) == false)
 		return mxp_default;
 
 	color returnValue = ::tex::lookup_color(tex: mxp_file, 
@@ -305,6 +309,8 @@ export core::color4 mx_image_color4(
 	if ( mxp_vaddressmode == core::mx_addressmode_type_constant
 	     && ( mxp_texcoord.y < 0.0 || mxp_texcoord.y > 1.0))
 		return mxp_default;
+	if (::tex::texture_isvalid(mxp_file) == false)
+		return mxp_default;
 
 	core::color4 returnValue = core::mk_color4(::tex::lookup_float4(tex: mxp_file, 
 						coord: mxp_flip_v
@@ -379,6 +385,8 @@ export float2 mx_image_vector2(
 		return mxp_default;
 	if ( mxp_vaddressmode == core::mx_addressmode_type_constant
 	     && ( mxp_texcoord.y < 0.0 || mxp_texcoord.y > 1.0))
+		return mxp_default;
+	if (::tex::texture_isvalid(mxp_file) == false)
 		return mxp_default;
 
 	float2 returnValue = ::tex::lookup_float2(tex: mxp_file, 
@@ -455,6 +463,8 @@ export float3 mx_image_vector3(
 	if ( mxp_vaddressmode == core::mx_addressmode_type_constant
 	     && ( mxp_texcoord.y < 0.0 || mxp_texcoord.y > 1.0))
 		return mxp_default;
+	if (::tex::texture_isvalid(mxp_file) == false)
+		return mxp_default;
 
 	float3 returnValue = ::tex::lookup_float3(tex: mxp_file, 
 						coord: mxp_flip_v
@@ -529,6 +539,8 @@ export float4 mx_image_vector4(
 		return mxp_default;
 	if ( mxp_vaddressmode == core::mx_addressmode_type_constant
 	     && ( mxp_texcoord.y < 0.0 || mxp_texcoord.y > 1.0))
+		return mxp_default;
+	if (::tex::texture_isvalid(mxp_file) == false)
 		return mxp_default;
 
 	float4 returnValue = ::tex::lookup_float4(tex: mxp_file, 


### PR DESCRIPTION
Fixed an issue where the `<image>` node did not return the correct value in MDL back-end when the file path was invalid.
