### PR TITLE
Restore windows-2022 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,18 +104,18 @@ jobs:
           python: 3.7
           cmake_config: -G "Visual Studio 16 2019" -A "Win32" -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Windows_VS2019_x64_Python311
-          os: windows-2019
+        - name: Windows_VS2022_x64_Python311
+          os: windows-2022
           architecture: x64
           python: 3.11
-          cmake_config: -G "Visual Studio 16 2019" -A "x64"
+          cmake_config: -G "Visual Studio 17 2022" -A "x64"
           test_shaders: ON
 
-        - name: Windows_VS2019_x64_Python312
-          os: windows-2019
+        - name: Windows_VS2022_x64_Python312
+          os: windows-2022
           architecture: x64
           python: 3.12
-          cmake_config: -G "Visual Studio 16 2019" -A "x64"
+          cmake_config: -G "Visual Studio 17 2022" -A "x64"
           upload_shaders: ON
 
     steps:
@@ -383,7 +383,7 @@ jobs:
       fail-fast: false
       matrix:
         python-minor: ['7', '8', '9', '10', '11', '12']
-        os: ['ubuntu-latest', 'windows-2019', 'macos-13']
+        os: ['ubuntu-latest', 'windows-2022', 'macos-13']
 
     steps:
     - name: Sync Repository


### PR DESCRIPTION
This changelist restores windows-2022 builds to our GitHub Actions CI, as the stability of these runners appears to have recently improved.