### PR TITLE
Fix edge case in version upgrade

### DIFF
--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1240,21 +1240,13 @@ void Document::upgradeVersion()
                         for (size_t i = 0; i < destChannelCount; i++)
                         {
                             InputPtr combineInInput = node->addInput(std::string("in") + std::to_string(i + 1), "float");
-                            if (i < channelString.size())
+                            if (i < channelString.size() && CHANNEL_CONSTANT_MAP.count(channelString[i]))
                             {
-                                if (CHANNEL_CONSTANT_MAP.count(channelString[i]))
-                                {
-                                    combineInInput->setValue(CHANNEL_CONSTANT_MAP.at(channelString[i]));
-                                }
-                                else
-                                {
-                                    copyInputWithBindings(node, inInput->getName(), node, combineInInput->getName());
-                                }
+                                combineInInput->setValue(CHANNEL_CONSTANT_MAP.at(channelString[i]));
                             }
                             else
                             {
-                                combineInInput->setConnectedNode(node);
-                                combineInInput->setOutputString(combineInInput->isColorType() ? "outr" : "outx");
+                                copyInputWithBindings(node, inInput->getName(), node, combineInInput->getName());
                             }
                         }
                         node->removeInput(inInput->getName());


### PR DESCRIPTION
This changelist fixes an edge case in the version upgrade logic from 1.38 to 1.39, where a swizzle node with a single-channel input and an empty channels string would upgrade incorrectly, generating a graph with a cycle.