### PR TITLE
Fix edge case in thin-film upgrade

### DIFF
--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1102,8 +1102,12 @@ void Document::upgradeVersion()
                         NodePtr upstream = edge.getUpstreamElement()->asA<Node>();
                         if (upstream && BSDF_WITH_THINFILM.count(upstream->getCategory()))
                         {
-                            copyInputWithBindings(top, "thickness", upstream, "thinfilm_thickness");
-                            copyInputWithBindings(top, "ior", upstream, "thinfilm_ior");
+                            InputPtr scatterMode = upstream->getInput("scatter_mode");
+                            if (!scatterMode || scatterMode->getValueString() != "T")
+                            {
+                                copyInputWithBindings(top, "thickness", upstream, "thinfilm_thickness");
+                                copyInputWithBindings(top, "ior", upstream, "thinfilm_ior");
+                            }
                         }
                     }
 


### PR DESCRIPTION
This changelist addresses an edge case in the upgrade logic for thin-film nodes, where purely transmissive upstream nodes would be incorrectly marked with thin-film properties.