### PR TITLE
Fix Fresnel computation in GLSL transmission

### DIFF
--- a/libraries/bxdf/lama/lama_generalized_schlick.mtlx
+++ b/libraries/bxdf/lama/lama_generalized_schlick.mtlx
@@ -63,14 +63,6 @@
       <input name="in2" type="color3" nodename="ior_multiply" />
       <input name="which" type="integer" interfacename="fresnelMode" />
     </switch>
-    <subtract name="transmission_color0" type="color3">
-      <input name="in1" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="in2" type="color3" nodename="fresnel_mode_switch" />
-    </subtract>
-    <subtract name="transmission_color90" type="color3">
-      <input name="in1" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="in2" type="color3" interfacename="reflectivity90" />
-    </subtract>
 
     <!-- Exponent -->
     <divide name="exponent" type="float">
@@ -132,8 +124,8 @@
     <!-- Transmission -->
     <generalized_schlick_bsdf name="transmission_bsdf" type="BSDF">
       <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" nodename="transmission_color0" />
-      <input name="color90" type="color3" nodename="transmission_color90" />
+      <input name="color0" type="color3" nodename="fresnel_mode_switch" />
+      <input name="color90" type="color3" interfacename="reflectivity90" />
       <input name="exponent" type="float" nodename="exponent" />
       <input name="roughness" type="vector2" nodename="roughness_anisotropic_squared_clamped" />
       <input name="normal" type="vector3" interfacename="normal" />

--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -43,7 +43,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
         // Compute the geometric term.
         float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
-        // Compute the combined FG term, which is inverted F for refraction.
+        // Compute the combined FG term, which simplifies to inverted Fresnel for refraction.
         vec3 FG = fd.refraction ? vec3(1.0) - F : F * G;
 
         // Add the radiance contribution of this sample.

--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -43,8 +43,8 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
         // Compute the geometric term.
         float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
 
-        // Compute the combined FG term, which is inverted for refraction.
-        vec3 FG = fd.refraction ? vec3(1.0) - (F * G) : F * G;
+        // Compute the combined FG term, which is inverted F for refraction.
+        vec3 FG = fd.refraction ? vec3(1.0) - F : F * G;
 
         // Add the radiance contribution of this sample.
         // From https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -66,7 +66,7 @@ void mx_generalized_schlick_bsdf_transmission(vec3 V, float weight, vec3 color0,
     {
         float avgF0 = dot(safeColor0, vec3(1.0 / 3.0));
         fd.ior = vec3(mx_f0_to_ior(avgF0));
-        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, safeColor0) * weight;
+        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, vec3(1.0)) * weight;
     }
 }
 

--- a/resources/Materials/TestSuite/pbrlib/bsdf/generalized_schlick.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/generalized_schlick.mtlx
@@ -2,11 +2,8 @@
 <materialx version="1.39">
   <nodegraph name="schlick_bsdf">
     <generalized_schlick_bsdf name="schlick_R" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.8, 0.8, 0.8" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="R" />
     </generalized_schlick_bsdf>
     <surface name="surface_R" type="surfaceshader">
@@ -15,11 +12,8 @@
     <output name="R_out" type="surfaceshader" nodename="surface_R" />
 
     <generalized_schlick_bsdf name="schlick_T" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.2, 0.2, 0.2" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="T" />
     </generalized_schlick_bsdf>
     <surface name="surface_T" type="surfaceshader">
@@ -28,11 +22,8 @@
     <output name="T_out" type="surfaceshader" nodename="surface_T" />
 
     <generalized_schlick_bsdf name="schlick_RT" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.7, 0.7, 0.7" />
-      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.2, 0.2, 0.2" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="RT" />
     </generalized_schlick_bsdf>
     <surface name="surface_RT" type="surfaceshader">
@@ -50,11 +41,9 @@
     <output name="layer_RT_out" type="surfaceshader" nodename="surface_layer_RT" />
 
     <generalized_schlick_bsdf name="schlick_R2" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.5, 0.0, 0.0" />
-      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="0.0, 1.0, 0.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.8, 0.2, 0.2" />
+      <input name="color90" type="color3" value="0.2, 0.8, 0.2" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="R" />
     </generalized_schlick_bsdf>
     <surface name="surface_R2" type="surfaceshader">
@@ -63,11 +52,9 @@
     <output name="R2_out" type="surfaceshader" nodename="surface_R2" />
 
     <generalized_schlick_bsdf name="schlick_T2" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.5, 0.0, 0.0" />
-      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="0.0, 1.0, 0.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.8, 0.2, 0.2" />
+      <input name="color90" type="color3" value="0.2, 0.8, 0.2" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="T" />
     </generalized_schlick_bsdf>
     <surface name="surface_T2" type="surfaceshader">
@@ -76,11 +63,9 @@
     <output name="T2_out" type="surfaceshader" nodename="surface_T2" />
 
     <generalized_schlick_bsdf name="schlick_RT2" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="0.5, 0.0, 0.0" />
-      <input name="color82" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color90" type="color3" value="0.0, 1.0, 0.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.8, 0.2, 0.2" />
+      <input name="color90" type="color3" value="0.2, 0.8, 0.2" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="RT" />
     </generalized_schlick_bsdf>
     <surface name="surface_RT2" type="surfaceshader">
@@ -98,11 +83,10 @@
     <output name="layer_RT2_out" type="surfaceshader" nodename="surface_layer_RT2" />
 
     <generalized_schlick_bsdf name="schlick_R3" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
-      <input name="color0" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="color82" type="color3" value="0.0, 0.0, 1.0" />
-      <input name="color90" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="exponent" type="float" value="5.0" />
+      <input name="color0" type="color3" value="0.8, 0.8, 0.8" />
+      <input name="color82" type="color3" value="0.2, 0.2, 0.8" />
+      <input name="color90" type="color3" value="0.8, 0.8, 0.8" />
+      <input name="roughness" type="vector2" value="0.02, 0.02" />
       <input name="scatter_mode" type="string" value="R" />
     </generalized_schlick_bsdf>
     <surface name="surface_R3" type="surfaceshader">


### PR DESCRIPTION
This changelist fixes an error in the Fresnel computation for GLSL transmission, improving the visual parity of transmissive materials across shading languages.

With this fix in place, the graph definition of LamaGeneralizedSchlick no longer requires a manual inversion of its F0 and F90 inputs for transmission, as this inversion is handled correctly in GLSL as well as OSL and MDL.