### PR TITLE
Update `standard_surface` to `open_pbr` translation graph  

### DIFF
--- a/libraries/bxdf/translation/open_pbr_to_standard_surface.mtlx
+++ b/libraries/bxdf/translation/open_pbr_to_standard_surface.mtlx
@@ -198,9 +198,9 @@
     <dot name="coatAffectColor" type="float">
       <input name="in" type="float" interfacename="coat_darkening" />
     </dot>
-    <dot name="coatAffectRoughness" type="float">
-      <input name="in" type="float" value="1.0" />
-    </dot>
+    <constant name="coatAffectRoughness" type="float">
+      <input name="value" type="float" value="1.0" />
+    </constant>
 
     <!--ThinFilm-->
     <multiply name="thinFilmThicknessConversion" type="float">

--- a/libraries/bxdf/translation/open_pbr_to_standard_surface.mtlx
+++ b/libraries/bxdf/translation/open_pbr_to_standard_surface.mtlx
@@ -199,7 +199,7 @@
       <input name="in" type="float" interfacename="coat_darkening" />
     </dot>
     <dot name="coatAffectRoughness" type="float">
-      <input name="in" type="float" interfacename="coat_darkening" />
+      <input name="in" type="float" value="1.0" />
     </dot>
 
     <!--ThinFilm-->


### PR DESCRIPTION
Replacing coat_affect_roughness with a constant value, since a coating always affects roughness in OpenPBR and is not dependent on the value of coat_darkening