### PR TITLE
Fix include install - compatible with cmake 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(MATERIALX_LIBRARY_VERSION ${MATERIALX_MAJOR_VERSION}.${MATERIALX_MINOR_VERSI
 
 # Cmake setup
 cmake_minimum_required(VERSION 3.16)
+cmake_policy(VERSION 3.16)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 set(CMAKE_MACOSX_RPATH ON)
@@ -347,17 +349,7 @@ function(mx_add_library MATERIALX_MODULE_NAME)
     target_sources(${TARGET_NAME}
         PRIVATE
             ${args_SOURCE_FILES}
-        PUBLIC
-            FILE_SET
-                mxHeaders
-            TYPE
-                HEADERS
-            BASE_DIRS
-                ${CMAKE_CURRENT_SOURCE_DIR}/..
-                ${CMAKE_CURRENT_BINARY_DIR}/..
-            FILES
-                ${args_HEADER_FILES}
-                ${args_INLINED_FILES})
+            ${args_INLINED_FILES})
 
     target_include_directories(${TARGET_NAME} PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)
@@ -370,8 +362,7 @@ function(mx_add_library MATERIALX_MODULE_NAME)
                     EXPORT MaterialX
                     ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
                     LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                    RUNTIME DESTINATION bin
-                    FILE_SET mxHeaders)
+                    RUNTIME DESTINATION bin)
         endif()
 
         install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${MATERIALX_MODULE_NAME}.pdb"
@@ -462,23 +453,6 @@ endif()
 
 if(MATERIALX_BUILD_JS)
     add_subdirectory(source/JsMaterialX)
-endif()
-
-if (MATERIALX_BUILD_MONOLITHIC)
-    # MaterialX monolithic build target needs to be installed after any other included
-    # modules to ensure the correct files are in mxHeaders
-    if(NOT SKBUILD)
-        install(TARGETS ${MATERIALX_MONOLITHIC_TARGET}
-                EXPORT MaterialX
-                ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                RUNTIME DESTINATION bin
-                FILE_SET mxHeaders)
-
-        # Note : we don't install the headers etc. here, and rely on each separate modules CMakeLists.txt
-        # to do that installation, thus we respect the build options configuration, and only install
-        # the headers for the modules we've built in to the monolithic build.
-    endif()
 endif()
 
 if(MATERIALX_BUILD_VIEWER)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -32,6 +32,17 @@ if (MATERIALX_BUILD_MONOLITHIC)
             PRIVATE
             ${EXTERNAL_INCLUDE_DIRS})
 
-    # Monolithic target is installed in the root CMakeLists.txt to allow for collection
-    # of all necessary headers.
+
+    if(NOT SKBUILD)
+        install(TARGETS ${MATERIALX_MONOLITHIC_TARGET}
+                EXPORT MaterialX
+                ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
+                LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
+                RUNTIME DESTINATION bin)
+
+        # Note : we don't install the headers etc. here, and rely on each separate modules CMakeLists.txt
+        # to do that installation, thus we respect the build options configuration, and only install
+        # the headers for the modules we've built in to the monolithic build.
+    endif()
+
 endif()

--- a/source/MaterialXCore/CMakeLists.txt
+++ b/source/MaterialXCore/CMakeLists.txt
@@ -1,9 +1,11 @@
+set(MATERIALX_MODULE_NAME MaterialXCore)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Generated.h.in ${CMAKE_CURRENT_BINARY_DIR}/Generated.h)
 
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h" "${CMAKE_CURRENT_BINARY_DIR}/*.h")
 
-mx_add_library(MaterialXCore
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -15,3 +17,8 @@ mx_add_library(MaterialXCore
 target_include_directories(${TARGET_NAME}
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>)
+
+if (NOT SKBUILD)
+    install(FILES ${materialx_headers}
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/)
+endif()

--- a/source/MaterialXFormat/CMakeLists.txt
+++ b/source/MaterialXFormat/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXFormat)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXFormat
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -10,3 +12,9 @@ mx_add_library(MaterialXFormat
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_FORMAT_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+endif()

--- a/source/MaterialXGenGlsl/CMakeLists.txt
+++ b/source/MaterialXGenGlsl/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXGenGlsl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXGenGlsl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -11,3 +13,9 @@ mx_add_library(MaterialXGenGlsl
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_GENGLSL_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+endif()

--- a/source/MaterialXGenMdl/CMakeLists.txt
+++ b/source/MaterialXGenMdl/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXGenMdl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXGenMdl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -13,6 +15,10 @@ mx_add_library(MaterialXGenMdl
         MATERIALX_GENMDL_EXPORTS)
 
 if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/mdl
             DESTINATION "${MATERIALX_INSTALL_MDL_MODULE_PATH}")
 endif()

--- a/source/MaterialXGenMsl/CMakeLists.txt
+++ b/source/MaterialXGenMsl/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXGenMsl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXGenMsl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -11,3 +13,9 @@ mx_add_library(MaterialXGenMsl
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_GENMSL_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+endif()

--- a/source/MaterialXGenOsl/CMakeLists.txt
+++ b/source/MaterialXGenOsl/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXGenOsl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXGenOsl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -11,3 +13,9 @@ mx_add_library(MaterialXGenOsl
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_GENOSL_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+endif()

--- a/source/MaterialXGenShader/CMakeLists.txt
+++ b/source/MaterialXGenShader/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXGenShader)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXGenShader
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -13,6 +15,10 @@ mx_add_library(MaterialXGenShader
         MATERIALX_GENSHADER_EXPORTS)
 
 if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../resources"
             DESTINATION . MESSAGE_NEVER)
 endif()

--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MATERIALX_MODULE_NAME MaterialXRender)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_inlined "${CMAKE_CURRENT_SOURCE_DIR}/*.inl")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
@@ -6,7 +8,7 @@ if(NOT MATERIALX_BUILD_OIIO)
     list(REMOVE_ITEM materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/OiioImageLoader.cpp")
 endif()
 
-mx_add_library(MaterialXRender
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     INLINED_FILES
@@ -30,4 +32,12 @@ if(MATERIALX_BUILD_OIIO)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/External/OpenImageIO")
     find_package(OpenImageIO CONFIG REQUIRED)
     target_link_libraries(${TARGET_NAME} OpenImageIO::OpenImageIO OpenImageIO::OpenImageIO_Util)
+endif()
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING
+            PATTERN "*.h*"
+            PATTERN "*.inl")
 endif()

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MATERIALX_MODULE_NAME MaterialXRenderGlsl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.c*")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -23,7 +25,7 @@ elseif(UNIX)
     find_package(OpenGL REQUIRED)
 endif()
 
-mx_add_library(MaterialXRenderGlsl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -75,4 +77,10 @@ elseif(UNIX)
             OpenGL::GL
             X11::X11
             X11::Xt)
+endif()
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
 endif()

--- a/source/MaterialXRenderHw/CMakeLists.txt
+++ b/source/MaterialXRenderHw/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(MATERIALX_MODULE_NAME MaterialXRenderHw)
 
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
@@ -15,7 +16,7 @@ elseif(UNIX)
     endif()
 endif()
 
-mx_add_library(MaterialXRenderHw
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -42,4 +43,10 @@ elseif(UNIX)
             ${TARGET_NAME}
             X11::X11
             X11::Xt)
+endif()
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
 endif()

--- a/source/MaterialXRenderMsl/CMakeLists.txt
+++ b/source/MaterialXRenderMsl/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(MATERIALX_MODULE_NAME MaterialXRenderMsl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.m*")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
@@ -21,7 +23,7 @@ elseif(UNIX)
     find_package(OpenGL REQUIRED)
 endif()
 
-mx_add_library(MaterialXRenderMsl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -66,4 +68,10 @@ elseif(UNIX)
             OpenGL::GL
             X11::X11
             X11::Xt)
+endif()
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
 endif()

--- a/source/MaterialXRenderOsl/CMakeLists.txt
+++ b/source/MaterialXRenderOsl/CMakeLists.txt
@@ -1,7 +1,9 @@
+set(MATERIALX_MODULE_NAME MaterialXRenderOsl)
+
 file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-mx_add_library(MaterialXRenderOsl
+mx_add_library(${MATERIALX_MODULE_NAME}
     SOURCE_FILES
         ${materialx_source}
     HEADER_FILES
@@ -10,3 +12,9 @@ mx_add_library(MaterialXRenderOsl
         MaterialXRender
     EXPORT_DEFINE
         MATERIALX_RENDEROSL_EXPORTS)
+
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+            DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH}/${MATERIALX_MODULE_NAME}/ MESSAGE_NEVER
+            FILES_MATCHING PATTERN "*.h*")
+endif()


### PR DESCRIPTION
Related to #1923 - that lifted the minimum cmake version 3.23 - but using `FILE_SET`.

This PR should provide the same install functionality, but compatible with cmake 3.16 - albeit with more cmake code complexity.

Ultimately I think it would be nice to move the cmake version up to 3.23, but if we're not able to do that now, then this is an alternate path forwards. 