### PR TITLE
Improvements to shader validation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,13 +229,14 @@ jobs:
       run: |
         vcpkg/vcpkg install glslang --triplet=x64-windows
         glslangValidator.exe -v
-        python python/Scripts/generateshader.py resources/Materials/Examples --target glsl --validator glslangValidator.exe --vulkanGlsl True --validatorArgs="-V --aml"
+        python python/Scripts/generateshader.py resources/Materials/Examples --target glsl --validator glslangValidator.exe
         python python/Scripts/generateshader.py resources/Materials/Examples --target essl --validator glslangValidator.exe
 
     - name: Shader Validation Tests (MacOS)
       if: matrix.test_shaders == 'ON' && runner.os == 'macOS'
       run: |
         python python/Scripts/generateshader.py resources/Materials/Examples --target msl --validator "xcrun metal --language=metal" --validatorArgs="-w"
+        python python/Scripts/generateshader.py resources/Materials/TestSuite/stdlib --target msl --validator "xcrun metal --language=metal" --validatorArgs="-w"
 
     - name: Coverage Analysis Tests
       if: matrix.coverage_analysis == 'ON'

--- a/python/Scripts/generateshader.py
+++ b/python/Scripts/generateshader.py
@@ -139,13 +139,6 @@ def main():
         shadergen.setUnitSystem(unitsystem)
         genoptions.targetDistanceUnit = 'meter'
 
-        # Look for renderable nodes
-        nodes = mx_gen_shader.findRenderableElements(doc)
-        if not nodes:
-            nodes = doc.getMaterialNodes()
-            if not nodes:
-                nodes = doc.getNodesOfType(mx.SURFACE_SHADER_TYPE_STRING)
-
         pathPrefix = ''
         if opts.outputPath and os.path.exists(opts.outputPath):
             pathPrefix = opts.outputPath + os.path.sep
@@ -154,11 +147,11 @@ def main():
         print('- Shader output path: ' + pathPrefix)
 
         failedShaders = ""
-        for node in nodes:
-            nodeName = node.getName()
-            print('-- Generate code for node: ' + nodeName)
-            nodeName = mx.createValidName(nodeName)
-            shader = shadergen.generate(nodeName, node, context)        
+        for elem in mx_gen_shader.findRenderableElements(doc):
+            elemName = elem.getName()
+            print('-- Generate code for element: ' + elemName)
+            elemName = mx.createValidName(elemName)
+            shader = shadergen.generate(elemName, elem, context)        
             if shader:
                 # Use extension of .vert and .frag as it's type is
                 # recognized by glslangValidator
@@ -189,17 +182,17 @@ def main():
                     errors = validateCode(filename, opts.validator, opts.validatorArgs)
 
                 if errors != "":
-                    print("--- Validation failed for node: ", nodeName)
+                    print("--- Validation failed for element: ", elemName)
                     print("----------------------------")
                     print('--- Error log: ', errors)
                     print("----------------------------")
-                    failedShaders += (nodeName + ' ')
+                    failedShaders += (elemName + ' ')
                 else:
-                    print("--- Validation passed for node:", nodeName)
+                    print("--- Validation passed for element:", elemName)
 
             else:
-                print("--- Validation failed for node:", nodeName)
-                failedShaders += (nodeName + ' ')
+                print("--- Validation failed for element:", elemName)
+                failedShaders += (elemName + ' ')
 
         if failedShaders != "":
             sys.exit(-1)

--- a/resources/Materials/TestSuite/stdlib/convert/convert.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convert/convert.mtlx
@@ -1,8 +1,5 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <!-- Tuple conversion tests to feed into surfaceshader conversions 
-       Note that as surfaceshader performs most of the basic tuple
-       conversions they are not added explicitly here. -->
   <nodegraph name="convert_float_color4">
     <constant name="constant1" type="float">
       <input name="value" type="float" value="0.5000" />
@@ -30,85 +27,4 @@
     </convert>
     <output name="out" type="vector4" nodename="convert1" />
   </nodegraph>
-
-  <!-- Conversion to shader tests -->
-  <convert name="convert_boolean_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="boolean" value="true" />
-  </convert>
-  <surfacematerial name="material_convert_boolean_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_boolean_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_color3_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="color3" value="1, 1, 1" />
-  </convert>
-  <surfacematerial name="material_convert_color3_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_color3_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_color4_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="color4" value="1, 1, 1, 1" />
-  </convert>
-  <surfacematerial name="material_convert_color4_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_color4_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_float_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="float" value="1" />
-  </convert>
-  <surfacematerial name="material_convert_float_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_float_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_integer_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="integer" value="1" />
-  </convert>
-  <surfacematerial name="material_convert_integer_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_integer_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_vector2_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="vector2" value="1, 1" />
-  </convert>
-  <surfacematerial name="material_convert_vector2_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_vector2_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_vector3_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="vector3" value="1, 1, 1" />
-  </convert>
-  <surfacematerial name="material_convert_vector3_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_vector3_surfaceshader" />
-  </surfacematerial>
-
-  <convert name="convert_vector4_surfaceshader" type="surfaceshader" version="1.0">
-    <input name="in" type="vector4" value="1, 1, 1, 1" />
-  </convert>
-  <surfacematerial name="material_convert_vector4_surfaceshader_out" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_vector4_surfaceshader" />
-  </surfacematerial>
-
-  <!-- With upstream convert graphs to test remaining convert variants -->
-  <convert name="convert_vector4_surfaceshader2" type="surfaceshader" version="1.0">
-    <input name="in" type="vector4" nodegraph="convert_float_vector4" />
-  </convert>
-  <surfacematerial name="material_convert_vector4_surfaceshader_out2" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_vector4_surfaceshader2" />
-  </surfacematerial>
-
-  <convert name="convert_vector4_surfaceshader3" type="surfaceshader" version="1.0">
-    <input name="in" type="vector4" nodegraph="convert_color4_vector4" />
-  </convert>
-  <surfacematerial name="material_convert_vector4_surfaceshader_out3" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_vector4_surfaceshader3" />
-  </surfacematerial>
-
-  <convert name="convert_color4_surfaceshader2" type="surfaceshader" version="1.0">
-    <input name="in" type="color4" nodegraph="convert_float_color4" />
-  </convert>
-  <surfacematerial name="material_convert_color4_surfaceshader_out2" type="material">
-    <input name="surfaceshader" type="surfaceshader" nodename="convert_color4_surfaceshader2" />
-  </surfacematerial>
-
-
 </materialx>


### PR DESCRIPTION
This changelist makes a handful of improvements to the GitHub CI for shader validation, increasing the level of coverage for future changes.

- Add MSL validation for the stdlib test suite.
- Replace a non-working Vulkan GLSL test with standard GLSL.
- Fix an edge case in generateshader.py.
- Remove unneeded tests from the stdlib test suite.