### PR TITLE
Fix OSL syntax for Convert nodes

### DIFF
--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -686,20 +686,20 @@
 
   <!-- <convert> -->
   <implementation name="IM_convert_float_color3_genosl" nodedef="ND_convert_float_color3" target="genosl" sourcecode="color({{in}},{{in}},{{in}})" />
-  <implementation name="IM_convert_float_color4_genosl" nodedef="ND_convert_float_color4" target="genosl" sourcecode="color4({ {{in}},{{in}},{{in}} },{{in}})" />
-  <implementation name="IM_convert_float_vector2_genosl" nodedef="ND_convert_float_vector2" target="genosl" sourcecode="vector2({{in}},{{in}})" />
+  <implementation name="IM_convert_float_color4_genosl" nodedef="ND_convert_float_color4" target="genosl" sourcecode="{ color({{in}},{{in}},{{in}}),{{in}}}" />
+  <implementation name="IM_convert_float_vector2_genosl" nodedef="ND_convert_float_vector2" target="genosl" sourcecode="{ {{in}},{{in}} }" />
   <implementation name="IM_convert_float_vector3_genosl" nodedef="ND_convert_float_vector3" target="genosl" sourcecode="vector({{in}},{{in}},{{in}})" />
-  <implementation name="IM_convert_float_vector4_genosl" nodedef="ND_convert_float_vector4" target="genosl" sourcecode="vector4({{in}},{{in}},{{in}},{{in}})" />
-  <implementation name="IM_convert_vector2_vector3_genosl" nodedef="ND_convert_vector2_vector3" target="genosl" sourcecode="vector({{in}}[0],{{in}}[1],0)" />
-  <implementation name="IM_convert_vector3_vector2_genosl" nodedef="ND_convert_vector3_vector2" target="genosl" sourcecode="vector2({{in}}[0],{{in}}[1])" />
+  <implementation name="IM_convert_float_vector4_genosl" nodedef="ND_convert_float_vector4" target="genosl" sourcecode="{ {{in}},{{in}},{{in}},{{in}} }" />
+  <implementation name="IM_convert_vector2_vector3_genosl" nodedef="ND_convert_vector2_vector3" target="genosl" sourcecode="vector({{in}}.x,{{in}}.y,0)" />
+  <implementation name="IM_convert_vector3_vector2_genosl" nodedef="ND_convert_vector3_vector2" target="genosl" sourcecode="{ {{in}}[0],{{in}}[1] }" />
   <implementation name="IM_convert_vector3_color3_genosl" nodedef="ND_convert_vector3_color3" target="genosl" sourcecode="color({{in}})" />
-  <implementation name="IM_convert_vector3_vector4_genosl" nodedef="ND_convert_vector3_vector4" target="genosl" sourcecode="vector4({{in}}[0],{{in}}[1],{{in}}[2],1)" />
-  <implementation name="IM_convert_vector4_vector3_genosl" nodedef="ND_convert_vector4_vector3" target="genosl" sourcecode="vector({{in}}[0],{{in}}[1],{{in}}[2])" />
-  <implementation name="IM_convert_vector4_color4_genosl" nodedef="ND_convert_vector4_color4" target="genosl" sourcecode="color4({ {{in}}[0],{{in}}[1],{{in}}[2] }, {{in}}[3])" />
+  <implementation name="IM_convert_vector3_vector4_genosl" nodedef="ND_convert_vector3_vector4" target="genosl" sourcecode="{ {{in}}[0],{{in}}[1],{{in}}[2],1 }" />
+  <implementation name="IM_convert_vector4_vector3_genosl" nodedef="ND_convert_vector4_vector3" target="genosl" sourcecode="vector({{in}}.x,{{in}}.y,{{in}}.z)" />
+  <implementation name="IM_convert_vector4_color4_genosl" nodedef="ND_convert_vector4_color4" target="genosl" sourcecode="{ color({{in}}.x,{{in}}.y,{{in}}.z), {{in}}.w }" />
   <implementation name="IM_convert_color3_vector3_genosl" nodedef="ND_convert_color3_vector3" target="genosl" sourcecode="vector({{in}})" />
-  <implementation name="IM_convert_color4_vector4_genosl" nodedef="ND_convert_color4_vector4" target="genosl" sourcecode="vector4({{in}})" />
-  <implementation name="IM_convert_color3_color4_genosl" nodedef="ND_convert_color3_color4" target="genosl" sourcecode="color4({ {{in}}[0],{{in}}[1],{{in}}[2] },1)" />
-  <implementation name="IM_convert_color4_color3_genosl" nodedef="ND_convert_color4_color3" target="genosl" sourcecode="color({{in}}[0],{{in}}[1],{{in}}[2])" />
+  <implementation name="IM_convert_color4_vector4_genosl" nodedef="ND_convert_color4_vector4" target="genosl" sourcecode="{ {{in}}.rgb[0],{{in}}.rgb[1],{{in}}.rgb[2],{{in}}.a }" />
+  <implementation name="IM_convert_color3_color4_genosl" nodedef="ND_convert_color3_color4" target="genosl" sourcecode="{ color({{in}}[0],{{in}}[1],{{in}}[2]),1 }" />
+  <implementation name="IM_convert_color4_color3_genosl" nodedef="ND_convert_color4_color3" target="genosl" sourcecode="color({{in}}.rgb[0],{{in}}.rgb[1],{{in}}.rgb[2])" />
   <implementation name="IM_convert_boolean_float_genosl" nodedef="ND_convert_boolean_float" target="genosl" sourcecode="float({{in}})" />
   <implementation name="IM_convert_integer_float_genosl" nodedef="ND_convert_integer_float" target="genosl" sourcecode="float({{in}})" />
 


### PR DESCRIPTION
PR #1854, previously removed the C++ implementations for `convert` and replaced them with direct source code implementations.  The testing done wasn't correctly running `oslc` so a few syntax errors slipped through.

These are corrected in this PR.

Note:
`vector2`, `vector4` and `color4` are implemented as structs in OSL, and so do not have constructors in the typical sense.   The following is not legal OSL syntax.
```
vector4 a = vector4(0,0,0,0);
```
instead you must use a list initializer to initialize the struct.
```
vector4 a = {0,0,0,0};
```

Conversely, currently it is NOT legal to initialize a builtin type, for instance `color` or `vector` using a list initializer. 
The following is not legal OSL syntax.
```
color a = {0,0,0};
```
instead you must use the type constructor.
```
color a = color(0,0,0);
```

Also note, subscript access also is also not legal OSL syntax because these types are implemented as structs. For example to access the green component of a `color4`, you must use `myColor.rgb[1]`. 
