### PR TITLE
Remove unused thin_surface node

### DIFF
--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -46,9 +46,6 @@
   <!-- <surface> -->
   <implementation name="IM_surface_genmdl" nodedef="ND_surface" target="genmdl" />
 
-  <!-- <thin_surface> -->
-  <implementation name="IM_thin_surface_genmdl" nodedef="ND_thin_surface" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_thin_surface(mxp_front_bsdf:{{front_bsdf}}, mxp_front_edf:{{front_edf}}, mxp_back_bsdf:{{back_bsdf}}, mxp_back_edf:{{back_edf}}, mxp_opacity:{{opacity}})" target="genmdl" />
-
   <!-- <volume> -->
   <implementation name="IM_volume_genmdl" nodedef="ND_volume" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_volume(mxp_vdf:{{vdf}}, mxp_edf:{{edf}})" target="genmdl" />
 

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -227,19 +227,6 @@
   </nodedef>
 
   <!--
-    Node: <thin_surface>
-    Construct a surface shader from scattering and emission distribution functions for non-closed "thin" objects.
-  -->
-  <nodedef name="ND_thin_surface" node="thin_surface" nodegroup="pbr" doc="A constructor node for the surfaceshader type for non-closed 'thin' objects.">
-    <input name="front_bsdf" type="BSDF" value="" doc="Distribution function for front-side surface scattering." />
-    <input name="front_edf" type="EDF" value="" doc="Distribution function for front-side surface emission." />
-    <input name="back_bsdf" type="BSDF" value="" doc="Distribution function for back-side surface scattering." />
-    <input name="back_edf" type="EDF" value="" doc="Distribution function for back-side surface emission." />
-    <input name="opacity" type="float" value="1.0" doc="Surface cutout opacity" />
-    <output name="out" type="surfaceshader" />
-  </nodedef>
-
-  <!--
     Node: <volume>
     Construct a volume shader describing a participating medium.
   -->

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
@@ -568,41 +568,6 @@ export material mx_surface(
     )
 );
 
-export material mx_thin_surface(
-    material mxp_front_bsdf    = material() [[ anno::usage( "materialx:bsdf") ]],
-    material mxp_front_edf     = material() [[ anno::usage( "materialx:edf") ]],
-    material mxp_back_bsdf     = material() [[ anno::usage( "materialx:bsdf") ]],
-    material mxp_back_edf      = material() [[ anno::usage( "materialx:edf") ]],
-    float    mxp_opacity = 1.0
-) [[ 
-    anno::usage( "materialx:surfaceshader") 
-]]
-= let {
-    bsdf              front_bsdf_node = mxp_front_bsdf.surface.scattering;
-    material_emission front_edf_node  = mxp_front_edf.surface.emission;
-    bsdf              back_bsdf_node  = mxp_back_bsdf.surface.scattering;
-    material_emission back_edf_node   = mxp_back_edf.surface.emission;
-    // we need to carry volume properties along for SSS
-    // TODO: clarify SSS behavior in MaterialX for thin-walled surfaces,
-    //       in MDL there is only one volume property
-    material_volume   bsdf_volume = mxp_front_bsdf.volume;
-} in material(
-    thin_walled: true,
-    surface: material_surface( 
-        scattering: front_bsdf_node,
-        emission: front_edf_node
-    ),
-    backface: material_surface( 
-        scattering: back_bsdf_node,
-        emission: back_edf_node
-    ),
-    ior: color(1.0),
-    volume: bsdf_volume,
-    geometry: material_geometry(
-        cutout_opacity: mxp_opacity
-    )
-);
-
 // MDL 1.6, Volumes do not support emission.
 export material mx_volume(
     material mxp_vdf    = material() [[ anno::usage( "materialx:vdf") ]],

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_7.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_7.mdl
@@ -54,7 +54,6 @@ export using .::pbrlib_1_6 import mx_measured_edf;
 export using .::pbrlib_1_6 import mx_absorption_vdf;
 export using .::pbrlib_1_6 import mx_anisotropic_vdf;
 export using .::pbrlib_1_6 import mx_surface;
-export using .::pbrlib_1_6 import mx_thin_surface;
 export using .::pbrlib_1_6 import mx_light;
 export using .::pbrlib_1_6 import mx_displacement_float;
 export using .::pbrlib_1_6 import mx_displacement_vector3;

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -3716,7 +3716,7 @@ export float4x4 mx_ifequal_matrix44(
 	if (mxp_value1 == mxp_value2) { return mxp_in1; } return mxp_in2;
 }
 
-export bool mx_ifequal_float(
+export bool mx_ifequal_boolean(
 	float mxp_value1 = float(0.0),
 	float mxp_value2 = float(0.0)
 )

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -81,7 +81,7 @@ TEST_CASE("GenShader: GLSL Implementation Check", "[genglsl]")
 
     mx::StringSet generatorSkipNodeTypes;
     mx::StringSet generatorSkipNodeDefs;
-    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 31);
+    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 30);
 }
 
 TEST_CASE("GenShader: GLSL Unique Names", "[genglsl]")

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -93,7 +93,7 @@ TEST_CASE("GenShader: MDL Implementation Check", "[genmdl]")
     generatorSkipNodeTypes.insert("light");
     mx::StringSet generatorSkipNodeDefs;
 
-    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 32);
+    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 31);
 }
 
 

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
@@ -80,7 +80,7 @@ class MdlShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
             "geompropvalue", "surfacematerial", "volumematerial", 
             "IM_absorption_vdf_", "IM_mix_vdf_", "IM_add_vdf_", "IM_multiply_vdf",
             "IM_measured_edf_", "IM_blackbody_", "IM_conical_edf_", 
-            "IM_displacement_", "IM_thin_surface_", "IM_volume_", "IM_light_"
+            "IM_displacement_", "IM_volume_", "IM_light_"
         };
         ShaderGeneratorTester::getImplementationWhiteList(whiteList);
     }

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
@@ -84,7 +84,7 @@ TEST_CASE("GenShader: MSL Implementation Check", "[genmsl]")
 
     mx::StringSet generatorSkipNodeTypes;
     mx::StringSet generatorSkipNodeDefs;
-    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 31);
+    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 30);
 }
 
 TEST_CASE("GenShader: MSL Unique Names", "[genmsl]")

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -89,7 +89,7 @@ TEST_CASE("GenShader: OSL Implementation Check", "[genosl]")
     generatorSkipNodeTypes.insert("light");
     mx::StringSet generatorSkipNodeDefs;
 
-    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 32);
+    GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs, 31);
 }
 
 TEST_CASE("GenShader: OSL Unique Names", "[genosl]")

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -97,7 +97,6 @@ void checkImplementations(mx::GenContext& context,
         "conical_edf",
         "measured_edf",
         "absorption_vdf",
-        "thin_surface",
         "geompropvalue",
         "surfacematerial",
         "volumematerial"


### PR DESCRIPTION
This changelist removes the `thin_surface` node. The specification for thin-walled surfaces was changed in 1.39, making this node deprecated. 

The node was never implemented across multiple targets (MDL is the only exception), and we've never heard of anyone trying to use it. So no upgrade logic is added at this point. Should anyone need an upgrade path we can add that later.
