### PR TITLE
Fix Graph Editor unintentional camera orbit in render view

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3240,6 +3240,15 @@ void Graph::graphButtons()
     ImGui::BeginChild("Selection", ImVec2(paneWidth, 0), false, windowFlags);
     ImVec2 windowPos = ImGui::GetWindowPos();
 
+    // Update cursorInRenderView to account for other windows overlapping the Render View (e.g. Menu dropdown).
+    cursorInRenderView &= ImGui::IsWindowHovered(ImGuiHoveredFlags_None);
+
+    // Update cursorInRenderView to account for visible scrollbar and scroll amount.
+    ImGuiContext* context = ImGui::GetCurrentContext();
+    bool hasScrollbar = context->CurrentWindow->ScrollbarY;
+    cursorInRenderView &= hasScrollbar ? mousePos.x < (tempWindowPos.x + screenSize.x - ImGui::GetStyle().ScrollbarSize) : true;
+    cursorInRenderView &= hasScrollbar ? mousePos.y < (tempWindowPos.y + screenSize.y - ImGui::GetScrollY()) : true;
+
     // RenderView window
     ImVec2 wsize = ImVec2((float) _renderer->getViewWidth(), (float) _renderer->getViewHeight());
     _renderer->setViewWidth((int) screenSize[0]);


### PR DESCRIPTION
This fixes the logic that detects whether the cursor is in the render view. Previously, there were three known issues that are fixed with this change:
- The camera would orbit when grabbing the scrollbar located next to the render view.
- The camera would orbit when clicking a menu option in the menu dropdown overlapping the render view.
- The previous logic to detect the cursor in the render view did not consider that the render view moves up when scrolling. As a result, the camera would still orbit when clicking parts of the Node Property Editor that were previously occupied by the render view.