### PR TITLE
Add mode input to sheen_bsdf

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -558,12 +558,12 @@
     </layer>
 
     <!-- Fuzz Layer -->
-    <!-- TODO: Add a new BSDF node for the selected fuzz model in OpenPBR -->
     <sheen_bsdf name="fuzz_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="fuzz_weight" />
       <input name="color" type="color3" interfacename="fuzz_color" />
       <input name="roughness" type="float" interfacename="fuzz_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="mode" type="string" value="zeltner" />
     </sheen_bsdf>
     <layer name="fuzz_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="fuzz_bsdf" />

--- a/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
@@ -46,20 +46,18 @@ void mx_sheen_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, v
     N = mx_forward_facing_normal(N, V);
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    vec3 Li = mx_environment_irradiance(N);
-
+    float dirAlbedo;
     if (mode == 0)
     {
-        float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
-        bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
-        bsdf.response = Li * color * dirAlbedo * weight;
+        dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
     }
     else
     {
         roughness = clamp(roughness, 0.01, 1.0); // Clamp to range of original impl.
-
-        float dirAlbedo = mx_zeltner_sheen_dir_albedo(NdotV, roughness);
-        bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
-        bsdf.response = Li * color * dirAlbedo * weight;
+        dirAlbedo = mx_zeltner_sheen_dir_albedo(NdotV, roughness);
     }
+
+    vec3 Li = mx_environment_irradiance(N);
+    bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+    bsdf.response = Li * color * dirAlbedo * weight;
 }

--- a/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
@@ -1,10 +1,6 @@
 #include "lib/mx_microfacet_sheen.glsl"
 
-#define SHEEN_METHOD 0
-
-#if SHEEN_METHOD == 0
-
-void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
+void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, int mode, inout BSDF bsdf)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -12,43 +8,35 @@ void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float wei
     }
 
     N = mx_forward_facing_normal(N, V);
-
-    vec3 H = normalize(L + V);
-
-    float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
-    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-    float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
-
-    vec3 fr = color * mx_imageworks_sheen_brdf(NdotL, NdotV, NdotH, roughness);
-    float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
-    bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
-
-    // We need to include NdotL from the light integral here
-    // as in this case it's not cancelled out by the BRDF denominator.
-    bsdf.response = fr * NdotL * occlusion * weight;
-}
-
-void mx_sheen_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
-{
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-
     float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
-    bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+    if (mode == 0)
+    {
+        vec3 H = normalize(L + V);
 
-    vec3 Li = mx_environment_irradiance(N);
-    bsdf.response = Li * color * dirAlbedo * weight;
+        float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
+        float NdotH = clamp(dot(N, H), M_FLOAT_EPS, 1.0);
+
+        vec3 fr = color * mx_imageworks_sheen_brdf(NdotL, NdotV, NdotH, roughness);
+        float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
+        bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+
+        // We need to include NdotL from the light integral here
+        // as in this case it's not cancelled out by the BRDF denominator.
+        bsdf.response = fr * NdotL * occlusion * weight;
+    }
+    else
+    {
+        roughness = clamp(roughness, 0.01, 1.0); // Clamp to range of original impl.
+
+        vec3 fr = color * mx_zeltner_sheen_brdf(L, V, N, NdotV, roughness);
+        float dirAlbedo = mx_zeltner_sheen_dir_albedo(NdotV, roughness);
+        bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+        bsdf.response = dirAlbedo * fr * occlusion * weight;
+    }
 }
 
-#elif SHEEN_METHOD == 1
-
-void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
+void mx_sheen_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 N, int mode, inout BSDF bsdf)
 {
     if (weight < M_FLOAT_EPS)
     {
@@ -56,34 +44,22 @@ void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float wei
     }
 
     N = mx_forward_facing_normal(N, V);
-
-    float NdotV = min(dot(N, V), 1.0);
-    roughness = clamp(roughness, 0.01, 1.0); // Clamp to range of original impl.
-
-    vec3 fr = color * mx_zeltner_sheen_brdf(L, V, N, NdotV, roughness);
-    float dirAlbedo = mx_zeltner_sheen_dir_albedo(NdotV, roughness);
-    bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
-
-    bsdf.response = dirAlbedo * fr * occlusion * weight;
-}
-
-void mx_sheen_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
-{
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-
-    float NdotV = min(dot(N, V), 1.0);
-    roughness = clamp(roughness, 0.01, 1.0); // Clamp to range of original impl.
-
-    float dirAlbedo = mx_zeltner_sheen_dir_albedo(NdotV, roughness);
-    bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     vec3 Li = mx_environment_irradiance(N);
-    bsdf.response = Li * color * dirAlbedo * weight;
-}
 
-#endif
+    if (mode == 0)
+    {
+        float dirAlbedo = mx_imageworks_sheen_dir_albedo(NdotV, roughness);
+        bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+        bsdf.response = Li * color * dirAlbedo * weight;
+    }
+    else
+    {
+        roughness = clamp(roughness, 0.01, 1.0); // Clamp to range of original impl.
+
+        float dirAlbedo = mx_zeltner_sheen_dir_albedo(NdotV, roughness);
+        bsdf.throughput = vec3(1.0 - dirAlbedo * weight);
+        bsdf.response = Li * color * dirAlbedo * weight;
+    }
+}

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -132,6 +132,7 @@
     <input name="color" type="color3" value="1.0, 1.0, 1.0" />
     <input name="roughness" type="float" value="0.3" />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
+    <input name="mode" type="string" value="conty_kulla" enum="conty_kulla, zeltner" uniform="true" />
     <output name="out" type="BSDF" />
   </nodedef>
 

--- a/resources/Materials/Examples/OpenPbr/open_pbr_velvet.mtlx
+++ b/resources/Materials/Examples/OpenPbr/open_pbr_velvet.mtlx
@@ -8,6 +8,6 @@
     <input name="specular_roughness" type="float" value="0.8" />
     <input name="fuzz_weight" type="float" value="1" />
     <input name="fuzz_color" type="color3" value="0.4, 0.4, 0.4" />
-    <input name="fuzz_roughness" type="float" value="0.2" />
+    <input name="fuzz_roughness" type="float" value="0.5" />
   </open_pbr_surface>
 </materialx>


### PR DESCRIPTION
This changelist adds a `mode` input to `sheen_bsdf`, allowing the user to select between Conty-Kulla and Zeltner sheen models.

The Zeltner model is initially supported only in GLSL, ESSL, and MSL, integrating recent work from Stephen Hill, with OSL and MDL falling back to the Conty-Kulla model for now.

The graph implementation of `open_pbr_surface` has been updated to take advantage of this new feature, and the `open_pbr_velvet.mtlx` example has been adjusted to take the visual behavior of Zeltner sheen into account.