### PR TITLE
Compile PugiXML source directly in to MaterialXFormat

### DIFF
--- a/source/MaterialXFormat/CMakeLists.txt
+++ b/source/MaterialXFormat/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory(External/PugiXML)
-set_property(TARGET pugixml PROPERTY FOLDER "External")
 
 file(GLOB materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
@@ -7,16 +6,11 @@ file(GLOB materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 mx_add_library(MaterialXFormat
     SOURCE_FILES
         ${materialx_source}
+        ${pugixml_source}
     HEADER_FILES
         ${materialx_headers}
+        ${pugixml_headers}
     MTLX_MODULES
         MaterialXCore
     EXPORT_DEFINE
         MATERIALX_FORMAT_EXPORTS)
-
-# we need to use BUILD_INTERFACE here to hide the use of pugixml from the cmake export when we're building
-# MaterialX as a static library - feels like maybe a cmake bug?
-
-target_link_libraries(${TARGET_NAME}
-        PRIVATE
-        "$<BUILD_INTERFACE:pugixml::pugixml>")

--- a/source/MaterialXFormat/External/PugiXML/CMakeLists.txt
+++ b/source/MaterialXFormat/External/PugiXML/CMakeLists.txt
@@ -1,13 +1,16 @@
-add_library(pugixml STATIC)
-add_library(pugixml::pugixml ALIAS pugixml)
+# Don't actually build a library for PugiXML as if we are building MaterialX as a static library
+# then we would also need to ship the PugiXML library, instead we just compile the sources
+# directly into MaterialXFormat, but take care to hide the symbols.
 
-target_sources(pugixml
-    PRIVATE
-        pugixml.cpp
-    PUBLIC
-        pugixml.hpp
-        pugiconfig.hpp
-)
+file(GLOB pugixml_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB pugixml_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
-set_target_properties(pugixml PROPERTIES CXX_VISIBILITY_PRESET hidden)
-set_target_properties(pugixml PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+set_source_files_properties(${pugixml_source} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+set_source_files_properties(${pugixml_source} PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+set_source_files_properties(${pugixml_source} PROPERTIES FOLDER External)
+set_source_files_properties(${pugixml_headers} PROPERTIES FOLDER External)
+
+set(pugixml_source ${pugixml_source} PARENT_SCOPE)
+set(pugixml_headers ${pugixml_headers} PARENT_SCOPE)
+


### PR DESCRIPTION
@krohmerNV stumbled across some issues with the previous approach to hiding the PugiXML symbols when building MaterialX statically on windows, and then trying to link to a downstream application.

This new PR should simplify the entire situation, and instead of creating a separate PugiXML library, it just compiles the source directly in to the MaterialXFormat module, but still hides the symbols. 
