### PR TITLE
Update Lama nodes to 1.39

### DIFF
--- a/libraries/bxdf/lama/lama_add.mtlx
+++ b/libraries/bxdf/lama/lama_add.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
 
   <!-- LamaAdd for BSDFs -->
   <nodedef name="ND_lama_add_bsdf" node="LamaAdd" nodegroup="pbr" version="1.0" isdefaultversion="true">

--- a/libraries/bxdf/lama/lama_conductor.mtlx
+++ b/libraries/bxdf/lama/lama_conductor.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_conductor" node="LamaConductor" nodegroup="pbr" doc="Lama conductor" version="1.0" isdefaultversion="true">
     <input name="tint" type="color3" value="1, 1, 1" uiname="Tint" uifolder="Main"
            doc="Overall color multiplier. It should be used with parcimony, as a non-white value breaks physicality. The prefered way to define the color of a conductor is through the Fresnel attributes right below." />
@@ -128,6 +128,8 @@
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="tangent_rotate_normalize" />
       <input name="distribution" type="string" value="ggx" />
+      <input name="thinfilm_thickness" type="float" interfacename="iridescenceThickness" />
+      <input name="thinfilm_ior" type="float" nodename="iridescence_relative_ior" />
     </conductor_bsdf>
 
     <!-- BRDF + Thin film -->
@@ -135,20 +137,12 @@
       <input name="in1" type="float" interfacename="iridescenceIOR" />
       <input name="in2" type="float" interfacename="exteriorIOR" />
     </divide>
-    <thin_film_bsdf name="thin_film_bsdf" type="BSDF">
-      <input name="thickness" type="float" interfacename="iridescenceThickness" />
-      <input name="ior" type="float" nodename="iridescence_relative_ior" />
-    </thin_film_bsdf>
 
     <!-- Layered BRDF -->
-    <layer name="thin_film_conductor_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="thin_film_bsdf" />
-      <input name="base" type="BSDF" nodename="conductor_bsdf" />
-    </layer>
 
     <!-- Tinted BRDF -->
     <multiply name="tinted_bsdf" type="BSDF">
-      <input name="in1" type="BSDF" nodename="thin_film_conductor_bsdf" />
+      <input name="in1" type="BSDF" nodename="conductor_bsdf" />
       <input name="in2" type="color3" interfacename="tint" />
     </multiply>
 

--- a/libraries/bxdf/lama/lama_dielectric.mtlx
+++ b/libraries/bxdf/lama/lama_dielectric.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_dielectric" node="LamaDielectric" nodegroup="pbr" doc="Lama dielectric" version="1.0" isdefaultversion="true">
     <input name="reflectionTint" type="color3" value="1.0, 1.0, 1.0" uiname="Reflection Tint" uifolder="Main"
            doc="Color multiplier for external reflection. It should be used with parcimony, as a non-white value breaks physicality." />
@@ -29,7 +29,7 @@
            doc="Absorption radius" />
     <input name="scatterColor" type="color3" value="0.0, 0.0, 0.0" uiname="Scatter Color" uifolder="Interior"
            doc="Scatter color" />
-    <input name="scatterAnisotropy" type="float" value="0.0" uimin="-1.0" uimax="1.0" uiname="Scatter Anisotropy" uifolder="Interior" 
+    <input name="scatterAnisotropy" type="float" value="0.0" uimin="-1.0" uimax="1.0" uiname="Scatter Anisotropy" uifolder="Interior"
            doc="Scatter anisotropy" />
     <output name="out" type="BSDF" />
   </nodedef>
@@ -44,9 +44,13 @@
       <input name="reflectivity" type="color3" nodename="reflectivity_color" />
       <input name="edge_color" type="color3" value="0.0, 0.0, 0.0" />
     </artistic_ior>
+    <extract name="ior_float" type="float">
+      <input name="in" type="color3" nodename="artistic_ior" output="ior" />
+      <input name="index" type="integer" value="0" />
+    </extract>
     <switch name="fresnel_mode_switch" type="float">
       <input name="in1" type="float" interfacename="IOR" />
-      <input name="in2" type="float" nodename="artistic_ior" output="ior" channels="r" />
+      <input name="in2" type="float" nodename="ior_float" />
       <input name="which" type="integer" interfacename="fresnelMode" />
     </switch>
     <divide name="relative_ior" type="float">

--- a/libraries/bxdf/lama/lama_diffuse.mtlx
+++ b/libraries/bxdf/lama/lama_diffuse.mtlx
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_diffuse" node="LamaDiffuse" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="color" uiname="Color" type="color3" value="0.18, 0.18, 0.18"
            doc="Diffuse color (aka albedo), defining what ratio of light is reflected for each color channel." />
-    <input name="roughness" uiname="Roughness" type="float" uimin="0.0" uimax="1.0" value="0.0" doc="Micro-facet distribution (Oren-Nayar) roughness." />
+    <input name="roughness" uiname="Roughness" type="float" uimin="0.0" uimax="1.0" value="0.0"
+           doc="Micro-facet distribution (Oren-Nayar) roughness." />
     <input name="normal" uiname="Normal" type="vector3" defaultgeomprop="Nworld"
            doc="Shading normal, typically defined by bump or normal mapping. Defaults to the smooth surface normal if not set." />
     <input name="energyCompensation" uiname="Energy Compensation" uifolder="Advanced" type="float" uniform="true" uimin="0.0" uimax="1.0" value="1.0"

--- a/libraries/bxdf/lama/lama_emission.mtlx
+++ b/libraries/bxdf/lama/lama_emission.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_emission" node="LamaEmission" nodegroup="pbr" doc="Lama emission" version="1.0" isdefaultversion="true">
     <input name="color" type="color3" value="1.0, 1.0, 1.0" uiname="Color" uifolder="Main"
            doc="Color being uniformly emitted in all directions above the surface." />

--- a/libraries/bxdf/lama/lama_layer.mtlx
+++ b/libraries/bxdf/lama/lama_layer.mtlx
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <!-- LamaLayer for BSDFs -->
   <nodedef name="ND_lama_layer_bsdf" node="LamaLayer" nodegroup="pbr" version="1.0" isdefaultversion="true">
-    <input name="materialTop" uiname="Material Top" type="BSDF" 
+    <input name="materialTop" uiname="Material Top" type="BSDF"
            doc="Material used for the top slab. If not set, the base material will be used by itself." />
-    <input name="materialBase" uiname="Material Base" type="BSDF" 
+    <input name="materialBase" uiname="Material Base" type="BSDF"
            doc="Base material, right under the top one." />
     <input name="topMix" uiname="Top Mix" type="float" uimin="0.0" uimax="1.0" value="1.0"
            doc="Defines how visible the top material is." />

--- a/libraries/bxdf/lama/lama_mix.mtlx
+++ b/libraries/bxdf/lama/lama_mix.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
 
   <!-- LamaMix for BSDFs -->
   <nodedef name="ND_lama_mix_bsdf" node="LamaMix" nodegroup="pbr" version="1.0" isdefaultversion="true">

--- a/libraries/bxdf/lama/lama_sheen.mtlx
+++ b/libraries/bxdf/lama/lama_sheen.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_sheen" node="LamaSheen" nodegroup="pbr" doc="Lama sheen" version="1.0" isdefaultversion="true">
     <input name="color" type="color3" value="1, 1, 1" uiname="Color" uifolder="Main"
            doc="Amount of sheen to add, per channel. When this node is used as top material in a stack, the more sheen is added, the less energy will be transmitted to the base material." />

--- a/libraries/bxdf/lama/lama_sss.mtlx
+++ b/libraries/bxdf/lama/lama_sss.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_sss" node="LamaSSS" nodegroup="pbr" doc="Lama SSS" version="1.0" isdefaultversion="true">
     <input name="color" type="color3" value="0.18, 0.18, 0.18" uiname="Color" uifolder="Main"
            doc="Diffuse color (aka albedo), defining what ratio of light is reflected -- or transmitted -- for each color channel." />

--- a/libraries/bxdf/lama/lama_translucent.mtlx
+++ b/libraries/bxdf/lama/lama_translucent.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="acescg">
+<materialx version="1.39" colorspace="acescg">
   <nodedef name="ND_lama_translucent" node="LamaTranslucent" nodegroup="pbr" version="1.0" isdefaultversion="true">
     <input name="color" uiname="Color" type="color3" value="0.18, 0.18, 0.18"
            doc="Translucent color (aka albedo), defining what ratio of light is transmitted for each color channel." />


### PR DESCRIPTION
This changelist updates the MaterialX Lama BSDF nodes to 1.39, providing a baseline for upcoming improvements.