### PR TITLE
Add missing inversesqrt support to MSL

### DIFF
--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -97,6 +97,9 @@ T atan(T y_over_x) { return ::atan(y_over_x); }
 template <typename T>
 T atan(T y, T x) { return ::atan2(y, x); }
 
+template <typename T>
+T inversesqrt(T x) { return ::rsqrt(x); }
+
 #define lessThan(a, b) ((a) < (b))
 #define lessThanEqual(a, b) ((a) <= (b))
 #define greaterThan(a, b) ((a) > (b))


### PR DESCRIPTION
While developing the GLSL implementation of a new sheen model for MaterialX, I noticed that `inversesqrt()` was not supported when running MaterialXView on macOS. This trivial change addresses that.