### PR TITLE
Update thin_film_ior default in OpenPBR

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -69,7 +69,7 @@
            doc="Coverage weight of the thin-film. Use for materials such as multi-tone car paint or soap bubbles." />
     <input name="thin_film_thickness" type="float" value="0.5" uimin="0.0" uisoftmax="1.0" uiname="Thin Film Thickness" uifolder="Thin Film" uiadvanced="true"
            doc="The thickness of the thin-film layer on the base (in micrometers)." />
-    <input name="thin_film_ior" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
+    <input name="thin_film_ior" type="float" value="1.4" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
            doc="The index of refraction of the thin-film." />
     <input name="emission_luminance" type="float" value="0.0" uimin="0.0" uisoftmax="1000.0" uiname="Emission Luminance" uifolder="Emission"
            doc="The amount of emitted light, as a luminance in nits." />

--- a/resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx
+++ b/resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx
@@ -37,7 +37,7 @@
     <input name="coat_darkening" type="float" value="1.0" />
     <input name="thin_film_weight" type="float" value="0" />
     <input name="thin_film_thickness" type="float" value="0.5" />
-    <input name="thin_film_ior" type="float" value="1.5" />
+    <input name="thin_film_ior" type="float" value="1.4" />
     <input name="emission_luminance" type="float" value="0.0" />
     <input name="emission_color" type="color3" value="1, 1, 1" />
     <input name="geometry_opacity" type="float" value="1" />


### PR DESCRIPTION
This changelist updates the default value of `thin_film_ior` in OpenPBR from 1.5 to 1.4, tracking the latest work in the OpenPBR repository.