### PR TITLE
Simplify mx_math files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,6 +127,7 @@ jobs:
     - name: Install Dependencies (Linux)
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
         sudo apt-get install xorg-dev
         if [ "${{ matrix.compiler_version }}" != 'None' ]; then
           if [ "${{ matrix.compiler }}" = "gcc" ]; then

--- a/libraries/pbrlib/genglsl/mx_hair_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_hair_bsdf.glsl
@@ -213,7 +213,7 @@ vec3 mx_chiang_hair_bsdf(
     float x1 = dot(L, Y);
     float y2 = dot(V, N);
     float x2 = dot(V, Y);
-    float phi = atan(y1 * x2 - y2 * x1, x1 * x2 + y1 * y2);
+    float phi = mx_atan(y1 * x2 - y2 * x1, x1 * x2 + y1 * y2);
 
     vec3 k1_p = normalize(V - X * dot(V, X));
     float cosGammaO = dot(N, k1_p);

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -1,13 +1,24 @@
 #define M_FLOAT_EPS 1e-8
 
+#define mx_inversesqrt inversesqrt
+#define mx_sin sin
+#define mx_cos cos
+#define mx_tan tan
+#define mx_asin asin
+#define mx_acos acos
+#define mx_atan atan
+#define mx_radians radians
+
 float mx_square(float x)
 {
     return x*x;
 }
+
 vec2 mx_square(vec2 x)
 {
     return x*x;
 }
+
 vec3 mx_square(vec3 x)
 {
     return x*x;
@@ -19,120 +30,4 @@ vec3 mx_srgb_encode(vec3 color)
     vec3 linSeg = color * 12.92;
     vec3 powSeg = 1.055 * pow(max(color, vec3(0.0)), vec3(1.0 / 2.4)) - 0.055;
     return mix(linSeg, powSeg, isAbove);
-}
-
-float mx_inversesqrt(float x)
-{
-    return inversesqrt(x);
-}
-
-float mx_radians(float degree)
-{
-    return radians(degree);
-}
-
-float mx_sin(float x)
-{
-    return sin(x);
-}
-vec2 mx_sin(vec2 x)
-{
-    return sin(x);
-}
-vec3 mx_sin(vec3 x)
-{
-    return sin(x);
-}
-vec4 mx_sin(vec4 x)
-{
-    return sin(x);
-}
-
-float mx_cos(float x)
-{
-    return cos(x);
-}
-vec2 mx_cos(vec2 x)
-{
-    return cos(x);
-}
-vec3 mx_cos(vec3 x)
-{
-    return cos(x);
-}
-vec4 mx_cos(vec4 x)
-{
-    return cos(x);
-}
-
-float mx_tan(float x)
-{
-    return tan(x);
-}
-vec2 mx_tan(vec2 x)
-{
-    return tan(x);
-}
-vec3 mx_tan(vec3 x)
-{
-    return tan(x);
-}
-vec4 mx_tan(vec4 x)
-{
-    return tan(x);
-}
-
-float mx_asin(float x)
-{
-    return asin(x);
-}
-vec2 mx_asin(vec2 x)
-{
-    return asin(x);
-}
-vec3 mx_asin(vec3 x)
-{
-    return asin(x);
-}
-vec4 mx_asin(vec4 x)
-{
-    return asin(x);
-}
-
-float mx_acos(float x)
-{
-    return acos(x);
-}
-vec2 mx_acos(vec2 x)
-{
-    return acos(x);
-}
-vec3 mx_acos(vec3 x)
-{
-    return acos(x);
-}
-vec4 mx_acos(vec4 x)
-{
-    return acos(x);
-}
-
-float mx_atan(float y_over_x)
-{
-    return atan(y_over_x);
-}
-float mx_atan(float y, float x)
-{
-    return atan(y, x);
-}
-vec2 mx_atan(vec2 y, vec2 x)
-{
-    return atan(y, x);
-}
-vec3 mx_atan(vec3 y, vec3 x)
-{
-    return atan(y, x);
-}
-vec4 mx_atan(vec4 y, vec4 x)
-{
-    return atan(y, x);
 }

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -1,22 +1,24 @@
 #define M_FLOAT_EPS 1e-8
 
+#define mx_sin sin
+#define mx_cos cos
+#define mx_tan tan
+#define mx_asin asin
+#define mx_acos acos
+
 float mx_square(float x)
 {
     return x*x;
 }
+
 vec2 mx_square(vec2 x)
 {
     return x*x;
 }
+
 vec3 mx_square(vec3 x)
 {
     return x*x;
-}
-
-template<class T1, class T2>
-T1 mx_mod(T1 x, T2 y)
-{
-    return x - y * floor(x/y);
 }
 
 float mx_inversesqrt(float x)
@@ -24,9 +26,10 @@ float mx_inversesqrt(float x)
     return ::rsqrt(x);
 }
 
-float mx_radians(float degree)
+template<class T1, class T2>
+T1 mx_mod(T1 x, T2 y)
 {
-    return (degree * M_PI_F / 180.0f);
+    return x - y * floor(x/y);
 }
 
 float3x3 mx_inverse(float3x3 m)
@@ -95,108 +98,32 @@ float4x4 mx_inverse(float4x4 m)
     return ret;
 }
 
-float mx_sin(float x)
-{
-    return sin(x);
-}
-vec2 mx_sin(vec2 x)
-{
-    return sin(x);
-}
-vec3 mx_sin(vec3 x)
-{
-    return sin(x);
-}
-vec4 mx_sin(vec4 x)
-{
-    return sin(x);
-}
-
-float mx_cos(float x)
-{
-    return cos(x);
-}
-vec2 mx_cos(vec2 x)
-{
-    return cos(x);
-}
-vec3 mx_cos(vec3 x)
-{
-    return cos(x);
-}
-vec4 mx_cos(vec4 x)
-{
-    return cos(x);
-}
-
-float mx_tan(float x)
-{
-    return tan(x);
-}
-vec2 mx_tan(vec2 x)
-{
-    return tan(x);
-}
-vec3 mx_tan(vec3 x)
-{
-    return tan(x);
-}
-vec4 mx_tan(vec4 x)
-{
-    return tan(x);
-}
-
-float mx_asin(float x)
-{
-    return asin(x);
-}
-vec2 mx_asin(vec2 x)
-{
-    return asin(x);
-}
-vec3 mx_asin(vec3 x)
-{
-    return asin(x);
-}
-vec4 mx_asin(vec4 x)
-{
-    return asin(x);
-}
-
-float mx_acos(float x)
-{
-    return acos(x);
-}
-vec2 mx_acos(vec2 x)
-{
-    return acos(x);
-}
-vec3 mx_acos(vec3 x)
-{
-    return acos(x);
-}
-vec4 mx_acos(vec4 x)
-{
-    return acos(x);
-}
-
 float mx_atan(float y_over_x)
 {
     return ::atan(y_over_x);
 }
+
 float mx_atan(float y, float x)
 {
     return ::atan2(y, x);
 }
+
 vec2 mx_atan(vec2 y, vec2 x)
 {
     return ::atan2(y, x);
 }
+
 vec3 mx_atan(vec3 y, vec3 x)
 {
     return ::atan2(y, x);
 }
+
 vec4 mx_atan(vec4 y, vec4 x)
 {
     return ::atan2(y, x);
+}
+
+float mx_radians(float degree)
+{
+    return (degree * M_PI_F / 180.0f);
 }


### PR DESCRIPTION
This changelist simplifies mx_math.glsl and mx_math.metal to reduce code repetition and clarify the differences between dedicated helper functions and simple keyword replacement.

Additionally it addresses an omitted update from atan to mx_atan in the implementation of chiang_hair_bsdf, and adds an update step to Linux CI for robustness.