### PR TITLE
Improve robustness of input connections

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsInterface.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsInterface.cpp
@@ -48,6 +48,7 @@ EMSCRIPTEN_BINDINGS(interface)
         .function("setConnectedOutput", &mx::Input::setConnectedOutput)
         .function("getConnectedOutput", &mx::Input::getConnectedOutput)
         .function("getInterfaceInput", &mx::Input::getInterfaceInput)
+        .function("setConnectedInterfaceName", &mx::Input::setConnectedInterfaceName)
         .class_property("CATEGORY", &mx::Input::CATEGORY)
         .class_property("DEFAULT_GEOM_PROP_ATTRIBUTE", &mx::Input::DEFAULT_GEOM_PROP_ATTRIBUTE);
 

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -211,6 +211,10 @@ class MX_CORE_API Input : public PortElement
     /// Return the node, if any, to which this input is connected.
     NodePtr getConnectedNode() const override;
 
+    /// Connects this input to a corresponding interface with the given name.
+    /// If the interface name specified is an empty string then any existing connection is removed.
+    void setConnectedInterfaceName(const string& interfaceName);
+
     /// Return the input on the parent graph corresponding to the interface name
     /// for this input.
     InputPtr getInterfaceInput() const;

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1834,7 +1834,7 @@ void Graph::copyInputs()
                             else if (upNode->getInput())
                             {
 
-                                copyNode->inputPins[count]->_input->setInterfaceName(upNode->getName());
+                                copyNode->inputPins[count]->_input->setConnectedInterfaceName(upNode->getName());
                             }
                             else
                             {
@@ -1860,7 +1860,7 @@ void Graph::copyInputs()
                         {
                             if (upNode->getInput())
                             {
-                                copyNode->inputPins[count]->_input->setInterfaceName(upNode->getName());
+                                copyNode->inputPins[count]->_input->setConnectedInterfaceName(upNode->getName());
                             }
                             else
                             {
@@ -1869,7 +1869,6 @@ void Graph::copyInputs()
                         }
 
                         copyNode->inputPins[count]->setConnected(true);
-                        copyNode->inputPins[count]->_input->removeAttribute(mx::ValueElement::VALUE_ATTRIBUTE);
                     }
                     else if (copyNode->getOutput() != nullptr)
                     {
@@ -1885,7 +1884,7 @@ void Graph::copyInputs()
                 {
                     if (pin->_input->getInterfaceInput())
                     {
-                        copyNode->inputPins[count]->_input->removeAttribute(mx::ValueElement::INTERFACE_NAME_ATTRIBUTE);
+                        copyNode->inputPins[count]->_input->setConnectedInterfaceName(mx::EMPTY_STRING);
                     }
                     copyNode->inputPins[count]->setConnected(false);
                     setDefaults(copyNode->inputPins[count]->_input);
@@ -2625,7 +2624,7 @@ void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
                         }
                         else if (uiUpNode->getInput() != nullptr)
                         {
-                            pin->_input->setInterfaceName(uiUpNode->getName());
+                            pin->_input->setConnectedInterfaceName(uiUpNode->getName());
                         }
                         else
                         {
@@ -2651,7 +2650,7 @@ void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
                     {
                         if (uiUpNode->getInput())
                         {
-                            pin->_input->setInterfaceName(uiUpNode->getName());
+                            pin->_input->setConnectedInterfaceName(uiUpNode->getName());
                         }
                         else
                         {
@@ -2697,7 +2696,6 @@ void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
                     }
 
                     pin->setConnected(true);
-                    pin->_input->removeAttribute(mx::ValueElement::VALUE_ATTRIBUTE);
                     connectingInput = pin->_input;
                     break;
                 }
@@ -2777,7 +2775,7 @@ void Graph::deleteLinkInfo(int startAttr, int endAttr)
                 if (_graphNodes[upNode]->getInput())
                 {
                     // Remove interface value in order to set the default of the input
-                    pin->_input->removeAttribute(mx::ValueElement::INTERFACE_NAME_ATTRIBUTE);
+                    pin->_input->setConnectedInterfaceName(mx::EMPTY_STRING);
                     setDefaults(pin->_input);
                     setDefaults(_graphNodes[upNode]->getInput());
                 }
@@ -2810,7 +2808,7 @@ void Graph::deleteLinkInfo(int startAttr, int endAttr)
                 removeEdge(downNode, upNode, pin);
                 if (_graphNodes[upNode]->getInput())
                 {
-                    _graphNodes[downNode]->getNodeGraph()->getInput(pin->_name)->removeAttribute(mx::ValueElement::INTERFACE_NAME_ATTRIBUTE);
+                    _graphNodes[downNode]->getNodeGraph()->getInput(pin->_name)->setConnectedInterfaceName(mx::EMPTY_STRING);
                     setDefaults(_graphNodes[upNode]->getInput());
                 }
                 for (UiPinPtr connect : pin->_connections)
@@ -2906,8 +2904,8 @@ void Graph::deleteNode(UiNodePtr node)
                 }
                 if (node->getInput())
                 {
-                    // Remove interface value in order to set the default of the input
-                    pin->_input->removeAttribute(mx::ValueElement::INTERFACE_NAME_ATTRIBUTE);
+                    // Remove interface in order to set the default of the input
+                    pin->_input->setConnectedInterfaceName(mx::EMPTY_STRING);
                     setDefaults(pin->_input);
                     setDefaults(node->getInput());
                 }
@@ -2916,7 +2914,7 @@ void Graph::deleteNode(UiNodePtr node)
             {
                 if (node->getInput())
                 {
-                    pin->_pinNode->getNodeGraph()->getInput(pin->_name)->removeAttribute(mx::ValueElement::INTERFACE_NAME_ATTRIBUTE);
+                    pin->_pinNode->getNodeGraph()->getInput(pin->_name)->setConnectedInterfaceName(mx::EMPTY_STRING);
                     setDefaults(node->getInput());
                 }
                 pin->_input->setConnectedNode(nullptr);
@@ -3320,7 +3318,7 @@ void Graph::propertyEditor()
                                 {
                                     _currUiNode->getInput()->setName(name);
                                     mx::ValuePtr val = _currUiNode->getInput()->getValue();
-                                    input->setInterfaceName(name);
+                                    input->setConnectedInterfaceName(name);
                                     mx::InputPtr pt = input->getInterfaceInput();
                                 }
                             }

--- a/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyInterface.cpp
@@ -37,6 +37,7 @@ void bindPyInterface(py::module& mod)
         .def("getDefaultGeomPropString", &mx::Input::getDefaultGeomPropString)
         .def("getDefaultGeomProp", &mx::Input::getDefaultGeomProp)
         .def("getConnectedNode", &mx::Input::getConnectedNode)
+        .def("setConnectedInterfaceName", &mx::Input::setConnectedInterfaceName)
         .def("getInterfaceInput", &mx::Input::getInterfaceInput)
         .def_readonly_static("CATEGORY", &mx::Input::CATEGORY);
 


### PR DESCRIPTION
## Issue Addressed

This change adds detection for the case where both a connection and a value are specified, adds and update connection APIs to enforce not creating invalid documents.

## Changes

- Adds a new `Input::setConnectedInterfaceName()` interface which clears the `value` attributes to avoid accidently creating invalid documents.
- Updates other existing connection APIs to also clear the `value` attribute appropriately.
- Updates validation on an input to mark when both a value and a connection are created.

## Tests
- Update invalid documents:
  - Fix existing error in one of the render test suite files (`color_management.mtlx`).
  - `mxvalidate.py` and code generation tests caught this error. Ran `mxvalidate` on everything in `libraries` and `resources`.
- Add a new `node` unit test to check interface setting and validity checking.
- Change the node graph editor to use the new interface and remove previous manual `value` and `interfacename` clearing calls.

