### PR TITLE
Updated markdown documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 <p float="left">
   <img title="Standard Surface Tiled Brass material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png"
-       width="48%" />
+       width="49%" />
   <img title="Standard Surface Tiled Wood material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png"
-       width="48%" />
+       width="49%" />
 </p>
 
 ## Open Chess Set

--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 
 The Open Chess Set is an open reference asset, consisting of a [MaterialX file](resources/Materials/Examples/StandardSurface/standard_surface_chess_set.mtlx) in the Standard Surface shading model and a [geometry file](resources/Geometry) in the glTF format.  It was authored by Moeen Sayed and Mujtaba Sayed, and was contributed to the MaterialX project by Side Effects.
 
-![The Open Chess Set rendered in Arnold for Maya](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Arnold_01.png)
-
 **Figure 3:** The Open Chess Set, rendered in Arnold for Maya
 
-![The Open Chess Set rendered in Karma XPU for Houdini](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Karma_01.png)
+![The Open Chess Set rendered in Arnold for Maya](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Arnold_01.png)
 
 **Figure 4:** The Open Chess Set, rendered in Karma XPU for Houdini
+
+![The Open Chess Set rendered in Karma XPU for Houdini](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Karma_01.png)
 
 ## Pre-Built Binaries
 

--- a/README.md
+++ b/README.md
@@ -38,23 +38,23 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
   <tbody>
     <tr>
       <td>
-        <img alt="A teapot with a MaterialX Marble material applied"
-             title="MaterialX Marble material"
+        <img alt="A teapot with a Standard Surface Marble material applied"
+             title="Standard Surface Marble material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
       </td>
       <td>
-        <img alt="A teapot with a MaterialX Copper material applied"
-             title="MaterialX Copper material"
+        <img alt="A teapot with a Standard Surface Copper material applied"
+             title="Standard Surface Copper material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
       </td>
       <td>
-        <img alt="A teapot with a MaterialX Plastic material applied"
-             title="MaterialX Plastic material"
+        <img alt="A teapot with a Standard Surface Plastic material applied"
+             title="Standard Surface Plastic material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
       </td>
       <td>
-        <img alt="A teapot with a MaterialX Carpaint material applied"
-             title="MaterialX Carpaint material"
+        <img alt="A teapot with a Standard Surface Carpaint material applied"
+             title="Standard Surface Carpaint material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
       </td>
     </tr>
@@ -67,13 +67,13 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
   <tbody>
     <tr>
       <td>
-        <img alt="A shader ball with a MaterialX TiledBrass material applied"
-             title="MaterialX TiledBrass material"
+        <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
+             title="Standard Surface Tiled Brass material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
       </td>
       <td>
-        <img alt="A shader ball with a MaterialX TiledWood material applied"
-             title="MaterialX TiledWood material"
+        <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
+             title="Standard Surface Tiled Wood material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 <p float="left">
   <img title="Standard Surface Tiled Brass material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png"
-       width="49%" />
+       width="48%" />
   <img title="Standard Surface Tiled Wood material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png"
-       width="49%" />
+       width="48%" />
 </p>
 
 ## Open Chess Set

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ The Python bindings for MaterialX are based on [PyBind11](https://github.com/pyb
 The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
-
 <p float="left">
   <img alt="A teapot with a Standard Surface Marble material applied"
        title="Standard Surface Marble material"
@@ -54,7 +53,6 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 </p>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
-
 <p float="left">
   <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
        title="Standard Surface Tiled Brass material"
@@ -71,11 +69,9 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 The Open Chess Set is an open reference asset, consisting of a [MaterialX file](resources/Materials/Examples/StandardSurface/standard_surface_chess_set.mtlx) in the Standard Surface shading model and a [geometry file](resources/Geometry) in the glTF format.  It was authored by Moeen Sayed and Mujtaba Sayed, and was contributed to the MaterialX project by Side Effects.
 
 **Figure 3:** The Open Chess Set, rendered in Arnold for Maya
-
 ![The Open Chess Set rendered in Arnold for Maya](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Arnold_01.png)
 
 **Figure 4:** The Open Chess Set, rendered in Karma XPU for Houdini
-
 ![The Open Chess Set rendered in Karma XPU for Houdini](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Karma_01.png)
 
 ## Pre-Built Binaries

--- a/README.md
+++ b/README.md
@@ -34,51 +34,37 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
-<table style="border: none; border-collapse: separate; border-spacing: 4px;">
-  <tbody>
-    <tr>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Marble material applied"
-             title="Standard Surface Marble material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Copper material applied"
-             title="Standard Surface Copper material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Plastic material applied"
-             title="Standard Surface Plastic material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Carpaint material applied"
-             title="Standard Surface Carpaint material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
-      </td>
-    </tr>
-  </tbody>
-</table>
+<p float="left">
+  <img alt="A teapot with a Standard Surface Marble material applied"
+       title="Standard Surface Marble material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png"
+       width="24%" />
+  <img alt="A teapot with a Standard Surface Copper material applied"
+       title="Standard Surface Copper material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png"
+       width="24%" />
+  <img alt="A teapot with a Standard Surface Plastic material applied"
+       title="Standard Surface Plastic material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png"
+       width="24%" />
+  <img alt="A teapot with a Standard Surface Carpaint material applied"
+       title="Standard Surface Carpaint material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png"
+       width="24%" />
+</p>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 
-<table style="border: none; border-collapse: separate; border-spacing: 4px;">
-  <tbody>
-    <tr>
-      <td style="padding: 0px;">
-        <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
-             title="Standard Surface Tiled Brass material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
-             title="Standard Surface Tiled Wood material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
-      </td>
-    </tr>
-  </tbody>
-</table>
+<p float="left">
+  <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
+       title="Standard Surface Tiled Brass material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png"
+       width="49%" />
+  <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
+       title="Standard Surface Tiled Wood material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png"
+       width="49%" />
+</p>
 
 ## Open Chess Set
 

--- a/README.md
+++ b/README.md
@@ -34,20 +34,16 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 <p float="left">
-  <img alt="A teapot with a Standard Surface Marble material applied"
-       title="Standard Surface Marble material"
+  <img title="Standard Surface Marble material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png"
        width="24%" />
-  <img alt="A teapot with a Standard Surface Copper material applied"
-       title="Standard Surface Copper material"
+  <img title="Standard Surface Copper material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png"
        width="24%" />
-  <img alt="A teapot with a Standard Surface Plastic material applied"
-       title="Standard Surface Plastic material"
+  <img title="Standard Surface Plastic material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png"
        width="24%" />
-  <img alt="A teapot with a Standard Surface Carpaint material applied"
-       title="Standard Surface Carpaint material"
+  <img title="Standard Surface Carpaint material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png"
        width="24%" />
 </p>

--- a/README.md
+++ b/README.md
@@ -50,12 +50,10 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 <p float="left">
-  <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
-       title="Standard Surface Tiled Brass material"
+  <img title="Standard Surface Tiled Brass material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png"
        width="49%" />
-  <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
-       title="Standard Surface Tiled Wood material"
+  <img title="Standard Surface Tiled Wood material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png"
        width="49%" />
 </p>

--- a/README.md
+++ b/README.md
@@ -32,17 +32,59 @@ The Python bindings for MaterialX are based on [PyBind11](https://github.com/pyb
 
 The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.
 
-| Marble | Copper | Plastic | Carpaint |
-|--------|--------|---------|----------|
-| ![MaterialX Marble material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png) | ![MaterialX Copper material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png) | ![MaterialX Plastic material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png) | ![MaterialX Carpaint material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png) |
-
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
-| Tiled Brass | Tiled Wood |
-|-------------|------------|
-| ![MaterialX TiledBrass material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png) | ![MaterialX TiledWood material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png) |
+<table>
+  <tbody>
+    <tr>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Marble material applied"
+             title="MaterialX Marble material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
+        <br><small>Marble</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Copper material applied"
+             title="MaterialX Copper material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
+        <br><small>Copper</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Plastic material applied"
+             title="MaterialX Plastic material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
+        <br><small>Plastic</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Carpaint material applied"
+             title="MaterialX Carpaint material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
+        <br><small>Carpaint</small>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
+
+<table>
+  <tbody>
+    <tr>
+      <td style="text-align: center">
+        <img alt="A shader ball with a MaterialX TiledBrass material applied"
+             title="MaterialX TiledBrass material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
+        <br><small>Tiled Brass</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A shader ball with a MaterialX TiledWood material applied"
+             title="MaterialX TiledWood material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
+        <br><small>Tiled Wood</small>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ## Open Chess Set
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="documents/Images/MaterialXLogo.png" height="170" />
+  <img src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXLogo.png" height="170" />
 </p>
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/LICENSE)
@@ -7,18 +7,18 @@
 [![Build Status](https://github.com/AcademySoftwareFoundation/MaterialX/workflows/main/badge.svg?branch=main)](https://github.com/AcademySoftwareFoundation/MaterialX/actions?query=branch%3Amain)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6025/badge)](https://bestpractices.coreinfrastructure.org/projects/6025)
 
-### Introduction
+## Introduction
 
 MaterialX is an open standard for representing rich material and look-development content in computer graphics, enabling its platform-independent description and exchange across applications and renderers.  Launched at [Industrial Light & Magic](https://www.ilm.com/) in 2012, MaterialX has been a key technology in their feature films and real-time experiences since _Star Wars: The Force Awakens_ and _Millennium Falcon: Smugglers Run_.  The project was released as open source in 2017, with companies including Sony Pictures Imageworks, Pixar, Autodesk, Adobe, and SideFX contributing to its ongoing development.  In 2021, MaterialX became the seventh hosted project of the [Academy Software Foundation](https://www.aswf.io/).
 
-### Quick Start for Developers
+## Quick Start for Developers
 
 - Download the latest version of the [CMake](https://cmake.org/) build system.
 - Point CMake to the root of the MaterialX library and generate C++ projects for your platform and compiler.
 - Select the `MATERIALX_BUILD_PYTHON` option to build Python bindings.
 - Select the `MATERIALX_BUILD_VIEWER` option to build the MaterialX viewer.
 
-### Supported Platforms
+## Supported Platforms
 
 The MaterialX codebase requires a compiler with support for C++17, and can be built with any of the following:
 
@@ -28,35 +28,35 @@ The MaterialX codebase requires a compiler with support for C++17, and can be bu
 
 The Python bindings for MaterialX are based on [PyBind11](https://github.com/pybind/pybind11), and support Python versions 3.6 and greater.
 
-### MaterialX Viewer
+## MaterialX Viewer
 
 The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.
 
+| Marble | Copper | Plastic | Carpaint |
+|--------|--------|---------|----------|
+| ![MaterialX Marble material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png) | ![MaterialX Copper material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png) | ![MaterialX Plastic material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png) | ![MaterialX Carpaint material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png) |
+
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
-<p float="left">
-  <img src="documents/Images/MaterialXView_Marble.png" width="204" />
-  <img src="documents/Images/MaterialXView_Copper.png" width="204" /> 
-  <img src="documents/Images/MaterialXView_Plastic.png" width="204" /> 
-  <img src="documents/Images/MaterialXView_Carpaint.png" width="204" /> 
-</p>
+
+| Tiled Brass | Tiled Wood |
+|-------------|------------|
+| ![MaterialX TiledBrass material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png) | ![MaterialX TiledWood material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png) |
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
-<p float="left">
-  <img src="documents/Images/MaterialXView_TiledBrass.png" width="412" />
-  <img src="documents/Images/MaterialXView_TiledWood.png" width="412" /> 
-</p>
 
-### Open Chess Set
+## Open Chess Set
 
 The Open Chess Set is an open reference asset, consisting of a [MaterialX file](resources/Materials/Examples/StandardSurface/standard_surface_chess_set.mtlx) in the Standard Surface shading model and a [geometry file](resources/Geometry) in the glTF format.  It was authored by Moeen Sayed and Mujtaba Sayed, and was contributed to the MaterialX project by Side Effects.
 
+![The Open Chess Set rendered in Arnold for Maya](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Arnold_01.png)
+
 **Figure 3:** The Open Chess Set, rendered in Arnold for Maya
-<img src="documents/Images/OpenChessSet_Arnold_01.png" />
+
+![The Open Chess Set rendered in Karma XPU for Houdini](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/OpenChessSet_Karma_01.png)
 
 **Figure 4:** The Open Chess Set, rendered in Karma XPU for Houdini
-<img src="documents/Images/OpenChessSet_Karma_01.png" />
 
-### Pre-Built Binaries
+## Pre-Built Binaries
 
 The following packages contain pre-built binaries for the latest release, including the MaterialX viewer, Python libraries, and example assets:
 
@@ -64,7 +64,7 @@ The following packages contain pre-built binaries for the latest release, includ
 - [MacOS (Xcode 15, Python 3.12)](https://github.com/AcademySoftwareFoundation/MaterialX/releases/latest/download/MaterialX_MacOS_Xcode_15_Python312.zip)
 - [Linux (GCC 14, Python 3.12)](https://github.com/AcademySoftwareFoundation/MaterialX/releases/latest/download/MaterialX_Linux_GCC_14_Python312.zip)
 
-### Additional Resources
+## Additional Resources
 
 - The [Developer Guide](http://www.materialx.org/docs/api/index.html) contains a developer-oriented overview of MaterialX with API documentation.
 - The [Python Scripts](python/Scripts) folder contains standalone examples of MaterialX Python code.

--- a/README.md
+++ b/README.md
@@ -34,25 +34,25 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
-<table>
+<table style="border: none; border-collapse: separate; border-spacing: 4px;">
   <tbody>
     <tr>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Marble material applied"
              title="Standard Surface Marble material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Copper material applied"
              title="Standard Surface Copper material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Plastic material applied"
              title="Standard Surface Plastic material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Carpaint material applied"
              title="Standard Surface Carpaint material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
@@ -63,15 +63,15 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 
-<table>
+<table style="border: none; border-collapse: separate; border-spacing: 4px;">
   <tbody>
     <tr>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
              title="Standard Surface Tiled Brass material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
              title="Standard Surface Tiled Wood material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">

--- a/README.md
+++ b/README.md
@@ -37,29 +37,25 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 <table>
   <tbody>
     <tr>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Marble material applied"
              title="MaterialX Marble material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
-        <br><small>Marble</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Copper material applied"
              title="MaterialX Copper material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
-        <br><small>Copper</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Plastic material applied"
              title="MaterialX Plastic material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
-        <br><small>Plastic</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Carpaint material applied"
              title="MaterialX Carpaint material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
-        <br><small>Carpaint</small>
       </td>
     </tr>
   </tbody>
@@ -70,17 +66,15 @@ The [MaterialX Viewer](documents/DeveloperGuide/Viewer.md) leverages shader gene
 <table>
   <tbody>
     <tr>
-      <td style="text-align: center">
+      <td>
         <img alt="A shader ball with a MaterialX TiledBrass material applied"
              title="MaterialX TiledBrass material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
-        <br><small>Tiled Brass</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A shader ball with a MaterialX TiledWood material applied"
              title="MaterialX TiledWood material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
-        <br><small>Tiled Wood</small>
       </td>
     </tr>
   </tbody>

--- a/documents/DeveloperGuide/GraphEditor.md
+++ b/documents/DeveloperGuide/GraphEditor.md
@@ -2,29 +2,28 @@
 
 The MaterialX Graph Editor is an example application for visualizing, creating, and editing MaterialX graphs.  It utilizes the ImGui framework as well as additional ImGui extensions such as the Node Editor.
 
-### Example Images
+![MaterialX Graph Editor with procedural marble example](https://github.com/AcademySoftwareFoundation/MaterialX/raw/main/documents/Images/MaterialXGraphEditor_Marble.png)
 
 **Figure 1:** MaterialX Graph Editor with procedural marble example
-<img src="/documents/Images/MaterialXGraphEditor_Marble.png" />
 
-## Building The MaterialX Graph Editor
+## Building the MaterialX Graph Editor
 Select the `MATERIALX_BUILD_GRAPH_EDITOR` option in CMake to build the MaterialX Graph Editor.  Installation will copy the **MaterialXGraphEditor** executable to a `/bin` directory within the selected install folder.
 
-### Summary of Graph Editor Features
+## Summary of Graph Editor Features
 
-1.  **Load Material**: Load a material document in the MTLX format.
-2.  **Save Material**: Save out a graph as a mterial document in MTLX format.
-3.  **New Material**: Clear all information to set up for the creation of a new material
-4.  **Node Property Editor**: View or edit properties of the selected node.
-5.  **Render View**: View the rendered material.
+1. **`Load Material`**: Load a material document in the MTLX format.
+2. **`Save Material`**: Save out a graph as a mterial document in MTLX format.
+3. **`New Material`**: Clear all information to set up for the creation of a new material
+4. **`Node Property Editor`**: View or edit properties of the selected node.
+5. **`Render View`**: View the rendered material.
 
-### Buttons
+## Buttons
 
-To display a new material and graph, click the `Load Material` button and and navigate to the [Example Materials](../../resources/Materials/Examples) folder, which contains a selection of materials in the MTLX format, and select a document to load.  The Graph Editor will display the graph hierarchy of the selected document for visualization and editing.
+To display a new material and graph, click the `Load Material` button and and navigate to the [Materials/Examples](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Materials/Examples) folder, which contains a selection of materials in the MTLX format, and select a document to load.  The Graph Editor will display the graph hierarchy of the selected document for visualization and editing.
 
 To save out changes to the graphs as MTLX files click the `Save Material` button.  This will save the position of the nodes in the graph for future use as well. 
 
-### Editor Window
+## Editor Window
 
 The MaterialX document is displayed as nodes in the Editor window.  When a file is intially loaded the material node, surface shader node, and any enclosing nodegraphs will be displayed.  Double-clicking on a nodegraph, or any node defined as a subgraph, will display the contents of that graph.
 
@@ -40,19 +39,19 @@ Another type of node present in the `Add Node` pop-up is the group, or backgroun
 
 To search the editor window for a specific node use `CTRL` + `F` to bring up the search bar. 
 
-### Node Property Editor
+## Node Property Editor
 When a node is selected in the graph, its information is displayed on the left-hand column in the `Node Property Editor`.  This editor displays the name of the node, its category, its inputs, the input name, types and values.  Inputs that are connected to other nodes will not display a value.
 
 This is where a node's properties such as its name and input values can be adjusted.  When an input value is changed the material is automatically updated to reflect that change.  The node info button displays the `doc` string for the selected node and its inputs if they exist. This `doc` string is currently read only.
 
 The show All Inputs checkbox displays all possible inputs for a node. With the box unchecked only inputs that have a connection or have had a value set will be shown. Only these inputs will be saved out when the graph is saved. 
 
-### Render View
+## Render View
 Above the `Node Property Editor`, the `Render View` displays the current material on the Arnold Shader Ball.  If inside a subgraph it will display the material associated with that subgraph; otherwise it will display the output of the selected node.  It automatically updates when any changes are made to the graph.
 
 To adjust the relative sizes of the Node Property Editor and Render View windows, drag the separator between these windows in the application. The render view window camera can be changed using the left or right mouse buttons to manipulate the shader ball. 
 
-### Keyboard Shortcuts
+## Keyboard Shortcuts
 
 - `TAB`: Add Node Popup
 - `Right Click`: pan along the editor
@@ -66,7 +65,7 @@ To adjust the relative sizes of the Node Property Editor and Render View windows
 - `+` : Zoom in with the camera when mouse is over the Render View Window.
 - `-` : Zoom out with the camera when mouse is over the Render View Window.
 
-### Command-Line Options
+## Command-Line Options
 
 The following are common command-line options for MaterialXGraphEditor, and a complete list can be displayed with the `--help` option.
 - `--material [FILENAME]` : Specify the filename of the MTLX document to be displayed in the graph editor
@@ -75,7 +74,7 @@ The following are common command-line options for MaterialXGraphEditor, and a co
 - `--library [FILEPATH]` : Specify an additional data library folder (e.g. 'vendorlib', 'studiolib').  This relative path will be appended to each location in the data search path when loading data libraries.
 - `--captureFilename [FILENAME]` : Specify the filename to which the first rendered frame should be written
 
-### Known Limitations
+## Known Limitations
 
 - Creating new connections using the `channels` attribute of an input is not yet supported, though existing `channels` connections will be displayed in graphs.
 - Assigning a new `colorspace` attribute to an input is not yet supported, though existing `colorspace` attributes on inputs will be respected by the render view.

--- a/documents/DeveloperGuide/GraphEditor.md
+++ b/documents/DeveloperGuide/GraphEditor.md
@@ -2,9 +2,9 @@
 
 The MaterialX Graph Editor is an example application for visualizing, creating, and editing MaterialX graphs.  It utilizes the ImGui framework as well as additional ImGui extensions such as the Node Editor.
 
-![MaterialX Graph Editor with procedural marble example](https://github.com/AcademySoftwareFoundation/MaterialX/raw/main/documents/Images/MaterialXGraphEditor_Marble.png)
-
 **Figure 1:** MaterialX Graph Editor with procedural marble example
+
+![MaterialX Graph Editor with procedural marble example](https://github.com/AcademySoftwareFoundation/MaterialX/raw/main/documents/Images/MaterialXGraphEditor_Marble.png)
 
 ## Building the MaterialX Graph Editor
 Select the `MATERIALX_BUILD_GRAPH_EDITOR` option in CMake to build the MaterialX Graph Editor.  Installation will copy the **MaterialXGraphEditor** executable to a `/bin` directory within the selected install folder.

--- a/documents/DeveloperGuide/GraphEditor.md
+++ b/documents/DeveloperGuide/GraphEditor.md
@@ -2,6 +2,8 @@
 
 The MaterialX Graph Editor is an example application for visualizing, creating, and editing MaterialX graphs.  It utilizes the ImGui framework as well as additional ImGui extensions such as the Node Editor.
 
+## Example Images
+
 **Figure 1:** MaterialX Graph Editor with procedural marble example
 
 ![MaterialX Graph Editor with procedural marble example](https://github.com/AcademySoftwareFoundation/MaterialX/raw/main/documents/Images/MaterialXGraphEditor_Marble.png)

--- a/documents/DeveloperGuide/MainPage.md
+++ b/documents/DeveloperGuide/MainPage.md
@@ -2,14 +2,14 @@
 
 MaterialX is an open standard for representing rich material and look-development content in computer graphics, enabling its platform-independent description and exchange across applications and renderers.  Launched at [Industrial Light & Magic](https://www.ilm.com/) in 2012, MaterialX has been a key technology in their feature films and real-time experiences since _Star Wars: The Force Awakens_ and _Millennium Falcon: Smugglers Run_.  The project was released as open source in 2017, with companies including Sony Pictures Imageworks, Pixar, Autodesk, Adobe, and SideFX contributing to its ongoing development.  In 2021, MaterialX became the seventh hosted project of the [Academy Software Foundation](https://www.aswf.io/).
 
-### Quick Start for Developers
+## Quick Start for Developers
 
 - Download the latest version of the [CMake](https://cmake.org/) build system.
 - Point CMake to the root of the MaterialX library and generate C++ projects for your platform and compiler.
 - Select the `MATERIALX_BUILD_PYTHON` option to build Python bindings.
 - Select the `MATERIALX_BUILD_VIEWER` option to build the MaterialX viewer.
 
-### Supported Platforms
+## Supported Platforms
 
 The MaterialX codebase requires a compiler with support for C++17, and can be built with any of the following:
 
@@ -19,9 +19,9 @@ The MaterialX codebase requires a compiler with support for C++17, and can be bu
 
 The Python bindings for MaterialX are based on [PyBind11](https://github.com/pybind/pybind11), and support Python versions 3.6 and greater.
 
-### Building MaterialX
+## Building MaterialX
 
-#### Building MaterialX C++
+### Building MaterialX C++
 
 The MaterialX C++ libraries are automatically included when building MaterialX through CMake.
 
@@ -32,7 +32,7 @@ To enable OpenImageIO support in MaterialX builds, the following additional opti
 
 See the [MaterialX Unit Tests](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/source/MaterialXTest) page for documentation on shader generation and render testing in GLSL, OSL, and MDL.
 
-#### Building MaterialX Python
+### Building MaterialX Python
 
 By default, the `MATERIALX_BUILD_PYTHON` option will use the active version of Python in the developer's path.  To select a specific version of Python, use one or more of the following advanced options:
 
@@ -44,32 +44,32 @@ Additional options for the generation of MaterialX Python include the following:
 - `MATERIALX_PYTHON_OCIO_DIR`: Path to a folder containing the default OCIO configuration to be packaged with MaterialX Python. The recommended OpenColorIO configuration for MaterialX is [ACES 1.2](https://github.com/colour-science/OpenColorIO-Configs/tree/feature/aces-1.2-config/aces_1.2).
 - `MATERIALX_PYTHON_PYBIND11_DIR`: Path to a folder containing the PyBind11 source to be used in building MaterialX Python. Defaults to the included PyBind11 source.
 
-#### Building The MaterialX Viewer
+### Building The MaterialX Viewer
 
-Select the `MATERIALX_BUILD_VIEWER` option to build the MaterialX Viewer.  Installation will copy the **MaterialXView** executable to a `bin/` directory within the selected install folder.
+Select the `MATERIALX_BUILD_VIEWER` option to build the MaterialX Viewer.  Installation will copy the `MaterialXView` executable to a `bin/` directory within the selected install folder.
 
-#### Building API Documentation
+### Building API Documentation
 
 To generate HTML documentation for the MaterialX C++ API, make sure a version of [Doxygen](https://www.doxygen.org/) is on your path, and select the advanced option `MATERIALX_BUILD_DOCS` in CMake.  This option will add a target named `MaterialXDocs` to your project, which can be built as an independent step from your development environment.
 
-### Installing MaterialX
+## Installing MaterialX
 
 Building the `install` target of your project will install the MaterialX C++ and Python libraries to the folder specified by the `CMAKE_INSTALL_PREFIX` setting, and will install MaterialX Python as a third-party library in your Python environment.  Installation of MaterialX Python as a third-party library can be disabled by setting `MATERIALX_INSTALL_PYTHON` to `OFF`.
 
-### MaterialX Versioning
+## MaterialX Versioning
 
-The MaterialX codebase uses a modified semantic versioning system where the *major* and *minor* versions match that of the corresponding MaterialX [specification](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md), and the *build* version represents engineering advances within that specification version.  MaterialX documents are similarly marked with the specification version they were authored in, and they are valid to load into any MaterialX codebase with an equal or higher specification version.
+The MaterialX codebase uses a modified semantic versioning system where the *major* and *minor* versions match that of the corresponding [MaterialX Specification](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md), and the *build* version represents engineering advances within that specification version.  MaterialX documents are similarly marked with the specification version they were authored in, and they are valid to load into any MaterialX codebase with an equal or higher specification version.
 
-Upgrading of MaterialX documents from earlier versions is handled at import time by the `Document::upgradeVersion` method, which applies the syntax and node interface upgrades that have occurred in previous specification revisions.  This allows the syntax conventions of MaterialX and the names and interfaces of nodes to evolve over time, without invalidating documents from earlier versions.
+Upgrading of MaterialX documents from earlier versions is handled at import time by the `Document::upgradeVersion()` method, which applies the syntax and node interface upgrades that have occurred in previous specification revisions.  This allows the syntax conventions of MaterialX and the names and interfaces of nodes to evolve over time, without invalidating documents from earlier versions.
 
-#### MaterialX API Changes
+### MaterialX API Changes
 
 The following rules describe the categories of changes to the [MaterialX API](https://materialx.org/docs/api/classes.html) that are allowed in version upgrades:
 
 - In *build* version upgrades, only non-breaking changes to the MaterialX API are allowed.  For any API call that is modified in a build version upgrade, backwards compatibility should be maintained using deprecated C++ and Python wrappers for the original API call.
 - In *minor* and *major* version upgrades, breaking changes to the MaterialX API are allowed, though their benefit should be carefully weighed against their cost.  Any breaking changes to API calls should be highlighted in the release notes for the new version.
 
-#### MaterialX Data Library Changes
+### MaterialX Data Library Changes
 
 The following rules describe the categories of changes to the [MaterialX Data Libraries](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/libraries) that are allowed in version upgrades:
 
@@ -77,7 +77,7 @@ The following rules describe the categories of changes to the [MaterialX Data Li
 - In *minor* version upgrades, changes to the names and interfaces of MaterialX nodes are allowed, with the requirement that version upgrade logic be used to maintain the validity and visual interpretation of documents from earlier versions.
 - In *major* version upgrades, changes to the syntax rules of MaterialX documents are allowed, with the requirement that version upgrade logic be used to maintain the validity and visual interpretation of documents from earlier versions.  These changes usually require synchronized updates to both the MaterialX API and data libraries.
 
-### Additional Links
+## Additional Links
 
 - The main [MaterialX website](http://www.materialx.org) provides background on the project's history, industry collaborations, and recent presentations.
 - The [Python Scripts](https://github.com/materialx/MaterialX/tree/main/python/Scripts) folder contains standalone examples of MaterialX Python code.

--- a/documents/DeveloperGuide/MainPage.md
+++ b/documents/DeveloperGuide/MainPage.md
@@ -58,7 +58,7 @@ Building the `install` target of your project will install the MaterialX C++ and
 
 ## MaterialX Versioning
 
-The MaterialX codebase uses a modified semantic versioning system where the *major* and *minor* versions match that of the corresponding [MaterialX Specification](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md), and the *build* version represents engineering advances within that specification version.  MaterialX documents are similarly marked with the specification version they were authored in, and they are valid to load into any MaterialX codebase with an equal or higher specification version.
+The MaterialX codebase uses a modified semantic versioning system where the *major* and *minor* versions match that of the corresponding [MaterialX Specification](https://materialx.org/Specification.html), and the *build* version represents engineering advances within that specification version.  MaterialX documents are similarly marked with the specification version they were authored in, and they are valid to load into any MaterialX codebase with an equal or higher specification version.
 
 Upgrading of MaterialX documents from earlier versions is handled at import time by the `Document::upgradeVersion()` method, which applies the syntax and node interface upgrades that have occurred in previous specification revisions.  This allows the syntax conventions of MaterialX and the names and interfaces of nodes to evolve over time, without invalidating documents from earlier versions.
 

--- a/documents/DeveloperGuide/ShaderGeneration.md
+++ b/documents/DeveloperGuide/ShaderGeneration.md
@@ -7,7 +7,7 @@ Note that this system has no runtime and the output produced is source code, not
 
 ![Shader generation with multiple shader generators](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/shadergen.png)
 
-**Figure 1**: Shader generation with multiple shader generators.
+**Figure 1:** Shader generation with multiple shader generators.
 
 ## 1.2 Languages and Shader Generators
 The MaterialX description is free from device specific details and all implementation details needs to be taken care of by shader generators. There is one shader generator for each supported shading language. However for each language there can also be variations needed for different renderers. For example; OpenGL renderers supporting GLSL can use forward rendering or deferred rendering, each with very different requirements for how the shaders are constructed. Another example is different renderers supporting OSL but with different sets of closures or closure parameters. Hence a separate shader generator can be defined for each language/target combination.
@@ -75,7 +75,7 @@ Figure 2. The first option is to keep inline code in a file. The file extension 
 {{in1}} + {{in2}}
 ```
 
-**Figure 2**: Inline expressions for implementing nodes `<add>` and `<mix>`. The code for `<add>` is stored in an additional file, while the code for `<mix>` is specified as part of the
+**Figure 2:** Inline expressions for implementing nodes `<add>` and `<mix>`. The code for `<add>` is stored in an additional file, while the code for `<mix>` is specified as part of the
 `<implemenentation>` declaration. 
 
 ### 1.3.2 Shading Language Function
@@ -115,7 +115,7 @@ void mx_image_color3(string file, string layer, color defaultvalue,
                   "wrap", uaddressmode);
 }
 ```
-**Figure 3**: Shading language function's implementation for node `<image>` in OSL.
+**Figure 3:** Shading language function's implementation for node `<image>` in OSL.
 
 ### 1.3.3 Node Graph Implementation
 As an alternative to defining source code, there is also an option to reference a nodegraph as the implementation of a nodedef. The only requirement is that the nodegraph and nodedef have matching inputs and outputs.
@@ -147,7 +147,7 @@ This is useful for creating a compound for a set of nodes performing some common
   <output name="out" type="float" nodename="modulo1" />
 </nodegraph>
 ```
-**Figure 4**: Checker node implementation using a nodegraph.
+**Figure 4:** Checker node implementation using a nodegraph.
 
 ### 1.3.4 Dynamic Code Generation
 In some situations static source code is not enough to implement a node. The code might need to be customized depending on parameters set on the node. Or for a hardware render target vertex streams or uniform inputs might need to be created in order to supply the data needed for the node implementation.
@@ -192,7 +192,7 @@ OslShaderGenerator::OslShaderGenerator() :
     ...
 }
 ```
-**Figure 5**: C++ class for dynamic code generation.
+**Figure 5:** C++ class for dynamic code generation.
 
 ## 1.4 Shader Generation Steps
 This section outlines the steps taken in general to produce a shader from the MaterialX description. The `ShaderGenerator` base class and its supporting classes will handle this for you, but it’s good to know the steps involved if custom changes are needed to support a new target.
@@ -305,7 +305,7 @@ class TexCoordGlsl : public ShaderNodeImpl
     }
 };
 ```
-**Figure 6**: Implementation of node `texcoord` in GLSL. Using a `ShaderNodeImpl` sub-class in order to control shader variable creation and code generation into separate shader stages.
+**Figure 6:** Implementation of node `texcoord` in GLSL. Using a `ShaderNodeImpl` sub-class in order to control shader variable creation and code generation into separate shader stages.
 
 ### 1.6.2 Variable Naming Convention
 
@@ -353,4 +353,4 @@ Uniform variables
 | u_lightData[]                       | struct  | Array of struct LightData holding parameters for active light sources. The `LightData` struct is built dynamically depending on requirements for bound light shaders. |
 | u_\<unitType>UnitTarget[]           | integer  | An attribute indicating the target unit for a given unit type definition (\<unitType>). |
 
-**Figure 7** : Listing of predefined variables with their binding rules.
+**Figure 7:** Listing of predefined variables with their binding rules.

--- a/documents/DeveloperGuide/ShaderGeneration.md
+++ b/documents/DeveloperGuide/ShaderGeneration.md
@@ -1,11 +1,11 @@
 # Shader Generation
 
 ## 1.1 Scope
-A shader generation framework is implemented as part of MaterialX. This can help applications to transform the agnostic MaterialX data description into executable shader code for a specific renderer. A library module named MaterialXGenShader contains the core shader generation features, and support for specific languages resides in separate libraries, e.g. [MaterialXGenGlsl](/source/MaterialXGenGlsl), [MaterialXGenOsl](/source/MaterialXGenOsl).
+A shader generation framework is implemented as part of MaterialX. This can help applications to transform the agnostic MaterialX data description into executable shader code for a specific renderer. A library module named MaterialXGenShader contains the core shader generation features, and support for specific languages resides in separate libraries, e.g. [MaterialXGenGlsl](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/source/MaterialXGenGlsl), [MaterialXGenOsl](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/source/MaterialXGenOsl).
 
 Note that this system has no runtime and the output produced is source code, not binary executable code. The source code produced needs to be compiled by a shading language compiler before being executed by the renderer. See Figure 1 for a high level overview of the system.
 
-![Shader generation with multiple shader generators](/documents/Images/shadergen.png)
+![Shader generation with multiple shader generators](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/shadergen.png)
 
 **Figure 1**: Shader generation with multiple shader generators.
 
@@ -28,11 +28,11 @@ In the following sub-sections each of these methods are explained. For all metho
 ### 1.3.1 Inline Expression
 Provided code generators support a very simple expression language for inlining code. This is useful for simple nodes where the operation can be expressed as a single line of code. Inlining will reduce the number of function calls and produce more compact code. The syntax to use is the same as the target shading language, with the addition of using the node’s input ports as variables wrapped in double curly brackets: `{{input}}`. The code generator will replace these variables with values assigned or connected to the respective inputs. Figure 2 gives an example.
 
-Connecting the expression to the nodedef is done using an `<implementation>` element as seen in
+Connecting the expression to the `nodedef` is done using an `<implementation>` element as seen in
 Figure 2. The first option is to keep inline code in a file. The file extension is used to differentiate inline expressions from source code functions, using `filename.inline`. The second option is to directly embed the inlined code using `sourcecode`. This is the recommended approach for inlining if there the logic can fit on one line of code.
 
 ```xml
-// Nodedef elements for node <add>
+<!-- Node definition elements for node <add> -->
 <nodedef name="ND_add_float" node="add">
   <input name="in1" type="float" />
   <input name="in2" type="float" />
@@ -43,14 +43,14 @@ Figure 2. The first option is to keep inline code in a file. The file extension 
   <input name="in2" type="color3" />
   <output name="out" type="color3" defaultinput="in1" />
 </nodedef>
-<... more types ...>
+<!-- ... more types ... -->
 
-// Implementation elements for node <add>
+<!-- Implementation elements for node <add> -->
 <implementation name="IM_add_float" nodedef="ND_add_float" file="mx_add.inline" />
 <implementation name="IM_add_color3" nodedef="ND_add_color3" file="mx_add.inline" />
-<... more types ...>
+<!-- ... more types ... -->
 
-// Nodedef elements for node <mix>
+<!-- Node definition elements for node <mix> -->
 <nodedef name="ND_mix_float" node="mix">
   <input name="fg" type="float" />
   <input name="bg" type="float" />
@@ -63,12 +63,12 @@ Figure 2. The first option is to keep inline code in a file. The file extension 
   <input name="mix" type="color3" />
   <output name="out" type="color3" defaultinput="bg" />
 </nodedef>
-<... more types ...>
+<!-- ... more types ... -->
 
-// Implementation elements for node <mix>
+<!-- Implementation elements for node <mix> -->
 <implementation name="IM_mix_float" nodedef="ND_mix_float" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
 <implementation name="IM_mix_color3" nodedef="ND_mix_color3" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-<... more types ...>
+<!-- ... more types ... -->
 ```
 ```c++
 // File 'mx_add.inline' contains:
@@ -79,10 +79,10 @@ Figure 2. The first option is to keep inline code in a file. The file extension 
 `<implemenentation>` declaration. 
 
 ### 1.3.2 Shading Language Function
-For nodes that can’t be implemented by inline expressions a function definition can be used instead. The function signature should match the nodedefs interface with inputs and outputs. See Figure 3 for an example. Connecting the source code to the nodedef is done using an `<implementation>` element, see the [MaterialX specification](../Specification/MaterialX.v1.36.Spec.pdf) for more information.
+For nodes that can’t be implemented by inline expressions a function definition can be used instead. The function signature should match the nodedefs interface with inputs and outputs. See Figure 3 for an example. Connecting the source code to the nodedef is done using an `<implementation>` element, see the [MaterialX Specification](https://materialx.org/Specification.html) for more information.
 
 ```xml
-// Nodedef element
+<!-- Node definition element -->
 <nodedef name="ND_image_color3" node="image">
   <input name="file" type="filename" value="" uniform="true" />
   <input name="layer" type="string" value="" uniform="true" />
@@ -97,7 +97,7 @@ For nodes that can’t be implemented by inline expressions a function definitio
   <output name="out" type="color3" default="0.0, 0.0, 0.0" />
 </nodedef>
 
-// Implementation element
+<!-- Implementation element -->
 <implementation name="IM_image_color3_osl" nodedef="ND_image_color3" file="mx_image_color3.osl" target="genosl" />
 ```
 ```c++

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -6,25 +6,25 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
-<table>
+<table style="border: none; border-collapse: separate; border-spacing: 4px;">
   <tbody>
     <tr>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Marble material applied"
              title="Standard Surface Marble material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Copper material applied"
              title="Standard Surface Copper material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Plastic material applied"
              title="Standard Surface Plastic material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A teapot with a Standard Surface Carpaint material applied"
              title="Standard Surface Carpaint material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
@@ -35,15 +35,15 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 
-<table>
+<table style="border: none; border-collapse: separate; border-spacing: 4px;">
   <tbody>
     <tr>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
              title="Standard Surface Tiled Brass material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
       </td>
-      <td>
+      <td style="padding: 0px;">
         <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
              title="Standard Surface Tiled Wood material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -10,23 +10,23 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
   <tbody>
     <tr>
       <td>
-        <img alt="A teapot with a MaterialX Marble material applied"
-             title="MaterialX Marble material"
+        <img alt="A teapot with a Standard Surface Marble material applied"
+             title="Standard Surface Marble material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
       </td>
       <td>
-        <img alt="A teapot with a MaterialX Copper material applied"
-             title="MaterialX Copper material"
+        <img alt="A teapot with a Standard Surface Copper material applied"
+             title="Standard Surface Copper material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
       </td>
       <td>
-        <img alt="A teapot with a MaterialX Plastic material applied"
-             title="MaterialX Plastic material"
+        <img alt="A teapot with a Standard Surface Plastic material applied"
+             title="Standard Surface Plastic material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
       </td>
       <td>
-        <img alt="A teapot with a MaterialX Carpaint material applied"
-             title="MaterialX Carpaint material"
+        <img alt="A teapot with a Standard Surface Carpaint material applied"
+             title="Standard Surface Carpaint material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
       </td>
     </tr>
@@ -39,13 +39,13 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
   <tbody>
     <tr>
       <td>
-        <img alt="A shader ball with a MaterialX TiledBrass material applied"
-             title="MaterialX TiledBrass material"
+        <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
+             title="Standard Surface Tiled Brass material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
       </td>
       <td>
-        <img alt="A shader ball with a MaterialX TiledWood material applied"
-             title="MaterialX TiledWood material"
+        <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
+             title="Standard Surface Tiled Wood material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
       </td>
     </tr>

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -5,7 +5,6 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 ## Example Images
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
-
 <p float="left">
   <img alt="A teapot with a Standard Surface Marble material applied"
        title="Standard Surface Marble material"
@@ -26,7 +25,6 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 </p>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
-
 <p float="left">
   <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
        title="Standard Surface Tiled Brass material"

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -6,51 +6,37 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
-<table style="border: none; border-collapse: separate; border-spacing: 4px;">
-  <tbody>
-    <tr>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Marble material applied"
-             title="Standard Surface Marble material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Copper material applied"
-             title="Standard Surface Copper material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Plastic material applied"
-             title="Standard Surface Plastic material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A teapot with a Standard Surface Carpaint material applied"
-             title="Standard Surface Carpaint material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
-      </td>
-    </tr>
-  </tbody>
-</table>
+<p float="left">
+  <img alt="A teapot with a Standard Surface Marble material applied"
+       title="Standard Surface Marble material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png"
+       width="24%" />
+  <img alt="A teapot with a Standard Surface Copper material applied"
+       title="Standard Surface Copper material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png"
+       width="24%" />
+  <img alt="A teapot with a Standard Surface Plastic material applied"
+       title="Standard Surface Plastic material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png"
+       width="24%" />
+  <img alt="A teapot with a Standard Surface Carpaint material applied"
+       title="Standard Surface Carpaint material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png"
+       width="24%" />
+</p>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 
-<table style="border: none; border-collapse: separate; border-spacing: 4px;">
-  <tbody>
-    <tr>
-      <td style="padding: 0px;">
-        <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
-             title="Standard Surface Tiled Brass material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
-      </td>
-      <td style="padding: 0px;">
-        <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
-             title="Standard Surface Tiled Wood material"
-             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
-      </td>
-    </tr>
-  </tbody>
-</table>
+<p float="left">
+  <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
+       title="Standard Surface Tiled Brass material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png"
+       width="49%" />
+  <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
+       title="Standard Surface Tiled Wood material"
+       src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png"
+       width="49%" />
+</p>
 
 ## Building The MaterialX Viewer
 Select the `MATERIALX_BUILD_VIEWER` option in CMake to build the MaterialX Viewer.  Installation will copy the **MaterialXView** executable to a `/bin` directory within the selected install folder.

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -2,6 +2,8 @@
 
 The MaterialX Viewer leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.  The standard set of pattern and physically based shading nodes is supported, and libraries of custom nodes can be included as additional library paths.
 
+## Example Images
+
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
 <table>

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -2,60 +2,56 @@
 
 The MaterialX Viewer leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.  The standard set of pattern and physically based shading nodes is supported, and libraries of custom nodes can be included as additional library paths.
 
-### Example Images
+| Marble | Copper | Plastic | Carpaint |
+|--------|--------|---------|----------|
+| ![MaterialX Marble material](../Images/MaterialXView_Marble.png) | ![MaterialX Copper material](../Images/MaterialXView_Copper.png) | ![MaterialX Plastic material](../Images/MaterialXView_Plastic.png) | ![MaterialX Carpaint material](../Images/MaterialXView_Carpaint.png) |
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
-<p float="left">
-  <img src="/documents/Images/MaterialXView_Marble.png" width="248" />
-  <img src="/documents/Images/MaterialXView_Copper.png" width="248" />
-  <img src="/documents/Images/MaterialXView_Plastic.png" width="248" />
-  <img src="/documents/Images/MaterialXView_Carpaint.png" width="248" />
-</p>
+
+| Tiled Brass | Tiled Wood |
+|-------------|------------|
+| ![MaterialX TiledBrass material](../Images/MaterialXView_TiledBrass.png) | ![MaterialX TiledWood material](../Images/MaterialXView_TiledWood.png) |
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
-<p float="left">
-  <img src="/documents/Images/MaterialXView_TiledBrass.png" width="500" />
-  <img src="/documents/Images/MaterialXView_TiledWood.png" width="500" />
-</p>
 
 ## Building The MaterialX Viewer
 Select the `MATERIALX_BUILD_VIEWER` option in CMake to build the MaterialX Viewer.  Installation will copy the **MaterialXView** executable to a `/bin` directory within the selected install folder.
 
-### Summary of Viewer Options
+## Summary of Viewer Options
 
-1.  **Load Mesh**: Load a new geometry in the OBJ or glTF format.
-2.  **Load Material**: Load a material document in the MTLX format.
-3.  **Load Environment**: Load a lat-long environment light in the HDR format.
-4.  **Property Editor**: View or edit properties of the current material.
-5.  **Advanced Settings** : Asset and rendering options.
+1. **`Load Mesh`**: Load a new geometry in the OBJ or glTF format.
+2. **`Load Material`**: Load a material document in the MTLX format.
+3. **`Load Environment`**: Load a lat-long environment light in the HDR format.
+4. **`Property Editor`**: View or edit properties of the current material.
+5. **`Advanced Settings`** : Asset and rendering options.
 
-### Geometry
+## Geometry
 
-The default display geometry for the MaterialX viewer is the Arnold Shader Ball, which was contributed to the MaterialX project by the Solid Angle team at Autodesk.  To change the display geometry, click `Load Mesh` and navigate to the [Geometry](../../resources/Geometry) folder for additional models in the OBJ format.
+The default display geometry for the MaterialX viewer is the Arnold Shader Ball, which was contributed to the MaterialX project by the Solid Angle team at Autodesk.  To change the display geometry, click `Load Mesh` and navigate to the [Geometry](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Geometry) folder for additional models in the OBJ format.
 
 If a loaded geometry contains more than one geometric group, then a `Select Geometry` drop-down box will appear, allowing the user to select which group is active.  The active geometric group will be used for subsequent actions such as material assignment and rendering property changes.
 
-### Materials
+## Materials
 
-To change the displayed material, click `Load Material` and navigate to the [Materials/Examples/StandardSurface](../../resources/Materials/Examples/StandardSurface) or [Materials/Examples/UsdPreviewSurface](../../resources/Materials/Examples/UsdPreviewSurface) folders, which contain a selection of example materials in the MTLX format.
+To change the displayed material, click `Load Material` and navigate to the [Materials/Examples/StandardSurface](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Materials/Examples/StandardSurface) or [Materials/Examples/UsdPreviewSurface](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Materials/Examples/UsdPreviewSurface) folders, which contain a selection of example materials in the MTLX format.
 
 Once a material is loaded into the viewer, its parameters may be inspected and adjusted by clicking the `Property Editor` and scrolling through the list of parameters.  An edited material may be saved to the file system by clicking `Save Material`.
 
 Multiple material documents can be combined in a single session by navigating to `Advanced Settings` and enabling `Merge Materials`.  Loading new materials with this setting enabled will add them to the current material list, where they can be assigned to geometry via the `Assigned Material` drop-down box.  Alternatively the `LEFT` and `RIGHT` arrows can be used to cycle through the list of available materials.
 
-If a material document containing `look` elements is loaded into the viewer, then any material assignments within the look will be applied to geometric groups that match the specified geometry strings.  See [standard_surface_look_brass_tiled.mtlx](../../resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx) for an example of a material document containing look elements.
+If a material document containing `look` elements is loaded into the viewer, then any material assignments within the look will be applied to geometric groups that match the specified geometry strings.  See [standard_surface_look_brass_tiled.mtlx](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Materials/Examples/StandardSurface/standard_surface_look_brass_tiled.mtlx) for an example of a material document containing look elements.
 
-### Lighting
+## Lighting
 
-The default lighting environment for the viewer is the San Giuseppe Bridge environment from HDRI Haven.  To load another environment into the viewer, click `Load Environment` and navigate to the [Lights](../../resources/Lights) folder, or load any HDR environment in the latitude-longitude format.  If the HDR file on disk has a companion MaterialX document with a matching name, then this document will be loaded as the direct lighting rig for the environment; otherwise only indirect lighting will be rendered.  If the HDR file on disk has a companion image in an `irradiance` subfolder, then this image will be loaded as the diffuse convolution of the environment; otherwise, a diffuse convolution will be generated at load-time using spherical harmonics.
+The default lighting environment for the viewer is the San Giuseppe Bridge environment from HDRI Haven.  To load another environment into the viewer, click `Load Environment` and navigate to the [Lights](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Lights) folder, or load any HDR environment in the latitude-longitude format.  If the HDR file on disk has a companion MaterialX document with a matching name, then this document will be loaded as the direct lighting rig for the environment; otherwise only indirect lighting will be rendered.  If the HDR file on disk has a companion image in an `irradiance` subfolder, then this image will be loaded as the diffuse convolution of the environment; otherwise, a diffuse convolution will be generated at load-time using spherical harmonics.
 
 Shadow maps from the primary directional light may be enabled with the `Shadow Map` option under `Advanced Settings`.  Ambient occlusion, if available for the given geometry, may be enabled with the `Ambient Occlusion` option.  The fidelity of environment lighting may be improved by increasing the value of `Environment Samples`, though this requires additional GPU resources and can affect the interactivity of the viewer.
 
-### Images
+## Images
 
 By default, the MaterialX viewer loads and saves image files using `stb_image`, which supports commmon 8-bit formats such as JPEG, PNG, TGA, and BMP, as well as the HDR format for high-dynamic-range images.  If you need access to additional image formats such as EXR and TIFF, then the MaterialX viewer can be built with support for `OpenImageIO`.  To build MaterialX with OpenImageIO, check the `MATERIALX_BUILD_OIIO` option in CMake, and specify the location of your OpenImageIO installation with the `MATERIALX_OIIO_DIR` option.
 
-### Keyboard Shortcuts
+## Keyboard Shortcuts
 
 - `R`: Reload the current material from file.  Hold `SHIFT` to reload all standard libraries as well.
 - `G`: Save the current GLSL shader source to file.
@@ -74,7 +70,7 @@ By default, the MaterialX viewer loads and saves image files using `stb_image`, 
 - `+` : Zoom in with the camera.
 - `-` : Zoom out with the camera.
 
-### Command-Line Options
+## Command-Line Options
 
 The following are common command-line options for MaterialXView, and a complete list can be displayed with the `--help` option.
 - `--material [FILENAME]` : Specify the filename of the MTLX document to be displayed in the viewer

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -2,6 +2,8 @@
 
 The MaterialX Viewer leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.  The standard set of pattern and physically based shading nodes is supported, and libraries of custom nodes can be included as additional library paths.
 
+**Figure 1:** Procedural and uniform materials in the MaterialX viewer
+
 <table>
   <tbody>
     <tr>
@@ -33,7 +35,7 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
   </tbody>
 </table>
 
-**Figure 1:** Procedural and uniform materials in the MaterialX viewer
+**Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 
 <table>
   <tbody>
@@ -53,8 +55,6 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
     </tr>
   </tbody>
 </table>
-
-**Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 
 ## Building The MaterialX Viewer
 Select the `MATERIALX_BUILD_VIEWER` option in CMake to build the MaterialX Viewer.  Installation will copy the **MaterialXView** executable to a `/bin` directory within the selected install folder.

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -6,32 +6,26 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 <p float="left">
-  <img alt="A teapot with a Standard Surface Marble material applied"
-       title="Standard Surface Marble material"
+  <img title="Standard Surface Marble material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png"
        width="24%" />
-  <img alt="A teapot with a Standard Surface Copper material applied"
-       title="Standard Surface Copper material"
+  <img title="Standard Surface Copper material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png"
        width="24%" />
-  <img alt="A teapot with a Standard Surface Plastic material applied"
-       title="Standard Surface Plastic material"
+  <img title="Standard Surface Plastic material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png"
        width="24%" />
-  <img alt="A teapot with a Standard Surface Carpaint material applied"
-       title="Standard Surface Carpaint material"
+  <img title="Standard Surface Carpaint material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png"
        width="24%" />
 </p>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 <p float="left">
-  <img alt="A shader ball with a Standard Surface Tiled Brass material applied"
-       title="Standard Surface Tiled Brass material"
+  <img title="Standard Surface Tiled Brass material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png"
        width="49%" />
-  <img alt="A shader ball with a Standard Surface Tiled Wood material applied"
-       title="Standard Surface Tiled Wood material"
+  <img title="Standard Surface Tiled Wood material"
        src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png"
        width="49%" />
 </p>

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -2,15 +2,57 @@
 
 The MaterialX Viewer leverages shader generation to build GLSL shaders from MaterialX graphs, rendering the results using the NanoGUI framework.  The standard set of pattern and physically based shading nodes is supported, and libraries of custom nodes can be included as additional library paths.
 
-| Marble | Copper | Plastic | Carpaint |
-|--------|--------|---------|----------|
-| ![MaterialX Marble material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png) | ![MaterialX Copper material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png) | ![MaterialX Plastic material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png) | ![MaterialX Carpaint material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png) |
+<table>
+  <tbody>
+    <tr>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Marble material applied"
+             title="MaterialX Marble material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
+        <br><small>Marble</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Copper material applied"
+             title="MaterialX Copper material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
+        <br><small>Copper</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Plastic material applied"
+             title="MaterialX Plastic material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
+        <br><small>Plastic</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A teapot with a MaterialX Carpaint material applied"
+             title="MaterialX Carpaint material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
+        <br><small>Carpaint</small>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
-| Tiled Brass | Tiled Wood |
-|-------------|------------|
-| ![MaterialX TiledBrass material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png) | ![MaterialX TiledWood material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png) |
+<table>
+  <tbody>
+    <tr>
+      <td style="text-align: center">
+        <img alt="A shader ball with a MaterialX TiledBrass material applied"
+             title="MaterialX TiledBrass material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
+        <br><small>Tiled Brass</small>
+      </td>
+      <td style="text-align: center">
+        <img alt="A shader ball with a MaterialX TiledWood material applied"
+             title="MaterialX TiledWood material"
+             src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
+        <br><small>Tiled Wood</small>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -4,13 +4,13 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 
 | Marble | Copper | Plastic | Carpaint |
 |--------|--------|---------|----------|
-| ![MaterialX Marble material](../Images/MaterialXView_Marble.png) | ![MaterialX Copper material](../Images/MaterialXView_Copper.png) | ![MaterialX Plastic material](../Images/MaterialXView_Plastic.png) | ![MaterialX Carpaint material](../Images/MaterialXView_Carpaint.png) |
+| ![MaterialX Marble material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png) | ![MaterialX Copper material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png) | ![MaterialX Plastic material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png) | ![MaterialX Carpaint material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png) |
 
 **Figure 1:** Procedural and uniform materials in the MaterialX viewer
 
 | Tiled Brass | Tiled Wood |
 |-------------|------------|
-| ![MaterialX TiledBrass material](../Images/MaterialXView_TiledBrass.png) | ![MaterialX TiledWood material](../Images/MaterialXView_TiledWood.png) |
+| ![MaterialX TiledBrass material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png) | ![MaterialX TiledWood material](https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png) |
 
 **Figure 2:** Textured, color-space-managed materials in the MaterialX viewer
 

--- a/documents/DeveloperGuide/Viewer.md
+++ b/documents/DeveloperGuide/Viewer.md
@@ -7,29 +7,25 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 <table>
   <tbody>
     <tr>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Marble material applied"
              title="MaterialX Marble material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Marble.png">
-        <br><small>Marble</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Copper material applied"
              title="MaterialX Copper material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Copper.png">
-        <br><small>Copper</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Plastic material applied"
              title="MaterialX Plastic material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Plastic.png">
-        <br><small>Plastic</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A teapot with a MaterialX Carpaint material applied"
              title="MaterialX Carpaint material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_Carpaint.png">
-        <br><small>Carpaint</small>
       </td>
     </tr>
   </tbody>
@@ -40,17 +36,15 @@ The MaterialX Viewer leverages shader generation to build GLSL shaders from Mate
 <table>
   <tbody>
     <tr>
-      <td style="text-align: center">
+      <td>
         <img alt="A shader ball with a MaterialX TiledBrass material applied"
              title="MaterialX TiledBrass material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledBrass.png">
-        <br><small>Tiled Brass</small>
       </td>
-      <td style="text-align: center">
+      <td>
         <img alt="A shader ball with a MaterialX TiledWood material applied"
              title="MaterialX TiledWood material"
              src="https://raw.githubusercontent.com/AcademySoftwareFoundation/MaterialX/main/documents/Images/MaterialXView_TiledWood.png">
-        <br><small>Tiled Wood</small>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Changes:
- Replaced relative image sources with absolute image URLs so that images load when viewed at https://pypi.org/project/MaterialX/ and when integrating the contents into the new Python API documentation
- Streamlined headline levels: page title (if any) uses `#`, first level uses `##`, second level uses `###`, etc.
- Used HTML tables for formatting image galleries
- Streamlined figure captions to format colons in **bold**
- Used HTML comment syntax for comments in XML blocks
- Other minor formatting changes, e.g. formatting the `MaterialXView` executable in a code font

Split from #1567.

Update #342.