### PR TITLE
Fix pugixml symbols missing in monolithic static build.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,20 @@ jobs:
           python: 3.11
           build_javascript: ON
 
+        - name: Linux_GCC_12_Python311_monolithic
+          os: ubuntu-22.04
+          compiler: gcc
+          compiler_version: "12"
+          python: 3.11
+          cmake_config: -DMATERIALX_BUILD_MONOLITHIC=ON
+
+        - name: Linux_GCC_12_Python311_static_monolithic
+          os: ubuntu-22.04
+          compiler: gcc
+          compiler_version: "12"
+          python: 3.11
+          cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON -DMATERIALX_BUILD_MONOLITHIC=ON
+
         - name: Linux_GCC_14_Python312
           os: ubuntu-24.04
           compiler: gcc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,7 @@ jobs:
           python: 3.11
           build_javascript: ON
 
-        - name: Linux_GCC_12_Python311_monolithic
-          os: ubuntu-22.04
-          compiler: gcc
-          compiler_version: "12"
-          python: 3.11
-          cmake_config: -DMATERIALX_BUILD_MONOLITHIC=ON
-
-        - name: Linux_GCC_12_Python311_static_monolithic
+        - name: Linux_GCC_12_Python311_Static_Monolithic
           os: ubuntu-22.04
           compiler: gcc
           compiler_version: "12"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,8 +300,7 @@ function(mx_add_library MATERIALX_MODULE_NAME)
             SOURCE_FILES
             HEADER_FILES
             INLINED_FILES
-            LIBRARIES
-            PRIVATE_LIBRARIES)
+            MTLX_MODULES)
     cmake_parse_arguments(args
             "${options}"
             "${oneValueArgs}"
@@ -331,12 +330,8 @@ function(mx_add_library MATERIALX_MODULE_NAME)
 
         target_link_libraries(${TARGET_NAME}
             PUBLIC
-                ${args_LIBRARIES}
+                ${args_MTLX_MODULES}
                 ${CMAKE_DL_LIBS})
-
-        target_link_libraries(${TARGET_NAME}
-             PRIVATE
-                ${args_PRIVATE_LIBRARIES})
 
         target_include_directories(${TARGET_NAME}
                 PUBLIC

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -14,8 +14,7 @@ if (MATERIALX_BUILD_MONOLITHIC)
         target_sources(${MATERIALX_MODULE_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
     endif()
 
-    set_target_properties(
-            ${MATERIALX_MODULE_NAME} PROPERTIES
+    set_target_properties(${MATERIALX_MODULE_NAME} PROPERTIES
             OUTPUT_NAME ${MATERIALX_MODULE_NAME}${MATERIALX_LIBNAME_SUFFIX}
             COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
             LINK_FLAGS "${EXTERNAL_LINK_FLAGS}"
@@ -23,8 +22,8 @@ if (MATERIALX_BUILD_MONOLITHIC)
             VERSION "${MATERIALX_LIBRARY_VERSION}"
             SOVERSION "${MATERIALX_MAJOR_VERSION}")
 
-    target_link_libraries(
-            ${MATERIALX_MODULE_NAME}
+    target_link_libraries(${MATERIALX_MODULE_NAME}
+            PUBLIC
             ${CMAKE_DL_LIBS})
 
     target_include_directories(${MATERIALX_MODULE_NAME}

--- a/source/MaterialXFormat/CMakeLists.txt
+++ b/source/MaterialXFormat/CMakeLists.txt
@@ -9,12 +9,14 @@ mx_add_library(MaterialXFormat
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXCore
-    PRIVATE_LIBRARIES
-        "$<BUILD_INTERFACE:pugixml::pugixml>"
     EXPORT_DEFINE
         MATERIALX_FORMAT_EXPORTS)
 
 # we need to use BUILD_INTERFACE here to hide the use of pugixml from the cmake export when we're building
 # MaterialX as a static library - feels like maybe a cmake bug?
+
+target_link_libraries(${TARGET_NAME}
+        PRIVATE
+        "$<BUILD_INTERFACE:pugixml::pugixml>")

--- a/source/MaterialXGenGlsl/CMakeLists.txt
+++ b/source/MaterialXGenGlsl/CMakeLists.txt
@@ -6,7 +6,7 @@ mx_add_library(MaterialXGenGlsl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE

--- a/source/MaterialXGenMdl/CMakeLists.txt
+++ b/source/MaterialXGenMdl/CMakeLists.txt
@@ -6,7 +6,7 @@ mx_add_library(MaterialXGenMdl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE

--- a/source/MaterialXGenMsl/CMakeLists.txt
+++ b/source/MaterialXGenMsl/CMakeLists.txt
@@ -6,7 +6,7 @@ mx_add_library(MaterialXGenMsl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE

--- a/source/MaterialXGenOsl/CMakeLists.txt
+++ b/source/MaterialXGenOsl/CMakeLists.txt
@@ -6,7 +6,7 @@ mx_add_library(MaterialXGenOsl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXGenShader
         MaterialXCore
     EXPORT_DEFINE

--- a/source/MaterialXGenShader/CMakeLists.txt
+++ b/source/MaterialXGenShader/CMakeLists.txt
@@ -6,7 +6,7 @@ mx_add_library(MaterialXGenShader
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXFormat
         MaterialXCore
     EXPORT_DEFINE

--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -13,7 +13,7 @@ mx_add_library(MaterialXRender
         ${materialx_inlined}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXGenShader
     EXPORT_DEFINE
         MATERIALX_RENDER_EXPORTS)

--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -28,7 +28,7 @@ mx_add_library(MaterialXRenderGlsl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXRenderHw
         MaterialXGenGlsl
     EXPORT_DEFINE

--- a/source/MaterialXRenderHw/CMakeLists.txt
+++ b/source/MaterialXRenderHw/CMakeLists.txt
@@ -20,7 +20,7 @@ mx_add_library(MaterialXRenderHw
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXRender
     EXPORT_DEFINE
         MATERIALX_RENDERHW_EXPORTS

--- a/source/MaterialXRenderMsl/CMakeLists.txt
+++ b/source/MaterialXRenderMsl/CMakeLists.txt
@@ -26,7 +26,7 @@ mx_add_library(MaterialXRenderMsl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXRenderHw
         MaterialXGenMsl
     EXPORT_DEFINE

--- a/source/MaterialXRenderOsl/CMakeLists.txt
+++ b/source/MaterialXRenderOsl/CMakeLists.txt
@@ -6,7 +6,7 @@ mx_add_library(MaterialXRenderOsl
         ${materialx_source}
     HEADER_FILES
         ${materialx_headers}
-    LIBRARIES
+    MTLX_MODULES
         MaterialXRender
     EXPORT_DEFINE
         MATERIALX_RENDEROSL_EXPORTS)


### PR DESCRIPTION
Fix bug reported by Kai Rohmer on Slack.

`pugixml` symbols are missing when linking MaterialX monolithic static library to other downstream applications.  

The `pugixml` library was missing from the monolithic build completely because of a bug in the way I wrote `mx_add_library()`.  The `PRIVATE_LIBRARIES` was only being added to the non-monolithic builds.

I think its cleaner and simpler to link any library dependencies in each modules `CMakeListst.txt` after `mx_add_library()` is called, which we already do in a number of the render module cases because additional logic is required to determine which libraries to add. 

In this PR I have renamed the `LIBRARIES` argument to `MTLX_MODULES` in `mx_add_library()` to make it clearer that it is only intended to declare dependencies between MaterialX modules.  

Any other library dependencies should be set on the ${TARGET_NAME} target after `mx_add_library()` has been called, as this will be the correct target regardless of if the build is monolithic or not.