### PR TITLE
Fix missing include install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ function(mx_add_library MATERIALX_MODULE_NAME)
     set(multiValueArgs
             SOURCE_FILES
             HEADER_FILES
+            INLINED_FILES
             LIBRARIES)
     cmake_parse_arguments(args
             "${options}"
@@ -301,11 +302,12 @@ function(mx_add_library MATERIALX_MODULE_NAME)
     endif()
 
     assign_source_group("Source Files" ${args_SOURCE_FILES})
+    assign_source_group("Source Files" ${args_INLINED_FILES})
     assign_source_group("Header Files" ${args_HEADER_FILES})
 
     if (NOT MATERIALX_BUILD_MONOLITHIC)
         set(TARGET_NAME ${MATERIALX_MODULE_NAME})
-        add_library(${TARGET_NAME} ${args_SOURCE_FILES} ${args_HEADER_FILES})
+        add_library(${TARGET_NAME})
 
         # Create version resource
         if(MATERIALX_BUILD_SHARED_LIBS AND MSVC)
@@ -336,14 +338,30 @@ function(mx_add_library MATERIALX_MODULE_NAME)
     else()
         set(TARGET_NAME ${MATERIALX_MONOLITHIC_TARGET})
 
-        target_sources(${TARGET_NAME} PRIVATE ${args_SOURCE_FILES})
-        target_sources(${TARGET_NAME} PRIVATE ${args_HEADER_FILES})
-
         add_library(${MATERIALX_MODULE_NAME} ALIAS ${MATERIALX_MONOLITHIC_TARGET})
 
         # Store the aliased MaterialX modules name to create cmake export aliases later.
         set_property(GLOBAL APPEND PROPERTY MATERIALX_MODULES ${MATERIALX_MODULE_NAME})
     endif()
+
+    target_sources(${TARGET_NAME}
+        PRIVATE
+            ${args_SOURCE_FILES}
+        PUBLIC
+            FILE_SET
+                mxHeaders
+            TYPE
+                HEADERS
+            BASE_DIRS
+                ${CMAKE_CURRENT_SOURCE_DIR}/..
+                ${CMAKE_CURRENT_BINARY_DIR}/..
+            FILES
+                ${args_HEADER_FILES}
+                ${args_INLINED_FILES})
+
+    target_include_directories(${TARGET_NAME} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}>)
 
     target_compile_definitions(${TARGET_NAME} PRIVATE "-D${args_EXPORT_DEFINE}")
 
@@ -353,14 +371,9 @@ function(mx_add_library MATERIALX_MODULE_NAME)
                     EXPORT MaterialX
                     ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
                     LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                    RUNTIME DESTINATION bin)
+                    RUNTIME DESTINATION bin
+                    FILE_SET mxHeaders)
         endif()
-
-        install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
-                DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
-                FILES_MATCHING
-                PATTERN "*.h*"
-                PATTERN "*.inl")
 
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${MATERIALX_MODULE_NAME}.pdb"
                 DESTINATION "${MATERIALX_INSTALL_LIB_PATH}/" OPTIONAL)
@@ -450,6 +463,23 @@ endif()
 
 if(MATERIALX_BUILD_JS)
     add_subdirectory(source/JsMaterialX)
+endif()
+
+if (MATERIALX_BUILD_MONOLITHIC)
+    # MaterialX monolithic build target needs to be installed after any other included
+    # modules to ensure the correct files are in mxHeaders
+    if(NOT SKBUILD)
+        install(TARGETS ${MATERIALX_MONOLITHIC_TARGET}
+                EXPORT MaterialX
+                ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
+                LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
+                RUNTIME DESTINATION bin
+                FILE_SET mxHeaders)
+
+        # Note : we don't install the headers etc. here, and rely on each separate modules CMakeLists.txt
+        # to do that installation, thus we respect the build options configuration, and only install
+        # the headers for the modules we've built in to the monolithic build.
+    endif()
 endif()
 
 if(MATERIALX_BUILD_VIEWER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,8 +360,7 @@ function(mx_add_library MATERIALX_MODULE_NAME)
                 ${args_INLINED_FILES})
 
     target_include_directories(${TARGET_NAME} PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}>)
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)
 
     target_compile_definitions(${TARGET_NAME} PRIVATE "-D${args_EXPORT_DEFINE}")
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -32,15 +32,6 @@ if (MATERIALX_BUILD_MONOLITHIC)
             PRIVATE
             ${EXTERNAL_INCLUDE_DIRS})
 
-    if(NOT SKBUILD)
-        install(TARGETS ${MATERIALX_MODULE_NAME}
-                EXPORT MaterialX
-                ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                RUNTIME DESTINATION bin)
-
-        # Note : we don't install the headers etc. here, and rely on each separate modules CMakeLists.txt
-        # to do that installation, thus we respect the build options configuration, and only install
-        # the headers for the modules we've built in to the monolithic build.
-    endif()
+    # Monolithic target is installed in the root CMakeLists.txt to allow for collection
+    # of all necessary headers.
 endif()

--- a/source/MaterialXGenMdl/CMakeLists.txt
+++ b/source/MaterialXGenMdl/CMakeLists.txt
@@ -11,3 +11,8 @@ mx_add_library(MaterialXGenMdl
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_GENMDL_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mdl
+            DESTINATION "${MATERIALX_INSTALL_MDL_MODULE_PATH}")
+endif()

--- a/source/MaterialXGenShader/CMakeLists.txt
+++ b/source/MaterialXGenShader/CMakeLists.txt
@@ -11,3 +11,8 @@ mx_add_library(MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_GENSHADER_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../resources"
+            DESTINATION . MESSAGE_NEVER)
+endif()

--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -8,7 +8,9 @@ endif()
 
 mx_add_library(MaterialXRender
     SOURCE_FILES
-        ${materialx_source} ${materialx_inlined}
+        ${materialx_source}
+    INLINED_FILES
+        ${materialx_inlined}
     HEADER_FILES
         ${materialx_headers}
     LIBRARIES


### PR DESCRIPTION
The `mx_add_library` refactor introduced in #1725, introduced a few bugs with installing files.

`Generated.h` was incorrectly being ignored, instead `Generated.h.in` was being installed, and also the mdl library files were missing, also some resources were also not being installed.

Should now be corrected in both monolithic  and non-monolithic builds.