### PR TITLE
Add boolean-output conditional nodes

### DIFF
--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -600,6 +600,7 @@
   <implementation name="IM_ifgreater_vector4_genglsl" nodedef="ND_ifgreater_vector4" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix33_genglsl" nodedef="ND_ifgreater_matrix33" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix44_genglsl" nodedef="ND_ifgreater_matrix44" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreater_boolean_genglsl" nodedef="ND_ifgreater_boolean" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? true : false" />
   <implementation name="IM_ifgreater_floatI_genglsl" nodedef="ND_ifgreater_floatI" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_integerI_genglsl" nodedef="ND_ifgreater_integerI" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_color3I_genglsl" nodedef="ND_ifgreater_color3I" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
@@ -609,6 +610,7 @@
   <implementation name="IM_ifgreater_vector4I_genglsl" nodedef="ND_ifgreater_vector4I" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix33I_genglsl" nodedef="ND_ifgreater_matrix33I" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix44I_genglsl" nodedef="ND_ifgreater_matrix44I" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreater_booleanI_genglsl" nodedef="ND_ifgreater_booleanI" target="genglsl" sourcecode="({{value1}} > {{value2}}) ? true : false" />
 
   <!-- <ifgreatereq -->
   <implementation name="IM_ifgreatereq_float_genglsl" nodedef="ND_ifgreatereq_float" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
@@ -620,6 +622,7 @@
   <implementation name="IM_ifgreatereq_vector4_genglsl" nodedef="ND_ifgreatereq_vector4" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix33_genglsl" nodedef="ND_ifgreatereq_matrix33" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix44_genglsl" nodedef="ND_ifgreatereq_matrix44" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreatereq_boolean_genglsl" nodedef="ND_ifgreatereq_boolean" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? true : false" />
   <implementation name="IM_ifgreatereq_floatI_genglsl" nodedef="ND_ifgreatereq_floatI" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_integerI_genglsl" nodedef="ND_ifgreatereq_integerI" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_color3I_genglsl" nodedef="ND_ifgreatereq_color3I" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
@@ -629,6 +632,7 @@
   <implementation name="IM_ifgreatereq_vector4I_genglsl" nodedef="ND_ifgreatereq_vector4I" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix33I_genglsl" nodedef="ND_ifgreatereq_matrix33I" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix44I_genglsl" nodedef="ND_ifgreatereq_matrix44I" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreatereq_booleanI_genglsl" nodedef="ND_ifgreatereq_booleanI" target="genglsl" sourcecode="({{value1}} >= {{value2}}) ? true : false" />
 
   <!-- <ifequal -->
   <implementation name="IM_ifequal_float_genglsl" nodedef="ND_ifequal_float" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
@@ -640,6 +644,7 @@
   <implementation name="IM_ifequal_vector4_genglsl" nodedef="ND_ifequal_vector4" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix33_genglsl" nodedef="ND_ifequal_matrix33" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix44_genglsl" nodedef="ND_ifequal_matrix44" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifequal_boolean_genglsl" nodedef="ND_ifequal_boolean" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
   <implementation name="IM_ifequal_floatI_genglsl" nodedef="ND_ifequal_floatI" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_integerI_genglsl" nodedef="ND_ifequal_integerI" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_color3I_genglsl" nodedef="ND_ifequal_color3I" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
@@ -649,6 +654,7 @@
   <implementation name="IM_ifequal_vector4I_genglsl" nodedef="ND_ifequal_vector4I" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix33I_genglsl" nodedef="ND_ifequal_matrix33I" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix44I_genglsl" nodedef="ND_ifequal_matrix44I" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifequal_booleanI_genglsl" nodedef="ND_ifequal_booleanI" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
   <implementation name="IM_ifequal_floatB_genglsl" nodedef="ND_ifequal_floatB" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_integerB_genglsl" nodedef="ND_ifequal_integerB" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_color3B_genglsl" nodedef="ND_ifequal_color3B" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
@@ -658,6 +664,7 @@
   <implementation name="IM_ifequal_vector4B_genglsl" nodedef="ND_ifequal_vector4B" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix33B_genglsl" nodedef="ND_ifequal_matrix33B" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix44B_genglsl" nodedef="ND_ifequal_matrix44B" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifequal_booleanB_genglsl" nodedef="ND_ifequal_booleanB" target="genglsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
 
   <!-- <switch> -->
 

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -610,6 +610,7 @@
   <implementation name="IM_ifgreater_vector4_genmdl" nodedef="ND_ifgreater_vector4" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_vector4({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreater_matrix33_genmdl" nodedef="ND_ifgreater_matrix33" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_matrix33({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreater_matrix44_genmdl" nodedef="ND_ifgreater_matrix44" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_matrix44({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifgreater_boolean_genmdl" nodedef="ND_ifgreater_boolean" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_boolean({{value1}}, {{value2}})" target="genmdl" />
   <implementation name="IM_ifgreater_floatI_genmdl" nodedef="ND_ifgreater_floatI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_floatI({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreater_integerI_genmdl" nodedef="ND_ifgreater_integerI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_integerI({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreater_color3I_genmdl" nodedef="ND_ifgreater_color3I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_color3I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
@@ -619,6 +620,7 @@
   <implementation name="IM_ifgreater_vector4I_genmdl" nodedef="ND_ifgreater_vector4I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_vector4I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreater_matrix33I_genmdl" nodedef="ND_ifgreater_matrix33I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_matrix33I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreater_matrix44I_genmdl" nodedef="ND_ifgreater_matrix44I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_matrix44I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifgreater_booleanI_genmdl" nodedef="ND_ifgreater_booleanI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreater_booleanI({{value1}}, {{value2}})" target="genmdl" />
 
   <!-- <ifgreatereq> -->
   <implementation name="IM_ifgreatereq_float_genmdl" nodedef="ND_ifgreatereq_float" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_float({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
@@ -630,6 +632,7 @@
   <implementation name="IM_ifgreatereq_vector4_genmdl" nodedef="ND_ifgreatereq_vector4" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_vector4({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_matrix33_genmdl" nodedef="ND_ifgreatereq_matrix33" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_matrix33({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_matrix44_genmdl" nodedef="ND_ifgreatereq_matrix44" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_matrix44({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifgreatereq_boolean_genmdl" nodedef="ND_ifgreatereq_boolean" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_boolean({{value1}}, {{value2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_floatI_genmdl" nodedef="ND_ifgreatereq_floatI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_floatI({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_integerI_genmdl" nodedef="ND_ifgreatereq_integerI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_integerI({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_color3I_genmdl" nodedef="ND_ifgreatereq_color3I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_color3I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
@@ -639,6 +642,7 @@
   <implementation name="IM_ifgreatereq_vector4I_genmdl" nodedef="ND_ifgreatereq_vector4I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_vector4I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_matrix33I_genmdl" nodedef="ND_ifgreatereq_matrix33I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_matrix33I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifgreatereq_matrix44I_genmdl" nodedef="ND_ifgreatereq_matrix44I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_matrix44I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifgreatereq_booleanI_genmdl" nodedef="ND_ifgreatereq_booleanI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifgreatereq_booleanI({{value1}}, {{value2}})" target="genmdl" />
 
   <!-- <ifequal> -->
   <implementation name="IM_ifequal_float_genmdl" nodedef="ND_ifequal_float" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_float({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
@@ -650,6 +654,7 @@
   <implementation name="IM_ifequal_vector4_genmdl" nodedef="ND_ifequal_vector4" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_vector4({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_matrix33_genmdl" nodedef="ND_ifequal_matrix33" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_matrix33({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_matrix44_genmdl" nodedef="ND_ifequal_matrix44" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_matrix44({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifequal_boolean4_genmdl" nodedef="ND_ifequal_boolean" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_boolean({{value1}}, {{value2}})" target="genmdl" />
   <implementation name="IM_ifequal_floatI_genmdl" nodedef="ND_ifequal_floatI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_floatI({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_integerI_genmdl" nodedef="ND_ifequal_integerI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_integerI({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_color3I_genmdl" nodedef="ND_ifequal_color3I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_color3I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
@@ -659,6 +664,7 @@
   <implementation name="IM_ifequal_vector4I_genmdl" nodedef="ND_ifequal_vector4I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_vector4I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_matrix33I_genmdl" nodedef="ND_ifequal_matrix33I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_matrix33I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_matrix44I_genmdl" nodedef="ND_ifequal_matrix44I" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_matrix44I({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifequal_booleanI_genmdl" nodedef="ND_ifequal_booleanI" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_booleanI({{value1}}, {{value2}})" target="genmdl" />
   <implementation name="IM_ifequal_floatB_genmdl" nodedef="ND_ifequal_floatB" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_floatB({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_integerB_genmdl" nodedef="ND_ifequal_integerB" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_integerB({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_color3B_genmdl" nodedef="ND_ifequal_color3B" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_color3B({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
@@ -668,6 +674,7 @@
   <implementation name="IM_ifequal_vector4B_genmdl" nodedef="ND_ifequal_vector4B" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_vector4B({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_matrix33B_genmdl" nodedef="ND_ifequal_matrix33B" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_matrix33B({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_ifequal_matrix44B_genmdl" nodedef="ND_ifequal_matrix44B" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_matrix44B({{value1}}, {{value2}}, {{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_ifequal_booleanB_genmdl" nodedef="ND_ifequal_booleanB" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_ifequal_booleanB({{value1}}, {{value2}})" target="genmdl" />
 
   <!-- <switch> -->
   <!-- 'which' type : float -->

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -600,6 +600,7 @@
   <implementation name="IM_ifgreater_vector4_genmsl" nodedef="ND_ifgreater_vector4" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix33_genmsl" nodedef="ND_ifgreater_matrix33" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix44_genmsl" nodedef="ND_ifgreater_matrix44" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreater_boolean_genmsl" nodedef="ND_ifgreater_boolean" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? true : false" />
   <implementation name="IM_ifgreater_floatI_genmsl" nodedef="ND_ifgreater_floatI" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_integerI_genmsl" nodedef="ND_ifgreater_integerI" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_color3I_genmsl" nodedef="ND_ifgreater_color3I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
@@ -609,6 +610,7 @@
   <implementation name="IM_ifgreater_vector4I_genmsl" nodedef="ND_ifgreater_vector4I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix33I_genmsl" nodedef="ND_ifgreater_matrix33I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreater_matrix44I_genmsl" nodedef="ND_ifgreater_matrix44I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreater_booleanI_genmsl" nodedef="ND_ifgreater_booleanI" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? true : false" />
 
   <!-- <ifgreatereq -->
   <implementation name="IM_ifgreatereq_float_genmsl" nodedef="ND_ifgreatereq_float" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
@@ -620,6 +622,7 @@
   <implementation name="IM_ifgreatereq_vector4_genmsl" nodedef="ND_ifgreatereq_vector4" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix33_genmsl" nodedef="ND_ifgreatereq_matrix33" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix44_genmsl" nodedef="ND_ifgreatereq_matrix44" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreatereq_boolean_genmsl" nodedef="ND_ifgreatereq_boolean" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? true : false" />
   <implementation name="IM_ifgreatereq_floatI_genmsl" nodedef="ND_ifgreatereq_floatI" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_integerI_genmsl" nodedef="ND_ifgreatereq_integerI" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_color3I_genmsl" nodedef="ND_ifgreatereq_color3I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
@@ -629,6 +632,7 @@
   <implementation name="IM_ifgreatereq_vector4I_genmsl" nodedef="ND_ifgreatereq_vector4I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix33I_genmsl" nodedef="ND_ifgreatereq_matrix33I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifgreatereq_matrix44I_genmsl" nodedef="ND_ifgreatereq_matrix44I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifgreatereq_booleanI_genmsl" nodedef="ND_ifgreatereq_booleanI" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? true : false" />
 
   <!-- <ifequal -->
   <implementation name="IM_ifequal_float_genmsl" nodedef="ND_ifequal_float" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
@@ -640,6 +644,7 @@
   <implementation name="IM_ifequal_vector4_genmsl" nodedef="ND_ifequal_vector4" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix33_genmsl" nodedef="ND_ifequal_matrix33" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix44_genmsl" nodedef="ND_ifequal_matrix44" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifequal_boolean_genmsl" nodedef="ND_ifequal_boolean" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
   <implementation name="IM_ifequal_floatI_genmsl" nodedef="ND_ifequal_floatI" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_integerI_genmsl" nodedef="ND_ifequal_integerI" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_color3I_genmsl" nodedef="ND_ifequal_color3I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
@@ -649,6 +654,7 @@
   <implementation name="IM_ifequal_vector4I_genmsl" nodedef="ND_ifequal_vector4I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix33I_genmsl" nodedef="ND_ifequal_matrix33I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix44I_genmsl" nodedef="ND_ifequal_matrix44I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifequal_booleanI_genmsl" nodedef="ND_ifequal_booleanI" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
   <implementation name="IM_ifequal_floatB_genmsl" nodedef="ND_ifequal_floatB" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_integerB_genmsl" nodedef="ND_ifequal_integerB" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_color3B_genmsl" nodedef="ND_ifequal_color3B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
@@ -658,6 +664,7 @@
   <implementation name="IM_ifequal_vector4B_genmsl" nodedef="ND_ifequal_vector4B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix33B_genmsl" nodedef="ND_ifequal_matrix33B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
   <implementation name="IM_ifequal_matrix44B_genmsl" nodedef="ND_ifequal_matrix44B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
+  <implementation name="IM_ifequal_booleanB_genmsl" nodedef="ND_ifequal_booleanB" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
 
   <!-- <switch> -->
 

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -601,6 +601,7 @@
   <implementation name="IM_ifgreater_vector4_genosl" nodedef="ND_ifgreater_vector4" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreater_matrix33_genosl" nodedef="ND_ifgreater_matrix33" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreater_matrix44_genosl" nodedef="ND_ifgreater_matrix44" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifgreater_boolean_genosl" nodedef="ND_ifgreater_boolean" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, 1, 0)" />
   <implementation name="IM_ifgreater_floatI_genosl" nodedef="ND_ifgreater_floatI" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreater_integerI_genosl" nodedef="ND_ifgreater_integerI" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreater_color3I_genosl" nodedef="ND_ifgreater_color3I" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
@@ -610,6 +611,7 @@
   <implementation name="IM_ifgreater_vector4I_genosl" nodedef="ND_ifgreater_vector4I" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreater_matrix33I_genosl" nodedef="ND_ifgreater_matrix33I" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreater_matrix44I_genosl" nodedef="ND_ifgreater_matrix44I" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifgreater_booleanI_genosl" nodedef="ND_ifgreater_booleanI" target="genosl" sourcecode="mx_ternary({{value1}} > {{value2}}, 1, 0)" />
 
   <!-- <ifgreatereq> -->
   <implementation name="IM_ifgreatereq_float_genosl" nodedef="ND_ifgreatereq_float" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
@@ -621,6 +623,7 @@
   <implementation name="IM_ifgreatereq_vector4_genosl" nodedef="ND_ifgreatereq_vector4" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreatereq_matrix33_genosl" nodedef="ND_ifgreatereq_matrix33" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreatereq_matrix44_genosl" nodedef="ND_ifgreatereq_matrix44" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifgreatereq_boolean_genosl" nodedef="ND_ifgreatereq_boolean" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, 1, 0)" />
   <implementation name="IM_ifgreatereq_floatI_genosl" nodedef="ND_ifgreatereq_floatI" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreatereq_integerI_genosl" nodedef="ND_ifgreatereq_integerI" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreatereq_color3I_genosl" nodedef="ND_ifgreatereq_color3I" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
@@ -630,6 +633,7 @@
   <implementation name="IM_ifgreatereq_vector4I_genosl" nodedef="ND_ifgreatereq_vector4I" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreatereq_matrix33I_genosl" nodedef="ND_ifgreatereq_matrix33I" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifgreatereq_matrix44I_genosl" nodedef="ND_ifgreatereq_matrix44I" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifgreatereq_booleanI_genosl" nodedef="ND_ifgreatereq_booleanI" target="genosl" sourcecode="mx_ternary({{value1}} >= {{value2}}, 1, 0)" />
 
   <!-- <ifequal> -->
   <implementation name="IM_ifequal_float_genosl" nodedef="ND_ifequal_float" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
@@ -641,6 +645,7 @@
   <implementation name="IM_ifequal_vector4_genosl" nodedef="ND_ifequal_vector4" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_matrix33_genosl" nodedef="ND_ifequal_matrix33" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_matrix44_genosl" nodedef="ND_ifequal_matrix44" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifequal_boolean_genosl" nodedef="ND_ifequal_boolean" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, 1, 0)" />
   <implementation name="IM_ifequal_floatI_genosl" nodedef="ND_ifequal_floatI" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_integerI_genosl" nodedef="ND_ifequal_integerI" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_color3I_genosl" nodedef="ND_ifequal_color3I" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
@@ -650,6 +655,7 @@
   <implementation name="IM_ifequal_vector4I_genosl" nodedef="ND_ifequal_vector4I" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_matrix33I_genosl" nodedef="ND_ifequal_matrix33I" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_matrix44I_genosl" nodedef="ND_ifequal_matrix44I" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifequal_booleanI_genosl" nodedef="ND_ifequal_booleanI" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, 1, 0)" />
   <implementation name="IM_ifequal_floatB_genosl" nodedef="ND_ifequal_floatB" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_integerB_genosl" nodedef="ND_ifequal_integerB" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_color3B_genosl" nodedef="ND_ifequal_color3B" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
@@ -659,6 +665,7 @@
   <implementation name="IM_ifequal_vector4B_genosl" nodedef="ND_ifequal_vector4B" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_matrix33B_genosl" nodedef="ND_ifequal_matrix33B" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
   <implementation name="IM_ifequal_matrix44B_genosl" nodedef="ND_ifequal_matrix44B" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, {{in1}}, {{in2}})" />
+  <implementation name="IM_ifequal_booleanB_genosl" nodedef="ND_ifequal_booleanB" target="genosl" sourcecode="mx_ternary({{value1}} == {{value2}}, 1, 0)" />
 
   <!-- <switch> -->
   <!-- 'which' type : float -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -3691,6 +3691,11 @@
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
+  <nodedef name="ND_ifgreater_boolean" node="ifgreater" nodegroup="conditional">
+    <input name="value1" type="float" value="1.0" />
+    <input name="value2" type="float" value="0.0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
   <nodedef name="ND_ifgreater_floatI" node="ifgreater" nodegroup="conditional">
     <input name="value1" type="integer" value="1" />
     <input name="value2" type="integer" value="0" />
@@ -3753,6 +3758,11 @@
     <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_ifgreater_booleanI" node="ifgreater" nodegroup="conditional">
+    <input name="value1" type="integer" value="1" />
+    <input name="value2" type="integer" value="0" />
+   <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <!--
@@ -3822,6 +3832,11 @@
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
+  <nodedef name="ND_ifgreatereq_boolean" node="ifgreatereq" nodegroup="conditional">
+    <input name="value1" type="float" value="1.0" />
+    <input name="value2" type="float" value="0.0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
   <nodedef name="ND_ifgreatereq_floatI" node="ifgreatereq" nodegroup="conditional">
     <input name="value1" type="integer" value="1" />
     <input name="value2" type="integer" value="0" />
@@ -3884,6 +3899,11 @@
     <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_ifgreatereq_booleanI" node="ifgreatereq" nodegroup="conditional">
+    <input name="value1" type="integer" value="1" />
+    <input name="value2" type="integer" value="0" />
+   <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <!--
@@ -3953,6 +3973,11 @@
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
+  <nodedef name="ND_ifequal_boolean" node="ifequal" nodegroup="conditional">
+    <input name="value1" type="float" value="1.0" />
+    <input name="value2" type="float" value="0.0" />
+    <output name="out" type="boolean" default="false" />
+  </nodedef>
   <nodedef name="ND_ifequal_floatI" node="ifequal" nodegroup="conditional">
     <input name="value1" type="integer" value="0" />
     <input name="value2" type="integer" value="0" />
@@ -4016,6 +4041,11 @@
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
+  <nodedef name="ND_ifequal_booleanI" node="ifequal" nodegroup="conditional">
+    <input name="value1" type="integer" value="1" />
+    <input name="value2" type="integer" value="0" />
+   <output name="out" type="boolean" default="false" />
+  </nodedef>
   <nodedef name="ND_ifequal_floatB" node="ifequal" nodegroup="conditional">
     <input name="value1" type="boolean" value="false" />
     <input name="value2" type="boolean" value="false" />
@@ -4078,6 +4108,11 @@
     <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     <output name="out" type="matrix44" defaultinput="in1" />
+  </nodedef>
+  <nodedef name="ND_ifequal_booleanB" node="ifequal" nodegroup="conditional">
+    <input name="value1" type="boolean" value="false" />
+    <input name="value2" type="boolean" value="false" />
+   <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <!--

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_if_float.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_if_float.mtlx
@@ -85,6 +85,13 @@
     </ifgreater>
     <output name="out" type="matrix44" nodename="ifgreater1" />
   </nodegraph>
+  <nodegraph name="ifgreater_boolean">
+    <ifgreater name="ifgreater1" type="boolean">
+      <input name="value1" type="float" value="0.8000" />
+      <input name="value2" type="float" value="0.6000" />
+    </ifgreater>
+    <output name="out" type="boolean" nodename="ifgreater1" />
+  </nodegraph>
   <nodegraph name="ifequal_float">
     <ifequal name="ifequal1" type="float">
       <input name="value1" type="float" value="0.8000" />
@@ -166,6 +173,13 @@
     </ifequal>
     <output name="out" type="matrix44" nodename="ifequal1" />
   </nodegraph>
+  <nodegraph name="ifequal_boolean">
+    <ifequal name="ifequal1" type="boolean">
+      <input name="value1" type="float" value="0.8000" />
+      <input name="value2" type="float" value="0.6000" />
+    </ifequal>
+    <output name="out" type="boolean" nodename="ifequal1" />
+  </nodegraph>
   <nodegraph name="ifgreatereq_float">
     <ifgreatereq name="ifgreatereq1" type="float">
       <input name="value1" type="float" value="0.8000" />
@@ -246,5 +260,12 @@
       <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     </ifgreatereq>
     <output name="out" type="matrix44" nodename="ifgreatereq1" />
+  </nodegraph>
+  <nodegraph name="ifgreatereq_boolean">
+    <ifgreatereq name="ifgreatereq1" type="boolean">
+      <input name="value1" type="float" value="0.8000" />
+      <input name="value2" type="float" value="0.6000" />
+    </ifgreatereq>
+    <output name="out" type="boolean" nodename="ifgreatereq1" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_if_int.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_if_int.mtlx
@@ -87,6 +87,13 @@
     </ifgreater>
     <output name="out" type="matrix44" nodename="ifgreater1" />
   </nodegraph>
+  <nodegraph name="ifgreater_boolean">
+    <ifgreater name="ifgreater1" type="boolean">
+      <input name="value1" type="integer" value="8" />
+      <input name="value2" type="integer" value="6" />
+    </ifgreater>
+    <output name="out" type="boolean" nodename="ifgreater1" />
+  </nodegraph>
 
   <!-- equal int condition -->
   <nodegraph name="ifequal_float">
@@ -169,6 +176,13 @@
       <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     </ifequal>
     <output name="out" type="matrix44" nodename="ifequal1" />
+  </nodegraph>
+  <nodegraph name="ifequal_boolean">
+    <ifequal name="ifequal1" type="boolean">
+      <input name="value1" type="integer" value="8" />
+      <input name="value2" type="integer" value="6" />
+    </ifequal>
+    <output name="out" type="boolean" nodename="ifequal1" />
   </nodegraph>
 
   <!-- equal boolean condition -->
@@ -253,6 +267,13 @@
     </ifequal>
     <output name="out" type="matrix44" nodename="ifequal1" />
   </nodegraph>
+  <nodegraph name="ifequalB_boolean">
+    <ifequal name="ifequal1" type="boolean">
+      <input name="value1" type="boolean" value="true" />
+      <input name="value2" type="boolean" value="true" />
+    </ifequal>
+    <output name="out" type="boolean" nodename="ifequal1" />
+  </nodegraph>
 
   <!-- greatereq int condition -->
   <nodegraph name="ifgreatereq_float">
@@ -335,5 +356,12 @@
       <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
     </ifgreatereq>
     <output name="out" type="matrix44" nodename="ifgreatereq1" />
+  </nodegraph>
+  <nodegraph name="ifgreatereq_boolean">
+    <ifgreatereq name="ifgreatereq1" type="boolean">
+      <input name="value1" type="integer" value="8" />
+      <input name="value2" type="integer" value="6" />
+    </ifgreatereq>
+    <output name="out" type="boolean" nodename="ifgreatereq1" />
   </nodegraph>
 </materialx>

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -3204,6 +3204,17 @@ export float4x4 mx_ifgreater_matrix44(
 	if (mxp_value1 > mxp_value2) { return mxp_in1; } return mxp_in2;
 }
 
+export bool mx_ifgreater_boolean(
+	float mxp_value1 = float(1.0),
+	float mxp_value2 = float(0.0)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 > mxp_value2) { return true; } return false;
+}
+
 export float mx_ifgreater_floatI(
 	int mxp_value1 = int(1),
 	int mxp_value2 = int(0),
@@ -3319,6 +3330,17 @@ export float4x4 mx_ifgreater_matrix44I(
 	]]
 {
 	if (mxp_value1 > mxp_value2) { return mxp_in1; } return mxp_in2;
+}
+
+export bool mx_ifgreater_booleanI(
+	int mxp_value1 = int(1),
+	int mxp_value2 = int(0)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 > mxp_value2) { return true; } return false;
 }
 
 export float mx_ifgreatereq_float(
@@ -3438,6 +3460,17 @@ export float4x4 mx_ifgreatereq_matrix44(
 	if (mxp_value1 >= mxp_value2) { return mxp_in1; } return mxp_in2;
 }
 
+export bool mx_ifgreatereq_boolean(
+	float mxp_value1 = float(1.0),
+	float mxp_value2 = float(0.0)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 >= mxp_value2) { return true; } return false;
+}
+
 export float mx_ifgreatereq_floatI(
 	int mxp_value1 = int(1),
 	int mxp_value2 = int(0),
@@ -3553,6 +3586,17 @@ export float4x4 mx_ifgreatereq_matrix44I(
 	]]
 {
 	if (mxp_value1 >= mxp_value2) { return mxp_in1; } return mxp_in2;
+}
+
+export bool mx_ifgreatereq_booleanI(
+	int mxp_value1 = int(1),
+	int mxp_value2 = int(0)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 >= mxp_value2) { return true; } return false;
 }
 
 export float mx_ifequal_float(
@@ -3672,6 +3716,17 @@ export float4x4 mx_ifequal_matrix44(
 	if (mxp_value1 == mxp_value2) { return mxp_in1; } return mxp_in2;
 }
 
+export bool mx_ifequal_float(
+	float mxp_value1 = float(0.0),
+	float mxp_value2 = float(0.0)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 == mxp_value2) { return true; } return false;
+}
+
 export float mx_ifequal_floatI(
 	int mxp_value1 = int(0),
 	int mxp_value2 = int(0),
@@ -3789,6 +3844,17 @@ export float4x4 mx_ifequal_matrix44I(
 	if (mxp_value1 == mxp_value2) { return mxp_in1; } return mxp_in2;
 }
 
+export bool mx_ifequal_booleanI(
+	int mxp_value1 = int(0),
+	int mxp_value2 = int(0)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 == mxp_value2) { return true; } return false;
+}
+
 export float mx_ifequal_floatB(
 	bool mxp_value1 = bool(false),
 	bool mxp_value2 = bool(false),
@@ -3904,6 +3970,17 @@ export float4x4 mx_ifequal_matrix44B(
 	]]
 {
 	if (mxp_value1 == mxp_value2) { return mxp_in1; } return mxp_in2;
+}
+
+export bool mx_ifequal_booleanB(
+	bool mxp_value1 = bool(false),
+	bool mxp_value2 = bool(false)
+)
+	[[
+		anno::description("Node Group: conditional")
+	]]
+{
+	if (mxp_value1 == mxp_value2) { return true; } return false;
 }
 
 export float mx_switch_float(


### PR DESCRIPTION
This changelist adds boolean-output versions of the `ifgreater`, `ifgreatereq`, `ifequal` nodes to the MaterialX data libraries, as defined in the 1.39 specification:

https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md#conditional-nodes