### PR TITLE
Refactor mx_math files to remove GLSL guard

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
@@ -13,9 +13,9 @@ vec3 mx_latlong_map_projection_inverse(vec2 uv)
     float latitude = (uv.y - 0.5) * M_PI;
     float longitude = (uv.x - 0.5) * M_PI * 2.0;
 
-    float x = -cos(latitude) * sin(longitude);
-    float y = -sin(latitude);
-    float z = cos(latitude) * cos(longitude);
+    float x = -mx_cos(latitude) * mx_sin(longitude);
+    float y = -mx_sin(latitude);
+    float z = mx_cos(latitude) * mx_cos(longitude);
 
     return vec3(x, y, z);
 }

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet.glsl
@@ -77,8 +77,8 @@ vec3 mx_uniform_sample_hemisphere(vec2 Xi)
     float phi = 2.0 * M_PI * Xi.x;
     float cosTheta = 1.0 - Xi.y;
     float sinTheta = sqrt(1.0 - mx_square(cosTheta));
-    return vec3(cos(phi) * sinTheta,
-                sin(phi) * sinTheta,
+    return vec3(mx_cos(phi) * sinTheta,
+                mx_sin(phi) * sinTheta,
                 cosTheta);
 }
 
@@ -88,8 +88,8 @@ vec3 mx_cosine_sample_hemisphere(vec2 Xi)
     float phi = 2.0 * M_PI * Xi.x;
     float cosTheta = sqrt(Xi.y);
     float sinTheta = sqrt(1.0 - Xi.y);
-    return vec3(cos(phi) * sinTheta,
-                sin(phi) * sinTheta,
+    return vec3(mx_cos(phi) * sinTheta,
+                mx_sin(phi) * sinTheta,
                 cosTheta);
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl
@@ -89,7 +89,7 @@ float mx_oren_nayar_fujii_diffuse_dir_albedo(float cosTheta, float roughness)
     float A = 1.0 / (1.0 + FUJII_CONSTANT_1 * roughness);
     float B = roughness * A;
     float Si = sqrt(max(0.0, 1.0 - mx_square(cosTheta)));
-    float G = Si * (acos(clamp(cosTheta, -1.0, 1.0)) - Si * cosTheta) +
+    float G = Si * (mx_acos(clamp(cosTheta, -1.0, 1.0)) - Si * cosTheta) +
               2.0 * ((Si / cosTheta) * (1.0 - Si * Si * Si) - Si) / 3.0;
     return A + (B * G * M_PI_INV);
 }
@@ -169,7 +169,7 @@ vec3 mx_burley_diffusion_profile(float dist, vec3 shape)
 // Inspired by Eric Penner's presentation in http://advances.realtimerendering.com/s2011/
 vec3 mx_integrate_burley_diffusion(vec3 N, vec3 L, float radius, vec3 mfp)
 {
-    float theta = acos(dot(N, L));
+    float theta = mx_acos(dot(N, L));
 
     // Estimate the Burley diffusion shape from mean free path.
     vec3 shape = vec3(1.0) / max(mfp, 0.1);
@@ -182,9 +182,9 @@ vec3 mx_integrate_burley_diffusion(vec3 N, vec3 L, float radius, vec3 mfp)
     for (int i = 0; i < SAMPLE_COUNT; i++)
     {
         float x = -M_PI + (float(i) + 0.5) * SAMPLE_WIDTH;
-        float dist = radius * abs(2.0 * sin(x * 0.5));
+        float dist = radius * abs(2.0 * mx_sin(x * 0.5));
         vec3 R = mx_burley_diffusion_profile(dist, shape);
-        sumD += R * max(cos(theta + x), 0.0);
+        sumD += R * max(mx_cos(theta + x), 0.0);
         sumR += R;
     }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -286,8 +286,8 @@ void mx_fresnel_conductor_phase_polarized(float cosTheta, float eta1, vec3 eta2,
     vec3 U = sqrt((A+B)/2.0);
     vec3 V = max(vec3(0.0), sqrt((B-A)/2.0));
 
-    phiS = mx_atan(2.0 * eta1 * V * cosTheta, U * U + V * V - mx_square(eta1 * cosTheta));
-    phiP = mx_atan(2.0 * eta1 * eta2 * eta2 * cosTheta * (2.0 * k2 * U - (vec3(1.0) - k2 * k2) * V),
+    phiS = mx_atan(2.0*eta1*V*cosTheta, U*U + V*V - mx_square(eta1*cosTheta));
+    phiP = mx_atan(2.0*eta1*eta2*eta2*cosTheta * (2.0*k2*U - (vec3(1.0)-k2*k2) * V),
                    mx_square(eta2*eta2*(vec3(1.0)+k2*k2)*cosTheta) - eta1*eta1*(U*U+V*V));
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -286,9 +286,9 @@ void mx_fresnel_conductor_phase_polarized(float cosTheta, float eta1, vec3 eta2,
     vec3 U = sqrt((A+B)/2.0);
     vec3 V = max(vec3(0.0), sqrt((B-A)/2.0));
 
-    phiS = atan(2.0*eta1*V*cosTheta, U*U + V*V - mx_square(eta1*cosTheta));
-    phiP = atan(2.0*eta1*eta2*eta2*cosTheta * (2.0*k2*U - (vec3(1.0)-k2*k2) * V),
-                mx_square(eta2*eta2*(vec3(1.0)+k2*k2)*cosTheta) - eta1*eta1*(U*U+V*V));
+    phiS = mx_atan(2.0 * eta1 * V * cosTheta, U * U + V * V - mx_square(eta1 * cosTheta));
+    phiP = mx_atan(2.0 * eta1 * eta2 * eta2 * cosTheta * (2.0 * k2 * U - (vec3(1.0) - k2 * k2) * V),
+                   mx_square(eta2*eta2*(vec3(1.0)+k2*k2)*cosTheta) - eta1*eta1*(U*U+V*V));
 }
 
 // https://belcour.github.io/blog/research/publication/2017/05/01/brdf-thin-film.html
@@ -341,7 +341,7 @@ vec3 mx_fresnel_airy(float cosTheta, FresnelData fd)
     }
 
     // Phase shift
-    float cosB = cos(atan(eta2 / eta1));
+    float cosB = cos(mx_atan(eta2 / eta1));
     vec2 phi21 = vec2(cosTheta < cosB ? 0.0 : M_PI, M_PI);
     vec3 phi23p, phi23s;
     if (fd.model == FRESNEL_MODEL_SCHLICK)
@@ -487,7 +487,7 @@ vec3 mx_refraction_solid_sphere(vec3 R, vec3 N, float ior)
 vec2 mx_latlong_projection(vec3 dir)
 {
     float latitude = -asin(dir.y) * M_PI_INV + 0.5;
-    float longitude = atan(dir.x, -dir.z) * M_PI_INV * 0.5 + 0.5;
+    float longitude = mx_atan(dir.x, -dir.z) * M_PI_INV * 0.5 + 0.5;
     return vec2(longitude, latitude);
 }
 

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -48,8 +48,8 @@ vec3 mx_ggx_importance_sample_VNDF(vec2 Xi, vec3 V, vec2 alpha)
     float phi = 2.0 * M_PI * Xi.x;
     float z = (1.0 - Xi.y) * (1.0 + V.z) - V.z;
     float sinTheta = sqrt(clamp(1.0 - z * z, 0.0, 1.0));
-    float x = sinTheta * cos(phi);
-    float y = sinTheta * sin(phi);
+    float x = sinTheta * mx_cos(phi);
+    float y = sinTheta * mx_sin(phi);
     vec3 c = vec3(x, y, z);
 
     // Compute the microfacet normal.
@@ -299,8 +299,8 @@ vec3 mx_eval_sensitivity(float opd, vec3 shift)
     vec3 val = vec3(5.4856e-13, 4.4201e-13, 5.2481e-13);
     vec3 pos = vec3(1.6810e+06, 1.7953e+06, 2.2084e+06);
     vec3 var = vec3(4.3278e+09, 9.3046e+09, 6.6121e+09);
-    vec3 xyz = val * sqrt(2.0*M_PI * var) * cos(pos * phase + shift) * exp(- var * phase*phase);
-    xyz.x   += 9.7470e-14 * sqrt(2.0*M_PI * 4.5282e+09) * cos(2.2399e+06 * phase + shift[0]) * exp(- 4.5282e+09 * phase*phase);
+    vec3 xyz = val * sqrt(2.0*M_PI * var) * mx_cos(pos * phase + shift) * exp(- var * phase*phase);
+    xyz.x   += 9.7470e-14 * sqrt(2.0*M_PI * 4.5282e+09) * mx_cos(2.2399e+06 * phase + shift[0]) * exp(- 4.5282e+09 * phase*phase);
     return xyz / 1.0685e-7;
 }
 
@@ -341,7 +341,7 @@ vec3 mx_fresnel_airy(float cosTheta, FresnelData fd)
     }
 
     // Phase shift
-    float cosB = cos(mx_atan(eta2 / eta1));
+    float cosB = mx_cos(mx_atan(eta2 / eta1));
     vec2 phi21 = vec2(cosTheta < cosB ? 0.0 : M_PI, M_PI);
     vec3 phi23p, phi23s;
     if (fd.model == FRESNEL_MODEL_SCHLICK)
@@ -486,7 +486,7 @@ vec3 mx_refraction_solid_sphere(vec3 R, vec3 N, float ior)
 
 vec2 mx_latlong_projection(vec3 dir)
 {
-    float latitude = -asin(dir.y) * M_PI_INV + 0.5;
+    float latitude = -mx_asin(dir.y) * M_PI_INV + 0.5;
     float longitude = mx_atan(dir.x, -dir.z) * M_PI_INV * 0.5 + 0.5;
     return vec2(longitude, latitude);
 }

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -27,3 +27,30 @@ float mx_inversesqrt(float x)
 {
     return inversesqrt(x);
 }
+
+float mx_radians(float degree)
+{
+    return radians(degree);
+}
+
+float mx_atan(float y_over_x)
+{
+    return atan(y_over_x);
+}
+
+float mx_atan(float y, float x)
+{
+    return atan(y, x);
+}
+vec2 mx_atan(vec2 y, vec2 x)
+{
+    return atan(y, x);
+}
+vec3 mx_atan(vec3 y, vec3 x)
+{
+    return atan(y, x);
+}
+vec4 mx_atan(vec4 y, vec4 x)
+{
+    return atan(y, x);
+}

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -38,11 +38,15 @@ float mx_radians(float degree)
     return radians(degree);
 }
 
+// GLSL uses atan(x,y) and MSL uses atan2(x,y)
+// follow the GLSL convention but prefix with mx_ to ensure consistent function
+// names between languages.
+
+// atan()
 float mx_atan(float y_over_x)
 {
     return atan(y_over_x);
 }
-
 float mx_atan(float y, float x)
 {
     return atan(y, x);
@@ -58,4 +62,97 @@ vec3 mx_atan(vec3 y, vec3 x)
 vec4 mx_atan(vec4 y, vec4 x)
 {
     return atan(y, x);
+}
+
+// the trigonometric functions below are one-to-one with their original counterparts
+// in GLSL and MSL - just here to ensure we mx_ prefix families of functions
+
+// cos()
+float mx_cos(float x)
+{
+    return cos(x);
+}
+vec2 mx_cos(vec2 x)
+{
+    return cos(x);
+}
+vec3 mx_cos(vec3 x)
+{
+    return cos(x);
+}
+vec4 mx_cos(vec4 x)
+{
+    return cos(x);
+}
+
+// sin()
+float mx_sin(float x)
+{
+    return sin(x);
+}
+vec2 mx_sin(vec2 x)
+{
+    return sin(x);
+}
+vec3 mx_sin(vec3 x)
+{
+    return sin(x);
+}
+vec4 mx_sin(vec4 x)
+{
+    return sin(x);
+}
+
+// tan()
+float mx_tan(float x)
+{
+    return tan(x);
+}
+vec2 mx_tan(vec2 x)
+{
+    return tan(x);
+}
+vec3 mx_tan(vec3 x)
+{
+    return tan(x);
+}
+vec4 mx_tan(vec4 x)
+{
+    return tan(x);
+}
+
+// acos()
+float mx_acos(float x)
+{
+    return acos(x);
+}
+vec2 mx_acos(vec2 x)
+{
+    return acos(x);
+}
+vec3 mx_acos(vec3 x)
+{
+    return acos(x);
+}
+vec4 mx_acos(vec4 x)
+{
+    return acos(x);
+}
+
+// asin()
+float mx_asin(float x)
+{
+    return asin(x);
+}
+vec2 mx_asin(vec2 x)
+{
+    return asin(x);
+}
+vec3 mx_asin(vec3 x)
+{
+    return asin(x);
+}
+vec4 mx_asin(vec4 x)
+{
+    return asin(x);
 }

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -1,20 +1,13 @@
-// This file, and the corresponding mx_math.msl provide functions with a common interface, to allow
-// code to be shared between GLSL and MSL.
-// Guideline : prefix any functions with `mx_` to ensure no conflict with code that other shader
-// generators (like HdStorm) might create.
-
 #define M_FLOAT_EPS 1e-8
 
 float mx_square(float x)
 {
     return x*x;
 }
-
 vec2 mx_square(vec2 x)
 {
     return x*x;
 }
-
 vec3 mx_square(vec3 x)
 {
     return x*x;
@@ -38,11 +31,91 @@ float mx_radians(float degree)
     return radians(degree);
 }
 
-// GLSL uses atan(x,y) and MSL uses atan2(x,y)
-// follow the GLSL convention but prefix with mx_ to ensure consistent function
-// names between languages.
+float mx_sin(float x)
+{
+    return sin(x);
+}
+vec2 mx_sin(vec2 x)
+{
+    return sin(x);
+}
+vec3 mx_sin(vec3 x)
+{
+    return sin(x);
+}
+vec4 mx_sin(vec4 x)
+{
+    return sin(x);
+}
 
-// atan()
+float mx_cos(float x)
+{
+    return cos(x);
+}
+vec2 mx_cos(vec2 x)
+{
+    return cos(x);
+}
+vec3 mx_cos(vec3 x)
+{
+    return cos(x);
+}
+vec4 mx_cos(vec4 x)
+{
+    return cos(x);
+}
+
+float mx_tan(float x)
+{
+    return tan(x);
+}
+vec2 mx_tan(vec2 x)
+{
+    return tan(x);
+}
+vec3 mx_tan(vec3 x)
+{
+    return tan(x);
+}
+vec4 mx_tan(vec4 x)
+{
+    return tan(x);
+}
+
+float mx_asin(float x)
+{
+    return asin(x);
+}
+vec2 mx_asin(vec2 x)
+{
+    return asin(x);
+}
+vec3 mx_asin(vec3 x)
+{
+    return asin(x);
+}
+vec4 mx_asin(vec4 x)
+{
+    return asin(x);
+}
+
+float mx_acos(float x)
+{
+    return acos(x);
+}
+vec2 mx_acos(vec2 x)
+{
+    return acos(x);
+}
+vec3 mx_acos(vec3 x)
+{
+    return acos(x);
+}
+vec4 mx_acos(vec4 x)
+{
+    return acos(x);
+}
+
 float mx_atan(float y_over_x)
 {
     return atan(y_over_x);
@@ -62,97 +135,4 @@ vec3 mx_atan(vec3 y, vec3 x)
 vec4 mx_atan(vec4 y, vec4 x)
 {
     return atan(y, x);
-}
-
-// the trigonometric functions below are one-to-one with their original counterparts
-// in GLSL and MSL - just here to ensure we mx_ prefix families of functions
-
-// cos()
-float mx_cos(float x)
-{
-    return cos(x);
-}
-vec2 mx_cos(vec2 x)
-{
-    return cos(x);
-}
-vec3 mx_cos(vec3 x)
-{
-    return cos(x);
-}
-vec4 mx_cos(vec4 x)
-{
-    return cos(x);
-}
-
-// sin()
-float mx_sin(float x)
-{
-    return sin(x);
-}
-vec2 mx_sin(vec2 x)
-{
-    return sin(x);
-}
-vec3 mx_sin(vec3 x)
-{
-    return sin(x);
-}
-vec4 mx_sin(vec4 x)
-{
-    return sin(x);
-}
-
-// tan()
-float mx_tan(float x)
-{
-    return tan(x);
-}
-vec2 mx_tan(vec2 x)
-{
-    return tan(x);
-}
-vec3 mx_tan(vec3 x)
-{
-    return tan(x);
-}
-vec4 mx_tan(vec4 x)
-{
-    return tan(x);
-}
-
-// acos()
-float mx_acos(float x)
-{
-    return acos(x);
-}
-vec2 mx_acos(vec2 x)
-{
-    return acos(x);
-}
-vec3 mx_acos(vec3 x)
-{
-    return acos(x);
-}
-vec4 mx_acos(vec4 x)
-{
-    return acos(x);
-}
-
-// asin()
-float mx_asin(float x)
-{
-    return asin(x);
-}
-vec2 mx_asin(vec2 x)
-{
-    return asin(x);
-}
-vec3 mx_asin(vec3 x)
-{
-    return asin(x);
-}
-vec4 mx_asin(vec4 x)
-{
-    return asin(x);
 }

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -1,3 +1,8 @@
+// This file, and the corresponding mx_math.msl provide functions with a common interface, to allow
+// code to be shared between GLSL and MSL.
+// Guideline : prefix any functions with `mx_` to ensure no conflict with code that other shader
+// generators (like HdStorm) might create.
+
 #define M_FLOAT_EPS 1e-8
 
 float mx_square(float x)

--- a/libraries/stdlib/genglsl/mx_rotate_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector2.glsl
@@ -1,6 +1,6 @@
 void mx_rotate_vector2(vec2 _in, float amount, out vec2 result)
 {
-    float rotationRadians = radians(amount);
+    float rotationRadians = mx_radians(amount);
     float sa = sin(rotationRadians);
     float ca = cos(rotationRadians);
     result = vec2(ca*_in.x + sa*_in.y, -sa*_in.x + ca*_in.y);

--- a/libraries/stdlib/genglsl/mx_rotate_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector2.glsl
@@ -1,7 +1,7 @@
 void mx_rotate_vector2(vec2 _in, float amount, out vec2 result)
 {
     float rotationRadians = mx_radians(amount);
-    float sa = sin(rotationRadians);
-    float ca = cos(rotationRadians);
+    float sa = mx_sin(rotationRadians);
+    float ca = mx_cos(rotationRadians);
     result = vec2(ca*_in.x + sa*_in.y, -sa*_in.x + ca*_in.y);
 }

--- a/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
@@ -13,7 +13,7 @@ mat4 mx_rotationMatrix(vec3 axis, float angle)
 
 void mx_rotate_vector3(vec3 _in, float amount, vec3 axis, out vec3 result)
 {
-    float rotationRadians = radians(amount);
+    float rotationRadians = mx_radians(amount);
     mat4 m = mx_rotationMatrix(axis, rotationRadians);
     result = (m * vec4(_in, 1.0)).xyz;
 }

--- a/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
@@ -1,8 +1,8 @@
 mat4 mx_rotationMatrix(vec3 axis, float angle)
 {
     axis = normalize(axis);
-    float s = sin(angle);
-    float c = cos(angle);
+    float s = mx_sin(angle);
+    float c = mx_cos(angle);
     float oc = 1.0 - c;
 
     return mat4(oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,  0.0,

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -331,29 +331,25 @@
   <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" target="genglsl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -326,29 +326,29 @@
   <implementation name="IM_power_vector4FA_genglsl" nodedef="ND_power_vector4FA" target="genglsl" sourcecode="pow({{in1}}, vec4({{in2}}))" />
 
   <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genglsl" nodedef="ND_sin_float" target="genglsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_float_genglsl" nodedef="ND_cos_float" target="genglsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" target="genglsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" target="genglsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" target="genglsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_float_genglsl" nodedef="ND_sin_float" target="genglsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_float_genglsl" nodedef="ND_cos_float" target="genglsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" target="genglsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" target="genglsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" target="genglsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
-  <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" target="genglsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" target="genglsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" target="genglsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" target="genglsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" target="genglsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" target="genglsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" target="genglsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" target="genglsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" target="genglsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" target="genglsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
-  <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" target="genglsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" target="genglsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" target="genglsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" target="genglsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" target="genglsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" target="genglsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" target="genglsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" target="genglsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" target="genglsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" target="genglsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
-  <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" target="genglsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" target="genglsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" target="genglsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" target="genglsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" target="genglsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" target="genglsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" target="genglsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" target="genglsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" target="genglsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" target="genglsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
 
   <!-- <sqrt> -->

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -331,25 +331,29 @@
   <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" target="genglsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" target="genglsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" target="genglsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" target="genglsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" target="genglsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" target="genglsl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
+++ b/libraries/stdlib/genglsl/stdlib_genglsl_impl.mtlx
@@ -331,25 +331,25 @@
   <implementation name="IM_tan_float_genglsl" nodedef="ND_tan_float" target="genglsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_float_genglsl" nodedef="ND_asin_float" target="genglsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_float_genglsl" nodedef="ND_acos_float" target="genglsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_float_genglsl" nodedef="ND_atan2_float" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector2_genglsl" nodedef="ND_sin_vector2" target="genglsl" sourcecode="mx_sin({{in}})" />
   <implementation name="IM_cos_vector2_genglsl" nodedef="ND_cos_vector2" target="genglsl" sourcecode="mx_cos({{in}})" />
   <implementation name="IM_tan_vector2_genglsl" nodedef="ND_tan_vector2" target="genglsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_vector2_genglsl" nodedef="ND_asin_vector2" target="genglsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_vector2_genglsl" nodedef="ND_acos_vector2" target="genglsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector2_genglsl" nodedef="ND_atan2_vector2" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector3_genglsl" nodedef="ND_sin_vector3" target="genglsl" sourcecode="mx_sin({{in}})" />
   <implementation name="IM_cos_vector3_genglsl" nodedef="ND_cos_vector3" target="genglsl" sourcecode="mx_cos({{in}})" />
   <implementation name="IM_tan_vector3_genglsl" nodedef="ND_tan_vector3" target="genglsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_vector3_genglsl" nodedef="ND_asin_vector3" target="genglsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_vector3_genglsl" nodedef="ND_acos_vector3" target="genglsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector3_genglsl" nodedef="ND_atan2_vector3" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector4_genglsl" nodedef="ND_sin_vector4" target="genglsl" sourcecode="mx_sin({{in}})" />
   <implementation name="IM_cos_vector4_genglsl" nodedef="ND_cos_vector4" target="genglsl" sourcecode="mx_cos({{in}})" />
   <implementation name="IM_tan_vector4_genglsl" nodedef="ND_tan_vector4" target="genglsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_vector4_genglsl" nodedef="ND_asin_vector4" target="genglsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_vector4_genglsl" nodedef="ND_acos_vector4" target="genglsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector4_genglsl" nodedef="ND_atan2_vector4" target="genglsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genglsl" nodedef="ND_sqrt_float" target="genglsl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -26,11 +26,12 @@ float mx_inversesqrt(float x)
     return ::rsqrt(x);
 }
 
-#ifdef __DECL_GL_MATH_FUNCTIONS__
+float mx_radians(float degree)
+{
+    return (degree * M_PI_F / 180.0f);
+}
 
-float radians(float degree) { return (degree * M_PI_F / 180.0f); }
-
-float3x3 inverse(float3x3 m)
+float3x3 mx_inverse(float3x3 m)
 {
     float n11 = m[0][0], n12 = m[1][0], n13 = m[2][0];
     float n21 = m[0][1], n22 = m[1][1], n23 = m[2][1];
@@ -56,7 +57,7 @@ float3x3 inverse(float3x3 m)
     return ret;
 }
 
-float4x4 inverse(float4x4 m)
+float4x4 mx_inverse(float4x4 m)
 {
     float n11 = m[0][0], n12 = m[1][0], n13 = m[2][0], n14 = m[3][0];
     float n21 = m[0][1], n22 = m[1][1], n23 = m[2][1], n24 = m[3][1];
@@ -96,17 +97,31 @@ float4x4 inverse(float4x4 m)
     return ret;
 }
 
-template <typename T>
-T atan(T y_over_x) { return ::atan(y_over_x); }
+float mx_atan(float y_over_x)
+{
+    return ::atan(y_over_x);
+}
 
-template <typename T>
-T atan(T y, T x) { return ::atan2(y, x); }
+float mx_atan(float y, float x)
+{
+    return ::atan2(y, x);
+}
+vec2 mx_atan(vec2 y, vec2 x)
+{
+    return ::atan2(y, x);
+}
+vec3 mx_atan(vec3 y, vec3 x)
+{
+    return ::atan2(y, x);
+}
+vec4 mx_atan(vec4 y, vec4 x)
+{
+    return ::atan2(y, x);
+}
 
-#define lessThan(a, b) ((a) < (b))
-#define lessThanEqual(a, b) ((a) <= (b))
-#define greaterThan(a, b) ((a) > (b))
-#define greaterThanEqual(a, b) ((a) >= (b))
-#define equal(a, b) ((a) == (b))
-#define notEqual(a, b) ((a) != (b))
-
-#endif
+// #define lessThan(a, b) ((a) < (b))
+// #define lessThanEqual(a, b) ((a) <= (b))
+// #define greaterThan(a, b) ((a) > (b))
+// #define greaterThanEqual(a, b) ((a) >= (b))
+// #define equal(a, b) ((a) == (b))
+// #define notEqual(a, b) ((a) != (b))

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -102,6 +102,11 @@ float4x4 mx_inverse(float4x4 m)
     return ret;
 }
 
+// GLSL uses atan(x,y) and MSL uses atan2(x,y)
+// follow the GLSL convention but prefix with mx_ to ensure consistent function
+// names between languages.
+
+// atan()
 float mx_atan(float y_over_x)
 {
     return ::atan(y_over_x);
@@ -122,4 +127,98 @@ vec3 mx_atan(vec3 y, vec3 x)
 vec4 mx_atan(vec4 y, vec4 x)
 {
     return ::atan2(y, x);
+}
+
+
+// the trigonometric functions below are one-to-one with their original counterparts
+// in GLSL and MSL - just here to ensure we mx_ prefix families of functions
+
+// cos()
+float mx_cos(float x)
+{
+    return cos(x);
+}
+vec2 mx_cos(vec2 x)
+{
+    return cos(x);
+}
+vec3 mx_cos(vec3 x)
+{
+    return cos(x);
+}
+vec4 mx_cos(vec4 x)
+{
+    return cos(x);
+}
+
+// sin()
+float mx_sin(float x)
+{
+    return sin(x);
+}
+vec2 mx_sin(vec2 x)
+{
+    return sin(x);
+}
+vec3 mx_sin(vec3 x)
+{
+    return sin(x);
+}
+vec4 mx_sin(vec4 x)
+{
+    return sin(x);
+}
+
+// tan()
+float mx_tan(float x)
+{
+    return tan(x);
+}
+vec2 mx_tan(vec2 x)
+{
+    return tan(x);
+}
+vec3 mx_tan(vec3 x)
+{
+    return tan(x);
+}
+vec4 mx_tan(vec4 x)
+{
+    return tan(x);
+}
+
+// acos()
+float mx_acos(float x)
+{
+    return acos(x);
+}
+vec2 mx_acos(vec2 x)
+{
+    return acos(x);
+}
+vec3 mx_acos(vec3 x)
+{
+    return acos(x);
+}
+vec4 mx_acos(vec4 x)
+{
+    return acos(x);
+}
+
+// asin()
+float mx_asin(float x)
+{
+    return asin(x);
+}
+vec2 mx_asin(vec2 x)
+{
+    return asin(x);
+}
+vec3 mx_asin(vec3 x)
+{
+    return asin(x);
+}
+vec4 mx_asin(vec4 x)
+{
+    return asin(x);
 }

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -1,20 +1,13 @@
-// This file, and the corresponding mx_math.glsl provide functions with a common interface, to allow
-// code to be shared between GLSL and MSL.
-// Guideline : prefix any functions with `mx_` to ensure no conflict with code that other shader
-// generators (like HdStorm) might create.
-
 #define M_FLOAT_EPS 1e-8
 
 float mx_square(float x)
 {
     return x*x;
 }
-
 vec2 mx_square(vec2 x)
 {
     return x*x;
 }
-
 vec3 mx_square(vec3 x)
 {
     return x*x;
@@ -102,56 +95,6 @@ float4x4 mx_inverse(float4x4 m)
     return ret;
 }
 
-// GLSL uses atan(x,y) and MSL uses atan2(x,y)
-// follow the GLSL convention but prefix with mx_ to ensure consistent function
-// names between languages.
-
-// atan()
-float mx_atan(float y_over_x)
-{
-    return ::atan(y_over_x);
-}
-
-float mx_atan(float y, float x)
-{
-    return ::atan2(y, x);
-}
-vec2 mx_atan(vec2 y, vec2 x)
-{
-    return ::atan2(y, x);
-}
-vec3 mx_atan(vec3 y, vec3 x)
-{
-    return ::atan2(y, x);
-}
-vec4 mx_atan(vec4 y, vec4 x)
-{
-    return ::atan2(y, x);
-}
-
-
-// the trigonometric functions below are one-to-one with their original counterparts
-// in GLSL and MSL - just here to ensure we mx_ prefix families of functions
-
-// cos()
-float mx_cos(float x)
-{
-    return cos(x);
-}
-vec2 mx_cos(vec2 x)
-{
-    return cos(x);
-}
-vec3 mx_cos(vec3 x)
-{
-    return cos(x);
-}
-vec4 mx_cos(vec4 x)
-{
-    return cos(x);
-}
-
-// sin()
 float mx_sin(float x)
 {
     return sin(x);
@@ -169,7 +112,23 @@ vec4 mx_sin(vec4 x)
     return sin(x);
 }
 
-// tan()
+float mx_cos(float x)
+{
+    return cos(x);
+}
+vec2 mx_cos(vec2 x)
+{
+    return cos(x);
+}
+vec3 mx_cos(vec3 x)
+{
+    return cos(x);
+}
+vec4 mx_cos(vec4 x)
+{
+    return cos(x);
+}
+
 float mx_tan(float x)
 {
     return tan(x);
@@ -187,7 +146,23 @@ vec4 mx_tan(vec4 x)
     return tan(x);
 }
 
-// acos()
+float mx_asin(float x)
+{
+    return asin(x);
+}
+vec2 mx_asin(vec2 x)
+{
+    return asin(x);
+}
+vec3 mx_asin(vec3 x)
+{
+    return asin(x);
+}
+vec4 mx_asin(vec4 x)
+{
+    return asin(x);
+}
+
 float mx_acos(float x)
 {
     return acos(x);
@@ -205,20 +180,23 @@ vec4 mx_acos(vec4 x)
     return acos(x);
 }
 
-// asin()
-float mx_asin(float x)
+float mx_atan(float y_over_x)
 {
-    return asin(x);
+    return ::atan(y_over_x);
 }
-vec2 mx_asin(vec2 x)
+float mx_atan(float y, float x)
 {
-    return asin(x);
+    return ::atan2(y, x);
 }
-vec3 mx_asin(vec3 x)
+vec2 mx_atan(vec2 y, vec2 x)
 {
-    return asin(x);
+    return ::atan2(y, x);
 }
-vec4 mx_asin(vec4 x)
+vec3 mx_atan(vec3 y, vec3 x)
 {
-    return asin(x);
+    return ::atan2(y, x);
+}
+vec4 mx_atan(vec4 y, vec4 x)
+{
+    return ::atan2(y, x);
 }

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -1,3 +1,8 @@
+// This file, and the corresponding mx_math.glsl provide functions with a common interface, to allow
+// code to be shared between GLSL and MSL.
+// Guideline : prefix any functions with `mx_` to ensure no conflict with code that other shader
+// generators (like HdStorm) might create.
+
 #define M_FLOAT_EPS 1e-8
 
 float mx_square(float x)
@@ -118,10 +123,3 @@ vec4 mx_atan(vec4 y, vec4 x)
 {
     return ::atan2(y, x);
 }
-
-// #define lessThan(a, b) ((a) < (b))
-// #define lessThanEqual(a, b) ((a) <= (b))
-// #define greaterThan(a, b) ((a) > (b))
-// #define greaterThanEqual(a, b) ((a) >= (b))
-// #define equal(a, b) ((a) == (b))
-// #define notEqual(a, b) ((a) != (b))

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -327,29 +327,29 @@
   <implementation name="IM_power_vector4FA_genmsl" nodedef="ND_power_vector4FA" target="genmsl" sourcecode="pow({{in1}}, vec4({{in2}}))" />
 
   <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genmsl" nodedef="ND_sin_float" target="genmsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_float_genmsl" nodedef="ND_cos_float" target="genmsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_float_genmsl" nodedef="ND_sin_float" target="genmsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_float_genmsl" nodedef="ND_cos_float" target="genmsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
-  <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
-  <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
-  <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="sin({{in}})" />
-  <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="cos({{in}})" />
-  <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="acos({{in}})" />
+  <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="mx_sin({{in}})" />
+  <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="mx_cos({{in}})" />
+  <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="mx_tan({{in}})" />
+  <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="mx_asin({{in}})" />
+  <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="mx_acos({{in}})" />
   <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
 
   <!-- <sqrt> -->

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -332,25 +332,25 @@
   <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="mx_sin({{in}})" />
   <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="mx_cos({{in}})" />
   <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="mx_sin({{in}})" />
   <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="mx_cos({{in}})" />
   <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
   <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="mx_sin({{in}})" />
   <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="mx_cos({{in}})" />
   <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="mx_tan({{in}})" />
   <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="mx_asin({{in}})" />
   <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genmsl" nodedef="ND_sqrt_float" target="genmsl" sourcecode="sqrt({{in}})" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -459,8 +459,8 @@
   <implementation name="IM_determinant_matrix44_genmsl" nodedef="ND_determinant_matrix44" target="genmsl" sourcecode="determinant({{in}})" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl" sourcecode="mx_inverse({{in}})"/>
-  <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl" sourcecode="mx_inverse({{in}})"/>
+  <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl" sourcecode="mx_inverse({{in}})" />
+  <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl" sourcecode="mx_inverse({{in}})" />
 
   <!-- <rotate2d> -->
   <implementation name="IM_rotate2d_vector2_genmsl" nodedef="ND_rotate2d_vector2" file="../genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genmsl" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -332,29 +332,25 @@
   <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl"
-                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
+  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})"/>
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genmsl" nodedef="ND_sqrt_float" target="genmsl" sourcecode="sqrt({{in}})" />
@@ -463,10 +459,8 @@
   <implementation name="IM_determinant_matrix44_genmsl" nodedef="ND_determinant_matrix44" target="genmsl" sourcecode="determinant({{in}})" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl"
-                  sourcecode="mx_inverse({{in}})"/>
-  <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl"
-                  sourcecode="mx_inverse({{in}})"/>
+  <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl" sourcecode="mx_inverse({{in}})"/>
+  <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl" sourcecode="mx_inverse({{in}})"/>
 
   <!-- <rotate2d> -->
   <implementation name="IM_rotate2d_vector2_genmsl" nodedef="ND_rotate2d_vector2" file="../genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genmsl" />

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -332,25 +332,29 @@
   <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
   <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="tan({{in}})" />
   <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="asin({{in}})" />
   <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="atan({{iny}}, {{inx}})" />
+  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl"
+                  sourcecode="mx_atan({{iny}}, {{inx}})"/>
 
   <!-- <sqrt> -->
   <implementation name="IM_sqrt_float_genmsl" nodedef="ND_sqrt_float" target="genmsl" sourcecode="sqrt({{in}})" />
@@ -459,8 +463,10 @@
   <implementation name="IM_determinant_matrix44_genmsl" nodedef="ND_determinant_matrix44" target="genmsl" sourcecode="determinant({{in}})" />
 
   <!-- <invertmatrix> -->
-  <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl" sourcecode="inverse({{in}})" />
-  <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl" sourcecode="inverse({{in}})" />
+  <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl"
+                  sourcecode="mx_inverse({{in}})"/>
+  <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl"
+                  sourcecode="mx_inverse({{in}})"/>
 
   <!-- <rotate2d> -->
   <implementation name="IM_rotate2d_vector2_genmsl" nodedef="ND_rotate2d_vector2" file="../genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genmsl" />


### PR DESCRIPTION
Refactor mx_math.glsl and mx_math.metal to remove the `__DECL_GL_MATH_FUNCTIONS__` guard, and prefix any necessary functions to ensure isolation from other shader generators, such as HdStorm