### PR TITLE
Update cibuildwheel to v2.19.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -401,7 +401,7 @@ jobs:
         path: sdist
 
     - name: Build Wheel
-      uses: pypa/cibuildwheel@v2.17.0
+      uses: pypa/cibuildwheel@v2.19.2
       with:
         package-dir: ${{ github.workspace }}/sdist/${{ needs.sdist.outputs.sdist_filename }}
       env:


### PR DESCRIPTION
This changelist updates cibuildwheel to v2.19.2, which contains a fix for the usage of CentOS 7 (now past-EOL) in manylinux2014.