### PR TITLE
Update legacy OSL function

### DIFF
--- a/libraries/pbrlib/genosl/legacy/mx_oren_nayar_diffuse_bsdf.osl
+++ b/libraries/pbrlib/genosl/legacy/mx_oren_nayar_diffuse_bsdf.osl
@@ -1,4 +1,4 @@
-void mx_oren_nayar_diffuse_bsdf(float weight, color _color, float roughness, normal N, output BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf(float weight, color _color, float roughness, normal N, bool energy_compensation, output BSDF bsdf)
 {
     bsdf.response = _color * weight * oren_nayar(N, roughness);
     bsdf.throughput = color(0.0);

--- a/libraries/pbrlib/genosl/legacy/mx_oren_nayar_diffuse_bsdf.osl
+++ b/libraries/pbrlib/genosl/legacy/mx_oren_nayar_diffuse_bsdf.osl
@@ -1,4 +1,4 @@
-void mx_oren_nayar_diffuse_bsdf(float weight, color _color, float roughness, normal N, bool energy_compensation, output BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf(float weight, color _color, float roughness, normal N, int energy_compensation, output BSDF bsdf)
 {
     bsdf.response = _color * weight * oren_nayar(N, roughness);
     bsdf.throughput = color(0.0);


### PR DESCRIPTION
This changelist updates the mx_oren_nayar_diffuse_bsdf function in the legacy OSL pathway, addressing a shader compilation issue when this option is enabled.