### PR TITLE
Upgrade data libraries to 1.39

### DIFF
--- a/libraries/bxdf/disney_brdf_2012.mtlx
+++ b/libraries/bxdf/disney_brdf_2012.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="lin_rec709">
+<materialx version="1.39" colorspace="lin_rec709">
   <nodedef name="ND_disney_brdf_2012_surface" node="disney_brdf_2012" nodegroup="pbr">
     <input name="baseColor" type="color3" value="0.16, 0.16, 0.16" />
     <input name="metallic" type="float" value="0" />

--- a/libraries/bxdf/disney_brdf_2015.mtlx
+++ b/libraries/bxdf/disney_brdf_2015.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38" colorspace="lin_rec709">
+<materialx version="1.39" colorspace="lin_rec709">
   <nodedef name="ND_disney_bsdf_2015_surface" node="disney_bsdf_2015" nodegroup="pbr">
     <input name="baseColor" type="color3" value="0.16, 0.16, 0.16" />
     <input name="metallic" type="float" value="0" />

--- a/libraries/bxdf/lama/lama_dielectric.mtlx
+++ b/libraries/bxdf/lama/lama_dielectric.mtlx
@@ -51,7 +51,7 @@
       <input name="in2" type="float" nodename="ior_float" />
       <input name="which" type="integer" interfacename="fresnelMode" />
     </switch>
-      
+
     <!-- Roughness -->
     <subtract name="roughness_inverse" type="float">
       <input name="in1" type="float" value="1.0" />

--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Autodesk Standard Surface node definition.
   -->
@@ -8,10 +8,11 @@
     <input name="base" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base" uifolder="Base"
            doc="Multiplier on the intensity of the diffuse reflection." />
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Base Color" uifolder="Base"
-           doc="Color of the diffuse reflection." />    
+           doc="Color of the diffuse reflection." />
   </nodedef>
 
-  <nodedef name="ND_standard_surface_surfaceshader_100" node="standard_surface" nodegroup="pbr" version="1.0.0" doc="Autodesk standard surface shader">
+  <nodedef name="ND_standard_surface_surfaceshader_100" node="standard_surface" nodegroup="pbr" version="1.0.0"
+           doc="Autodesk standard surface shader">
     <input name="base" type="float" value="0.8" uimin="0.0" uimax="1.0" uiname="Base" uifolder="Base"
            doc="Multiplier on the intensity of the diffuse reflection." />
     <input name="base_color" type="color3" value="1.0, 1.0, 1.0" uimin="0,0,0" uimax="1,1,1" uiname="Base Color" uifolder="Base"
@@ -296,6 +297,8 @@
       <input name="tangent" type="vector3" nodename="main_tangent" />
       <input name="distribution" type="string" value="ggx" />
       <input name="scatter_mode" type="string" value="R" />
+      <input name="thinfilm_thickness" type="float" interfacename="thin_film_thickness" />
+      <input name="thinfilm_ior" type="float" interfacename="thin_film_IOR" />
     </dielectric_bsdf>
     <layer name="specular_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="specular_bsdf" />
@@ -323,22 +326,14 @@
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="tangent" type="vector3" nodename="main_tangent" />
       <input name="distribution" type="string" value="ggx" />
+      <input name="thinfilm_thickness" type="float" interfacename="thin_film_thickness" />
+      <input name="thinfilm_ior" type="float" interfacename="thin_film_IOR" />
     </conductor_bsdf>
     <mix name="metalness_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="metal_bsdf" />
       <input name="bg" type="BSDF" nodename="specular_layer" />
       <input name="mix" type="float" interfacename="metalness" />
     </mix>
-
-    <!-- Thin-film Layer -->
-    <thin_film_bsdf name="thin_film_bsdf" type="BSDF">
-      <input name="thickness" type="float" interfacename="thin_film_thickness" />
-      <input name="ior" type="float" interfacename="thin_film_IOR" />
-    </thin_film_bsdf>
-    <layer name="thin_film_layer" type="BSDF">
-      <input name="top" type="BSDF" nodename="thin_film_bsdf" />
-      <input name="base" type="BSDF" nodename="metalness_mix" />
-    </layer>
 
     <!-- Coat Layer -->
     <mix name="coat_attenuation" type="color3">
@@ -347,7 +342,7 @@
       <input name="mix" type="float" interfacename="coat" />
     </mix>
     <multiply name="thin_film_layer_attenuated" type="BSDF">
-      <input name="in1" type="BSDF" nodename="thin_film_layer" />
+      <input name="in1" type="BSDF" nodename="metalness_mix" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
     <roughness_anisotropy name="coat_roughness_vector" type="vector2">
@@ -401,8 +396,11 @@
       <input name="in1" type="EDF" nodename="emission_edf" />
       <input name="in2" type="color3" interfacename="coat_color" />
     </multiply>
+    <convert name="emission_color0" type="color3">
+      <input name="in" type="float" nodename="one_minus_coat_ior_to_F0" />
+    </convert>
     <generalized_schlick_edf name="coat_emission_edf" type="EDF">
-      <input name="color0" type="color3" nodename="one_minus_coat_ior_to_F0" channels="rrr" />
+      <input name="color0" type="color3" nodename="emission_color0" />
       <input name="color90" type="color3" value="0.0, 0.0, 0.0" />
       <input name="exponent" type="float" value="5.0" />
       <input name="base" type="EDF" nodename="coat_tinted_emission_edf" />
@@ -418,10 +416,14 @@
     <luminance name="opacity_luminance" type="color3">
       <input name="in" type="color3" interfacename="opacity" />
     </luminance>
+    <extract name="opacity_luminance_float" type="float">
+      <input name="in" type="color3" nodename="opacity_luminance" />
+      <input name="index" type="integer" value="0" />
+    </extract>
     <surface name="shader_constructor" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="coat_layer" />
       <input name="edf" type="EDF" nodename="blended_coat_emission_edf" />
-      <input name="opacity" type="float" nodename="opacity_luminance" channels="r" />
+      <input name="opacity" type="float" nodename="opacity_luminance_float" />
     </surface>
 
     <!-- Output -->

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <nodedef name="ND_standard_surface_to_gltf_pbr" node="standard_surface_to_gltf_pbr" nodegroup="translation">
     <input name="base" type="float" value="1" />
@@ -33,10 +33,22 @@
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
 
+    <!-- Constants -->
+    <divide name="constantOneThird" type="float">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" value="3" />
+    </divide>
+    <convert name="constantOneThirdVector" type="vector3">
+      <input name="in" type="float" nodename="constantOneThird" />
+    </convert>
+
     <!-- Coat attenuation -->
-    <dotproduct name="has_coat_color" type="float">
-      <input name="in1" type="vector3" interfacename="coat_color" channels="rgb" />
-      <input name="in2" type="vector3" value="1,1,1" />
+    <convert name="coatColorVector" type="vector3">
+      <input name="in" type="color3" interfacename="coat_color" />
+    </convert>
+    <dotproduct name="hasCoatColor" type="float">
+      <input name="in1" type="vector3" nodename="coatColorVector" />
+      <input name="in2" type="vector3" value="1, 1, 1" />
     </dotproduct>
     <multiply name="scaledBaseColor" type="color3">
       <input name="in1" type="color3" interfacename="base_color" />
@@ -44,29 +56,28 @@
     </multiply>
     <mix name="coatAttenuation" type="color3">
       <input name="fg" type="color3" interfacename="coat_color" />
-      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="bg" type="color3" value="1, 1, 1" />
       <input name="mix" type="float" interfacename="coat" />
     </mix>
     <multiply name="mixedBaseColor" type="color3">
       <input name="in1" type="color3" nodename="scaledBaseColor" />
       <input name="in2" type="color3" nodename="coatAttenuation" />
     </multiply>
-    <divide name="constantOneThird" type="float">
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" value="3" />
-    </divide>
-    <multiply name="coatColor" type="color3">
+    <multiply name="coatColorScaled" type="color3">
       <input name="in1" type="color3" interfacename="coat_color" />
       <input name="in2" type="float" interfacename="coat" />
     </multiply>
+    <convert name="coatColorScaledVector" type="vector3">
+      <input name="in" type="color3" nodename="coatColorScaled" />
+    </convert>
     <dotproduct name="weightedCoat" type="float">
-      <input name="in1" type="vector3" nodename="coatColor" channels="rgb" />
-      <input name="in2" type="vector3" nodename="constantOneThird" channels="xxx" />
+      <input name="in1" type="vector3" nodename="coatColorScaledVector" />
+      <input name="in2" type="vector3" nodename="constantOneThirdVector" />
     </dotproduct>
 
     <!-- Metallic roughness -->
     <ifequal name="base_color" type="color3">
-      <input name="value1" type="float" nodename="has_coat_color" />
+      <input name="value1" type="float" nodename="hasCoatColor" />
       <input name="value2" type="float" value="0" />
       <input name="in1" type="color3" nodename="scaledBaseColor" />
       <input name="in2" type="color3" nodename="mixedBaseColor" />
@@ -103,7 +114,7 @@
 
     <!-- Clearcoat -->
     <ifequal name="clearcoat" type="float">
-      <input name="value1" type="float" nodename="has_coat_color" />
+      <input name="value1" type="float" nodename="hasCoatColor" />
       <input name="value2" type="float" value="0" />
       <input name="in1" type="float" interfacename="coat" />
       <input name="in2" type="float" nodename="weightedCoat" />

--- a/libraries/bxdf/translation/standard_surface_to_usd.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_usd.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <nodedef name="ND_standard_surface_to_UsdPreviewSurface" node="standard_surface_to_UsdPreviewSurface" nodegroup="translation">
     <input name="metalness" type="float" value="0" />
@@ -35,6 +35,9 @@
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="3" />
     </divide>
+    <convert name="constantOneThirdVector" type="vector3">
+      <input name="in" type="float" nodename="constantOneThird" />
+    </convert>
 
     <!-- Diffuse/Specular -->
     <dot name="metallic" type="float">
@@ -65,9 +68,12 @@
       <input name="in1" type="color3" interfacename="coat_color" />
       <input name="in2" type="float" interfacename="coat" />
     </multiply>
+    <convert name="coatColorVector" type="vector3">
+      <input name="in" type="color3" nodename="coatColor" />
+    </convert>
     <dotproduct name="clearcoat" type="float">
-      <input name="in1" type="vector3" nodename="coatColor" channels="rgb" />
-      <input name="in2" type="vector3" nodename="constantOneThird" channels="xxx" />
+      <input name="in1" type="vector3" nodename="coatColorVector" />
+      <input name="in2" type="vector3" nodename="constantOneThirdVector" />
     </dotproduct>
     <dot name="clearcoatRoughness" type="float">
       <input name="in" type="float" interfacename="coat_roughness" />
@@ -80,9 +86,12 @@
     </multiply>
 
     <!-- Opacity -->
+    <convert name="opacityVector" type="vector3">
+      <input name="in" type="color3" interfacename="opacity" />
+    </convert>
     <dotproduct name="opacity" type="float">
-      <input name="in1" type="vector3" interfacename="opacity" channels="rgb" />
-      <input name="in2" type="vector3" nodename="constantOneThird" channels="xxx" />
+      <input name="in1" type="vector3" nodename="opacityVector" />
+      <input name="in2" type="vector3" nodename="constantOneThirdVector" />
     </dotproduct>
 
     <!-- Normal Map -->

--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- ======================================================================== -->
   <!-- USD Preview Surface node definitions                                     -->
@@ -300,11 +300,17 @@
       <input name="in1" type="color4" nodename="image_scale" />
       <input name="in2" type="color4" interfacename="bias" />
     </add>
-    <output name="r" type="float" nodename="image_bias" channels="r" />
-    <output name="g" type="float" nodename="image_bias" channels="g" />
-    <output name="b" type="float" nodename="image_bias" channels="b" />
-    <output name="a" type="float" nodename="image_bias" channels="a" />
-    <output name="rgb" type="color3" nodename="image_bias" channels="rgb" />
+    <separate4 name="image_bias_separate" type="multioutput">
+      <input name="in" type="color4" nodename="image_bias" />
+    </separate4>
+    <convert name="image_bias_color3" type="color3">
+      <input name="in" type="color4" nodename="image_bias" />
+    </convert>
+    <output name="r" type="float" nodename="image_bias_separate" output="outr" />
+    <output name="g" type="float" nodename="image_bias_separate" output="outg" />
+    <output name="b" type="float" nodename="image_bias_separate" output="outb" />
+    <output name="a" type="float" nodename="image_bias_separate" output="outa" />
+    <output name="rgb" type="color3" nodename="image_bias_color3" />
     <output name="rgba" type="color4" nodename="image_bias" />
   </nodegraph>
 
@@ -324,11 +330,17 @@
       <input name="in1" type="color4" nodename="image_scale" />
       <input name="in2" type="color4" interfacename="bias" />
     </add>
-    <output name="r" type="float" nodename="image_bias" channels="r" />
-    <output name="g" type="float" nodename="image_bias" channels="g" />
-    <output name="b" type="float" nodename="image_bias" channels="b" />
-    <output name="a" type="float" nodename="image_bias" channels="a" />
-    <output name="rgb" type="color3" nodename="image_bias" channels="rgb" />
+    <separate4 name="image_bias_separate" type="multioutput">
+      <input name="in" type="color4" nodename="image_bias" />
+    </separate4>
+    <convert name="image_bias_color3" type="color3">
+      <input name="in" type="color4" nodename="image_bias" />
+    </convert>
+    <output name="r" type="float" nodename="image_bias_separate" output="outr" />
+    <output name="g" type="float" nodename="image_bias_separate" output="outg" />
+    <output name="b" type="float" nodename="image_bias_separate" output="outb" />
+    <output name="a" type="float" nodename="image_bias_separate" output="outa" />
+    <output name="rgb" type="color3" nodename="image_bias_color3" />
   </nodegraph>
 
   <!-- Node: UsdPrimvarReader -->

--- a/libraries/cmlib/cmlib_defs.mtlx
+++ b/libraries/cmlib/cmlib_defs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/cmlib/cmlib_ng.mtlx
+++ b/libraries/cmlib/cmlib_ng.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -26,12 +26,14 @@
     <g18_rec709_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </g18_rec709_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -54,12 +56,14 @@
     <g22_rec709_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </g22_rec709_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -82,12 +86,14 @@
     <rec709_display_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </rec709_display_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -115,12 +121,14 @@
     <acescg_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </acescg_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -146,12 +154,14 @@
     <g22_ap1_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </g22_ap1_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -159,20 +169,23 @@
     <constant name="threshhold" type="float">
       <input name="value" type="float" value="0.04045" />
     </constant>
+    <separate3 name="colorSeparate" type="multioutput">
+      <input name="in" type="color3" interfacename="in" />
+    </separate3>
     <ifgreater name="isAboveR" type="float">
-      <input name="value1" type="float" interfacename="in" channels="r" />
+      <input name="value1" type="float" nodename="colorSeparate" output="outr" />
       <input name="value2" type="float" nodename="threshhold" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
     </ifgreater>
     <ifgreater name="isAboveG" type="float">
-      <input name="value1" type="float" interfacename="in" channels="g" />
+      <input name="value1" type="float" nodename="colorSeparate" output="outg" />
       <input name="value2" type="float" nodename="threshhold" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
     </ifgreater>
     <ifgreater name="isAboveB" type="float">
-      <input name="value1" type="float" interfacename="in" channels="b" />
+      <input name="value1" type="float" nodename="colorSeparate" output="outb" />
       <input name="value2" type="float" nodename="threshhold" />
       <input name="in1" type="float" value="1" />
       <input name="in2" type="float" value="0" />
@@ -217,12 +230,14 @@
     <srgb_texture_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </srgb_texture_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -250,12 +265,14 @@
     <lin_adobergb_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </lin_adobergb_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -285,12 +302,14 @@
     <adobergb_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </adobergb_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -322,12 +341,14 @@
     <srgb_displayp3_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </srgb_displayp3_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
@@ -355,12 +376,14 @@
     <lin_displayp3_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
     </lin_displayp3_to_lin_rec709>
-    <combine4 name="asColor4" type="color4">
-      <input name="in1" type="float" nodename="transform" channels="r" />
-      <input name="in2" type="float" nodename="transform" channels="g" />
-      <input name="in3" type="float" nodename="transform" channels="b" />
-      <input name="in4" type="float" interfacename="in" channels="a" />
-    </combine4>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 

--- a/libraries/lights/genglsl/lights_genglsl_impl.mtlx
+++ b/libraries/lights/genglsl/lights_genglsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- <point_light> -->
   <implementation name="IM_point_light_genglsl" nodedef="ND_point_light" file="mx_point_light.glsl" function="mx_point_light" target="genglsl" />

--- a/libraries/lights/genmsl/lights_genmsl_impl.mtlx
+++ b/libraries/lights/genmsl/lights_genmsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- <point_light> -->
   <implementation name="IM_point_light_genmsl" nodedef="ND_point_light" file="mx_point_light.metal" function="mx_point_light" target="genmsl" />

--- a/libraries/lights/lights_defs.mtlx
+++ b/libraries/lights/lights_defs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/nprlib/genglsl/nprlib_genglsl_impl.mtlx
+++ b/libraries/nprlib/genglsl/nprlib_genglsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/nprlib/genmdl/nprlib_genmdl_impl.mtlx
+++ b/libraries/nprlib/genmdl/nprlib_genmdl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/nprlib/genmsl/nprlib_genmsl_impl.mtlx
+++ b/libraries/nprlib/genmsl/nprlib_genmsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/nprlib/genosl/nprlib_genosl_impl.mtlx
+++ b/libraries/nprlib/genosl/nprlib_genosl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/nprlib/nprlib_defs.mtlx
+++ b/libraries/nprlib/nprlib_defs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/nprlib/nprlib_ng.mtlx
+++ b/libraries/nprlib/nprlib_ng.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -48,10 +48,10 @@
     Node: <gooch_shade>
   -->
   <nodegraph name="NG_gooch_shade" type="color3" nodedef="ND_gooch_shade">
-    <normal name="normal" type="vector3" >
+    <normal name="normal" type="vector3">
       <input name="space" type="string" value="world" />
     </normal>
-    <viewdirection name="viewdir" type="vector3" >
+    <viewdirection name="viewdir" type="vector3">
       <input name="space" type="string" value="world" />
     </viewdirection>
     <normalize name="unit_normal" type="vector3">

--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
   <implementation name="IM_oren_nayar_diffuse_bsdf_genglsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genglsl" />

--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
   <implementation name="IM_oren_nayar_diffuse_bsdf_genmdl" nodedef="ND_oren_nayar_diffuse_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_oren_nayar_diffuse_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_roughness:{{roughness}}, mxp_normal:{{normal}})" target="genmdl" />

--- a/libraries/pbrlib/genmsl/pbrlib_genmsl_impl.mtlx
+++ b/libraries/pbrlib/genmsl/pbrlib_genmsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
   <implementation name="IM_oren_nayar_diffuse_bsdf_genmsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="../genglsl/mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genmsl" />

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
   <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" sourcecode="{{weight}} * oren_nayar_diffuse_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl" />

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/pbrlib/pbrlib_ng.mtlx
+++ b/libraries/pbrlib/pbrlib_ng.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -690,18 +690,18 @@
   <implementation name="IM_convert_integer_float_genglsl" nodedef="ND_convert_integer_float" target="genglsl" sourcecode="float({{in}})" />
 
   <!-- <combine2> -->
-  <implementation name="IM_combine2_vector2_genglsl" nodedef="ND_combine2_vector2" target="genglsl" sourcecode="vec2({{in1}},{{in2}})"/>
-  <implementation name="IM_combine2_color4CF_genglsl" nodedef="ND_combine2_color4CF" target="genglsl" sourcecode="vec4({{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}})"/>
-  <implementation name="IM_combine2_vector4VF_genglsl" nodedef="ND_combine2_vector4VF" target="genglsl" sourcecode="vec4({{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}})"/>
-  <implementation name="IM_combine2_vector4VV_genglsl" nodedef="ND_combine2_vector4VV" target="genglsl" sourcecode="vec4({{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1])"/>
+  <implementation name="IM_combine2_vector2_genglsl" nodedef="ND_combine2_vector2" target="genglsl" sourcecode="vec2({{in1}},{{in2}})" />
+  <implementation name="IM_combine2_color4CF_genglsl" nodedef="ND_combine2_color4CF" target="genglsl" sourcecode="vec4({{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}})" />
+  <implementation name="IM_combine2_vector4VF_genglsl" nodedef="ND_combine2_vector4VF" target="genglsl" sourcecode="vec4({{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}})" />
+  <implementation name="IM_combine2_vector4VV_genglsl" nodedef="ND_combine2_vector4VV" target="genglsl" sourcecode="vec4({{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1])" />
 
   <!-- <combine3> -->
-  <implementation name="IM_combine3_color3_genglsl" nodedef="ND_combine3_color3" target="genglsl" sourcecode="vec3({{in1}},{{in2}},{{in3}})"/>
-  <implementation name="IM_combine3_vector3_genglsl" nodedef="ND_combine3_vector3" target="genglsl" sourcecode="vec3({{in1}},{{in2}},{{in3}})"/>
+  <implementation name="IM_combine3_color3_genglsl" nodedef="ND_combine3_color3" target="genglsl" sourcecode="vec3({{in1}},{{in2}},{{in3}})" />
+  <implementation name="IM_combine3_vector3_genglsl" nodedef="ND_combine3_vector3" target="genglsl" sourcecode="vec3({{in1}},{{in2}},{{in3}})" />
 
   <!-- <combine4> -->
-  <implementation name="IM_combine4_color4_genglsl" nodedef="ND_combine4_color4" target="genglsl" sourcecode="vec4({{in1}},{{in2}},{{in3}},{{in4}})"/>
-  <implementation name="IM_combine4_vector4_genglsl" nodedef="ND_combine4_vector4" target="genglsl" sourcecode="vec4({{in1}},{{in2}},{{in3}},{{in4}})"/>
+  <implementation name="IM_combine4_color4_genglsl" nodedef="ND_combine4_color4" target="genglsl" sourcecode="vec4({{in1}},{{in2}},{{in3}},{{in4}})" />
+  <implementation name="IM_combine4_vector4_genglsl" nodedef="ND_combine4_vector4" target="genglsl" sourcecode="vec4({{in1}},{{in2}},{{in3}},{{in4}})" />
 
   <!-- <creatematrix> -->
   <implementation name="IM_creatematrix_vector3_matrix33_genglsl" nodedef="ND_creatematrix_vector3_matrix33" file="mx_creatematrix_vector3_matrix33.glsl" function="mx_creatematrix_vector3_matrix33" target="genglsl" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -700,18 +700,18 @@
   <implementation name="IM_convert_integer_float_genmdl" nodedef="ND_convert_integer_float" target="genmdl" sourcecode="float({{in}})" />
 
   <!-- <combine2> -->
-  <implementation name="IM_combine2_vector2_genmdl" nodedef="ND_combine2_vector2" target="genmdl" sourcecode="float2( {{in1}},{{in2}} )"/>
-  <implementation name="IM_combine2_color4CF_genmdl" nodedef="ND_combine2_color4CF" target="genmdl" sourcecode="color4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )"/>
-  <implementation name="IM_combine2_vector4VF_genmdl" nodedef="ND_combine2_vector4VF" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )"/>
-  <implementation name="IM_combine2_vector4VV_genmdl" nodedef="ND_combine2_vector4VV" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1] )"/>
+  <implementation name="IM_combine2_vector2_genmdl" nodedef="ND_combine2_vector2" target="genmdl" sourcecode="float2( {{in1}},{{in2}} )" />
+  <implementation name="IM_combine2_color4CF_genmdl" nodedef="ND_combine2_color4CF" target="genmdl" sourcecode="color4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )" />
+  <implementation name="IM_combine2_vector4VF_genmdl" nodedef="ND_combine2_vector4VF" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )" />
+  <implementation name="IM_combine2_vector4VV_genmdl" nodedef="ND_combine2_vector4VV" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1] )" />
 
   <!-- <combine3> -->
-  <implementation name="IM_combine3_color3_genmdl" nodedef="ND_combine3_color3" target="genmdl" sourcecode="color( {{in1}},{{in2}},{{in3}} )"/>
-  <implementation name="IM_combine3_vector3_genmdl" nodedef="ND_combine3_vector3" target="genmdl" sourcecode="float3( {{in1}},{{in2}},{{in3}} )"/>
+  <implementation name="IM_combine3_color3_genmdl" nodedef="ND_combine3_color3" target="genmdl" sourcecode="color( {{in1}},{{in2}},{{in3}} )" />
+  <implementation name="IM_combine3_vector3_genmdl" nodedef="ND_combine3_vector3" target="genmdl" sourcecode="float3( {{in1}},{{in2}},{{in3}} )" />
 
   <!-- <combine4> -->
-  <implementation name="IM_combine4_color4_genmdl" nodedef="ND_combine4_color4" target="genmdl" sourcecode="color4( {{in1}},{{in2}},{{in3}},{{in4}} )"/>
-  <implementation name="IM_combine4_vector4_genmdl" nodedef="ND_combine4_vector4" target="genmdl" sourcecode="float4( {{in1}},{{in2}},{{in3}},{{in4}} )"/>
+  <implementation name="IM_combine4_color4_genmdl" nodedef="ND_combine4_color4" target="genmdl" sourcecode="color4( {{in1}},{{in2}},{{in3}},{{in4}} )" />
+  <implementation name="IM_combine4_vector4_genmdl" nodedef="ND_combine4_vector4" target="genmdl" sourcecode="float4( {{in1}},{{in2}},{{in3}},{{in4}} )" />
 
   <!-- <creatematrix> -->
   <implementation name="IM_creatematrix_vector3_matrix33_genmdl" nodedef="ND_creatematrix_vector3_matrix33" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_creatematrix_vector3_matrix33({{in1}}, {{in2}}, {{in3}})" target="genmdl" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -690,18 +690,18 @@
   <implementation name="IM_convert_integer_float_genmsl" nodedef="ND_convert_integer_float" target="genmsl" sourcecode="float({{in}})" />
 
   <!-- <combine2> -->
-  <implementation name="IM_combine2_vector2_genmsl" nodedef="ND_combine2_vector2" target="genmsl" sourcecode="{ {{in1}},{{in2}} }"/>
-  <implementation name="IM_combine2_color4CF_genmsl" nodedef="ND_combine2_color4CF" target="genmsl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} }"/>
-  <implementation name="IM_combine2_vector4VF_genmsl" nodedef="ND_combine2_vector4VF" target="genmsl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} }"/>
-  <implementation name="IM_combine2_vector4VV_genmsl" nodedef="ND_combine2_vector4VV" target="genmsl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1] }"/>
+  <implementation name="IM_combine2_vector2_genmsl" nodedef="ND_combine2_vector2" target="genmsl" sourcecode="{ {{in1}},{{in2}} }" />
+  <implementation name="IM_combine2_color4CF_genmsl" nodedef="ND_combine2_color4CF" target="genmsl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} }" />
+  <implementation name="IM_combine2_vector4VF_genmsl" nodedef="ND_combine2_vector4VF" target="genmsl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} }" />
+  <implementation name="IM_combine2_vector4VV_genmsl" nodedef="ND_combine2_vector4VV" target="genmsl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1] }" />
 
   <!-- <combine3> -->
-  <implementation name="IM_combine3_color3_genmsl" nodedef="ND_combine3_color3" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}} }"/>
-  <implementation name="IM_combine3_vector3_genmsl" nodedef="ND_combine3_vector3" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}} }"/>
+  <implementation name="IM_combine3_color3_genmsl" nodedef="ND_combine3_color3" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}} }" />
+  <implementation name="IM_combine3_vector3_genmsl" nodedef="ND_combine3_vector3" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}} }" />
 
   <!-- <combine4> -->
-  <implementation name="IM_combine4_color4_genmsl" nodedef="ND_combine4_color4" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }"/>
-  <implementation name="IM_combine4_vector4_genmsl" nodedef="ND_combine4_vector4" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }"/>
+  <implementation name="IM_combine4_color4_genmsl" nodedef="ND_combine4_color4" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }" />
+  <implementation name="IM_combine4_vector4_genmsl" nodedef="ND_combine4_vector4" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }" />
 
   <!-- <creatematrix> -->
   <implementation name="IM_creatematrix_vector3_matrix33_genmsl" nodedef="ND_creatematrix_vector3_matrix33" file="../genglsl/mx_creatematrix_vector3_matrix33.glsl" function="mx_creatematrix_vector3_matrix33" target="genmsl" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -691,18 +691,18 @@
   <implementation name="IM_convert_integer_float_genosl" nodedef="ND_convert_integer_float" target="genosl" sourcecode="float({{in}})" />
 
   <!-- <combine2> -->
-  <implementation name="IM_combine2_vector2_genosl" nodedef="ND_combine2_vector2" target="genosl" sourcecode="{ {{in1}},{{in2}} }"/>
-  <implementation name="IM_combine2_color4CF_genosl" nodedef="ND_combine2_color4CF" target="genosl" sourcecode="{ color({{in1}}[0],{{in1}}[1],{{in1}}[2]),{{in2}} }"/>
-  <implementation name="IM_combine2_vector4VF_genosl" nodedef="ND_combine2_vector4VF" target="genosl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} }"/>
-  <implementation name="IM_combine2_vector4VV_genosl" nodedef="ND_combine2_vector4VV" target="genosl" sourcecode="{ {{in1}}.x,{{in1}}.y,{{in2}}.x,{{in2}}.y }"/>
+  <implementation name="IM_combine2_vector2_genosl" nodedef="ND_combine2_vector2" target="genosl" sourcecode="{ {{in1}},{{in2}} }" />
+  <implementation name="IM_combine2_color4CF_genosl" nodedef="ND_combine2_color4CF" target="genosl" sourcecode="{ color({{in1}}[0],{{in1}}[1],{{in1}}[2]),{{in2}} }" />
+  <implementation name="IM_combine2_vector4VF_genosl" nodedef="ND_combine2_vector4VF" target="genosl" sourcecode="{ {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} }" />
+  <implementation name="IM_combine2_vector4VV_genosl" nodedef="ND_combine2_vector4VV" target="genosl" sourcecode="{ {{in1}}.x,{{in1}}.y,{{in2}}.x,{{in2}}.y }" />
 
   <!-- <combine3> -->
-  <implementation name="IM_combine3_color3_genosl" nodedef="ND_combine3_color3" target="genosl" sourcecode="color( {{in1}},{{in2}},{{in3}} )"/>
-  <implementation name="IM_combine3_vector3_genosl" nodedef="ND_combine3_vector3" target="genosl" sourcecode="vector( {{in1}},{{in2}},{{in3}} )"/>
+  <implementation name="IM_combine3_color3_genosl" nodedef="ND_combine3_color3" target="genosl" sourcecode="color( {{in1}},{{in2}},{{in3}} )" />
+  <implementation name="IM_combine3_vector3_genosl" nodedef="ND_combine3_vector3" target="genosl" sourcecode="vector( {{in1}},{{in2}},{{in3}} )" />
 
   <!-- <combine4> -->
-  <implementation name="IM_combine4_color4_genosl" nodedef="ND_combine4_color4" target="genosl" sourcecode="{ color({{in1}},{{in2}},{{in3}}),{{in4}} }"/>
-  <implementation name="IM_combine4_vector4_genosl" nodedef="ND_combine4_vector4" target="genosl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }"/>
+  <implementation name="IM_combine4_color4_genosl" nodedef="ND_combine4_color4" target="genosl" sourcecode="{ color({{in1}},{{in2}},{{in3}}),{{in4}} }" />
+  <implementation name="IM_combine4_vector4_genosl" nodedef="ND_combine4_vector4" target="genosl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }" />
 
   <!-- <creatematrix> -->
   <implementation name="IM_creatematrix_vector3_matrix33_genosl" nodedef="ND_creatematrix_vector3_matrix33" file="mx_creatematrix.osl" function="mx_creatematrix_vector3_matrix33" target="genosl" />
@@ -711,10 +711,10 @@
 
   <!-- <extract> -->
   <implementation name="IM_extract_color3_genosl" nodedef="ND_extract_color3" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
-  <implementation name="IM_extract_color4_genosl" nodedef="ND_extract_color4" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
-  <implementation name="IM_extract_vector2_genosl" nodedef="ND_extract_vector2" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
-  <implementation name="IM_extract_vector3_genosl" nodedef="ND_extract_vector3" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
-  <implementation name="IM_extract_vector4_genosl" nodedef="ND_extract_vector4" sourcecode="mx_extract({{in}}, {{index}})"  target="genosl" />
+  <implementation name="IM_extract_color4_genosl" nodedef="ND_extract_color4" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
+  <implementation name="IM_extract_vector2_genosl" nodedef="ND_extract_vector2" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
+  <implementation name="IM_extract_vector3_genosl" nodedef="ND_extract_vector3" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
+  <implementation name="IM_extract_vector4_genosl" nodedef="ND_extract_vector4" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -3762,7 +3762,7 @@
   <nodedef name="ND_ifgreater_booleanI" node="ifgreater" nodegroup="conditional">
     <input name="value1" type="integer" value="1" />
     <input name="value2" type="integer" value="0" />
-   <output name="out" type="boolean" default="false" />
+    <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <!--
@@ -3903,7 +3903,7 @@
   <nodedef name="ND_ifgreatereq_booleanI" node="ifgreatereq" nodegroup="conditional">
     <input name="value1" type="integer" value="1" />
     <input name="value2" type="integer" value="0" />
-   <output name="out" type="boolean" default="false" />
+    <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <!--
@@ -4044,7 +4044,7 @@
   <nodedef name="ND_ifequal_booleanI" node="ifequal" nodegroup="conditional">
     <input name="value1" type="integer" value="1" />
     <input name="value2" type="integer" value="0" />
-   <output name="out" type="boolean" default="false" />
+    <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_ifequal_floatB" node="ifequal" nodegroup="conditional">
     <input name="value1" type="boolean" value="false" />
@@ -4112,7 +4112,7 @@
   <nodedef name="ND_ifequal_booleanB" node="ifequal" nodegroup="conditional">
     <input name="value1" type="boolean" value="false" />
     <input name="value2" type="boolean" value="false" />
-   <output name="out" type="boolean" default="false" />
+    <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <!--

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
   <!--
     Copyright Contributors to the MaterialX Project
     SPDX-License-Identifier: Apache-2.0
@@ -1318,7 +1318,10 @@
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
-    <output name="out" type="color3" nodename="N_noise2d" channels="xyz" />
+    <convert name="N_convert" type="color3">
+      <input name="in" type="vector3" nodename="N_noise2d" />
+    </convert>
+    <output name="out" type="color3" nodename="N_convert" />
   </nodegraph>
   <nodegraph name="NG_noise2d_color4" nodedef="ND_noise2d_color4">
     <noise2d name="N_noise2d" type="vector4">
@@ -1326,43 +1329,61 @@
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
-    <output name="out" type="color4" nodename="N_noise2d" channels="xyzw" />
+    <convert name="N_convert" type="color4">
+      <input name="in" type="vector4" nodename="N_noise2d" />
+    </convert>
+    <output name="out" type="color4" nodename="N_convert" />
   </nodegraph>
   <nodegraph name="NG_noise2d_color3FA" nodedef="ND_noise2d_color3FA">
+    <convert name="N_convert" type="vector3">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise2d name="N_noise2d" type="color3">
-      <input name="amplitude" type="vector3" interfacename="amplitude" channels="xxx" />
+      <input name="amplitude" type="vector3" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
     <output name="out" type="color3" nodename="N_noise2d" />
   </nodegraph>
   <nodegraph name="NG_noise2d_color4FA" nodedef="ND_noise2d_color4FA">
+    <convert name="N_convert" type="vector4">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise2d name="N_noise2d" type="color4">
-      <input name="amplitude" type="vector4" interfacename="amplitude" channels="xxxx" />
+      <input name="amplitude" type="vector4" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
     <output name="out" type="color4" nodename="N_noise2d" />
   </nodegraph>
   <nodegraph name="NG_noise2d_vector2FA" nodedef="ND_noise2d_vector2FA">
+    <convert name="N_convert" type="vector2">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise2d name="N_noise2d" type="vector2">
-      <input name="amplitude" type="vector2" interfacename="amplitude" channels="xx" />
+      <input name="amplitude" type="vector2" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
     <output name="out" type="vector2" nodename="N_noise2d" />
   </nodegraph>
   <nodegraph name="NG_noise2d_vector3FA" nodedef="ND_noise2d_vector3FA">
+    <convert name="N_convert" type="vector3">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise2d name="N_noise2d" type="vector3">
-      <input name="amplitude" type="vector3" interfacename="amplitude" channels="xxx" />
+      <input name="amplitude" type="vector3" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
     <output name="out" type="vector3" nodename="N_noise2d" />
   </nodegraph>
   <nodegraph name="NG_noise2d_vector4FA" nodedef="ND_noise2d_vector4FA">
+    <convert name="N_convert" type="vector4">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise2d name="N_noise2d" type="vector4">
-      <input name="amplitude" type="vector4" interfacename="amplitude" channels="xxxx" />
+      <input name="amplitude" type="vector4" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="texcoord" type="vector2" interfacename="texcoord" />
     </noise2d>
@@ -1378,7 +1399,10 @@
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
-    <output name="out" type="color3" nodename="N_noise3d" channels="xyz" />
+    <convert name="N_convert" type="color3">
+      <input name="in" type="vector3" nodename="N_noise3d" />
+    </convert>
+    <output name="out" type="color3" nodename="N_convert" />
   </nodegraph>
   <nodegraph name="NG_noise3d_color4" nodedef="ND_noise3d_color4">
     <noise3d name="N_noise3d" type="vector4">
@@ -1386,43 +1410,61 @@
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
-    <output name="out" type="color4" nodename="N_noise3d" channels="xyzw" />
+    <convert name="N_convert" type="color4">
+      <input name="in" type="vector4" nodename="N_noise3d" />
+    </convert>
+    <output name="out" type="color4" nodename="N_convert" />
   </nodegraph>
   <nodegraph name="NG_noise3d_color3FA" nodedef="ND_noise3d_color3FA">
+    <convert name="N_convert" type="vector3">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise3d name="N_noise3d" type="color3">
-      <input name="amplitude" type="vector3" interfacename="amplitude" channels="xxx" />
+      <input name="amplitude" type="vector3" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
     <output name="out" type="color3" nodename="N_noise3d" />
   </nodegraph>
   <nodegraph name="NG_noise3d_color4FA" nodedef="ND_noise3d_color4FA">
+    <convert name="N_convert" type="vector4">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise3d name="N_noise3d" type="color4">
-      <input name="amplitude" type="vector4" interfacename="amplitude" channels="xxxx" />
+      <input name="amplitude" type="vector4" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
     <output name="out" type="color4" nodename="N_noise3d" />
   </nodegraph>
   <nodegraph name="NG_noise3d_vector2FA" nodedef="ND_noise3d_vector2FA">
+    <convert name="N_convert" type="vector2">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise3d name="N_noise3d" type="vector2">
-      <input name="amplitude" type="vector2" interfacename="amplitude" channels="xx" />
+      <input name="amplitude" type="vector2" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
     <output name="out" type="vector2" nodename="N_noise3d" />
   </nodegraph>
   <nodegraph name="NG_noise3d_vector3FA" nodedef="ND_noise3d_vector3FA">
+    <convert name="N_convert" type="vector3">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise3d name="N_noise3d" type="vector3">
-      <input name="amplitude" type="vector3" interfacename="amplitude" channels="xxx" />
+      <input name="amplitude" type="vector3" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
     <output name="out" type="vector3" nodename="N_noise3d" />
   </nodegraph>
   <nodegraph name="NG_noise3d_vector4FA" nodedef="ND_noise3d_vector4FA">
+    <convert name="N_convert" type="vector4">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <noise3d name="N_noise3d" type="vector4">
-      <input name="amplitude" type="vector4" interfacename="amplitude" channels="xxxx" />
+      <input name="amplitude" type="vector4" nodename="N_convert" />
       <input name="pivot" type="float" interfacename="pivot" />
       <input name="position" type="vector3" interfacename="position" />
     </noise3d>
@@ -1440,7 +1482,10 @@
       <input name="diminish" type="float" interfacename="diminish" />
       <input name="position" type="vector3" interfacename="position" />
     </fractal3d>
-    <output name="out" type="color3" nodename="N_fractal3d" channels="xyz" />
+    <convert name="N_convert" type="color3">
+      <input name="in" type="vector3" nodename="N_fractal3d" />
+    </convert>
+    <output name="out" type="color3" nodename="N_convert" />
   </nodegraph>
   <nodegraph name="NG_fractal3d_color4" nodedef="ND_fractal3d_color4">
     <fractal3d name="N_fractal3d" type="vector4">
@@ -1450,11 +1495,17 @@
       <input name="diminish" type="float" interfacename="diminish" />
       <input name="position" type="vector3" interfacename="position" />
     </fractal3d>
-    <output name="out" type="color4" nodename="N_fractal3d" channels="xyzw" />
+    <convert name="N_convert" type="color4">
+      <input name="in" type="vector4" nodename="N_fractal3d" />
+    </convert>
+    <output name="out" type="color4" nodename="N_convert" />
   </nodegraph>
   <nodegraph name="NG_fractal3d_color3FA" nodedef="ND_fractal3d_color3FA">
+    <convert name="N_convert" type="vector3">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <fractal3d name="N_fractal3d" type="color3">
-      <input name="amplitude" type="vector3" interfacename="amplitude" channels="xxx" />
+      <input name="amplitude" type="vector3" nodename="N_convert" />
       <input name="octaves" type="integer" interfacename="octaves" />
       <input name="lacunarity" type="float" interfacename="lacunarity" />
       <input name="diminish" type="float" interfacename="diminish" />
@@ -1463,8 +1514,11 @@
     <output name="out" type="color3" nodename="N_fractal3d" />
   </nodegraph>
   <nodegraph name="NG_fractal3d_color4FA" nodedef="ND_fractal3d_color4FA">
+    <convert name="N_convert" type="vector4">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <fractal3d name="N_fractal3d" type="color4">
-      <input name="amplitude" type="vector4" interfacename="amplitude" channels="xxxx" />
+      <input name="amplitude" type="vector4" nodename="N_convert" />
       <input name="octaves" type="integer" interfacename="octaves" />
       <input name="lacunarity" type="float" interfacename="lacunarity" />
       <input name="diminish" type="float" interfacename="diminish" />
@@ -1473,8 +1527,11 @@
     <output name="out" type="color4" nodename="N_fractal3d" />
   </nodegraph>
   <nodegraph name="NG_fractal3d_vector2FA" nodedef="ND_fractal3d_vector2FA">
+    <convert name="N_convert" type="vector2">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <fractal3d name="N_fractal3d" type="vector2">
-      <input name="amplitude" type="vector2" interfacename="amplitude" channels="xx" />
+      <input name="amplitude" type="vector2" nodename="N_convert" />
       <input name="octaves" type="integer" interfacename="octaves" />
       <input name="lacunarity" type="float" interfacename="lacunarity" />
       <input name="diminish" type="float" interfacename="diminish" />
@@ -1483,8 +1540,11 @@
     <output name="out" type="vector2" nodename="N_fractal3d" />
   </nodegraph>
   <nodegraph name="NG_fractal3d_vector3FA" nodedef="ND_fractal3d_vector3FA">
+    <convert name="N_convert" type="vector3">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <fractal3d name="N_fractal3d" type="vector3">
-      <input name="amplitude" type="vector3" interfacename="amplitude" channels="xxx" />
+      <input name="amplitude" type="vector3" nodename="N_convert" />
       <input name="octaves" type="integer" interfacename="octaves" />
       <input name="lacunarity" type="float" interfacename="lacunarity" />
       <input name="diminish" type="float" interfacename="diminish" />
@@ -1493,8 +1553,11 @@
     <output name="out" type="vector3" nodename="N_fractal3d" />
   </nodegraph>
   <nodegraph name="NG_fractal3d_vector4FA" nodedef="ND_fractal3d_vector4FA">
+    <convert name="N_convert" type="vector4">
+      <input name="in" type="float" interfacename="amplitude" />
+    </convert>
     <fractal3d name="N_fractal3d" type="vector4">
-      <input name="amplitude" type="vector4" interfacename="amplitude" channels="xxxx" />
+      <input name="amplitude" type="vector4" nodename="N_convert" />
       <input name="octaves" type="integer" interfacename="octaves" />
       <input name="lacunarity" type="float" interfacename="lacunarity" />
       <input name="diminish" type="float" interfacename="diminish" />
@@ -1895,21 +1958,30 @@
       <input name="in1" type="vector2" nodename="sample_double" />
       <input name="in2" type="float" interfacename="radius" />
     </subtract>
+    <separate2 name="sample_double_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="sample_double" />
+    </separate2>
+    <separate2 name="sample_add_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="sample_add" />
+    </separate2>
+    <separate2 name="sample_subtract_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="sample_subtract" />
+    </separate2>
     <combine2 name="coord1" type="vector2">
-      <input name="in1" type="float" nodename="sample_add" channels="x" />
-      <input name="in2" type="float" nodename="sample_double" channels="y" />
+      <input name="in1" type="float" nodename="sample_add_separate" output="outx" />
+      <input name="in2" type="float" nodename="sample_double_separate" output="outy" />
     </combine2>
     <combine2 name="coord2" type="vector2">
-      <input name="in1" type="float" nodename="sample_subtract" channels="x" />
-      <input name="in2" type="float" nodename="sample_double" channels="y" />
+      <input name="in1" type="float" nodename="sample_subtract_separate" output="outx" />
+      <input name="in2" type="float" nodename="sample_double_separate" output="outy" />
     </combine2>
     <combine2 name="coord3" type="vector2">
-      <input name="in1" type="float" nodename="sample_double" channels="x" />
-      <input name="in2" type="float" nodename="sample_subtract" channels="y" />
+      <input name="in1" type="float" nodename="sample_double_separate" output="outx" />
+      <input name="in2" type="float" nodename="sample_subtract_separate" output="outy" />
     </combine2>
     <combine2 name="coord4" type="vector2">
-      <input name="in1" type="float" nodename="sample_double" channels="x" />
-      <input name="in2" type="float" nodename="sample_add" channels="y" />
+      <input name="in1" type="float" nodename="sample_double_separate" output="outx" />
+      <input name="in2" type="float" nodename="sample_add_separate" output="outy" />
     </combine2>
     <circle name="circle1" type="float">
       <input name="texcoord" type="vector2" nodename="coord1" />
@@ -1952,6 +2024,19 @@
     Uses formulas from Inigo Quilez SDF samples (iquilezles.org)
   -->
   <nodegraph name="NG_hexagon_float" nodedef="ND_hexagon_float">
+    <constant name="k" type="vector3">
+      <input name="value" type="vector3" value="-0.866025, 0.5, 0.57735" />
+    </constant>
+    <multiply name="minus_k" type="vector3">
+      <input name="in1" type="vector3" nodename="k" />
+      <input name="in2" type="float" value="-1.0" />
+    </multiply>
+    <separate3 name="k_separate" type="multioutput">
+      <input name="in" type="vector3" nodename="k" />
+    </separate3>
+    <separate3 name="minus_k_separate" type="multioutput">
+      <input name="in" type="vector3" nodename="minus_k" />
+    </separate3>
     <subtract name="delta" type="vector2">
       <input name="in1" type="vector2" interfacename="texcoord" />
       <input name="in2" type="vector2" interfacename="center" />
@@ -1959,32 +2044,28 @@
     <absval name="delta_abs" type="vector2">
       <input name="in" type="vector2" nodename="delta" />
     </absval>
+    <separate2 name="delta_abs_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="delta_abs" />
+    </separate2>
     <combine2 name="p" type="vector2">
-      <input name="in1" type="float" nodename="delta_abs" channels="y" />
-      <input name="in2" type="float" nodename="delta_abs" channels="x" />
+      <input name="in1" type="float" nodename="delta_abs_separate" output="outy" />
+      <input name="in2" type="float" nodename="delta_abs_separate" output="outx" />
     </combine2>
-    <constant name="k" type="vector3">
-      <input name="value" type="vector3" value="-0.866025, 0.5, 0.57735" />
-    </constant>
     <multiply name="kz_r1" type="float">
-      <input name="in1" type="float" nodename="k" channels="z" />
+      <input name="in1" type="float" nodename="k_separate" output="outz" />
       <input name="in2" type="float" interfacename="radius" />
     </multiply>
-    <multiply name="minus_k" type="vector3">
-      <input name="in1" type="vector3" nodename="k" />
-      <input name="in2" type="float" value="-1.0" />
-    </multiply>
     <multiply name="minus_kz_r" type="float">
-      <input name="in1" type="float" nodename="minus_k" channels="z" />
+      <input name="in1" type="float" nodename="minus_k_separate" output="outz" />
       <input name="in2" type="float" interfacename="radius" />
     </multiply>
     <combine2 name="combine_mkx_ky" type="vector2">
-      <input name="in1" type="float" nodename="minus_k" channels="x" />
-      <input name="in2" type="float" nodename="k" channels="y" />
+      <input name="in1" type="float" nodename="minus_k_separate" output="outx" />
+      <input name="in2" type="float" nodename="k_separate" output="outy" />
     </combine2>
     <combine2 name="kxy" type="vector2">
-      <input name="in1" type="float" nodename="k" channels="x" />
-      <input name="in2" type="float" nodename="k" channels="y" />
+      <input name="in1" type="float" nodename="k_separate" output="outx" />
+      <input name="in2" type="float" nodename="k_separate" output="outy" />
     </combine2>
     <dotproduct name="dot_kxy_p" type="float">
       <input name="in1" type="vector2" nodename="kxy" />
@@ -2016,8 +2097,12 @@
       <input name="in1" type="vector2" nodename="multiply_min_comb" />
       <input name="in2" type="float" value="2" />
     </multiply>
+    <extract name="new_p2_x" type="float">
+      <input name="in" type="vector2" nodename="new_p2" />
+      <input name="index" type="integer" value="0" />
+    </extract>
     <clamp name="clamp" type="float">
-      <input name="in" type="float" nodename="new_p2" channels="x" />
+      <input name="in" type="float" nodename="new_p2_x" />
       <input name="low" type="float" nodename="minus_kz_r" />
       <input name="high" type="float" nodename="kz_r1" />
     </clamp>
@@ -2067,15 +2152,18 @@
       <input name="in1" type="vector2" nodename="texcoord_scale" />
       <input name="in2" type="vector2" interfacename="uvoffset" />
     </subtract>
+    <separate2 name="texcoord_bias_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="texcoord_bias" />
+    </separate2>
     <subtract name="thick_to_size" type="float">
       <input name="in1" type="float" value="1.0" />
       <input name="in2" type="float" interfacename="thickness" />
     </subtract>
     <modulo name="mod_Y" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
     </modulo>
     <modulo name="mod_Y_row" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="2" />
     </modulo>
     <multiply name="mody_2" type="float">
@@ -2088,14 +2176,14 @@
       <input name="in1" type="float" value="0.5" />
     </ifgreater>
     <add name="shift_X" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outx" />
       <input name="in2" type="float" nodename="alt_rows_shift" />
     </add>
     <ifequal name="stagger_selection" type="float">
       <input name="value1" type="boolean" interfacename="staggered" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="float" nodename="shift_X" />
-      <input name="in2" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in2" type="float" nodename="texcoord_bias_separate" output="outx" />
     </ifequal>
     <modulo name="mod_X" type="float">
       <input name="in1" type="float" nodename="stagger_selection" />
@@ -2158,11 +2246,14 @@
       <input name="in1" type="vector2" nodename="texcoord_scale" />
       <input name="in2" type="vector2" interfacename="uvoffset" />
     </subtract>
+    <separate2 name="texcoord_bias_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="texcoord_bias" />
+    </separate2>
     <modulo name="mod_Y" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
     </modulo>
     <modulo name="mod_Y_row" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="2" />
     </modulo>
     <multiply name="mody_2" type="float">
@@ -2175,14 +2266,14 @@
       <input name="in1" type="float" value="0.5" />
     </ifgreater>
     <add name="shift_X" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outx" />
       <input name="in2" type="float" nodename="alt_rows_shift" />
     </add>
     <ifequal name="stagger_selection" type="float">
       <input name="value1" type="boolean" interfacename="staggered" />
       <input name="value2" type="boolean" value="true" />
       <input name="in1" type="float" nodename="shift_X" />
-      <input name="in2" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in2" type="float" nodename="texcoord_bias_separate" output="outx" />
     </ifequal>
     <modulo name="mod_X" type="float">
       <input name="in1" type="float" nodename="stagger_selection" />
@@ -2243,6 +2334,9 @@
       <input name="in1" type="vector2" nodename="texcoord_scale" />
       <input name="in2" type="vector2" interfacename="uvoffset" />
     </subtract>
+    <separate2 name="texcoord_bias_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="texcoord_bias" />
+    </separate2>
     <modulo name="mod_texcoord" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord_bias" />
     </modulo>
@@ -2255,7 +2349,7 @@
       <input name="in2" type="float" value="1" />
     </subtract>
     <modulo name="stagg_Y" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="1.73205" />
     </modulo>
     <ifgreater name="delta_X" type="float">
@@ -2264,14 +2358,14 @@
       <input name="in1" type="float" value="0.5" />
     </ifgreater>
     <add name="shift_X" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outx" />
       <input name="in2" type="float" nodename="delta_X" />
     </add>
     <modulo name="mod_X_1" type="float">
       <input name="in1" type="float" nodename="shift_X" />
     </modulo>
     <modulo name="mod_Y_1" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="0.866025" />
     </modulo>
     <subtract name="coord_adj_1" type="float">
@@ -2352,6 +2446,9 @@
       <input name="in1" type="vector2" nodename="texcoord_scale" />
       <input name="in2" type="vector2" interfacename="uvoffset" />
     </subtract>
+    <separate2 name="texcoord_bias_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="texcoord_bias" />
+    </separate2>
     <modulo name="mod_texcoord" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord_bias" />
     </modulo>
@@ -2364,7 +2461,7 @@
       <input name="in2" type="float" value="1" />
     </subtract>
     <modulo name="stagg_Y" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="1" />
     </modulo>
     <ifgreater name="delta_X" type="float">
@@ -2373,14 +2470,14 @@
       <input name="in1" type="float" value="0.5" />
     </ifgreater>
     <add name="shift_X" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outx" />
       <input name="in2" type="float" nodename="delta_X" />
     </add>
     <modulo name="mod_X_1" type="float">
       <input name="in1" type="float" nodename="shift_X" />
     </modulo>
     <modulo name="mod_Y_1" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="0.5" />
     </modulo>
     <subtract name="coord_adj_1" type="float">
@@ -2461,6 +2558,9 @@
       <input name="in1" type="vector2" nodename="texcoord_scale" />
       <input name="in2" type="vector2" interfacename="uvoffset" />
     </subtract>
+    <separate2 name="texcoord_bias_separate" type="multioutput">
+      <input name="in" type="vector2" nodename="texcoord_bias" />
+    </separate2>
     <modulo name="mod_texcoord" type="vector2">
       <input name="in1" type="vector2" nodename="texcoord_bias" />
     </modulo>
@@ -2473,7 +2573,7 @@
       <input name="in2" type="float" value="1" />
     </subtract>
     <modulo name="stagg_Y" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="1.73205" />
     </modulo>
     <ifgreater name="delta_X" type="float">
@@ -2482,14 +2582,14 @@
       <input name="in1" type="float" value="0.5" />
     </ifgreater>
     <add name="shift_X" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="x" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outx" />
       <input name="in2" type="float" nodename="delta_X" />
     </add>
     <modulo name="mod_X_1" type="float">
       <input name="in1" type="float" nodename="shift_X" />
     </modulo>
     <modulo name="mod_Y_1" type="float">
-      <input name="in1" type="float" nodename="texcoord_bias" channels="y" />
+      <input name="in1" type="float" nodename="texcoord_bias_separate" output="outy" />
       <input name="in2" type="float" value="0.866025" />
     </modulo>
     <subtract name="coord_adj_1" type="float">
@@ -2799,60 +2899,114 @@
     to output 0-1.
   -->
   <nodegraph name="NG_smoothstep_color3" nodedef="ND_smoothstep_color3">
-    <smoothstep name="N_smoothstep" type="vector3">
-      <input name="in" type="vector3" interfacename="in" channels="rgb" />
-      <input name="low" type="vector3" interfacename="low" channels="rgb" />
-      <input name="high" type="vector3" interfacename="high" channels="rgb" />
+    <convert name="in_vector" type="vector3">
+      <input name="in" type="color3" interfacename="in" />
+    </convert>
+    <convert name="low_vector" type="vector3">
+      <input name="in" type="color3" interfacename="low" />
+    </convert>
+    <convert name="high_vector" type="vector3">
+      <input name="in" type="color3" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="vector3">
+      <input name="in" type="vector3" nodename="in_vector" />
+      <input name="low" type="vector3" nodename="low_vector" />
+      <input name="high" type="vector3" nodename="high_vector" />
     </smoothstep>
-    <output name="out" type="color3" nodename="N_smoothstep" channels="xyz" />
+    <convert name="smoothstep_color" type="color3">
+      <input name="in" type="vector3" nodename="smoothstep" />
+    </convert>
+    <output name="out" type="color3" nodename="smoothstep_color" />
   </nodegraph>
   <nodegraph name="NG_smoothstep_color4" nodedef="ND_smoothstep_color4">
-    <smoothstep name="N_smoothstep" type="vector4">
-      <input name="in" type="vector4" interfacename="in" channels="rgba" />
-      <input name="low" type="vector4" interfacename="low" channels="rgba" />
-      <input name="high" type="vector4" interfacename="high" channels="rgba" />
+    <convert name="in_vector" type="vector4">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <convert name="low_vector" type="vector4">
+      <input name="in" type="color4" interfacename="low" />
+    </convert>
+    <convert name="high_vector" type="vector4">
+      <input name="in" type="color4" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="vector4">
+      <input name="in" type="vector4" nodename="in_vector" />
+      <input name="low" type="vector4" nodename="low_vector" />
+      <input name="high" type="vector4" nodename="high_vector" />
     </smoothstep>
-    <output name="out" type="color4" nodename="N_smoothstep" channels="xyzw" />
+    <convert name="smoothstep_color" type="color4">
+      <input name="in" type="vector4" nodename="smoothstep" />
+    </convert>
+    <output name="out" type="color4" nodename="smoothstep_color" />
   </nodegraph>
   <nodegraph name="NG_smoothstep_color3FA" nodedef="ND_smoothstep_color3FA">
-    <smoothstep name="N_smoothstep" type="color3">
+    <convert name="low_color" type="color3">
+      <input name="in" type="float" interfacename="low" />
+    </convert>
+    <convert name="high_color" type="color3">
+      <input name="in" type="float" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="color3">
       <input name="in" type="color3" interfacename="in" />
-      <input name="low" type="color3" interfacename="low" channels="xxx" />
-      <input name="high" type="color3" interfacename="high" channels="xxx" />
+      <input name="low" type="color3" nodename="low_color" />
+      <input name="high" type="color3" nodename="high_color" />
     </smoothstep>
-    <output name="out" type="color3" nodename="N_smoothstep" />
+    <output name="out" type="color3" nodename="smoothstep" />
   </nodegraph>
   <nodegraph name="NG_smoothstep_color4FA" nodedef="ND_smoothstep_color4FA">
-    <smoothstep name="N_smoothstep" type="color4">
+    <convert name="low_color" type="color4">
+      <input name="in" type="float" interfacename="low" />
+    </convert>
+    <convert name="high_color" type="color4">
+      <input name="in" type="float" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="color4">
       <input name="in" type="color4" interfacename="in" />
-      <input name="low" type="color4" interfacename="low" channels="xxxx" />
-      <input name="high" type="color4" interfacename="high" channels="xxxx" />
+      <input name="low" type="color4" nodename="low_color" />
+      <input name="high" type="color4" nodename="high_color" />
     </smoothstep>
-    <output name="out" type="color4" nodename="N_smoothstep" />
+    <output name="out" type="color4" nodename="smoothstep" />
   </nodegraph>
   <nodegraph name="NG_smoothstep_vector2FA" nodedef="ND_smoothstep_vector2FA">
-    <smoothstep name="N_smoothstep" type="vector2">
+    <convert name="low_vector" type="vector2">
+      <input name="in" type="float" interfacename="low" />
+    </convert>
+    <convert name="high_vector" type="vector2">
+      <input name="in" type="float" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="vector2">
       <input name="in" type="vector2" interfacename="in" />
-      <input name="low" type="vector2" interfacename="low" channels="xx" />
-      <input name="high" type="vector2" interfacename="high" channels="xx" />
+      <input name="low" type="vector2" nodename="low_vector" />
+      <input name="high" type="vector2" nodename="high_vector" />
     </smoothstep>
-    <output name="out" type="vector2" nodename="N_smoothstep" />
+    <output name="out" type="vector2" nodename="smoothstep" />
   </nodegraph>
   <nodegraph name="NG_smoothstep_vector3FA" nodedef="ND_smoothstep_vector3FA">
-    <smoothstep name="N_smoothstep" type="vector3">
+    <convert name="low_vector" type="vector3">
+      <input name="in" type="float" interfacename="low" />
+    </convert>
+    <convert name="high_vector" type="vector3">
+      <input name="in" type="float" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="vector3">
       <input name="in" type="vector3" interfacename="in" />
-      <input name="low" type="vector3" interfacename="low" channels="xxx" />
-      <input name="high" type="vector3" interfacename="high" channels="xxx" />
+      <input name="low" type="vector3" nodename="low_vector" />
+      <input name="high" type="vector3" nodename="high_vector" />
     </smoothstep>
-    <output name="out" type="vector3" nodename="N_smoothstep" />
+    <output name="out" type="vector3" nodename="smoothstep" />
   </nodegraph>
   <nodegraph name="NG_smoothstep_vector4FA" nodedef="ND_smoothstep_vector4FA">
-    <smoothstep name="N_smoothstep" type="vector4">
+    <convert name="low_vector" type="vector4">
+      <input name="in" type="float" interfacename="low" />
+    </convert>
+    <convert name="high_vector" type="vector4">
+      <input name="in" type="float" interfacename="high" />
+    </convert>
+    <smoothstep name="smoothstep" type="vector4">
       <input name="in" type="vector4" interfacename="in" />
-      <input name="low" type="vector4" interfacename="low" channels="xxxx" />
-      <input name="high" type="vector4" interfacename="high" channels="xxxx" />
+      <input name="low" type="vector4" nodename="low_vector" />
+      <input name="high" type="vector4" nodename="high_vector" />
     </smoothstep>
-    <output name="out" type="vector4" nodename="N_smoothstep" />
+    <output name="out" type="vector4" nodename="smoothstep" />
   </nodegraph>
 
   <!--
@@ -4168,7 +4322,7 @@
     <output name="outb" type="float" nodename="N_extract_2" />
   </nodegraph>
   <nodegraph name="NG_separate4_color4" nodedef="ND_separate4_color4">
-     <extract name="N_extract_0" type="float">
+    <extract name="N_extract_0" type="float">
       <input name="in" type="color4" interfacename="in" />
       <input name="index" type="integer" value="0" />
     </extract>
@@ -4190,7 +4344,7 @@
     <output name="outa" type="float" nodename="N_extract_3" />
   </nodegraph>
   <nodegraph name="NG_separate2_vector2" nodedef="ND_separate2_vector2">
-     <extract name="N_extract_0" type="float">
+    <extract name="N_extract_0" type="float">
       <input name="in" type="vector2" interfacename="in" />
       <input name="index" type="integer" value="0" />
     </extract>
@@ -4202,7 +4356,7 @@
     <output name="outy" type="float" nodename="N_extract_1" />
   </nodegraph>
   <nodegraph name="NG_separate3_vector3" nodedef="ND_separate3_vector3">
-     <extract name="N_extract_0" type="float">
+    <extract name="N_extract_0" type="float">
       <input name="in" type="vector3" interfacename="in" />
       <input name="index" type="integer" value="0" />
     </extract>

--- a/libraries/targets/essl.mtlx
+++ b/libraries/targets/essl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!--
   Copyright Contributors to the MaterialX Project

--- a/libraries/targets/genglsl.mtlx
+++ b/libraries/targets/genglsl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!--
     Copyright Contributors to the MaterialX Project

--- a/libraries/targets/genmdl.mtlx
+++ b/libraries/targets/genmdl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!--
     Copyright Contributors to the MaterialX Project

--- a/libraries/targets/genmsl.mtlx
+++ b/libraries/targets/genmsl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!--
     Copyright Contributors to the MaterialX Project

--- a/libraries/targets/genosl.mtlx
+++ b/libraries/targets/genosl.mtlx
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<materialx version="1.38">
+<materialx version="1.39">
 
   <!--
     Copyright Contributors to the MaterialX Project


### PR DESCRIPTION
This changelist upgrades the documents in the MaterialX data libraries to v1.39, leveraging the `mxformat.py` script and making additional minor edits for clarity.