### PR TITLE
Restore ubuntu-24.04 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,10 @@ jobs:
           python: 3.11
           build_javascript: ON
 
-        - name: Linux_GCC_12_Python312
-          os: ubuntu-22.04
+        - name: Linux_GCC_13_Python312
+          os: ubuntu-24.04
           compiler: gcc
-          compiler_version: "12"
+          compiler_version: "13"
           python: 3.12
           static_analysis: ON
           cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
@@ -55,10 +55,10 @@ jobs:
           python: 3.7
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_Clang_15_Python312
-          os: ubuntu-22.04
+        - name: Linux_Clang_18_Python312
+          os: ubuntu-24.04
           compiler: clang
-          compiler_version: "15"
+          compiler_version: "18"
           python: 3.12
           test_render: ON
           clang_format: ON


### PR DESCRIPTION
This changelist restores two ubuntu-24.04 builds to our GitHub Actions CI, as the stability of these runners appears to have recently improved.