### PR TITLE
Prefix MSL mod function name to avoid clash in Storm

### DIFF
--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -15,6 +15,12 @@ vec3 mx_square(vec3 x)
     return x*x;
 }
 
+template<class T1, class T2>
+T1 mx_mod(T1 x, T2 y)
+{
+    return x - y * floor(x/y);
+}
+
 #ifdef __DECL_GL_MATH_FUNCTIONS__
 
 float radians(float degree) { return (degree * M_PI_F / 180.0f); }
@@ -83,12 +89,6 @@ float4x4 inverse(float4x4 m)
     ret[3][3] = (n12 * n23 * n31 - n13 * n22 * n31 + n13 * n21 * n32 - n11 * n23 * n32 - n12 * n21 * n33 + n11 * n22 * n33) * idet;
 
     return ret;
-}
-
-template<class T1, class T2>
-T1 mod(T1 x, T2 y)
-{
-    return x - y * floor(x/y);
 }
 
 template <typename T>

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -253,17 +253,17 @@
   <implementation name="IM_divide_matrix44_genmsl" nodedef="ND_divide_matrix44" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
 
   <!-- <modulo> -->
-  <implementation name="IM_modulo_float_genmsl" nodedef="ND_modulo_float" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_color3_genmsl" nodedef="ND_modulo_color3" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_color3FA_genmsl" nodedef="ND_modulo_color3FA" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_color4_genmsl" nodedef="ND_modulo_color4" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_color4FA_genmsl" nodedef="ND_modulo_color4FA" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_vector2_genmsl" nodedef="ND_modulo_vector2" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_vector2FA_genmsl" nodedef="ND_modulo_vector2FA" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_vector3_genmsl" nodedef="ND_modulo_vector3" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_vector3FA_genmsl" nodedef="ND_modulo_vector3FA" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_vector4_genmsl" nodedef="ND_modulo_vector4" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
-  <implementation name="IM_modulo_vector4FA_genmsl" nodedef="ND_modulo_vector4FA" target="genmsl" sourcecode="mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_float_genmsl" nodedef="ND_modulo_float" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_color3_genmsl" nodedef="ND_modulo_color3" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_color3FA_genmsl" nodedef="ND_modulo_color3FA" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_color4_genmsl" nodedef="ND_modulo_color4" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_color4FA_genmsl" nodedef="ND_modulo_color4FA" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_vector2_genmsl" nodedef="ND_modulo_vector2" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_vector2FA_genmsl" nodedef="ND_modulo_vector2FA" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_vector3_genmsl" nodedef="ND_modulo_vector3" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_vector3FA_genmsl" nodedef="ND_modulo_vector3FA" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_vector4_genmsl" nodedef="ND_modulo_vector4" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
+  <implementation name="IM_modulo_vector4FA_genmsl" nodedef="ND_modulo_vector4FA" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
 
   <!-- <invert> -->
   <implementation name="IM_invert_float_genmsl" nodedef="ND_invert_float" target="genmsl" sourcecode="{{amount}} - {{in}}" />


### PR DESCRIPTION
Using a `ND_modulo_vector2FA` node in a material causes the shader code generated by Storm to fail to compile when using Metal.

```
 > usdview mod_bug.usda
Warning: in _ValidateCompilation at line 229 of ../../pxr/imaging/hdSt/glslProgram.cpp -- Failed to compile shader (FRAGMENT_SHADER): program_source:3055:33: error: no matching function for call to 'mod'
    vec2 modulo_vector2FA_out = mod(multiply_vector2_out, modulo_vector2FA_in2);
                                ^~~
program_source:136:3: note: candidate template ignored: deduced conflicting types for parameter 'T' ('float2' (vector of 2 'float' values) vs. 'float')
T mod(T y, T x) { return fmod(y, x); }
  ^

Warning: in _ValidateCompilation at line 229 of ../../pxr/imaging/hdSt/glslProgram.cpp -- Failed to compile shader (FRAGMENT_SHADER): program_source:4312:33: error: no matching function for call to 'mod'
    vec2 modulo_vector2FA_out = mod(multiply_vector2_out, modulo_vector2FA_in2);
                                ^~~
program_source:136:3: note: candidate template ignored: deduced conflicting types for parameter 'T' ('float2' (vector of 2 'float' values) vs. 'float')
T mod(T y, T x) { return fmod(y, x); }
  ^

ERROR: Usdview encountered an error while rendering.
	Error in '&pxrInternal_v0_24__pxrReserved__::HdSt_DrawBatch::_GetDrawingProgram' at line 408 in file ../../pxr/imaging/hdSt/drawBatch.cpp : 'Failed to compile shader for prim /Root/Geo/Cube.'
```
[mod_bug.zip](https://github.com/user-attachments/files/15894967/mod_bug.zip)

What's happening here is that Storm declares `T mod(T y, T x) { return fmod(y, x); }` earlier in the shader code, so the MaterialX defined Metal code for `mod()` isn't seen by the compiler.

By just renaming `mod()` to `mx_mod()` in the Metal source code provided by MaterialX, we avoid this name conflict.  Using this `mx_` "namespace" seems like a reasonable, pragmatic solution.

Moving the `mx_mod()` function outside of the `#ifdef __DECL_GL_MATH_FUNCTIONS__` guard ensures it's always used.  I think previously outside of the Storm context Metal may have been using the built in `mod()` call which doesn't follow the same math. (see https://stackoverflow.com/questions/41169747/solving-odd-behavior-re-glsl-metal-shader-unintentional-coordinate-flipping)
