### PR TITLE
Add support for GCC 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,10 @@ jobs:
           python: 3.11
           build_javascript: ON
 
-        - name: Linux_GCC_13_Python312
+        - name: Linux_GCC_14_Python312
           os: ubuntu-24.04
           compiler: gcc
-          compiler_version: "13"
+          compiler_version: "14"
           python: 3.12
           static_analysis: ON
           cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON

--- a/source/MaterialXCore/CMakeLists.txt
+++ b/source/MaterialXCore/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Generated.h.in ${CMAKE_CURRENT_BINARY_DIR}/Generated.h)
 
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
@@ -10,11 +9,9 @@ mx_add_library(MaterialXCore
     HEADER_FILES
         ${materialx_headers}
     EXPORT_DEFINE
-        MATERIALX_CORE_EXPORTS
-)
+        MATERIALX_CORE_EXPORTS)
 
 # Need to add the binary directory to find the Generated.h file generated above.
 target_include_directories(${TARGET_NAME}
         PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>
-)
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>)

--- a/source/MaterialXFormat/CMakeLists.txt
+++ b/source/MaterialXFormat/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -10,5 +9,4 @@ mx_add_library(MaterialXFormat
     LIBRARIES
         MaterialXCore
     EXPORT_DEFINE
-        MATERIALX_FORMAT_EXPORTS
-)
+        MATERIALX_FORMAT_EXPORTS)

--- a/source/MaterialXGenGlsl/CMakeLists.txt
+++ b/source/MaterialXGenGlsl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -11,5 +10,4 @@ mx_add_library(MaterialXGenGlsl
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE
-        MATERIALX_GENGLSL_EXPORTS
-)
+        MATERIALX_GENGLSL_EXPORTS)

--- a/source/MaterialXGenMdl/CMakeLists.txt
+++ b/source/MaterialXGenMdl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -11,6 +10,4 @@ mx_add_library(MaterialXGenMdl
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE
-        MATERIALX_GENMDL_EXPORTS
-)
-
+        MATERIALX_GENMDL_EXPORTS)

--- a/source/MaterialXGenMsl/CMakeLists.txt
+++ b/source/MaterialXGenMsl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -11,5 +10,4 @@ mx_add_library(MaterialXGenMsl
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE
-        MATERIALX_GENMSL_EXPORTS
-)
+        MATERIALX_GENMSL_EXPORTS)

--- a/source/MaterialXGenOsl/CMakeLists.txt
+++ b/source/MaterialXGenOsl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -11,5 +10,4 @@ mx_add_library(MaterialXGenOsl
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE
-        MATERIALX_GENOSL_EXPORTS
-)
+        MATERIALX_GENOSL_EXPORTS)

--- a/source/MaterialXGenShader/CMakeLists.txt
+++ b/source/MaterialXGenShader/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -11,5 +10,4 @@ mx_add_library(MaterialXGenShader
         MaterialXFormat
         MaterialXCore
     EXPORT_DEFINE
-        MATERIALX_GENSHADER_EXPORTS
-)
+        MATERIALX_GENSHADER_EXPORTS)

--- a/source/MaterialXGraphEditor/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/CMakeLists.txt
@@ -80,10 +80,10 @@ set(MATERIALX_LIBRARIES
     MaterialXGenGlsl
     MaterialXRenderGlsl)
 
-if (APPLE)
+if(APPLE)
     find_library(CORE_FOUNDATION Foundation REQUIRED)
     list(APPEND MATERIALX_LIBRARIES ${CORE_FOUNDATION})
-endif ()
+endif()
 
 target_link_libraries(
     MaterialXGraphEditor

--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_inlined "${CMAKE_CURRENT_SOURCE_DIR}/*.inl")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
@@ -15,11 +14,13 @@ mx_add_library(MaterialXRender
     LIBRARIES
         MaterialXGenShader
     EXPORT_DEFINE
-        MATERIALX_RENDER_EXPORTS
-)
+        MATERIALX_RENDER_EXPORTS)
 
 if(UNIX)
     target_compile_options(${TARGET_NAME} PRIVATE -Wno-unused-function)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        target_compile_options(${TARGET_NAME} PRIVATE -Wno-stringop-overflow)
+    endif()
 endif()
 
 if(MATERIALX_BUILD_OIIO)

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.c*")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -24,7 +23,6 @@ elseif(UNIX)
     find_package(OpenGL REQUIRED)
 endif()
 
-
 mx_add_library(MaterialXRenderGlsl
     SOURCE_FILES
         ${materialx_source}
@@ -35,9 +33,7 @@ mx_add_library(MaterialXRenderGlsl
         MaterialXGenGlsl
     EXPORT_DEFINE
         MATERIALX_RENDERGLSL_EXPORTS
-    ADD_OBJECTIVE_C_CODE
-)
-
+    ADD_OBJECTIVE_C_CODE)
 
 if(APPLE)
     target_compile_definitions(${TARGET_NAME} PRIVATE -DGL_SILENCE_DEPRECATION)

--- a/source/MaterialXRenderHw/CMakeLists.txt
+++ b/source/MaterialXRenderHw/CMakeLists.txt
@@ -15,7 +15,6 @@ elseif(UNIX)
     endif()
 endif()
 
-
 mx_add_library(MaterialXRenderHw
     SOURCE_FILES
         ${materialx_source}
@@ -25,8 +24,7 @@ mx_add_library(MaterialXRenderHw
         MaterialXRender
     EXPORT_DEFINE
         MATERIALX_RENDERHW_EXPORTS
-    ADD_OBJECTIVE_C_CODE
-)
+    ADD_OBJECTIVE_C_CODE)
 
 if(APPLE)
     target_link_libraries(

--- a/source/MaterialXRenderMsl/CMakeLists.txt
+++ b/source/MaterialXRenderMsl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.m*")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -22,7 +21,6 @@ elseif(UNIX)
     find_package(OpenGL REQUIRED)
 endif()
 
-
 mx_add_library(MaterialXRenderMsl
     SOURCE_FILES
         ${materialx_source}
@@ -33,9 +31,7 @@ mx_add_library(MaterialXRenderMsl
         MaterialXGenMsl
     EXPORT_DEFINE
         MATERIALX_RENDERMSL_EXPORTS
-    ADD_OBJECTIVE_C_CODE
-)
-
+    ADD_OBJECTIVE_C_CODE)
 
 if(APPLE)
     target_compile_definitions(${TARGET_NAME} PRIVATE -DGL_SILENCE_DEPRECATION)

--- a/source/MaterialXRenderOsl/CMakeLists.txt
+++ b/source/MaterialXRenderOsl/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -10,5 +9,4 @@ mx_add_library(MaterialXRenderOsl
     LIBRARIES
         MaterialXRender
     EXPORT_DEFINE
-        MATERIALX_RENDEROSL_EXPORTS
-)
+        MATERIALX_RENDEROSL_EXPORTS)

--- a/source/MaterialXView/CMakeLists.txt
+++ b/source/MaterialXView/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Wno-deprecated)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(-Wno-format-truncation -Wno-use-after-free)
+        add_compile_options(-Wno-format-truncation -Wno-stringop-overflow -Wno-use-after-free)
     endif()
 
     # Disable NanoGUI compiler modifications for Clang

--- a/source/PyMaterialX/CMakeLists.txt
+++ b/source/PyMaterialX/CMakeLists.txt
@@ -1,8 +1,7 @@
 include_directories(
     ${EXTERNAL_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../
-    ${CMAKE_CURRENT_SOURCE_DIR}
-)
+    ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Apply Python version and location requests from the user.
 set(PYBIND11_PYTHON_VERSION ${MATERIALX_PYTHON_VERSION})


### PR DESCRIPTION
This changelist adds a GCC 14 build to GitHub CI, and updates compiler warning settings as needed for external libraries such as stb_image.

Additional minor formatting updates have been made to CMakeLists.txt files for consistency.