### PR TITLE
Update LamaConductor Node

### DIFF
--- a/libraries/bxdf/lama/lama_conductor.mtlx
+++ b/libraries/bxdf/lama/lama_conductor.mtlx
@@ -23,24 +23,12 @@
            doc="Overrides the surface tangent as the anisotropy direction." />
     <input name="anisotropyRotation" type="float" value="0.0" uiname="Rotation" uifolder="Anisotropy"
            doc="Rotates the anisotropy direction (possibly overriden by the previous attribute) around the normal, from 0 to 360 degrees." />
-    <input name="iridescenceThickness" type="float" value="0.0" uimin="0.0" uisoftmax="200.0" uiname="Thickness" uifolder="Iridescence"
-           doc="Thin film thickness in nanometers, driving the iridescent effect." />
-    <input name="iridescenceIOR" type="float" value="1.5" uimin="1.0" uimax="3.0" uiname="IOR" uifolder="Iridescence"
-           doc="Thin film index of refraction, driving the iridescent effect." />
-    <input name="exteriorIOR" type="float" value="1.0" uimin="1.0" uimax="3.0" uiname="Exterior IOR" uifolder="Advanced"
-           doc="Defines what the IOR of the exterior medium is (can be either the outside medium, eg. air or water, or in case of a layered material, the top layer medium, like plexiglass or varnish)." />
     <output name="out" type="BSDF" />
   </nodedef>
 
   <nodegraph name="IMPL_lama_conductor" nodedef="ND_lama_conductor">
 
     <!-- IOR -->
-    <ifgreater name="exterior_ior_switch" type="float">
-      <input name="in1" type="float" interfacename="iridescenceIOR" />
-      <input name="in2" type="float" interfacename="exteriorIOR" />
-      <input name="value1" type="float" interfacename="iridescenceThickness" />
-      <input name="value2" type="float" value="0" />
-    </ifgreater>
     <artistic_ior name="artistic_ior" type="multioutput">
       <input name="reflectivity" type="color3" interfacename="reflectivity" />
       <input name="edge_color" type="color3" interfacename="edgeColor" />
@@ -61,14 +49,6 @@
       <input name="in2" type="color3" nodename="artistic_ior" output="extinction" />
       <input name="which" type="integer" interfacename="fresnelMode" />
     </switch>
-    <divide name="relative_eta" type="color3">
-      <input name="in1" type="color3" nodename="eta_switch" />
-      <input name="in2" type="float" nodename="exterior_ior_switch" />
-    </divide>
-    <divide name="relative_kappa" type="color3">
-      <input name="in1" type="color3" nodename="kappa_switch" />
-      <input name="in2" type="float" nodename="exterior_ior_switch" />
-    </divide>
 
     <!-- Roughness -->
     <subtract name="roughness_inverse" type="float">
@@ -122,21 +102,13 @@
     <!-- BRDF -->
     <conductor_bsdf name="conductor_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
-      <input name="ior" type="color3" nodename="relative_eta" />
-      <input name="extinction" type="color3" nodename="relative_kappa" />
+      <input name="ior" type="color3" nodename="eta_switch" />
+      <input name="extinction" type="color3" nodename="kappa_switch" />
       <input name="roughness" type="vector2" nodename="roughness_anisotropic_squared_clamped" />
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="tangent_rotate_normalize" />
       <input name="distribution" type="string" value="ggx" />
-      <input name="thinfilm_thickness" type="float" interfacename="iridescenceThickness" />
-      <input name="thinfilm_ior" type="float" nodename="iridescence_relative_ior" />
     </conductor_bsdf>
-
-    <!-- BRDF + Thin film -->
-    <divide name="iridescence_relative_ior" type="float">
-      <input name="in1" type="float" interfacename="iridescenceIOR" />
-      <input name="in2" type="float" interfacename="exteriorIOR" />
-    </divide>
 
     <!-- Layered BRDF -->
 

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/lama_tests.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/lama_tests.mtlx
@@ -12,9 +12,6 @@
     <input name="roughness" type="float" value="0.1" />
     <input name="anisotropy" type="float" value="0.0" />
     <input name="anisotropyRotation" type="float" value="0.0" />
-    <input name="iridescenceThickness" type="float" value="0.0" />
-    <input name="iridescenceIOR" type="float" value="1.5" />
-    <input name="exteriorIOR" type="float" value="1.0" />
   </LamaConductor>
   <surface name="LamaConductorSurface" type="surfaceshader">
     <input name="bsdf" type="BSDF" nodename="LamaConductor" />


### PR DESCRIPTION
1. Removed the iridescenceThickness and iridescenceIOR inputs, as these are not present in the RenderMan definition of the node.

2. Removed the exteriorIor input, as we expect relative IOR to be computed by the renderer.