### PR TITLE
Assign PugiXML to External source folder

### DIFF
--- a/source/MaterialXFormat/CMakeLists.txt
+++ b/source/MaterialXFormat/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(External/PugiXML)
+set_property(TARGET pugixml PROPERTY FOLDER "External")
 
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")


### PR DESCRIPTION
This changelist assigns the PugiXML project to the External source folder, improving clarity in Visual Studio builds.