### PR TITLE
Fix MSL syntax bug

### DIFF
--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -281,7 +281,7 @@ MslSyntax::MslSyntax()
         Type::VDF,
         std::make_shared<AggregateTypeSyntax>(
             "BSDF",
-            "BSDF{float3(0.0),float3(1.0), 0.0, 0.0}",
+            "BSDF{float3(0.0),float3(1.0)}",
             EMPTY_STRING));
 
     registerTypeSyntax(


### PR DESCRIPTION
After [commit 2007ebf](https://github.com/AcademySoftwareFoundation/MaterialX/commit/2007ebf3ff887e098c8b3240036da3d438c3ec17) was merged to `dev_1.39` branch the unit tests for MSL rendering started failing.

This patch rectifies the syntax error created.