### PR TITLE
Remove extra resources install

### DIFF
--- a/source/MaterialXGenShader/CMakeLists.txt
+++ b/source/MaterialXGenShader/CMakeLists.txt
@@ -11,8 +11,3 @@ mx_add_library(MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_GENSHADER_EXPORTS)
-
-if(NOT SKBUILD)
-    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../resources"
-            DESTINATION . MESSAGE_NEVER)
-endif()


### PR DESCRIPTION
This change removes an extra install of the resources folder in MaterialXGenShader, as this dependency does not appear to be required in 1.39.