### PR TITLE
Use MTLDataType in MaterialXRenderMsl

### DIFF
--- a/source/MaterialXRenderMsl/MslPipelineStateObject.h
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.h
@@ -87,12 +87,12 @@ class MX_RENDERMSL_API MslProgram
     /// optimized out if they are unused.
     struct MX_RENDERMSL_API Input
     {
-        static int INVALID_METAL_TYPE;
+        static MTLDataType INVALID_METAL_TYPE;
 
         /// Program location. -1 means an invalid location
         int location;
-        /// Metal type of the input. -1 means an invalid type
-        int resourceType;
+        /// Metal type of the input.
+        MTLDataType resourceType;
         /// Size.
         int size;
         /// Input type string. Will only be non-empty if initialized stages with a HwShader
@@ -110,7 +110,7 @@ class MX_RENDERMSL_API MslProgram
         string colorspace;
 
         /// Program input constructor
-        Input(int inputLocation, int inputType, int inputSize, const string& inputPath) :
+        Input(int inputLocation, MTLDataType inputType, int inputSize, const string& inputPath) :
             location(inputLocation),
             resourceType(inputType),
             size(inputSize),

--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -30,7 +30,7 @@ const float PI = std::acos(-1.0f);
 // Metal Constants
 unsigned int MslProgram::UNDEFINED_METAL_RESOURCE_ID = 0;
 int MslProgram::UNDEFINED_METAL_PROGRAM_LOCATION = -1;
-int MslProgram::Input::INVALID_METAL_TYPE = -1;
+MTLDataType MslProgram::Input::INVALID_METAL_TYPE = MTLDataTypeNone;
 
 //
 // MslProgram methods
@@ -957,7 +957,7 @@ const MslProgram::InputMap& MslProgram::updateUniformsList()
             if(HW::ENV_RADIANCE != arg.name.UTF8String && HW::ENV_IRRADIANCE != arg.name.UTF8String)
             {
                 std::string texture_name = arg.name.UTF8String;
-                InputPtr inputPtr = std::make_shared<Input>(arg.index, 58, -1, EMPTY_STRING);
+                InputPtr inputPtr = std::make_shared<Input>(arg.index, MTLDataTypeTexture, -1, EMPTY_STRING);
                 _uniformList[texture_name] = inputPtr;
             }
         }
@@ -983,8 +983,8 @@ const MslProgram::InputMap& MslProgram::updateUniformsList()
                 continue;
             }
 
-            // TODO: Shoud we really create new ones here each update?
-            InputPtr inputPtr = std::make_shared<Input>(-1, -1, int(v->getType().getSize()), EMPTY_STRING);
+            // TODO: Should we really create new ones here each update?
+            InputPtr inputPtr = std::make_shared<Input>(-1, MTLDataTypeNone, int(v->getType().getSize()), EMPTY_STRING);
             _uniformList[v->getVariable()] = inputPtr;
             inputPtr->isConstant = true;
             inputPtr->value = v->getValue();

--- a/source/PyMaterialX/PyMaterialXRenderMsl/PyMslProgram.mm
+++ b/source/PyMaterialX/PyMaterialXRenderMsl/PyMslProgram.mm
@@ -43,5 +43,11 @@ void bindPyMslProgram(py::module& mod)
         .def_readwrite("value", &mx::MslProgram::Input::value)
         .def_readwrite("isConstant", &mx::MslProgram::Input::isConstant)
         .def_readwrite("path", &mx::MslProgram::Input::path)
-        .def(py::init<int, int, int, std::string>());
+        .def(py::init([](int inputLocation,
+                         int inputType,
+                         int inputSize,
+                         const std::string& inputPath)
+            {
+                return mx::MslProgram::Input(inputLocation, static_cast<MTLDataType>(inputType), inputSize, inputPath);
+            }));
 }


### PR DESCRIPTION
While poking around inside `MaterialXRenderMSL` I found myself poking around in headers to look up what magical numbers like `58` meant.  Metal has an enum we can use instead to make the code a little easier to read.