### PR TITLE
Initial support for EON diffuse

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -200,6 +200,7 @@
       <input name="weight" type="float" interfacename="base_weight" />
       <input name="color" type="color3" nodename="base_color_nonnegative" />
       <input name="roughness" type="float" interfacename="base_diffuse_roughness" />
+      <input name="energy_compensation" type="boolean" value="true" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
     </oren_nayar_diffuse_bsdf>
     <convert name="subsurface_selector" type="float">

--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -200,8 +200,8 @@
       <input name="weight" type="float" interfacename="base_weight" />
       <input name="color" type="color3" nodename="base_color_nonnegative" />
       <input name="roughness" type="float" interfacename="base_diffuse_roughness" />
-      <input name="energy_compensation" type="boolean" value="true" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <convert name="subsurface_selector" type="float">
       <input name="in" type="boolean" interfacename="geometry_thin_walled" />

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -128,7 +128,6 @@ vec3 mx_oren_nayar_compensated_diffuse(float NdotV, float NdotL, float LdotV, fl
 
 vec3 mx_oren_nayar_compensated_diffuse_dir_albedo(float cosTheta, float roughness, vec3 color)
 {
-    float A = 1.0 / (1.0 + FUJII_CONSTANT_1 * roughness);
     float dirAlbedoFujii = mx_oren_nayar_fujii_diffuse_dir_albedo(cosTheta, roughness);
     float avgAlbedoFujii = mx_oren_nayar_fujii_diffuse_avg_albedo(roughness);
     vec3 colorMultiScatter = mx_square(color) * avgAlbedoFujii /

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -8,7 +8,7 @@ const float FUJII_CONSTANT_2 = 2.0 / 3.0 - 28.0 / (15.0 * M_PI);
 float mx_oren_nayar_diffuse(float NdotV, float NdotL, float LdotV, float roughness)
 {
     float s = LdotV - NdotL * NdotV;
-    float stinv = (s > 0.0f) ? s / max(NdotL, NdotV) : 0.0;
+    float stinv = (s > 0.0) ? s / max(NdotL, NdotV) : 0.0;
 
     float sigma2 = mx_square(roughness);
     float A = 1.0 - 0.5 * (sigma2 / (sigma2 + 0.33));
@@ -41,7 +41,7 @@ float mx_oren_nayar_diffuse_dir_albedo_table_lookup(float NdotV, float roughness
 float mx_oren_nayar_diffuse_dir_albedo_monte_carlo(float NdotV, float roughness)
 {
     NdotV = clamp(NdotV, M_FLOAT_EPS, 1.0);
-    vec3 V = vec3(sqrt(1.0f - mx_square(NdotV)), 0, NdotV);
+    vec3 V = vec3(sqrt(1.0 - mx_square(NdotV)), 0, NdotV);
 
     float radiance = 0.0;
     const int SAMPLE_COUNT = 64;

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -128,11 +128,11 @@ vec3 mx_oren_nayar_compensated_diffuse(float NdotV, float NdotL, float LdotV, fl
 
 vec3 mx_oren_nayar_compensated_diffuse_dir_albedo(float cosTheta, float roughness, vec3 color)
 {
-    float dirAlbedoFujii = mx_oren_nayar_fujii_diffuse_dir_albedo(cosTheta, roughness);
-    float avgAlbedoFujii = mx_oren_nayar_fujii_diffuse_avg_albedo(roughness);
-    vec3 colorMultiScatter = mx_square(color) * avgAlbedoFujii /
-                             (vec3(1.0) - color * max(0.0, 1.0 - avgAlbedoFujii));
-    return mix(colorMultiScatter, color, dirAlbedoFujii);
+    float dirAlbedo = mx_oren_nayar_fujii_diffuse_dir_albedo(cosTheta, roughness);
+    float avgAlbedo = mx_oren_nayar_fujii_diffuse_avg_albedo(roughness);
+    vec3 colorMultiScatter = mx_square(color) * avgAlbedo /
+                             (vec3(1.0) - color * max(0.0, 1.0 - avgAlbedo));
+    return mix(colorMultiScatter, color, dirAlbedo);
 }
   
 // https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -99,7 +99,7 @@ float mx_oren_nayar_fujii_diffuse_avg_albedo(float roughness)
 }   
 
 // Energy-compensated Oren-Nayar diffuse, as defined in the OpenPBR project.
-vec3 mx_energy_compensated_oren_nayar_diffuse(float NdotV, float NdotL, float LdotV, float roughness, vec3 color)
+vec3 mx_oren_nayar_energy_compensated_diffuse(float NdotV, float NdotL, float LdotV, float roughness, vec3 color)
 {
     float s = LdotV - NdotL * NdotV;
     float stinv = s > 0.0 ? s / max(NdotL, NdotV) : s;

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -102,7 +102,7 @@ float mx_oren_nayar_fujii_diffuse_avg_albedo(float roughness)
 vec3 mx_oren_nayar_energy_compensated_diffuse(float NdotV, float NdotL, float LdotV, float roughness, vec3 color)
 {
     float s = LdotV - NdotL * NdotV;
-    float stinv = s > 0.0 ? s / max(NdotL, NdotV) : s;
+    float stinv = (s > 0.0) ? s / max(NdotL, NdotV) : s;
 
     // Compute the single-scatter lobe.
     float A = 1.0 / (1.0 + FUJII_CONSTANT_1 * roughness);

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -89,7 +89,7 @@ float mx_oren_nayar_fujii_diffuse_dir_albedo(float cosTheta, float roughness)
     float Si = sqrt(max(0.0, 1.0 - mx_square(cosTheta)));
     float G = Si * (acos(clamp(cosTheta, -1.0, 1.0)) - Si * cosTheta) +
               2.0 * ((Si / cosTheta) * (1.0 - Si * Si * Si) - Si) / 3.0;
-    return A + (B * float(M_PI_INV)) * G;
+    return A + (B * M_PI_INV) * G;
 }
 
 float mx_oren_nayar_fujii_diffuse_avg_albedo(float roughness)

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -3,8 +3,8 @@
 const float FUJII_CONSTANT_1 = 0.5 - 2.0 / (3.0 * M_PI);
 const float FUJII_CONSTANT_2 = 2.0 / 3.0 - 28.0 / (15.0 * M_PI);
 
-// Qualitative Oren-Nayar diffuse with minor improvements from Fujii:
-// https://mimosa-pudica.net/improved-oren-nayar.html
+// Qualitative Oren-Nayar diffuse with simplified math:
+// https://www1.cs.columbia.edu/CAVE/publications/pdfs/Oren_SIGGRAPH94.pdf
 float mx_oren_nayar_diffuse(float NdotV, float NdotL, float LdotV, float roughness)
 {
     float s = LdotV - NdotL * NdotV;
@@ -82,7 +82,7 @@ float mx_oren_nayar_diffuse_dir_albedo(float NdotV, float roughness)
     return clamp(dirAlbedo, 0.0, 1.0);
 }
 
-// Proposed upgrade to Oren-Nayar diffuse from Fujii:
+// Improved Oren-Nayar diffuse from Fujii:
 // https://mimosa-pudica.net/improved-oren-nayar.html
 float mx_oren_nayar_fujii_diffuse_dir_albedo(float cosTheta, float roughness)
 {
@@ -100,7 +100,8 @@ float mx_oren_nayar_fujii_diffuse_avg_albedo(float roughness)
     return A * (1.0 + FUJII_CONSTANT_2 * roughness);
 }   
 
-// Energy-compensated Oren-Nayar diffuse, as defined in the OpenPBR project.
+// Energy-compensated Oren-Nayar diffuse from OpenPBR Surface:
+// https://academysoftwarefoundation.github.io/OpenPBR/
 vec3 mx_oren_nayar_energy_compensated_diffuse(float NdotV, float NdotL, float LdotV, float roughness, vec3 color)
 {
     float s = LdotV - NdotL * NdotV;
@@ -121,7 +122,7 @@ vec3 mx_oren_nayar_energy_compensated_diffuse(float NdotV, float NdotL, float Ld
                             max(M_FLOAT_EPS, 1.0 - dirAlbedoL) /
                             max(M_FLOAT_EPS, 1.0 - avgAlbedo);
 
-    // Return the sum of lobes.
+    // Return the sum.
     return lobeSingleScatter + lobeMultiScatter;
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -1,6 +1,9 @@
 #include "mx_microfacet.glsl"
 
-// Qualitative Oren-Nayar diffuse with improvements from Fujii:
+const float FUJII_CONSTANT_1 = 0.5 - 2.0 / (3.0 * M_PI);
+const float FUJII_CONSTANT_2 = 2.0 / 3.0 - 28.0 / (15.0 * M_PI);
+
+// Qualitative Oren-Nayar diffuse with minor improvements from Fujii:
 // https://mimosa-pudica.net/improved-oren-nayar.html
 float mx_oren_nayar_diffuse(float NdotV, float NdotL, float LdotV, float roughness)
 {
@@ -79,9 +82,8 @@ float mx_oren_nayar_diffuse_dir_albedo(float NdotV, float roughness)
     return clamp(dirAlbedo, 0.0, 1.0);
 }
 
-const float FUJII_CONSTANT_1 = 0.5 - 2.0 / (3.0 * M_PI);
-const float FUJII_CONSTANT_2 = 2.0 / 3.0 - 28.0 / (15.0 * M_PI);
-
+// Proposed upgrade to Oren-Nayar diffuse from Fujii:
+// https://mimosa-pudica.net/improved-oren-nayar.html
 float mx_oren_nayar_fujii_diffuse_dir_albedo(float cosTheta, float roughness)
 {
     float A = 1.0 / (1.0 + FUJII_CONSTANT_1 * roughness);

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -123,7 +123,6 @@ vec3 mx_energy_compensated_oren_nayar_diffuse(float NdotV, float NdotL, float Ld
     return lobeSingleScatter + lobeMultiScatter;
 }
 
-
 // https://media.disneyanimation.com/uploads/production/publication_asset/48/asset/s2012_pbs_disney_brdf_notes_v3.pdf
 // Section 5.3
 float mx_burley_diffuse(float NdotV, float NdotL, float LdotH, float roughness)

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -91,7 +91,7 @@ float mx_oren_nayar_fujii_diffuse_dir_albedo(float cosTheta, float roughness)
     float Si = sqrt(max(0.0, 1.0 - mx_square(cosTheta)));
     float G = Si * (acos(clamp(cosTheta, -1.0, 1.0)) - Si * cosTheta) +
               2.0 * ((Si / cosTheta) * (1.0 - Si * Si * Si) - Si) / 3.0;
-    return A + (B * M_PI_INV) * G;
+    return A + (B * G * M_PI_INV);
 }
 
 float mx_oren_nayar_fujii_diffuse_avg_albedo(float roughness)

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -15,16 +15,9 @@ void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusi
     float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
     float LdotV = clamp(dot(L, V), M_FLOAT_EPS, 1.0);
 
-    vec3 diffuse;
-    if (energy_compensation)
-    {
-        diffuse = mx_oren_nayar_energy_compensated_diffuse(NdotV, NdotL, LdotV, roughness, color);
-    }
-    else
-    {
-        diffuse = mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) * color;
-    }
-
+    vec3 diffuse = energy_compensation ?
+                   mx_oren_nayar_compensated_diffuse(NdotV, NdotL, LdotV, roughness, color) :
+                   mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) * color;
     bsdf.response = diffuse * occlusion * weight * NdotL * M_PI_INV;
 }
 
@@ -41,17 +34,9 @@ void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float
 
     float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
 
-    float dirAlbedo;
-    if (energy_compensation)
-    {
-        dirAlbedo = mx_oren_nayar_fujii_diffuse_dir_albedo(NdotV, roughness) /
-                    mx_oren_nayar_fujii_diffuse_avg_albedo(roughness);
-    }
-    else
-    {
-        dirAlbedo = mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness);
-    }
-
+    vec3 diffuse = energy_compensation ?
+                   mx_oren_nayar_compensated_diffuse_dir_albedo(NdotV, roughness, color) :
+                   mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness) * color;
     vec3 Li = mx_environment_irradiance(normal);
-    bsdf.response = Li * dirAlbedo * color * weight;
+    bsdf.response = Li * diffuse * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -1,6 +1,6 @@
 #include "lib/mx_microfacet_diffuse.glsl"
 
-void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, bool energy_compensation, vec3 normal, inout BSDF bsdf)
 {
     bsdf.throughput = vec3(0.0);
 
@@ -15,14 +15,15 @@ void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusi
     float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
     float LdotV = clamp(dot(L, V), M_FLOAT_EPS, 1.0);
 
-    bsdf.response = color * occlusion * weight * NdotL * M_PI_INV;
-    if (roughness > 0.0)
-    {
-        bsdf.response *= mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness);
-    }
+    vec3 compColor = energy_compensation ?
+                     mx_oren_nayar_diffuse_energy_compensation(NdotV, NdotL, roughness, color) :
+                     vec3(0.0);
+
+    bsdf.response = color * mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) + compColor;
+    bsdf.response *= occlusion * weight * NdotL * M_PI_INV;
 }
 
-void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, bool energy_compensation, vec3 normal, inout BSDF bsdf)
 {
     bsdf.throughput = vec3(0.0);
 
@@ -35,7 +36,11 @@ void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float
 
     float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
 
-    vec3 Li = mx_environment_irradiance(normal) *
-              mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness);
-    bsdf.response = Li * color * weight;
+    vec3 compColor = energy_compensation ?
+                     mx_oren_nayar_diffuse_energy_compensation(NdotV, 1.0, roughness, color) :
+                     vec3(0.0);
+
+    vec3 Li = mx_environment_irradiance(normal);
+    bsdf.response = color * mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness) + compColor;
+    bsdf.response *= Li * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -1,6 +1,6 @@
 #include "lib/mx_microfacet_diffuse.glsl"
 
-void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, bool energy_compensation, vec3 normal, inout BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)
 {
     bsdf.throughput = vec3(0.0);
 
@@ -23,7 +23,7 @@ void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusi
     bsdf.response *= occlusion * weight * NdotL * M_PI_INV;
 }
 
-void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, bool energy_compensation, vec3 normal, inout BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)
 {
     bsdf.throughput = vec3(0.0);
 

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -15,12 +15,17 @@ void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusi
     float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
     float LdotV = clamp(dot(L, V), M_FLOAT_EPS, 1.0);
 
-    vec3 compColor = energy_compensation ?
-                     mx_oren_nayar_diffuse_energy_compensation(NdotV, NdotL, roughness, color) :
-                     vec3(0.0);
+    vec3 diffuse;
+    if (energy_compensation)
+    {
+        diffuse = mx_energy_compensated_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness, color);
+    }
+    else
+    {
+        diffuse = mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) * color;
+    }
 
-    bsdf.response = color * mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) + compColor;
-    bsdf.response *= occlusion * weight * NdotL * M_PI_INV;
+    bsdf.response = diffuse * occlusion * weight * NdotL * M_PI_INV;
 }
 
 void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)
@@ -36,11 +41,17 @@ void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float
 
     float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
 
-    vec3 compColor = energy_compensation ?
-                     mx_oren_nayar_diffuse_energy_compensation(NdotV, 1.0, roughness, color) :
-                     vec3(0.0);
+    float dirAlbedo;
+    if (energy_compensation)
+    {
+        dirAlbedo = mx_oren_nayar_fujii_diffuse_dir_albedo(NdotV, roughness) /
+                    mx_oren_nayar_fujii_diffuse_avg_albedo(roughness);
+    }
+    else
+    {
+        dirAlbedo = mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness);
+    }
 
     vec3 Li = mx_environment_irradiance(normal);
-    bsdf.response = color * mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness) + compColor;
-    bsdf.response *= Li * weight;
+    bsdf.response = Li * dirAlbedo * color * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -18,7 +18,7 @@ void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusi
     vec3 diffuse;
     if (energy_compensation)
     {
-        diffuse = mx_energy_compensated_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness, color);
+        diffuse = mx_oren_nayar_energy_compensated_diffuse(NdotV, NdotL, LdotV, roughness, color);
     }
     else
     {

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -27,8 +27,8 @@
     <input name="weight" type="float" value="1.0" uimin="0.0" uimax="1.0" />
     <input name="color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="roughness" type="float" value="0.0" />
-    <input name="energy_compensation" type="boolean" value="false" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
+    <input name="energy_compensation" type="boolean" value="false" uniform="true" />
     <output name="out" type="BSDF" />
   </nodedef>
 

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -27,6 +27,7 @@
     <input name="weight" type="float" value="1.0" uimin="0.0" uimax="1.0" />
     <input name="color" type="color3" value="0.18, 0.18, 0.18" />
     <input name="roughness" type="float" value="0.0" />
+    <input name="energy_compensation" type="boolean" value="false" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
     <output name="out" type="BSDF" />
   </nodedef>

--- a/resources/Materials/TestSuite/pbrlib/bsdf/oren_nayar_diffuse.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/oren_nayar_diffuse.mtlx
@@ -5,6 +5,7 @@
     <oren_nayar_diffuse_bsdf name="diffuse1" type="BSDF">
       <input name="color" type="color3" value="0.6, 0.6, 0.6" />
       <input name="roughness" type="float" value="0.0" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="diffuse1" />
@@ -14,6 +15,7 @@
     <oren_nayar_diffuse_bsdf name="diffuse2" type="BSDF">
       <input name="color" type="color3" value="0.6, 0.6, 0.6" />
       <input name="roughness" type="float" value="0.25" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <surface name="surface2" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="diffuse2" />
@@ -23,6 +25,7 @@
     <oren_nayar_diffuse_bsdf name="diffuse3" type="BSDF">
       <input name="color" type="color3" value="0.6, 0.6, 0.6" />
       <input name="roughness" type="float" value="0.5" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <surface name="surface3" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="diffuse3" />
@@ -32,6 +35,7 @@
     <oren_nayar_diffuse_bsdf name="diffuse4" type="BSDF">
       <input name="color" type="color3" value="0.6, 0.6, 0.6" />
       <input name="roughness" type="float" value="0.75" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <surface name="surface4" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="diffuse4" />
@@ -41,6 +45,7 @@
     <oren_nayar_diffuse_bsdf name="diffuse5" type="BSDF">
       <input name="color" type="color3" value="0.6, 0.6, 0.6" />
       <input name="roughness" type="float" value="1.0" />
+      <input name="energy_compensation" type="boolean" value="true" />
     </oren_nayar_diffuse_bsdf>
     <surface name="surface5" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="diffuse5" />


### PR DESCRIPTION
This changelist adds initial support for the EON diffuse model in MaterialX, enabled through the use of an `energy_compensation` option on the `oren_nayar_diffuse_bsdf` node.

For now, MaterialX shader generation only supports the new option in GLSL, ESSL, and MSL, with other shading languages to be added once this initial implementation has been vetted by the community.

See the OpenPBR whitepaper at openpbr.org for full details on the EON diffuse model, including its formal definition and goals.