### PR TITLE
Simplify TypeSyntax API 

### DIFF
--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -44,23 +44,6 @@ class GlslArrayTypeSyntax : public ScalarTypeSyntax
         return EMPTY_STRING;
     }
 
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct an array value");
-        }
-
-        string result = _name + "[" + std::to_string(values.size()) + "](" + values[0];
-        for (size_t i = 1; i < values.size(); ++i)
-        {
-            result += ", " + values[i];
-        }
-        result += ")";
-
-        return result;
-    }
-
   protected:
     virtual size_t getSize(const Value& value) const = 0;
 };

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -93,23 +93,6 @@ class MdlArrayTypeSyntax : public ScalarTypeSyntax
         return EMPTY_STRING;
     }
 
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct an array value");
-        }
-
-        string result = getName() + "[](" + values[0];
-        for (size_t i = 1; i < values.size(); ++i)
-        {
-            result += ", " + values[i];
-        }
-        result += ")";
-
-        return result;
-    }
-
   protected:
     virtual bool isEmpty(const Value& value) const = 0;
 };
@@ -177,20 +160,6 @@ class MdlColor4TypeSyntax : public AggregateTypeSyntax
         ss << "mk_color4(" << c[0] << ", " << c[1] << ", " << c[2] << ", " << c[3] << ")";
 
         return ss.str();
-    }
-
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
-        size_t valueCount = values.size();
-        if (valueCount == 4)
-        {
-            return "mk_color4(" + values[0] + ", " + values[1] + ", " + values[2] + ", " + values[3] + ")";
-        }
-        else if (valueCount == 2)
-        {
-            return "mk_color4(" + values[0] + ", " + values[1] + ")";
-        }
-        throw ExceptionShaderGenError("Incorrect number of values to construct a color4 value:" + std::to_string(valueCount));
     }
 };
 

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -44,23 +44,6 @@ class MslArrayTypeSyntax : public ScalarTypeSyntax
         return EMPTY_STRING;
     }
 
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct an array value");
-        }
-
-        string result = "{" + values[0];
-        for (size_t i = 1; i < values.size(); ++i)
-        {
-            result += ", " + values[i] + "f";
-        }
-        result += "}";
-
-        return result;
-    }
-
   protected:
     virtual size_t getSize(const Value& value) const = 0;
 };

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -26,11 +26,6 @@ class OslBooleanTypeSyntax : public ScalarTypeSyntax
     {
         return value.asA<bool>() ? "1" : "0";
     }
-
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
-        return values.size() && values[0] == "true" ? "1" : "0";
-    }
 };
 
 class OslArrayTypeSyntax : public ScalarTypeSyntax
@@ -53,23 +48,6 @@ class OslArrayTypeSyntax : public ScalarTypeSyntax
             throw ExceptionShaderGenError("Uniform array cannot initialize to a empty value.");
         }
         return EMPTY_STRING;
-    }
-
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct an array value");
-        }
-
-        string result = "{" + values[0];
-        for (size_t i = 1; i < values.size(); ++i)
-        {
-            result += ", " + values[i];
-        }
-        result += "}";
-
-        return result;
     }
 
   protected:
@@ -131,23 +109,6 @@ class OslStructTypeSyntax : public AggregateTypeSyntax
             return getName() + "(" + value.getValueString() + ")";
         }
     }
-
-    string getValue(const StringVec& values, bool uniform) const override
-    {
-        if (values.empty())
-        {
-            throw ExceptionShaderGenError("No values given to construct a value");
-        }
-
-        string result = uniform ? "{" : getName() + "(" + values[0];
-        for (size_t i = 1; i < values.size(); ++i)
-        {
-            result += ", " + values[i];
-        }
-        result += uniform ? "}" : ")";
-
-        return result;
-    }
 };
 
 // For the color4 type we need even more specialization since it's a struct of a struct:
@@ -189,23 +150,6 @@ class OslColor4TypeSyntax : public OslStructTypeSyntax
 
         return ss.str();
     }
-
-    string getValue(const StringVec& values, bool uniform) const override
-    {
-        if (values.size() < 4)
-        {
-            throw ExceptionShaderGenError("Too few values given to construct a color4 value");
-        }
-
-        if (uniform)
-        {
-            return "{color(" + values[0] + ", " + values[1] + ", " + values[2] + "), " + values[3] + "}";
-        }
-        else
-        {
-            return "color4(color(" + values[0] + ", " + values[1] + ", " + values[2] + "), " + values[3] + ")";
-        }
-    }
 };
 
 class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
@@ -218,14 +162,9 @@ class OSLMatrix3TypeSyntax : public AggregateTypeSyntax
     {
     }
 
-    string getValue(const Value& value, bool uniform) const override
+    string getValue(const Value& value, bool /*uniform*/) const override
     {
         StringVec values = splitString(value.getValueString(), ",");
-        return getValue(values, uniform);
-    }
-
-    string getValue(const StringVec& values, bool /*uniform*/) const override
-    {
         if (values.empty())
         {
             throw ExceptionShaderGenError("No values given to construct a value");
@@ -279,18 +218,6 @@ class OSLFilenameTypeSyntax : public AggregateTypeSyntax
         const string prefix = uniform ? "{" : getName() + "(";
         const string suffix = uniform ? "}" : ")";
         return prefix + "\"" + value.getValueString() + "\", \"\"" + suffix;
-    }
-
-    string getValue(const StringVec& values, bool uniform) const override
-    {
-        if (values.size() != 2)
-        {
-            throw ExceptionShaderGenError("Incorrect number of values given to construct a value");
-        }
-
-        const string prefix = uniform ? "{" : getName() + "(";
-        const string suffix = uniform ? "}" : ")";
-        return prefix + "\"" + values[0] + "\", \"" + values[1] + "\"" + suffix;
     }
 };
 

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -224,19 +224,6 @@ string ScalarTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
     return value.getValueString();
 }
 
-string ScalarTypeSyntax::getValue(const StringVec& values, bool /*uniform*/) const
-{
-    if (values.empty())
-    {
-        throw ExceptionShaderGenError("No values given to construct a value");
-    }
-    // Write the value using a stream to maintain any float formatting set
-    // using Value::setFloatFormat() and Value::setFloatPrecision()
-    StringStream ss;
-    ss << values[0];
-    return ss.str();
-}
-
 StringTypeSyntax::StringTypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
                                    const string& typeAlias, const string& typeDefinition) :
     ScalarTypeSyntax(name, defaultValue, uniformDefaultValue, typeAlias, typeDefinition)
@@ -258,26 +245,6 @@ string AggregateTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
 {
     const string valueString = value.getValueString();
     return valueString.empty() ? valueString : getName() + "(" + valueString + ")";
-}
-
-string AggregateTypeSyntax::getValue(const StringVec& values, bool /*uniform*/) const
-{
-    if (values.empty())
-    {
-        throw ExceptionShaderGenError("No values given to construct a value");
-    }
-
-    // Write the value using a stream to maintain any float formatting set
-    // using Value::setFloatFormat() and Value::setFloatPrecision()
-    StringStream ss;
-    ss << getName() << "(" << values[0];
-    for (size_t i = 1; i < values.size(); ++i)
-    {
-        ss << ", " << values[i];
-    }
-    ss << ")";
-
-    return ss.str();
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -246,11 +246,6 @@ class MX_GENSHADER_API TypeSyntax
     /// The value is constructed from the given value object.
     virtual string getValue(const Value& value, bool uniform) const = 0;
 
-    /// Returns a value formatted according to this type syntax.
-    /// The value is constructed from the given list of value entries
-    /// with one entry for each member of the type.
-    virtual string getValue(const StringVec& values, bool uniform) const = 0;
-
   protected:
     /// Protected constructor
     TypeSyntax(const string& name, const string& defaultValue, const string& uniformDefaultValue,
@@ -274,7 +269,6 @@ class MX_GENSHADER_API ScalarTypeSyntax : public TypeSyntax
                      const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING);
 
     string getValue(const Value& value, bool uniform) const override;
-    string getValue(const StringVec& values, bool uniform) const override;
 };
 
 /// Specialization of TypeSyntax for string types.
@@ -296,7 +290,6 @@ class MX_GENSHADER_API AggregateTypeSyntax : public TypeSyntax
                         const StringVec& members = EMPTY_MEMBERS);
 
     string getValue(const Value& value, bool uniform) const override;
-    string getValue(const StringVec& values, bool uniform) const override;
 };
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
After the recent refactor of `<convert>` (#1854) and `<combine>` (#1855) the `getValue()` function overload is no longer needed.