### PR TITLE
Refinements to chiang_hair_bsdf

### DIFF
--- a/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
@@ -49,10 +49,10 @@ void mx_chiang_hair_roughness(
     float ar = clamp(azimuthal, 0.001, 1.0);
 
     // longitudinal variance
-    float v = 0.726 * lr + 0.812 * lr * lr + 3.7 * pow(lr, 20);
+    float v = 0.726 * lr + 0.812 * lr * lr + 3.7 * pow(lr, 20.0);
     v = v * v;
 
-    float s = 0.265 * ar + 1.194 * ar * ar + 5.372 * pow(ar, 22);
+    float s = 0.265 * ar + 1.194 * ar * ar + 5.372 * pow(ar, 22.0);
 
     roughness_R = vec2(v, s);
     roughness_TT = vec2(v * scale_TT * scale_TT, s);
@@ -111,7 +111,8 @@ float mx_hair_trimmed_logistic(float x, float s, float a, float b)
 
 float mx_hair_phi(int p, float gammaO, float gammaT)
 {
-    return 2.0 * p * gammaT - 2.0 * gammaO + p * M_PI;
+    float fP = float(p);
+    return 2.0 * fP * gammaT - 2.0 * gammaO + fP * M_PI;
 }
 
 float mx_hair_longitudinal_scattering(  // Mp
@@ -260,9 +261,7 @@ vec3 mx_chiang_hair_bsdf(
     vec3 F = vec3(0.0);
     for (int i = 0; i <= 3; ++i)
     {
-        if (all(lessThanEqual(tint[i], vec3(0.0))))
-            continue;
-
+        tint[i] = max(tint[i], vec3(0.0));
         float Mp = mx_hair_longitudinal_scattering(angles[i].x, angles[i].y, sinThetaO, cosThetaO, vs[i].x);
         float Np = (i == 3) ?  (1.0 / 2.0 * M_PI) : mx_hair_azimuthal_scattering(phi, i, vs[i].y, gammaO, gammaT);
         F += Mp * Np * tint[i] * Ap[i];

--- a/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
+++ b/libraries/pbrlib/genglsl/pbrlib_genglsl_impl.mtlx
@@ -26,7 +26,7 @@
   <implementation name="IM_sheen_bsdf_genglsl" nodedef="ND_sheen_bsdf" file="mx_sheen_bsdf.glsl" function="mx_sheen_bsdf" target="genglsl" />
 
   <!-- <chiang_hair_bsdf> -->
-  <implementation name="IM_chiang_hair_bsdf_genglsl" nodedef="ND_chiang_hair_bsdf" file="mx_hair_bsdf.glsl" function="mx_chiang_hair_bsdf" target="genglsl" />
+  <implementation name="IM_chiang_hair_bsdf_genglsl" nodedef="ND_chiang_hair_bsdf" file="mx_chiang_hair_bsdf.glsl" function="mx_chiang_hair_bsdf" target="genglsl" />
 
   <!-- <anisotropic_vdf> -->
   <implementation name="IM_anisotropic_vdf_genglsl" nodedef="ND_anisotropic_vdf" file="mx_anisotropic_vdf.glsl" function="mx_anisotropic_vdf" target="genglsl" />
@@ -78,12 +78,12 @@
   <implementation name="IM_blackbody_genglsl" nodedef="ND_blackbody" file="mx_blackbody.glsl" function="mx_blackbody" target="genglsl" />
 
   <!-- <deon_hair_absorption_from_melanin -->
-  <implementation name="IM_deon_hair_absorption_from_melanin_genglsl" nodedef="ND_deon_hair_absorption_from_melanin" file="mx_hair_bsdf.glsl" function="mx_deon_hair_absorption_from_melanin" target="genglsl" />
+  <implementation name="IM_deon_hair_absorption_from_melanin_genglsl" nodedef="ND_deon_hair_absorption_from_melanin" file="mx_chiang_hair_bsdf.glsl" function="mx_deon_hair_absorption_from_melanin" target="genglsl" />
 
   <!-- <chiang_hair_absorption_from_color -->
-  <implementation name="IM_chiang_hair_absorption_from_color_genglsl" nodedef="ND_chiang_hair_absorption_from_color" file="mx_hair_bsdf.glsl" function="mx_chiang_hair_absorption_from_color" target="genglsl" />
+  <implementation name="IM_chiang_hair_absorption_from_color_genglsl" nodedef="ND_chiang_hair_absorption_from_color" file="mx_chiang_hair_bsdf.glsl" function="mx_chiang_hair_absorption_from_color" target="genglsl" />
 
   <!-- <chiang_hair_roughness -->
-  <implementation name="IM_chiang_hair_roughness_genglsl" nodedef="ND_chiang_hair_roughness" file="mx_hair_bsdf.glsl" function="mx_chiang_hair_roughness" target="genglsl" />
+  <implementation name="IM_chiang_hair_roughness_genglsl" nodedef="ND_chiang_hair_roughness" file="mx_chiang_hair_bsdf.glsl" function="mx_chiang_hair_roughness" target="genglsl" />
 
 </materialx>

--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -100,6 +100,6 @@
   <implementation name="IM_chiang_hair_absorption_from_color_genmdl" nodedef="ND_chiang_hair_absorption_from_color" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_chiang_hair_absorption_from_color(mxp_color:{{color}}, mxp_azimuthal_roughness:{{azimuthal_roughness}})" function="mx_chiang_hair_absorption_from_color" target="genmdl" />
 
   <!-- <chiang_hair_roughness> -->
-  <implementation name="IM_chiang_hair_roughness_genmdl" nodedef="ND_chiang_hair_roughness" file="mx_hair_bsdf.glsl" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_chiang_hair_roughness(mxp_longitudinal:{{longitudinal}}, mxp_azimuthal:{{azimuthal}}, mxp_scale_TT:{{scale_TT}}, mxp_scale_TRT:{{scale_TRT}})" target="genmdl" />
+  <implementation name="IM_chiang_hair_roughness_genmdl" nodedef="ND_chiang_hair_roughness" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_chiang_hair_roughness(mxp_longitudinal:{{longitudinal}}, mxp_azimuthal:{{azimuthal}}, mxp_scale_TT:{{scale_TT}}, mxp_scale_TRT:{{scale_TRT}})" target="genmdl" />
 
 </materialx>


### PR DESCRIPTION
- Fix MSL and ESSL compatibility issues in the implementation of chiang_hair_bsdf, including integer-to-float conversions and computations of boolean arrays.
- Move the GLSL implementation of chiang_hair_bsdf to mx_chiang_hair_bsdf.glsl for consistency with other nodes.
- Remove a stray reference to the GLSL implementation in MDL.