### PR TITLE
Assign glfw_minimal to External source folder

### DIFF
--- a/source/MaterialXGraphEditor/CMakeLists.txt
+++ b/source/MaterialXGraphEditor/CMakeLists.txt
@@ -61,6 +61,7 @@ set(GLFW_INSTALL OFF)
 set(BUILD_SHARED_LIBS OFF)
 
 add_subdirectory(External/Glfw)
+set_property(TARGET glfw_minimal PROPERTY FOLDER "External")
 
 if(MSVC)
     SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /ENTRY:mainCRTStartup")


### PR DESCRIPTION
This changelist assigns the glfw_minimal project in MaterialXGraphEditor to the External source folder, improving clarity in Visual Studio builds.