### PR TITLE
Unhide inversesqrt() function in mx_math.metal

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_sheen.glsl
@@ -123,7 +123,7 @@ mat3 mx_orthonormal_basis_ltc(vec3 V, vec3 N, float NdotV)
     float lenSqr = dot(X, X);
     if (lenSqr > 0.0)
     {
-        X *= inversesqrt(lenSqr);
+        X *= mx_inversesqrt(lenSqr);
         vec3 Y = cross(N, X);
         return mat3(X, Y, N);
     }
@@ -173,7 +173,7 @@ vec3 mx_zeltner_sheen_importance_sample(vec2 Xi, vec3 V, vec3 N, float roughness
     vec3 w = vec3(wo.x/aInv - wo.z*bInv/aInv, wo.y / aInv, wo.z);
 
     float lenSqr = dot(w, w);
-    w *= inversesqrt(lenSqr);
+    w *= mx_inversesqrt(lenSqr);
 
     // D(w) = Do(wo) . ||M.wo||^3 / |M|
     //      = Do(wo / ||M.wo||) . ||M.wo||^4 / |M| 

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -22,3 +22,8 @@ vec3 mx_srgb_encode(vec3 color)
     vec3 powSeg = 1.055 * pow(max(color, vec3(0.0)), vec3(1.0 / 2.4)) - 0.055;
     return mix(linSeg, powSeg, isAbove);
 }
+
+float mx_inversesqrt(float x)
+{
+    return inversesqrt(x);
+}

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -21,8 +21,7 @@ T1 mx_mod(T1 x, T2 y)
     return x - y * floor(x/y);
 }
 
-template <typename T>
-T mx_inversesqrt(T x)
+float mx_inversesqrt(float x)
 {
     return ::rsqrt(x);
 }

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -21,6 +21,12 @@ T1 mx_mod(T1 x, T2 y)
     return x - y * floor(x/y);
 }
 
+template <typename T>
+T mx_inversesqrt(T x)
+{
+    return ::rsqrt(x);
+}
+
 #ifdef __DECL_GL_MATH_FUNCTIONS__
 
 float radians(float degree) { return (degree * M_PI_F / 180.0f); }
@@ -96,9 +102,6 @@ T atan(T y_over_x) { return ::atan(y_over_x); }
 
 template <typename T>
 T atan(T y, T x) { return ::atan2(y, x); }
-
-template <typename T>
-T inversesqrt(T x) { return ::rsqrt(x); }
 
 #define lessThan(a, b) ((a) < (b))
 #define lessThanEqual(a, b) ((a) <= (b))


### PR DESCRIPTION
`inversesqrt()` is currently inside of a `#ifdef __DECL_GL_MATH_FUNCTIONS__` guard, which means it is not visible inside of OpenUSD's Storm hdMetal backend.

This PR moves it outside of the guard, and renames the function to `mx_inversesqrt()` to avoid possible name conflicts in other shader generators. 
