### PR TITLE
Reinstate logic to provide a path for OSL shader includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,8 @@ if(MATERIALX_BUILD_RENDER AND MATERIALX_BUILD_GEN_OSL AND MATERIALX_BUILD_TESTS)
             # currently OSL does not export a cmake target for testrender, but once that's added this can be simplified.
             set(MATERIALX_OSL_BINARY_TESTRENDER $<TARGET_FILE_DIR:OSL::oslc>/testrender)
         endif()
+        # NOTE : we do not derive a value for MATERIALX_OSL_INCLUDE_PATH here, as a a cmake installed OSL package
+        # should have the shader includes in the expected location.
     endif()
 endif()
 

--- a/source/MaterialXTest/MaterialXRenderOsl/CMakeLists.txt
+++ b/source/MaterialXTest/MaterialXRenderOsl/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(MaterialXTest PUBLIC ${source} ${headers})
 target_compile_definitions(MaterialXTest PRIVATE
         MATERIALX_OSL_BINARY_OSLC=\"${MATERIALX_OSL_BINARY_OSLC}\"
         MATERIALX_OSL_BINARY_TESTRENDER=\"${MATERIALX_OSL_BINARY_TESTRENDER}\"
+        MATERIALX_OSL_INCLUDE_PATH=\"${MATERIALX_OSL_INCLUDE_PATH}\"
 )
 
 add_tests("${source}")

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -33,7 +33,12 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     {
         oslRenderer = mx::OslRenderer::create();
         oslRenderer->setOslCompilerExecutable(MATERIALX_OSL_BINARY_OSLC);
-        mx::FileSearchPath oslIncludePaths; 
+        mx::FileSearchPath oslIncludePaths;
+        mx::FilePath oslStandardIncludePath = mx::FilePath(MATERIALX_OSL_INCLUDE_PATH);
+        if (!oslStandardIncludePath.isEmpty())
+        {
+            oslIncludePaths.append(oslStandardIncludePath);
+        }
         // Add in library include path for compile testing as the generated
         // shader's includes are not added with absolute paths.
         oslIncludePaths.append(searchPath.find("libraries/stdlib/genosl/include"));

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -126,6 +126,11 @@ void OslShaderRenderTester::createRenderer(std::ostream& log)
     _renderer->setOslCompilerExecutable(oslcExecutable);
     const std::string testRenderExecutable(MATERIALX_OSL_BINARY_TESTRENDER);
     _renderer->setOslTestRenderExecutable(testRenderExecutable);
+    mx::FilePath oslStandardIncludePath = mx::FilePath(MATERIALX_OSL_INCLUDE_PATH);
+    if (!oslStandardIncludePath.isEmpty())
+    {
+        _renderer->setOslIncludePath(mx::FileSearchPath(oslStandardIncludePath));
+    }
 
     try
     {


### PR DESCRIPTION
A previous PR #1868 removed the ability to define the location for the OSL standard includes.  This is still required for Windows builds.