### PR TITLE
Upgrade minimum CMake for GLFW

### DIFF
--- a/source/MaterialXGraphEditor/External/Glfw/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/External/Glfw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(GLFW VERSION 3.4.0 LANGUAGES C)
 


### PR DESCRIPTION
This changelist upgrades the minimum version of CMake for the custom GLFW build in the Graph Editor, resolving warnings when building with the recommended versions of CMake in MaterialX.