### PR TITLE
Update gltf_pbr to 1.39

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <nodedef name="ND_gltf_pbr_surfaceshader" node="gltf_pbr" nodegroup="pbr" doc="glTF PBR" version="2.0.1" isdefaultversion="true">
     <input name="base_color" type="color3" value="1, 1, 1" uimin="0, 0, 0" uimax="1, 1, 1" uiname="Base Color" uifolder="Base" />
     <input name="metallic" type="float" value="1" uimin="0" uimax="1" uiname="Metallic" uifolder="Base" />
@@ -148,16 +148,6 @@
     <!-- Thin-film + Dielectric
          Note: Due to limitations in codegen, the base layer BSDF is duplicated (#1035). -->
 
-    <dielectric_bsdf name="tf_transmission_bsdf" type="BSDF">
-      <input name="weight" type="float" value="1" />
-      <input name="tint" type="color3" interfacename="base_color" />
-      <input name="ior" type="float" interfacename="ior" />
-      <input name="roughness" type="vector2" nodename="roughness_uv" />
-      <input name="normal" type="vector3" interfacename="normal" />
-      <input name="tangent" type="vector3" interfacename="tangent" />
-      <input name="scatter_mode" type="string" value="T" />
-    </dielectric_bsdf>
-
     <generalized_schlick_bsdf name="tf_reflection_bsdf" type="BSDF">
       <input name="color0" type="color3" nodename="dielectric_f0" />
       <input name="color90" type="color3" nodename="dielectric_f90" />
@@ -165,32 +155,19 @@
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" interfacename="tangent" />
       <input name="scatter_mode" type="string" value="R" />
+      <input name="thinfilm_thickness" type="float" interfacename="iridescence_thickness" />
+      <input name="thinfilm_ior" type="float" interfacename="iridescence_ior" />
     </generalized_schlick_bsdf>
 
-    <mix name="tf_transmission_mix" type="BSDF">
-      <input name="bg" type="BSDF" nodename="diffuse_bsdf" />
-      <input name="fg" type="BSDF" nodename="tf_transmission_bsdf" />
-      <input name="mix" type="float" interfacename="transmission" />
-    </mix>
 
     <layer name="tf_dielectric_bsdf" type="BSDF">
       <input name="top" type="BSDF" nodename="tf_reflection_bsdf" />
-      <input name="base" type="BSDF" nodename="tf_transmission_mix" />
-    </layer>
-
-    <thin_film_bsdf name="dielectric_thinfilm_bsdf" type="BSDF">
-      <input name="thickness" type="float" interfacename="iridescence_thickness" />
-      <input name="ior" type="float" interfacename="iridescence_ior" />
-    </thin_film_bsdf>
-
-    <layer name="iridescent_dielectric_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="dielectric_thinfilm_bsdf" />
-      <input name="base" type="BSDF" nodename="tf_dielectric_bsdf" />
+      <input name="base" type="BSDF" nodename="transmission_mix" />
     </layer>
 
     <mix name="mix_iridescent_dielectric_bsdf" type="BSDF">
       <input name="bg" type="BSDF" nodename="dielectric_bsdf" />
-      <input name="fg" type="BSDF" nodename="iridescent_dielectric_bsdf" />
+      <input name="fg" type="BSDF" nodename="tf_dielectric_bsdf" />
       <input name="mix" type="float" interfacename="iridescence" />
     </mix>
 
@@ -213,21 +190,13 @@
       <input name="roughness" type="vector2" nodename="roughness_uv" />
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" interfacename="tangent" />
+      <input name="thinfilm_thickness" type="float" interfacename="iridescence_thickness" />
+      <input name="thinfilm_ior" type="float" interfacename="iridescence_ior" />
     </generalized_schlick_bsdf>
-
-    <thin_film_bsdf name="metal_thinfilm_bsdf" type="BSDF">
-      <input name="thickness" type="float" interfacename="iridescence_thickness" />
-      <input name="ior" type="float" interfacename="iridescence_ior" />
-    </thin_film_bsdf>
-
-    <layer name="iridescent_metal_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="metal_thinfilm_bsdf" />
-      <input name="base" type="BSDF" nodename="tf_metal_bsdf" />
-    </layer>
 
     <mix name="mix_iridescent_metal_bsdf" type="BSDF">
       <input name="bg" type="BSDF" nodename="metal_bsdf" />
-      <input name="fg" type="BSDF" nodename="iridescent_metal_bsdf" />
+      <input name="fg" type="BSDF" nodename="tf_metal_bsdf" />
       <input name="mix" type="float" interfacename="iridescence" />
     </mix>
 


### PR DESCRIPTION
This changelist updates the gltf_pbr shading model to 1.39, making additional simplifications for clarity and performance.