### PR TITLE
Lock version of deploy action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,7 +332,7 @@ jobs:
 
     - name: Deploy Web Viewer
       if: matrix.build_javascript == 'ON' && github.event_name != 'pull_request'
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: JamesIves/github-pages-deploy-action@v4.6.4
       with:
         branch: gh-pages
         folder: javascript/MaterialXView/dist


### PR DESCRIPTION
This changelist updates our GitHub CI to lock the version of the web deployment action, as the head revision of this action is currently broken.