### PR TITLE
Add code generation hints support

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -24,7 +24,7 @@
     <input name="specular_roughness_anisotropy" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Specular Anisotropy" uifolder="Specular" uiadvanced="true"
            doc="The directional bias of the roughness of the metal/dielectric base, resulting in increasingly stretched highlights along the tangent direction." />
     <input name="transmission_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Transmission Weight" uifolder="Transmission" uiadvanced="true"
-           doc="Mixture weight between the transparent and opaque dielectric base. The greater the value the more transparent the material." />
+           doc="Mixture weight between the transparent and opaque dielectric base. The greater the value the more transparent the material." hint="transparency"/>
     <input name="transmission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Color" uifolder="Transmission" uiadvanced="true"
            doc="Controls color of the transparent base due to Beer's law volumetric absorption under the surface (reverts to a non-physical tint when transmission_depth is zero)." />
     <input name="transmission_depth" type="float" value="0.0" uimin="0.0" uisoftmax="1.0" uiname="Transmission Depth" uifolder="Transmission" uiadvanced="true"
@@ -76,7 +76,7 @@
     <input name="emission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Emission Color" uifolder="Emission"
            doc="The color of the emitted light." />
     <input name="geometry_opacity" type="float" value="1" uimin="0" uimax="1" uiname="Opacity" uifolder="Geometry"
-           doc="The opacity of the entire material." />
+           doc="The opacity of the entire material." hint="opacity"/>
     <input name="geometry_thin_walled" type="boolean" value="false" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true"
            doc="If true the surface is double-sided and represents an infinitesimally thin shell. Suitable for extremely geometrically thin objects such as leaves or paper." />
     <input name="geometry_normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Geometry"

--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -23,8 +23,8 @@
            doc="Index of refraction of the dielectric base." />
     <input name="specular_roughness_anisotropy" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Specular Anisotropy" uifolder="Specular" uiadvanced="true"
            doc="The directional bias of the roughness of the metal/dielectric base, resulting in increasingly stretched highlights along the tangent direction." />
-    <input name="transmission_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Transmission Weight" uifolder="Transmission" uiadvanced="true"
-           doc="Mixture weight between the transparent and opaque dielectric base. The greater the value the more transparent the material." hint="transparency"/>
+    <input name="transmission_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Transmission Weight" uifolder="Transmission" uiadvanced="true" hint="transparency"
+           doc="Mixture weight between the transparent and opaque dielectric base. The greater the value the more transparent the material." />
     <input name="transmission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Color" uifolder="Transmission" uiadvanced="true"
            doc="Controls color of the transparent base due to Beer's law volumetric absorption under the surface (reverts to a non-physical tint when transmission_depth is zero)." />
     <input name="transmission_depth" type="float" value="0.0" uimin="0.0" uisoftmax="1.0" uiname="Transmission Depth" uifolder="Transmission" uiadvanced="true"
@@ -75,8 +75,8 @@
            doc="The amount of emitted light, as a luminance in nits." />
     <input name="emission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Emission Color" uifolder="Emission"
            doc="The color of the emitted light." />
-    <input name="geometry_opacity" type="float" value="1" uimin="0" uimax="1" uiname="Opacity" uifolder="Geometry"
-           doc="The opacity of the entire material." hint="opacity"/>
+    <input name="geometry_opacity" type="float" value="1" uimin="0" uimax="1" uiname="Opacity" uifolder="Geometry" hint="opacity"
+           doc="The opacity of the entire material." />
     <input name="geometry_thin_walled" type="boolean" value="false" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true"
            doc="If true the surface is double-sided and represents an infinitesimally thin shell. Suitable for extremely geometrically thin objects such as leaves or paper." />
     <input name="geometry_normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Geometry"

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_hints.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/transparency_hints.mtlx
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <surfacematerial name="geom_hint" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="geometric_opacity_hint" />
+  </surfacematerial>
+  <open_pbr_surface name="geometric_opacity_hint" type="surfaceshader">
+    <input name="geometry_opacity" type="float" value="0.5" />
+  </open_pbr_surface>
+  <surfacematerial name="transp_hint" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="transparency_weight_hint" />
+  </surfacematerial>
+  <open_pbr_surface name="transparency_weight_hint" type="surfaceshader">
+    <input name="transmission_weight" type="float" value="0.8" />
+  </open_pbr_surface>
+</materialx>

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -100,6 +100,19 @@ InterfaceElementPtr NodeDef::getImplementation(const string& target) const
     return InterfaceElementPtr();
 }
 
+const StringMap NodeDef::getInputHints() const
+{
+    StringMap hints;
+    for (InputPtr input : getActiveInputs())
+    {
+        if (input->hasHint())
+        {
+            hints[input->getName()] = input->getHint();
+        }
+    }
+    return hints;
+}
+
 bool NodeDef::validate(string* message) const
 {
     bool res = true;

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -147,6 +147,13 @@ class MX_CORE_API NodeDef : public InterfaceElement
     InterfaceElementPtr getImplementation(const string& target = EMPTY_STRING) const;
 
     /// @}
+    /// @name Hints
+    /// @{
+
+    /// Return list of input hint pairs of the form { input_name, hint_string }
+    const StringMap getInputHints() const;
+
+    /// @}
     /// @name Validation
     /// @{
 

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -20,6 +20,10 @@ const string InterfaceElement::TARGET_ATTRIBUTE = "target";
 const string InterfaceElement::VERSION_ATTRIBUTE = "version";
 const string InterfaceElement::DEFAULT_VERSION_ATTRIBUTE = "isdefaultversion";
 const string Input::DEFAULT_GEOM_PROP_ATTRIBUTE = "defaultgeomprop";
+const string Input::HINT_ATTRIBUTE = "hint";
+const string Input::TRANSPARENCY_HINT = "transparency";
+const string Input::OPACITY_HINT = "opacity";
+const string Input::ANISOTROPY_HINT = "anisotropy";
 const string Output::DEFAULT_INPUT_ATTRIBUTE = "defaultinput";
 
 //

--- a/source/MaterialXCore/Interface.h
+++ b/source/MaterialXCore/Interface.h
@@ -220,6 +220,28 @@ class MX_CORE_API Input : public PortElement
     InputPtr getInterfaceInput() const;
 
     /// @}
+    /// @name Hints
+    /// @{
+
+    /// Return true if the input has a hint
+    bool hasHint() const
+    {
+        return hasAttribute(HINT_ATTRIBUTE);
+    }
+
+    /// Return the code generation hint
+    const string& getHint() const
+    {
+        return getAttribute(HINT_ATTRIBUTE);
+    }
+
+    // Set the code generation hint
+    void setHint(const string& hint)
+    {
+        setAttribute(HINT_ATTRIBUTE, hint);
+    }
+
+    /// @}
     /// @name Validation
     /// @{
 
@@ -232,6 +254,10 @@ class MX_CORE_API Input : public PortElement
   public:
     static const string CATEGORY;
     static const string DEFAULT_GEOM_PROP_ATTRIBUTE;
+    static const string HINT_ATTRIBUTE;
+    static const string TRANSPARENCY_HINT;
+    static const string OPACITY_HINT;
+    static const string ANISOTROPY_HINT;
 };
 
 /// @class Output

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -117,7 +117,7 @@ bool isTransparentShaderNode(NodePtr node, NodePtr interfaceNode)
     }
 
     // Check against nodedef input hints
-    OpaqueTestPairList testList = DEFAULT_INPUT_PAIR_LIST;
+    OpaqueTestPairList inputPairList = DEFAULT_INPUT_PAIR_LIST;
     NodeDefPtr nodeDef = node->getNodeDef();
     StringMap nodeDefList = nodeDef ? nodeDef->getInputHints() : StringMap();
     for (auto &item : nodeDefList)
@@ -125,11 +125,11 @@ bool isTransparentShaderNode(NodePtr node, NodePtr interfaceNode)
         string inputName = item.first;
         if (item.second == Input::TRANSPARENCY_HINT)
         {
-            testList.push_back(std::make_pair(inputName, 0.0f) );
+            inputPairList.push_back(std::make_pair(inputName, 0.0f) );
         }
         else if (item.second == Input::OPACITY_HINT)
         {
-            testList.push_back(std::make_pair(inputName, 1.0f));
+            inputPairList.push_back(std::make_pair(inputName, 1.0f));
         }
     }
 
@@ -137,7 +137,7 @@ bool isTransparentShaderNode(NodePtr node, NodePtr interfaceNode)
     OpaqueTestPairList interfaceNames;
     if (interfaceNode)
     {
-        for (auto inputPair : testList)
+        for (auto inputPair : inputPairList)
         {
             InputPtr checkInput = node->getActiveInput(inputPair.first);
             if (checkInput)
@@ -161,7 +161,7 @@ bool isTransparentShaderNode(NodePtr node, NodePtr interfaceNode)
     // Check against the child input or the corresponding
     // functional nodegraph's interface if the input is mapped
     // via an interface name.
-    for (auto inputPair : testList)
+    for (auto inputPair : inputPairList)
     {
         InputPtr checkInput = node->getActiveInput(inputPair.first);
         if (checkInput)


### PR DESCRIPTION
## Implementation for Specification of Input "Hints"

### Interface changes

Add in support for accessing "hints" on inputs as follows:

1. Add has/get/get hint methods on Inputs
2. Add a get to return a list of { input name, hint string } pairs.

### Issue Address
Fixes #1946 

### Test

1. Add `transparency` and `opacity` hints to OpenPBR. 
2. Updates the transparency check logic to include checking for hints on a node's nodedef and adds those items to the input list to check. 
3. Add test case to RTS with a test for transparency and opacity:
```xml
<?xml version="1.0"?>
<materialx version="1.39" colorspace="lin_rec709">
  <surfacematerial name="geom_hint" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="geometric_opacity_hint" />
  </surfacematerial>
  <open_pbr_surface name="geometric_opacity_hint" type="surfaceshader">
    <input name="geometry_opacity" type="float" value="0.5" />
  </open_pbr_surface>
  <surfacematerial name="transp_hint" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="transparency_weight_hint" />
  </surfacematerial>
  <open_pbr_surface name="transparency_weight_hint" type="surfaceshader">
    <input name="transmission_weight" type="float" value="0.8" />
  </open_pbr_surface>
</materialx>
```

### Results

| Opacity Test | Transparency Test |
|:--:|:--:|
| ![image](https://github.com/user-attachments/assets/6f11f453-75a1-4509-b688-6314dc4f33a4) | ![image](https://github.com/user-attachments/assets/4a7e9d78-d25b-40e0-b6ed-584702aa3445) |
