### PR TITLE
Extend shader validation tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,13 +229,13 @@ jobs:
       run: |
         vcpkg/vcpkg install glslang --triplet=x64-windows
         glslangValidator.exe -v
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface --target essl --validator glslangValidator.exe
+        python python/Scripts/generateshader.py resources/Materials/Examples --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
+        python python/Scripts/generateshader.py resources/Materials/Examples --target essl --validator glslangValidator.exe
 
     - name: Shader Validation Tests (MacOS)
       if: matrix.test_shaders == 'ON' && runner.os == 'macOS'
       run: |
-        python python/Scripts/generateshader.py resources/Materials/Examples/StandardSurface --target msl --validator "xcrun metal --language=metal" --validatorArgs="-w"
+        python python/Scripts/generateshader.py resources/Materials/Examples --target msl --validator "xcrun metal --language=metal" --validatorArgs="-w"
 
     - name: Coverage Analysis Tests
       if: matrix.coverage_analysis == 'ON'

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 '''
-Utility to generate the shader for materials found in a MaterialX document. One file will be generated
-for each material / shader found. The currently supported target languages are GLSL, OSL, MDL and ESSL.
+Generate shader code for each renderable element in a MaterialX document or folder.
+The currently supported target languages are GLSL, ESSL, MSL, OSL, and MDL.
 '''
 
 import sys, os, argparse, subprocess
@@ -43,7 +43,7 @@ def getMaterialXFiles(rootPath):
     return filelist
 
 def main():
-    parser = argparse.ArgumentParser(description='Generate shader code for each material / shader in a document.')
+    parser = argparse.ArgumentParser(description='Generate shader code for each renderable element in a MaterialX document or folder.')
     parser.add_argument('--path', dest='paths', action='append', nargs='+', help='An additional absolute search path location (e.g. "/projects/MaterialX")')
     parser.add_argument('--library', dest='libraries', action='append', nargs='+', help='An additional relative path to a custom data library folder (e.g. "libraries/custom")')
     parser.add_argument('--target', dest='target', default='glsl', help='Target shader generator to use (e.g. "glsl, osl, mdl, essl, vulkan"). Default is glsl.')


### PR DESCRIPTION
This changelist extends the set of shader validation tests in GitHub CI from `StandardSurface` to the complete `Examples` folder, allowing more recent shading models (e.g. `open_pbr_surface`) and BSDF nodes (e.g. `chiang_hair_bsdf`) to be included as well.