### PR TITLE
Docstrings for PyMaterialXGen* classes.

### DIFF
--- a/source/MaterialXGenMsl/MslResourceBindingContext.h
+++ b/source/MaterialXGenMsl/MslResourceBindingContext.h
@@ -19,7 +19,7 @@ MATERIALX_NAMESPACE_BEGIN
 using MslResourceBindingContextPtr = shared_ptr<class MslResourceBindingContext>;
 
 /// @class MslResourceBindingContext
-/// Class representing a resource binding for Msl shader resources.
+/// Class representing a resource binding for MSL shader resources.
 class MX_GENMSL_API MslResourceBindingContext : public HwResourceBindingContext
 {
   public:

--- a/source/MaterialXGenMsl/MslShaderGenerator.h
+++ b/source/MaterialXGenMsl/MslShaderGenerator.h
@@ -20,7 +20,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 using MslShaderGeneratorPtr = shared_ptr<class MslShaderGenerator>;
 
-/// Base class for MSL (OpenGL Shading Language) code generation.
+/// Base class for MSL (Metal Shading Language) code generation.
 /// A generator for a specific MSL target should be derived from this class.
 class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
 {

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
@@ -25,6 +25,12 @@ void bindPyGlslShaderGenerator(py::module& mod)
         .def("generate", &mx::GlslShaderGenerator::generate)
         .def("getTarget", &mx::GlslShaderGenerator::getTarget)
         .def("getVersion", &mx::GlslShaderGenerator::getVersion);
+    mod.attr("GlslShaderGenerator").doc() = R"docstring(
+    Base class for GLSL (OpenGL Shading Language) code generation.
+
+    A generator for a specific GLSL target should be derived from this class.
+
+    :see: https://materialx.org/docs/api/class_glsl_shader_generator.html)docstring";
 }
 
 void bindPyGlslResourceBindingContext(py::module &mod)
@@ -34,6 +40,11 @@ void bindPyGlslResourceBindingContext(py::module &mod)
         .def(py::init<size_t, size_t>())
         .def("emitDirectives", &mx::GlslResourceBindingContext::emitDirectives)
         .def("emitResourceBindings", &mx::GlslResourceBindingContext::emitResourceBindings);
+    mod.attr("GlslResourceBindingContext").doc() = R"docstring(
+    Class representing a resource binding for GLSL (OpenGL Shading Language)
+    shader resources.
+
+    :see: https://materialx.org/docs/api/class_glsl_resource_binding_context.html)docstring";
 }
 
 // Essl shader generator bindings
@@ -46,6 +57,10 @@ void bindPyEsslShaderGenerator(py::module& mod)
         .def("generate", &mx::EsslShaderGenerator::generate)
         .def("getTarget", &mx::EsslShaderGenerator::getTarget)
         .def("getVersion", &mx::EsslShaderGenerator::getVersion);
+    mod.attr("EsslShaderGenerator").doc() = R"docstring(
+    An ESSL (OpenGL ES Shading Language) shader generator.
+
+    :see: https://materialx.org/docs/api/class_essl_shader_generator.html)docstring";
 }
 
 // Glsl Vulkan shader generator bindings
@@ -58,4 +73,8 @@ void bindPyVkShaderGenerator(py::module& mod)
         .def("generate", &mx::VkShaderGenerator::generate)
         .def("getTarget", &mx::VkShaderGenerator::getTarget)
         .def("getVersion", &mx::VkShaderGenerator::getVersion);
+    mod.attr("VkShaderGenerator").doc() = R"docstring(
+    A Vulkan GLSL (OpenGL Shading Language) shader generator.
+
+    :see: https://materialx.org/docs/api/class_vk_shader_generator.html)docstring";
 }

--- a/source/PyMaterialX/PyMaterialXGenMdl/PyMdlShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMdl/PyMdlShaderGenerator.cpp
@@ -17,4 +17,8 @@ void bindPyMdlShaderGenerator(py::module& mod)
         .def_static("create", &mx::MdlShaderGenerator::create)
         .def(py::init<>())
         .def("getTarget", &mx::MdlShaderGenerator::getTarget);
+    mod.attr("MdlShaderGenerator").doc() = R"docstring(
+    Shader generator for MDL (Material Definition Language).
+
+    :see: https://materialx.org/docs/api/class_mdl_shader_generator.html)docstring";
 }

--- a/source/PyMaterialX/PyMaterialXGenMsl/PyMslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMsl/PyMslShaderGenerator.cpp
@@ -23,6 +23,10 @@ void bindPyMslShaderGenerator(py::module& mod)
         .def("generate", &mx::MslShaderGenerator::generate)
         .def("getTarget", &mx::MslShaderGenerator::getTarget)
         .def("getVersion", &mx::MslShaderGenerator::getVersion);
+    mod.attr("MslShaderGenerator").doc() = R"docstring(
+    Base class for MSL (Metal Shading Language) code generation.
+
+    A generator for a specific MSL target should be derived from this class.)docstring";
 }
 
 void bindPyMslResourceBindingContext(py::module &mod)
@@ -32,4 +36,6 @@ void bindPyMslResourceBindingContext(py::module &mod)
         .def(py::init<size_t, size_t>())
         .def("emitDirectives", &mx::MslResourceBindingContext::emitDirectives)
         .def("emitResourceBindings", &mx::MslResourceBindingContext::emitResourceBindings);
+    mod.attr("MslResourceBindingContext").doc() = R"docstring(
+    Class representing a resource binding for MSL shader resources.)docstring";
 }

--- a/source/PyMaterialX/PyMaterialXGenOsl/PyOslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenOsl/PyOslShaderGenerator.cpp
@@ -23,4 +23,10 @@ void bindPyOslShaderGenerator(py::module& mod)
         .def(py::init<>())
         .def("getTarget", &mx::OslShaderGenerator::getTarget)
         .def("generate", &mx::OslShaderGenerator::generate);
+    mod.attr("OslShaderGenerator").doc() = R"docstring(
+    Base class for OSL (Open Shading Language) shader generators.
+
+    A generator for a specific OSL target should be derived from this class.
+
+    :see: https://materialx.org/docs/api/class_osl_shader_generator.html)docstring";
 }


### PR DESCRIPTION
Similar to https://github.com/AcademySoftwareFoundation/MaterialX/pull/2051, https://github.com/AcademySoftwareFoundation/MaterialX/pull/2061 and https://github.com/AcademySoftwareFoundation/MaterialX/pull/2063.

Also fixed a typo in `MslShaderGenerator.h`.

Split from #1567.

Update #342.