### PR TITLE
Add logical operator node definitions

### DIFF
--- a/documents/Specification/MaterialX.Specification.md
+++ b/documents/Specification/MaterialX.Specification.md
@@ -61,6 +61,7 @@ This document describes the core MaterialX specification.  Companion documents [
 
  [Standard Operator Nodes](#standard-operator-nodes)  
   [Math Nodes](#math-nodes)  
+  [Logical Operator Nodes](#logical-operator-nodes)  
   [Adjustment Nodes](#adjustment-nodes)  
   [Compositing Nodes](#compositing-nodes)  
   [Conditional Nodes](#conditional-nodes)  
@@ -1498,6 +1499,34 @@ Math nodes have one or two spatially-varying inputs, and are used to perform a m
 * **`dot`**: a no-op, passes its input through to its output unchanged.  Users can use dot nodes to shape edge connection paths or provide documentation checkpoints in node graph layout UI's.  Dot nodes may also pass uniform values from &lt;constant>, &lt;tokenvalue> or other nodes with uniform="true" outputs to uniform &lt;input>s and &lt;token>s.
     * `in` (any type): the nodename to be connected to the Dot node's "in" input.  Unlike inputs on other node types, the &lt;dot> node's input is specifically disallowed to provide a `channels` attribute: input data can only be passed through unmodified.
 
+
+### Logical Operator Nodes
+
+Logical operator nodes have one or two boolean typed inputs, and are used to construct higher level logical flow through the nodegraph.
+
+<a id="node-and"> </a>
+
+* **`and`**: logically And the two input boolean values.
+  * `in1` (boolean): the value or nodename for the first input; the default is false.
+  * `in2` (boolean): the value or nodename for the second input; the default is false.
+
+<a id="node-or"> </a>
+
+* **`or`**: logically Inclusive Or the two input boolean values.
+  * `in1` (boolean): the value or nodename for the first input; the default is false.
+  * `in2` (boolean): the value or nodename for the second input; the default is false.
+
+<a id="node-xor"> </a>
+
+* **`xor`**: logically Exclusive Or the two input boolean values.
+  * `in1` (boolean): the value or nodename for the first input; the default is false.
+  * `in2` (boolean): the value or nodename for the second input; the default is false.
+
+<a id="node-not"> </a>
+
+* **`not`**: logically Not the input boolean value.
+  * `in1` (boolean): the value or nodename for the first input; the default is false.
+  * `in2` (boolean): the value or nodename for the second input; the default is false.
 
 
 ### Adjustment Nodes

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -731,6 +731,14 @@
   <implementation name="IM_heighttonormal_vector3_genglsl" nodedef="ND_heighttonormal_vector3" target="genglsl" />
 
   <!-- ======================================================================== -->
+  <!-- Logical operator nodes                                                   -->
+  <!-- ======================================================================== -->
+
+  <implementation name="IM_logical_and_genglsl" nodedef="ND_logical_and" target="genglsl" sourcecode="{{in1}} && {{in2}}"/>
+  <implementation name="IM_logical_or_genglsl" nodedef="ND_logical_or" target="genglsl" sourcecode="{{in1}} || {{in2}}"/>
+  <implementation name="IM_logical_not_genglsl" nodedef="ND_logical_not" target="genglsl" sourcecode="!{{in}}"/>
+
+  <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -741,6 +741,14 @@
   <implementation name="IM_heighttonormal_vector3_genmdl" nodedef="ND_heighttonormal_vector3" target="genmdl" />
 
   <!-- ======================================================================== -->
+  <!-- Logical operator nodes                                                   -->
+  <!-- ======================================================================== -->
+
+  <implementation name="IM_logical_and_genmdl" nodedef="ND_logical_and" target="genmdl" sourcecode="{{in1}} && {{in2}}"/>
+  <implementation name="IM_logical_or_genmdl" nodedef="ND_logical_or" target="genmdl" sourcecode="{{in1}} || {{in2}}"/>
+  <implementation name="IM_logical_not_genmdl" nodedef="ND_logical_not" target="genmdl" sourcecode="!{{in}}"/>
+
+  <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -731,6 +731,14 @@
   <implementation name="IM_heighttonormal_vector3_genmsl" nodedef="ND_heighttonormal_vector3" target="genmsl" />
 
   <!-- ======================================================================== -->
+  <!-- Logical operator nodes                                                   -->
+  <!-- ======================================================================== -->
+
+  <implementation name="IM_logical_and_genmsl" nodedef="ND_logical_and" target="genmsl" sourcecode="{{in1}} && {{in2}}"/>
+  <implementation name="IM_logical_or_genmsl" nodedef="ND_logical_or" target="genmsl" sourcecode="{{in1}} || {{in2}}"/>
+  <implementation name="IM_logical_not_genmsl" nodedef="ND_logical_not" target="genmsl" sourcecode="!{{in}}"/>
+
+  <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -732,6 +732,14 @@
   <implementation name="IM_heighttonormal_vector3_genosl" nodedef="ND_heighttonormal_vector3" file="mx_heighttonormal_vector3.osl" function="mx_heighttonormal_vector3" target="genosl" />
 
   <!-- ======================================================================== -->
+  <!-- Logical operator nodes                                                   -->
+  <!-- ======================================================================== -->
+
+  <implementation name="IM_logical_and_genosl" nodedef="ND_logical_and" target="genosl" sourcecode="{{in1}} && {{in2}}"/>
+  <implementation name="IM_logical_or_genosl" nodedef="ND_logical_or" target="genosl" sourcecode="{{in1}} || {{in2}}"/>
+  <implementation name="IM_logical_not_genosl" nodedef="ND_logical_not" target="genosl" sourcecode="!{{in}}"/>
+
+  <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -4667,6 +4667,49 @@
   </nodedef>
 
   <!-- ======================================================================== -->
+  <!-- Logical operator nodes                                                   -->
+  <!-- ======================================================================== -->
+
+  <!--
+    Node: <and>
+    Logical And operation for two boolean values.
+  -->
+  <nodedef name="ND_logical_and" node="and" nodegroup="conditional">
+    <input name="in1" type="boolean" value="false" />
+    <input name="in2" type="boolean" value="false" />
+    <output name="out" type="boolean" defaultinput="in1" />
+  </nodedef>
+
+  <!--
+    Node: <or>
+    Logical Inclusive Or operation for two boolean values.
+  -->
+  <nodedef name="ND_logical_or" node="or" nodegroup="conditional">
+    <input name="in1" type="boolean" value="false" />
+    <input name="in2" type="boolean" value="false" />
+    <output name="out" type="boolean" defaultinput="in1" />
+  </nodedef>
+
+  <!--
+    Node: <xor>
+    Logical Exclusive Or operation for two boolean values.
+  -->
+  <nodedef name="ND_logical_xor" node="xor" nodegroup="conditional">
+    <input name="in1" type="boolean" value="false" />
+    <input name="in2" type="boolean" value="false" />
+    <output name="out" type="boolean" defaultinput="in1" />
+  </nodedef>
+
+  <!--
+    Node: <not>
+    Returns logical Not of input.
+  -->
+  <nodedef name="ND_logical_not" node="not" nodegroup="conditional">
+    <input name="in" type="boolean" value="false" />
+    <output name="out" type="boolean" default="true"/>
+  </nodedef>
+
+  <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -5255,4 +5255,36 @@
     <output name="out" type="matrix44" nodename="ifgreater_1" />
   </nodegraph>
 
+
+  <!-- ======================================================================== -->
+  <!-- Logical operator nodes                                                   -->
+  <!-- ======================================================================== -->
+
+  <!--
+    Node: <xor>
+    Logical XOR operation for two boolean values.
+  -->
+  <nodegraph name="NG_logical_xor" nodedef="ND_logical_xor">
+    <not name="not_in1" type="boolean">
+      <input name="in" type="boolean" interfacename="in1"/>
+    </not>
+    <not name="not_in2" type="boolean">
+      <input name="in" type="boolean" interfacename="in2"/>
+    </not>
+    <and name="in1_and_not_in2" type="boolean">
+      <input name="in1" type="boolean" interfacename="in1" />
+      <input name="in2" type="boolean" nodename="not_in2" />
+    </and>
+    <and name="in2_and_not_in1" type="boolean">
+      <input name="in1" type="boolean" interfacename="in2" />
+      <input name="in2" type="boolean" nodename="not_in1" />
+    </and>
+    <or name="or" type="boolean">
+      <input name="in1" type="boolean" nodename="in1_and_not_in2"/>
+      <input name="in2" type="boolean" nodename="in2_and_not_in1"/>
+    </or>
+    <output name="out" type="boolean" nodename="or" />
+  </nodegraph>
+
+
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/conditional/conditional_logic.mtlx
+++ b/resources/Materials/TestSuite/stdlib/conditional/conditional_logic.mtlx
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<materialx version="1.38">
+  <!--
+  Basic conditional logic function tests each test is in a separate graph.
+  -->
+  <nodegraph name="and_boolean">
+    <and name="and" type="boolean">
+      <input name="in1" type="boolean" value="true" />
+      <input name="in2" type="boolean" value="true" />
+    </and>
+    <output name="out" type="boolean" nodename="and" />
+  </nodegraph>
+  <nodegraph name="or_boolean">
+    <or name="or" type="boolean">
+      <input name="in1" type="boolean" value="true" />
+      <input name="in2" type="boolean" value="false" />
+    </or>
+    <output name="out" type="boolean" nodename="or" />
+  </nodegraph>
+  <nodegraph name="xor_boolean">
+    <xor name="xor" type="boolean">
+      <input name="in1" type="boolean" value="true" />
+      <input name="in2" type="boolean" value="false" />
+    </xor>
+    <output name="out" type="boolean" nodename="xor" />
+  </nodegraph>
+  <nodegraph name="and_boolean">
+    <not name="not" type="boolean">
+      <input name="in" type="boolean" value="false" />
+    </not>
+    <output name="out" type="boolean" nodename="not" />
+  </nodegraph>
+
+</materialx>


### PR DESCRIPTION
When experimenting with some of the `<convert>` nodes I found I really wanted a logcical `<not>` to implement `ND_convert_integer_boolean` as a nodegraph using `<ifequal>`.

We actually have these logical operators in the RealityKit MaterialX nodes already (recently shared publicly at WWDC 2024), so I thought it might be useful to propose we add them to the standard library. 