### PR TITLE
Fix combine2 implementation in MDL

### DIFF
--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -686,7 +686,7 @@
 
   <!-- <combine2> -->
   <implementation name="IM_combine2_vector2_genmdl" nodedef="ND_combine2_vector2" target="genmdl" sourcecode="float2( {{in1}},{{in2}} )" />
-  <implementation name="IM_combine2_color4CF_genmdl" nodedef="ND_combine2_color4CF" target="genmdl" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_combine2_color4CF({{in1}}, {{in2}})" target="genmdl" />
+  <implementation name="IM_combine2_color4CF_genmdl" nodedef="ND_combine2_color4CF" target="genmdl" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_combine2_color4CF({{in1}}, {{in2}})" />
   <implementation name="IM_combine2_vector4VF_genmdl" nodedef="ND_combine2_vector4VF" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )" />
   <implementation name="IM_combine2_vector4VV_genmdl" nodedef="ND_combine2_vector4VV" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1] )" />
 

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -686,7 +686,7 @@
 
   <!-- <combine2> -->
   <implementation name="IM_combine2_vector2_genmdl" nodedef="ND_combine2_vector2" target="genmdl" sourcecode="float2( {{in1}},{{in2}} )" />
-  <implementation name="IM_combine2_color4CF_genmdl" nodedef="ND_combine2_color4CF" target="genmdl" sourcecode="color4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )" />
+  <implementation name="IM_combine2_color4CF_genmdl" nodedef="ND_combine2_color4CF" target="genmdl" sourcecode="materialx::stdlib_{{MDL_VERSION_SUFFIX}}::mx_combine2_color4CF({{in1}}, {{in2}})" target="genmdl" />
   <implementation name="IM_combine2_vector4VF_genmdl" nodedef="ND_combine2_vector4VF" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in1}}[2],{{in2}} )" />
   <implementation name="IM_combine2_vector4VV_genmdl" nodedef="ND_combine2_vector4VV" target="genmdl" sourcecode="float4( {{in1}}[0],{{in1}}[1],{{in2}}[0],{{in2}}[1] )" />
 

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -4437,3 +4437,9 @@ export float3 mx_worleynoise3d_float3(
 {
     return noise::mx_worley_noise_float3(mxp_position, mxp_jitter, 0);
 }
+
+export core::color4 mx_combine2_color4CF(color in1, float in2)
+{
+	float3 in1_as_float3 = float3(in1);
+	return core::mk_color4(in1_as_float3.x, in1_as_float3.y, in1_as_float3.z, in2);	
+}

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -4440,6 +4440,6 @@ export float3 mx_worleynoise3d_float3(
 
 export core::color4 mx_combine2_color4CF(color in1, float in2)
 {
-	float3 in1_as_float3 = float3(in1);
-	return core::mk_color4(in1_as_float3.x, in1_as_float3.y, in1_as_float3.z, in2);	
+    float3 in1_as_float3 = float3(in1);
+    return core::mk_color4(in1_as_float3.x, in1_as_float3.y, in1_as_float3.z, in2);	
 }

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_8.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_8.mdl
@@ -321,6 +321,7 @@ export using .::stdlib_1_7 import mx_worleynoise2d_float3;
 export using .::stdlib_1_7 import mx_worleynoise3d_float;
 export using .::stdlib_1_7 import mx_worleynoise3d_float2;
 export using .::stdlib_1_7 import mx_worleynoise3d_float3;
+export using .::stdlib_1_7 import mx_combine2_color4CF;
 
 // NOTE: Not planned to be implemented.
 export using .::stdlib_1_7 import mx_geompropvalue_string;


### PR DESCRIPTION
Fix a regression after this [commit](https://github.com/AcademySoftwareFoundation/MaterialX/commit/4713ec9ff9edcc33e6ec663e7d4c35e3ce68e385#diff-0bae9161e30f26f13ee964c3007c7f13d51d971da82c9fab4184cda13e26400c).

Add a custom implementation for combine2(color, float) because the index access is not allowed on the MDL color type.