### PR TITLE
Adding a docstring for PyMaterialXFormat.

### DIFF
--- a/python/MaterialX/main.py
+++ b/python/MaterialX/main.py
@@ -288,13 +288,6 @@ stringToValue = _stringToValue
 
 
 #
-# XmlIo
-#
-
-readFromXmlFile = readFromXmlFileBase
-
-
-#
 # Default Data Paths
 #
 

--- a/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyModule.cpp
@@ -4,6 +4,7 @@
 //
 
 #include <PyMaterialX/PyMaterialX.h>
+#include "__doc__.md.h"
 
 namespace py = pybind11;
 
@@ -13,7 +14,7 @@ void bindPyUtil(py::module& mod);
 
 PYBIND11_MODULE(PyMaterialXFormat, mod)
 {
-    mod.doc() = "Module containing Python bindings for the MaterialXFormat library";
+    mod.doc() = PyMaterialXFormat_DOCSTRING;
 
     // PyMaterialXFormat depends on types defined in PyMaterialXCore
     PYMATERIALX_IMPORT_MODULE(PyMaterialXCore);

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -26,7 +26,7 @@ void bindPyXmlIo(py::module& mod)
         .def_readwrite("writeXIncludeEnable", &mx::XmlWriteOptions::writeXIncludeEnable)
         .def_readwrite("elementPredicate", &mx::XmlWriteOptions::elementPredicate);
 
-    mod.def("readFromXmlFileBase", &mx::readFromXmlFile,
+    mod.def("readFromXmlFile", &mx::readFromXmlFile,
         py::arg("doc"), py::arg("filename"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);
     mod.def("readFromXmlString", &mx::readFromXmlString,
         py::arg("doc"), py::arg("str"), py::arg("searchPath") = mx::FileSearchPath(), py::arg("readOptions") = (mx::XmlReadOptions*) nullptr);

--- a/source/PyMaterialX/PyMaterialXFormat/__doc__.md.h
+++ b/source/PyMaterialX/PyMaterialXFormat/__doc__.md.h
@@ -1,0 +1,59 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Docstring for the PyMaterialXFormat module
+
+#define PyMaterialXFormat_DOCSTRING PYMATERIALX_DOCSTRING(R"docstring(
+Cross-platform support for file and search paths, and XML serialization.
+
+All functions and classes that are defined in this module are available in
+the top-level `MaterialX` Python package, and are typically used via an
+`import` alias named `mx`:
+
+.. code:: python
+
+    import MaterialX as mx
+
+File and Search Paths
+---------------------
+
+.. autofunction:: flattenFilenames
+.. autofunction:: getEnvironmentPath
+.. autofunction:: getSourceSearchPath
+.. autofunction:: getSubdirectories
+.. autofunction:: loadDocuments
+.. autofunction:: loadLibraries
+.. autofunction:: loadLibrary
+.. autofunction:: prependXInclude
+
+**Classes and Enumerations**
+
+.. autosummary::
+    :toctree: file-and-search-paths
+
+    FilePath
+    FileSearchPath
+    Format
+    Type
+
+XML Serialization
+-----------------
+
+.. autofunction:: readFile
+.. autofunction:: readFromXmlFile
+.. autofunction:: readFromXmlString
+.. autofunction:: writeToXmlFile
+.. autofunction:: writeToXmlString
+
+**Classes and Exceptions**
+
+.. autosummary::
+    :toctree: xml-serialization
+
+    XmlReadOptions
+    XmlWriteOptions
+    ExceptionParseError
+    ExceptionFileMissing
+)docstring");


### PR DESCRIPTION
This PR adds a docstring in markdown format to the `PyMaterialXFormat` module.

The docstring is defined in a macro named `PyMaterialXFormat_DOCSTRING` that uses the new `PYMATERIALX_DOCSTRING` macro that is introduced in #2038 to allow us to place the first and last lines in lines by themselves, rather than starting the docstring contents immediately after the `R"docstring(` marker.

The `PyMaterialXFormat_DOCSTRING` macro is placed in a separate header file named `__doc__.md.h` which lives side-by-side with the `PyModule.cpp` file in which it is included.

Note that the docstrings for individual classes, methods, and functions are to be added in separate PRs.

Note that this PR also renames `readFromXmlFileBase()` to `readFromXmlFile()` allowing us to remove the alias from `python/MaterialX/main.py`.

| Before | After |
|-|-|
| ![Screenshot 2024-09-30 at 11 16 34](https://github.com/user-attachments/assets/6ba49fea-917e-477a-a18e-caeae8a6a853) | ![Screenshot 2024-09-30 at 11 19 47](https://github.com/user-attachments/assets/24cbb4ba-3839-46be-bf14-6f9b19724f16) |

Split from #1567.

Depends on #2038.

Update #342.