### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -129,7 +129,7 @@ class MX_CORE_API PortElement : public ValueElement
     void setConnectedOutput(ConstOutputPtr output);
 
     /// Return the output, if any, to which this input is connected.
-    virtual OutputPtr getConnectedOutput() const;
+    OutputPtr getConnectedOutput() const;
 
     /// Return the output string of this element.
     const string& getOutputString() const

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -68,30 +68,6 @@ string Node::getConnectedNodeName(const string& inputName) const
     return input->getNodeName();
 }
 
-void Node::setConnectedOutput(const string& inputName, OutputPtr output)
-{
-    InputPtr input = getInput(inputName);
-    if (!input)
-    {
-        input = addInput(inputName, DEFAULT_TYPE_STRING);
-    }
-    if (output)
-    {
-        input->setType(output->getType());
-    }
-    input->setConnectedOutput(output);
-}
-
-OutputPtr Node::getConnectedOutput(const string& inputName) const
-{
-    InputPtr input = getInput(inputName);
-    if (!input)
-    {
-        return OutputPtr();
-    }
-    return input->getConnectedOutput();
-}
-
 NodeDefPtr Node::getNodeDef(const string& target, bool allowRoughMatch) const
 {
     if (hasNodeDefString())

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -78,15 +78,6 @@ class MX_CORE_API Node : public InterfaceElement
     /// input is not present, then an empty string is returned.
     string getConnectedNodeName(const string& inputName) const;
 
-    /// Set the output to which the given input is connected, creating a
-    /// child input if needed.  If the node argument is null, then any
-    /// existing output connection on the input will be cleared.
-    void setConnectedOutput(const string& inputName, OutputPtr output);
-
-    /// Return the output connected to the given input.  If the given input is
-    /// not present, then an empty OutputPtr is returned.
-    OutputPtr getConnectedOutput(const string& inputName) const;
-
     /// @}
     /// @name NodeDef References
     /// @{

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -146,7 +146,7 @@ class MX_FORMAT_API FilePath
             size_t i = baseName.rfind('.');
             if (i != string::npos)
             {
-                baseName = baseName.substr(0, i);
+                baseName.resize(i);
             }
         }
     }

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -50,7 +50,7 @@ void GlslResourceBindingContext::emitDirectives(GenContext& context, ShaderStage
         }
     }
 
-    for (auto& extension : _requiredExtensions)
+    for (const string& extension : _requiredExtensions)
     {
         generator.emitLine("#extension " + extension + " : enable", stage, false);
     }

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -383,7 +383,7 @@ void ShaderGenerator::registerShaderMetadata(const DocumentPtr& doc, GenContext&
         ShaderMetadata(ValueElement::UNIT_ATTRIBUTE, Type::STRING),
         ShaderMetadata(ValueElement::COLOR_SPACE_ATTRIBUTE, Type::STRING)
     };
-    for (auto data : DEFAULT_METADATA)
+    for (const ShaderMetadata& data : DEFAULT_METADATA)
     {
         registry->addMetadata(data.name, data.type);
     }


### PR DESCRIPTION
This changelist addresses a handful of static analysis warnings flagged by Cppcheck.

- Remove the virtual keyword from PortElement::getConnectedOutput, which is never overridden in subclasses.
- Fix an unintended duplication of InterfaceElement::setConnectedOutput and InterfaceElement::getConnectedOutput in the Node class.
- Simplify the implementation of the removeExtension helper method.
- Mark iterators as const references for efficiency and clarity.