### PR TITLE
Reduce duplication in MSL implementations

### DIFF
--- a/libraries/pbrlib/genmsl/pbrlib_genmsl_impl.mtlx
+++ b/libraries/pbrlib/genmsl/pbrlib_genmsl_impl.mtlx
@@ -1,33 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
 
-  <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genmsl" nodedef="ND_oren_nayar_diffuse_bsdf" file="../genglsl/mx_oren_nayar_diffuse_bsdf.glsl" function="mx_oren_nayar_diffuse_bsdf" target="genmsl" />
-
-  <!-- <burley_diffuse_bsdf> -->
-  <implementation name="IM_burley_diffuse_bsdf_genmsl" nodedef="ND_burley_diffuse_bsdf" file="../genglsl/mx_burley_diffuse_bsdf.glsl" function="mx_burley_diffuse_bsdf" target="genmsl" />
-
-  <!-- <translucent_bsdf> -->
-  <implementation name="IM_translucent_bsdf_genmsl" nodedef="ND_translucent_bsdf" file="../genglsl/mx_translucent_bsdf.glsl" function="mx_translucent_bsdf" target="genmsl" />
-
-  <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genmsl" nodedef="ND_dielectric_bsdf" file="../genglsl/mx_dielectric_bsdf.glsl" function="mx_dielectric_bsdf" target="genmsl" />
-
-  <!-- <conductor_bsdf> -->
-  <implementation name="IM_conductor_bsdf_genmsl" nodedef="ND_conductor_bsdf" file="../genglsl/mx_conductor_bsdf.glsl" function="mx_conductor_bsdf" target="genmsl" />
-
-  <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genmsl" nodedef="ND_generalized_schlick_bsdf" file="../genglsl/mx_generalized_schlick_bsdf.glsl" function="mx_generalized_schlick_bsdf" target="genmsl" />
-
-  <!-- <subsurface_bsdf> -->
-  <implementation name="IM_subsurface_bsdf_genmsl" nodedef="ND_subsurface_bsdf" file="../genglsl/mx_subsurface_bsdf.glsl" function="mx_subsurface_bsdf" target="genmsl" />
-
-  <!-- <sheen_bsdf> -->
-  <implementation name="IM_sheen_bsdf_genmsl" nodedef="ND_sheen_bsdf" file="../genglsl/mx_sheen_bsdf.glsl" function="mx_sheen_bsdf" target="genmsl" />
-
-  <!-- <anisotropic_vdf> -->
-  <implementation name="IM_anisotropic_vdf_genmsl" nodedef="ND_anisotropic_vdf" file="../genglsl/mx_anisotropic_vdf.glsl" function="mx_anisotropic_vdf" target="genmsl" />
-
   <!-- <layer> -->
   <implementation name="IM_layer_bsdf_genmsl" nodedef="ND_layer_bsdf" target="genmsl" />
   <implementation name="IM_layer_vdf_genmsl" nodedef="ND_layer_vdf" target="genmsl" />
@@ -46,29 +19,10 @@
   <implementation name="IM_multiply_edfC_genmsl" nodedef="ND_multiply_edfC" target="genmsl" />
   <implementation name="IM_multiply_edfF_genmsl" nodedef="ND_multiply_edfF" target="genmsl" />
 
-  <!-- <uniform_edf> -->
-  <implementation name="IM_uniform_edf_genmsl" nodedef="ND_uniform_edf" file="../genglsl/mx_uniform_edf.glsl" function="mx_uniform_edf" target="genmsl" />
-
   <!-- <surface> -->
   <implementation name="IM_surface_genmsl" nodedef="ND_surface" target="genmsl" />
 
-  <!-- <displacement> -->
-  <implementation name="IM_displacement_float_genmsl" nodedef="ND_displacement_float" file="../genglsl/mx_displacement_float.glsl" function="mx_displacement_float" target="genmsl" />
-  <implementation name="IM_displacement_vector3_genmsl" nodedef="ND_displacement_vector3" file="../genglsl/mx_displacement_vector3.glsl" function="mx_displacement_vector3" target="genmsl" />
-
   <!-- <light> -->
   <implementation name="IM_light_genmsl" nodedef="ND_light" target="genmsl" />
-
-  <!-- <roughness_anisotropy> -->
-  <implementation name="IM_roughness_anisotropy_genmsl" nodedef="ND_roughness_anisotropy" file="../genglsl/mx_roughness_anisotropy.glsl" function="mx_roughness_anisotropy" target="genmsl" />
-
-  <!-- <roughness_dual> -->
-  <implementation name="IM_roughness_dual_genmsl" nodedef="ND_roughness_dual" file="../genglsl/mx_roughness_dual.glsl" function="mx_roughness_dual" target="genmsl" />
-
-  <!-- <artistic_ior> -->
-  <implementation name="IM_artistic_ior_genmsl" nodedef="ND_artistic_ior" file="../genglsl/mx_artistic_ior.glsl" function="mx_artistic_ior" target="genmsl" />
-
-  <!-- <blackbody> -->
-  <implementation name="IM_blackbody_genmsl" nodedef="ND_blackbody" file="../genglsl/mx_blackbody.glsl" function="mx_blackbody" target="genmsl" />
 
 </materialx>

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -49,91 +49,9 @@
   <!-- Procedural nodes                                                         -->
   <!-- ======================================================================== -->
 
-  <!-- <constant> -->
-  <implementation name="IM_constant_float_genmsl" nodedef="ND_constant_float" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_color3_genmsl" nodedef="ND_constant_color3" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_color4_genmsl" nodedef="ND_constant_color4" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_vector2_genmsl" nodedef="ND_constant_vector2" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_vector3_genmsl" nodedef="ND_constant_vector3" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_vector4_genmsl" nodedef="ND_constant_vector4" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_boolean_genmsl" nodedef="ND_constant_boolean" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_integer_genmsl" nodedef="ND_constant_integer" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_matrix33_genmsl" nodedef="ND_constant_matrix33" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_matrix44_genmsl" nodedef="ND_constant_matrix44" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_string_genmsl" nodedef="ND_constant_string" target="genmsl" sourcecode="{{value}}" />
-  <implementation name="IM_constant_filename_genmsl" nodedef="ND_constant_filename" target="genmsl" sourcecode="{{value}}" />
-
-  <!-- <ramplr> -->
-  <implementation name="IM_ramplr_float_genmsl" nodedef="ND_ramplr_float" file="../genglsl/mx_ramplr_float.glsl" function="mx_ramplr_float" target="genmsl" />
-  <implementation name="IM_ramplr_color3_genmsl" nodedef="ND_ramplr_color3" file="../genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genmsl" />
-  <implementation name="IM_ramplr_color4_genmsl" nodedef="ND_ramplr_color4" file="../genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genmsl" />
-  <implementation name="IM_ramplr_vector2_genmsl" nodedef="ND_ramplr_vector2" file="../genglsl/mx_ramplr_vector2.glsl" function="mx_ramplr_vector2" target="genmsl" />
-  <implementation name="IM_ramplr_vector3_genmsl" nodedef="ND_ramplr_vector3" file="../genglsl/mx_ramplr_vector3.glsl" function="mx_ramplr_vector3" target="genmsl" />
-  <implementation name="IM_ramplr_vector4_genmsl" nodedef="ND_ramplr_vector4" file="../genglsl/mx_ramplr_vector4.glsl" function="mx_ramplr_vector4" target="genmsl" />
-
-  <!-- <ramptb> -->
-  <implementation name="IM_ramptb_float_genmsl" nodedef="ND_ramptb_float" file="../genglsl/mx_ramptb_float.glsl" function="mx_ramptb_float" target="genmsl" />
-  <implementation name="IM_ramptb_color3_genmsl" nodedef="ND_ramptb_color3" file="../genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genmsl" />
-  <implementation name="IM_ramptb_color4_genmsl" nodedef="ND_ramptb_color4" file="../genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genmsl" />
-  <implementation name="IM_ramptb_vector2_genmsl" nodedef="ND_ramptb_vector2" file="../genglsl/mx_ramptb_vector2.glsl" function="mx_ramptb_vector2" target="genmsl" />
-  <implementation name="IM_ramptb_vector3_genmsl" nodedef="ND_ramptb_vector3" file="../genglsl/mx_ramptb_vector3.glsl" function="mx_ramptb_vector3" target="genmsl" />
-  <implementation name="IM_ramptb_vector4_genmsl" nodedef="ND_ramptb_vector4" file="../genglsl/mx_ramptb_vector4.glsl" function="mx_ramptb_vector4" target="genmsl" />
-
-  <!-- <splitlr> -->
-  <implementation name="IM_splitlr_float_genmsl" nodedef="ND_splitlr_float" file="../genglsl/mx_splitlr_float.glsl" function="mx_splitlr_float" target="genmsl" />
-  <implementation name="IM_splitlr_color3_genmsl" nodedef="ND_splitlr_color3" file="../genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genmsl" />
-  <implementation name="IM_splitlr_color4_genmsl" nodedef="ND_splitlr_color4" file="../genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genmsl" />
-  <implementation name="IM_splitlr_vector2_genmsl" nodedef="ND_splitlr_vector2" file="../genglsl/mx_splitlr_vector2.glsl" function="mx_splitlr_vector2" target="genmsl" />
-  <implementation name="IM_splitlr_vector3_genmsl" nodedef="ND_splitlr_vector3" file="../genglsl/mx_splitlr_vector3.glsl" function="mx_splitlr_vector3" target="genmsl" />
-  <implementation name="IM_splitlr_vector4_genmsl" nodedef="ND_splitlr_vector4" file="../genglsl/mx_splitlr_vector4.glsl" function="mx_splitlr_vector4" target="genmsl" />
-
-  <!-- <splittb> -->
-  <implementation name="IM_splittb_float_genmsl" nodedef="ND_splittb_float" file="../genglsl/mx_splittb_float.glsl" function="mx_splittb_float" target="genmsl" />
-  <implementation name="IM_splittb_color3_genmsl" nodedef="ND_splittb_color3" file="../genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genmsl" />
-  <implementation name="IM_splittb_color4_genmsl" nodedef="ND_splittb_color4" file="../genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genmsl" />
-  <implementation name="IM_splittb_vector2_genmsl" nodedef="ND_splittb_vector2" file="../genglsl/mx_splittb_vector2.glsl" function="mx_splittb_vector2" target="genmsl" />
-  <implementation name="IM_splittb_vector3_genmsl" nodedef="ND_splittb_vector3" file="../genglsl/mx_splittb_vector3.glsl" function="mx_splittb_vector3" target="genmsl" />
-  <implementation name="IM_splittb_vector4_genmsl" nodedef="ND_splittb_vector4" file="../genglsl/mx_splittb_vector4.glsl" function="mx_splittb_vector4" target="genmsl" />
-
-  <!-- <noise2d> -->
-  <implementation name="IM_noise2d_float_genmsl" nodedef="ND_noise2d_float" file="../genglsl/mx_noise2d_float.glsl" function="mx_noise2d_float" target="genmsl" />
-  <implementation name="IM_noise2d_vector2_genmsl" nodedef="ND_noise2d_vector2" file="../genglsl/mx_noise2d_vector2.glsl" function="mx_noise2d_vector2" target="genmsl" />
-  <implementation name="IM_noise2d_vector3_genmsl" nodedef="ND_noise2d_vector3" file="../genglsl/mx_noise2d_vector3.glsl" function="mx_noise2d_vector3" target="genmsl" />
-  <implementation name="IM_noise2d_vector4_genmsl" nodedef="ND_noise2d_vector4" file="../genglsl/mx_noise2d_vector4.glsl" function="mx_noise2d_vector4" target="genmsl" />
-
-  <!-- <noise3d> -->
-  <implementation name="IM_noise3d_float_genmsl" nodedef="ND_noise3d_float" file="../genglsl/mx_noise3d_float.glsl" function="mx_noise3d_float" target="genmsl" />
-  <implementation name="IM_noise3d_vector2_genmsl" nodedef="ND_noise3d_vector2" file="../genglsl/mx_noise3d_vector2.glsl" function="mx_noise3d_vector2" target="genmsl" />
-  <implementation name="IM_noise3d_vector3_genmsl" nodedef="ND_noise3d_vector3" file="../genglsl/mx_noise3d_vector3.glsl" function="mx_noise3d_vector3" target="genmsl" />
-  <implementation name="IM_noise3d_vector4_genmsl" nodedef="ND_noise3d_vector4" file="../genglsl/mx_noise3d_vector4.glsl" function="mx_noise3d_vector4" target="genmsl" />
-
-  <!-- <fractal3d> -->
-  <implementation name="IM_fractal3d_float_genmsl" nodedef="ND_fractal3d_float" file="../genglsl/mx_fractal3d_float.glsl" function="mx_fractal3d_float" target="genmsl" />
-  <implementation name="IM_fractal3d_vector2_genmsl" nodedef="ND_fractal3d_vector2" file="../genglsl/mx_fractal3d_vector2.glsl" function="mx_fractal3d_vector2" target="genmsl" />
-  <implementation name="IM_fractal3d_vector3_genmsl" nodedef="ND_fractal3d_vector3" file="../genglsl/mx_fractal3d_vector3.glsl" function="mx_fractal3d_vector3" target="genmsl" />
-  <implementation name="IM_fractal3d_vector4_genmsl" nodedef="ND_fractal3d_vector4" file="../genglsl/mx_fractal3d_vector4.glsl" function="mx_fractal3d_vector4" target="genmsl" />
-
-  <!-- <cellnoise2d> -->
-  <implementation name="IM_cellnoise2d_float_genmsl" nodedef="ND_cellnoise2d_float" file="../genglsl/mx_cellnoise2d_float.glsl" function="mx_cellnoise2d_float" target="genmsl" />
-
-  <!-- <cellnoise3d> -->
-  <implementation name="IM_cellnoise3d_float_genmsl" nodedef="ND_cellnoise3d_float" file="../genglsl/mx_cellnoise3d_float.glsl" function="mx_cellnoise3d_float" target="genmsl" />
-
-  <!-- <worleynoise2d> -->
-  <implementation name="IM_worleynoise2d_float_genmsl" nodedef="ND_worleynoise2d_float" file="../genglsl/mx_worleynoise2d_float.glsl" function="mx_worleynoise2d_float" target="genmsl" />
-  <implementation name="IM_worleynoise2d_vector2_genmsl" nodedef="ND_worleynoise2d_vector2" file="../genglsl/mx_worleynoise2d_vector2.glsl" function="mx_worleynoise2d_vector2" target="genmsl" />
-  <implementation name="IM_worleynoise2d_vector3_genmsl" nodedef="ND_worleynoise2d_vector3" file="../genglsl/mx_worleynoise2d_vector3.glsl" function="mx_worleynoise2d_vector3" target="genmsl" />
-
-  <!-- <worleynoise3d> -->
-  <implementation name="IM_worleynoise3d_float_genmsl" nodedef="ND_worleynoise3d_float" file="../genglsl/mx_worleynoise3d_float.glsl" function="mx_worleynoise3d_float" target="genmsl" />
-  <implementation name="IM_worleynoise3d_vector2_genmsl" nodedef="ND_worleynoise3d_vector2" file="../genglsl/mx_worleynoise3d_vector2.glsl" function="mx_worleynoise3d_vector2" target="genmsl" />
-  <implementation name="IM_worleynoise3d_vector3_genmsl" nodedef="ND_worleynoise3d_vector3" file="../genglsl/mx_worleynoise3d_vector3.glsl" function="mx_worleynoise3d_vector3" target="genmsl" />
-
   <!-- ======================================================================== -->
   <!-- Global nodes                                                             -->
   <!-- ======================================================================== -->
-
-  <!-- <ambientocclusion> -->
 
   <!-- ======================================================================== -->
   <!-- Geometric nodes                                                          -->
@@ -186,72 +104,6 @@
   <!-- Math nodes                                                               -->
   <!-- ======================================================================== -->
 
-  <!-- <add> -->
-  <implementation name="IM_add_float_genmsl" nodedef="ND_add_float" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_integer_genmsl" nodedef="ND_add_integer" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_color3_genmsl" nodedef="ND_add_color3" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_color3FA_genmsl" nodedef="ND_add_color3FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_color4_genmsl" nodedef="ND_add_color4" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_color4FA_genmsl" nodedef="ND_add_color4FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_vector2_genmsl" nodedef="ND_add_vector2" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_vector2FA_genmsl" nodedef="ND_add_vector2FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_vector3_genmsl" nodedef="ND_add_vector3" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_vector3FA_genmsl" nodedef="ND_add_vector3FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_vector4_genmsl" nodedef="ND_add_vector4" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_vector4FA_genmsl" nodedef="ND_add_vector4FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_matrix33_genmsl" nodedef="ND_add_matrix33" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_matrix33FA_genmsl" nodedef="ND_add_matrix33FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_matrix44_genmsl" nodedef="ND_add_matrix44" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-  <implementation name="IM_add_matrix44FA_genmsl" nodedef="ND_add_matrix44FA" target="genmsl" sourcecode="{{in1}} + {{in2}}" />
-
-  <!-- <subtract> -->
-  <implementation name="IM_subtract_float_genmsl" nodedef="ND_subtract_float" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_integer_genmsl" nodedef="ND_subtract_integer" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_color3_genmsl" nodedef="ND_subtract_color3" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_color3FA_genmsl" nodedef="ND_subtract_color3FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_color4_genmsl" nodedef="ND_subtract_color4" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_color4FA_genmsl" nodedef="ND_subtract_color4FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_vector2_genmsl" nodedef="ND_subtract_vector2" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_vector2FA_genmsl" nodedef="ND_subtract_vector2FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_vector3_genmsl" nodedef="ND_subtract_vector3" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_vector3FA_genmsl" nodedef="ND_subtract_vector3FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_vector4_genmsl" nodedef="ND_subtract_vector4" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_vector4FA_genmsl" nodedef="ND_subtract_vector4FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_matrix33_genmsl" nodedef="ND_subtract_matrix33" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_matrix33FA_genmsl" nodedef="ND_subtract_matrix33FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_matrix44_genmsl" nodedef="ND_subtract_matrix44" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-  <implementation name="IM_subtract_matrix44FA_genmsl" nodedef="ND_subtract_matrix44FA" target="genmsl" sourcecode="{{in1}} - {{in2}}" />
-
-  <!-- <multiply> -->
-  <implementation name="IM_multiply_float_genmsl" nodedef="ND_multiply_float" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_color3_genmsl" nodedef="ND_multiply_color3" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_color3FA_genmsl" nodedef="ND_multiply_color3FA" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_color4_genmsl" nodedef="ND_multiply_color4" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_color4FA_genmsl" nodedef="ND_multiply_color4FA" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_vector2_genmsl" nodedef="ND_multiply_vector2" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_vector2FA_genmsl" nodedef="ND_multiply_vector2FA" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_vector3_genmsl" nodedef="ND_multiply_vector3" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_vector3FA_genmsl" nodedef="ND_multiply_vector3FA" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_vector4_genmsl" nodedef="ND_multiply_vector4" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_vector4FA_genmsl" nodedef="ND_multiply_vector4FA" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_matrix33_genmsl" nodedef="ND_multiply_matrix33" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-  <implementation name="IM_multiply_matrix44_genmsl" nodedef="ND_multiply_matrix44" target="genmsl" sourcecode="{{in1}} * {{in2}}" />
-
-  <!-- <divide> -->
-  <implementation name="IM_divide_float_genmsl" nodedef="ND_divide_float" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_color3_genmsl" nodedef="ND_divide_color3" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_color3FA_genmsl" nodedef="ND_divide_color3FA" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_color4_genmsl" nodedef="ND_divide_color4" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_color4FA_genmsl" nodedef="ND_divide_color4FA" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_vector2_genmsl" nodedef="ND_divide_vector2" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_vector2FA_genmsl" nodedef="ND_divide_vector2FA" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_vector3_genmsl" nodedef="ND_divide_vector3" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_vector3FA_genmsl" nodedef="ND_divide_vector3FA" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_vector4_genmsl" nodedef="ND_divide_vector4" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_vector4FA_genmsl" nodedef="ND_divide_vector4FA" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_matrix33_genmsl" nodedef="ND_divide_matrix33" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-  <implementation name="IM_divide_matrix44_genmsl" nodedef="ND_divide_matrix44" target="genmsl" sourcecode="{{in1}} / {{in2}}" />
-
   <!-- <modulo> -->
   <implementation name="IM_modulo_float_genmsl" nodedef="ND_modulo_float" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
   <implementation name="IM_modulo_color3_genmsl" nodedef="ND_modulo_color3" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
@@ -265,176 +117,6 @@
   <implementation name="IM_modulo_vector4_genmsl" nodedef="ND_modulo_vector4" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
   <implementation name="IM_modulo_vector4FA_genmsl" nodedef="ND_modulo_vector4FA" target="genmsl" sourcecode="mx_mod({{in1}}, {{in2}})" />
 
-  <!-- <invert> -->
-  <implementation name="IM_invert_float_genmsl" nodedef="ND_invert_float" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_color3_genmsl" nodedef="ND_invert_color3" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_color3FA_genmsl" nodedef="ND_invert_color3FA" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_color4_genmsl" nodedef="ND_invert_color4" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_color4FA_genmsl" nodedef="ND_invert_color4FA" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_vector2_genmsl" nodedef="ND_invert_vector2" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_vector2FA_genmsl" nodedef="ND_invert_vector2FA" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_vector3_genmsl" nodedef="ND_invert_vector3" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_vector3FA_genmsl" nodedef="ND_invert_vector3FA" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_vector4_genmsl" nodedef="ND_invert_vector4" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-  <implementation name="IM_invert_vector4FA_genmsl" nodedef="ND_invert_vector4FA" target="genmsl" sourcecode="{{amount}} - {{in}}" />
-
-  <!-- <absval> -->
-  <implementation name="IM_absval_float_genmsl" nodedef="ND_absval_float" target="genmsl" sourcecode="abs({{in}})" />
-  <implementation name="IM_absval_color3_genmsl" nodedef="ND_absval_color3" target="genmsl" sourcecode="abs({{in}})" />
-  <implementation name="IM_absval_color4_genmsl" nodedef="ND_absval_color4" target="genmsl" sourcecode="abs({{in}})" />
-  <implementation name="IM_absval_vector2_genmsl" nodedef="ND_absval_vector2" target="genmsl" sourcecode="abs({{in}})" />
-  <implementation name="IM_absval_vector3_genmsl" nodedef="ND_absval_vector3" target="genmsl" sourcecode="abs({{in}})" />
-  <implementation name="IM_absval_vector4_genmsl" nodedef="ND_absval_vector4" target="genmsl" sourcecode="abs({{in}})" />
-
-  <!-- <floor> -->
-  <implementation name="IM_floor_float_genmsl" nodedef="ND_floor_float" target="genmsl" sourcecode="floor({{in}})" />
-  <implementation name="IM_floor_color3_genmsl" nodedef="ND_floor_color3" target="genmsl" sourcecode="floor({{in}})" />
-  <implementation name="IM_floor_color4_genmsl" nodedef="ND_floor_color4" target="genmsl" sourcecode="floor({{in}})" />
-  <implementation name="IM_floor_vector2_genmsl" nodedef="ND_floor_vector2" target="genmsl" sourcecode="floor({{in}})" />
-  <implementation name="IM_floor_vector3_genmsl" nodedef="ND_floor_vector3" target="genmsl" sourcecode="floor({{in}})" />
-  <implementation name="IM_floor_vector4_genmsl" nodedef="ND_floor_vector4" target="genmsl" sourcecode="floor({{in}})" />
-  <implementation name="IM_floor_integer_genmsl" nodedef="ND_floor_integer" target="genmsl" sourcecode="int(floor({{in}}))" />
-
-  <!-- <ceil> -->
-  <implementation name="IM_ceil_float_genmsl" nodedef="ND_ceil_float" target="genmsl" sourcecode="ceil({{in}})" />
-  <implementation name="IM_ceil_color3_genmsl" nodedef="ND_ceil_color3" target="genmsl" sourcecode="ceil({{in}})" />
-  <implementation name="IM_ceil_color4_genmsl" nodedef="ND_ceil_color4" target="genmsl" sourcecode="ceil({{in}})" />
-  <implementation name="IM_ceil_vector2_genmsl" nodedef="ND_ceil_vector2" target="genmsl" sourcecode="ceil({{in}})" />
-  <implementation name="IM_ceil_vector3_genmsl" nodedef="ND_ceil_vector3" target="genmsl" sourcecode="ceil({{in}})" />
-  <implementation name="IM_ceil_vector4_genmsl" nodedef="ND_ceil_vector4" target="genmsl" sourcecode="ceil({{in}})" />
-  <implementation name="IM_ceil_integer_genmsl" nodedef="ND_ceil_integer" target="genmsl" sourcecode="int(ceil({{in}}))" />
-
-  <!-- <round> -->
-  <implementation name="IM_round_float_genmsl" nodedef="ND_round_float" target="genmsl" sourcecode="round({{in}})" />
-  <implementation name="IM_round_color3_genmsl" nodedef="ND_round_color3" target="genmsl" sourcecode="round({{in}})" />
-  <implementation name="IM_round_color4_genmsl" nodedef="ND_round_color4" target="genmsl" sourcecode="round({{in}})" />
-  <implementation name="IM_round_vector2_genmsl" nodedef="ND_round_vector2" target="genmsl" sourcecode="round({{in}})" />
-  <implementation name="IM_round_vector3_genmsl" nodedef="ND_round_vector3" target="genmsl" sourcecode="round({{in}})" />
-  <implementation name="IM_round_vector4_genmsl" nodedef="ND_round_vector4" target="genmsl" sourcecode="round({{in}})" />
-  <implementation name="IM_round_integer_genmsl" nodedef="ND_round_integer" target="genmsl" sourcecode="int(round({{in}}))" />
-
-  <!-- <power> -->
-  <implementation name="IM_power_float_genmsl" nodedef="ND_power_float" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
-  <implementation name="IM_power_color3_genmsl" nodedef="ND_power_color3" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
-  <implementation name="IM_power_color3FA_genmsl" nodedef="ND_power_color3FA" target="genmsl" sourcecode="pow({{in1}}, vec3({{in2}}))" />
-  <implementation name="IM_power_color4_genmsl" nodedef="ND_power_color4" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
-  <implementation name="IM_power_color4FA_genmsl" nodedef="ND_power_color4FA" target="genmsl" sourcecode="pow({{in1}}, vec4({{in2}}))" />
-  <implementation name="IM_power_vector2_genmsl" nodedef="ND_power_vector2" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
-  <implementation name="IM_power_vector2FA_genmsl" nodedef="ND_power_vector2FA" target="genmsl" sourcecode="pow({{in1}}, vec2({{in2}}))" />
-  <implementation name="IM_power_vector3_genmsl" nodedef="ND_power_vector3" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
-  <implementation name="IM_power_vector3FA_genmsl" nodedef="ND_power_vector3FA" target="genmsl" sourcecode="pow({{in1}}, vec3({{in2}}))" />
-  <implementation name="IM_power_vector4_genmsl" nodedef="ND_power_vector4" target="genmsl" sourcecode="pow({{in1}}, {{in2}})" />
-  <implementation name="IM_power_vector4FA_genmsl" nodedef="ND_power_vector4FA" target="genmsl" sourcecode="pow({{in1}}, vec4({{in2}}))" />
-
-  <!-- <sin>, <cos>, <tan>, <asin>, <acos>, <atan2> -->
-  <implementation name="IM_sin_float_genmsl" nodedef="ND_sin_float" target="genmsl" sourcecode="mx_sin({{in}})" />
-  <implementation name="IM_cos_float_genmsl" nodedef="ND_cos_float" target="genmsl" sourcecode="mx_cos({{in}})" />
-  <implementation name="IM_tan_float_genmsl" nodedef="ND_tan_float" target="genmsl" sourcecode="mx_tan({{in}})" />
-  <implementation name="IM_asin_float_genmsl" nodedef="ND_asin_float" target="genmsl" sourcecode="mx_asin({{in}})" />
-  <implementation name="IM_acos_float_genmsl" nodedef="ND_acos_float" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_float_genmsl" nodedef="ND_atan2_float" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
-  <implementation name="IM_sin_vector2_genmsl" nodedef="ND_sin_vector2" target="genmsl" sourcecode="mx_sin({{in}})" />
-  <implementation name="IM_cos_vector2_genmsl" nodedef="ND_cos_vector2" target="genmsl" sourcecode="mx_cos({{in}})" />
-  <implementation name="IM_tan_vector2_genmsl" nodedef="ND_tan_vector2" target="genmsl" sourcecode="mx_tan({{in}})" />
-  <implementation name="IM_asin_vector2_genmsl" nodedef="ND_asin_vector2" target="genmsl" sourcecode="mx_asin({{in}})" />
-  <implementation name="IM_acos_vector2_genmsl" nodedef="ND_acos_vector2" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector2_genmsl" nodedef="ND_atan2_vector2" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
-  <implementation name="IM_sin_vector3_genmsl" nodedef="ND_sin_vector3" target="genmsl" sourcecode="mx_sin({{in}})" />
-  <implementation name="IM_cos_vector3_genmsl" nodedef="ND_cos_vector3" target="genmsl" sourcecode="mx_cos({{in}})" />
-  <implementation name="IM_tan_vector3_genmsl" nodedef="ND_tan_vector3" target="genmsl" sourcecode="mx_tan({{in}})" />
-  <implementation name="IM_asin_vector3_genmsl" nodedef="ND_asin_vector3" target="genmsl" sourcecode="mx_asin({{in}})" />
-  <implementation name="IM_acos_vector3_genmsl" nodedef="ND_acos_vector3" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector3_genmsl" nodedef="ND_atan2_vector3" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
-  <implementation name="IM_sin_vector4_genmsl" nodedef="ND_sin_vector4" target="genmsl" sourcecode="mx_sin({{in}})" />
-  <implementation name="IM_cos_vector4_genmsl" nodedef="ND_cos_vector4" target="genmsl" sourcecode="mx_cos({{in}})" />
-  <implementation name="IM_tan_vector4_genmsl" nodedef="ND_tan_vector4" target="genmsl" sourcecode="mx_tan({{in}})" />
-  <implementation name="IM_asin_vector4_genmsl" nodedef="ND_asin_vector4" target="genmsl" sourcecode="mx_asin({{in}})" />
-  <implementation name="IM_acos_vector4_genmsl" nodedef="ND_acos_vector4" target="genmsl" sourcecode="mx_acos({{in}})" />
-  <implementation name="IM_atan2_vector4_genmsl" nodedef="ND_atan2_vector4" target="genmsl" sourcecode="mx_atan({{iny}}, {{inx}})" />
-
-  <!-- <sqrt> -->
-  <implementation name="IM_sqrt_float_genmsl" nodedef="ND_sqrt_float" target="genmsl" sourcecode="sqrt({{in}})" />
-  <implementation name="IM_sqrt_vector2_genmsl" nodedef="ND_sqrt_vector2" target="genmsl" sourcecode="sqrt({{in}})" />
-  <implementation name="IM_sqrt_vector3_genmsl" nodedef="ND_sqrt_vector3" target="genmsl" sourcecode="sqrt({{in}})" />
-  <implementation name="IM_sqrt_vector4_genmsl" nodedef="ND_sqrt_vector4" target="genmsl" sourcecode="sqrt({{in}})" />
-
-  <!-- <ln> -->
-  <implementation name="IM_ln_float_genmsl" nodedef="ND_ln_float" target="genmsl" sourcecode="log({{in}})" />
-  <implementation name="IM_ln_vector2_genmsl" nodedef="ND_ln_vector2" target="genmsl" sourcecode="log({{in}})" />
-  <implementation name="IM_ln_vector3_genmsl" nodedef="ND_ln_vector3" target="genmsl" sourcecode="log({{in}})" />
-  <implementation name="IM_ln_vector4_genmsl" nodedef="ND_ln_vector4" target="genmsl" sourcecode="log({{in}})" />
-
-  <!-- <exp> -->
-  <implementation name="IM_exp_float_genmsl" nodedef="ND_exp_float" target="genmsl" sourcecode="exp({{in}})" />
-  <implementation name="IM_exp_vector2_genmsl" nodedef="ND_exp_vector2" target="genmsl" sourcecode="exp({{in}})" />
-  <implementation name="IM_exp_vector3_genmsl" nodedef="ND_exp_vector3" target="genmsl" sourcecode="exp({{in}})" />
-  <implementation name="IM_exp_vector4_genmsl" nodedef="ND_exp_vector4" target="genmsl" sourcecode="exp({{in}})" />
-
-  <!-- sign -->
-  <implementation name="IM_sign_float_genmsl" nodedef="ND_sign_float" target="genmsl" sourcecode="sign({{in}})" />
-  <implementation name="IM_sign_color3_genmsl" nodedef="ND_sign_color3" target="genmsl" sourcecode="sign({{in}})" />
-  <implementation name="IM_sign_color4_genmsl" nodedef="ND_sign_color4" target="genmsl" sourcecode="sign({{in}})" />
-  <implementation name="IM_sign_vector2_genmsl" nodedef="ND_sign_vector2" target="genmsl" sourcecode="sign({{in}})" />
-  <implementation name="IM_sign_vector3_genmsl" nodedef="ND_sign_vector3" target="genmsl" sourcecode="sign({{in}})" />
-  <implementation name="IM_sign_vector4_genmsl" nodedef="ND_sign_vector4" target="genmsl" sourcecode="sign({{in}})" />
-
-  <!-- <clamp> -->
-  <implementation name="IM_clamp_float_genmsl" nodedef="ND_clamp_float" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color3_genmsl" nodedef="ND_clamp_color3" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color3FA_genmsl" nodedef="ND_clamp_color3FA" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color4_genmsl" nodedef="ND_clamp_color4" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color4FA_genmsl" nodedef="ND_clamp_color4FA" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector2_genmsl" nodedef="ND_clamp_vector2" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector2FA_genmsl" nodedef="ND_clamp_vector2FA" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector3_genmsl" nodedef="ND_clamp_vector3" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector3FA_genmsl" nodedef="ND_clamp_vector3FA" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector4_genmsl" nodedef="ND_clamp_vector4" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector4FA_genmsl" nodedef="ND_clamp_vector4FA" target="genmsl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-
-  <!-- <min> -->
-  <implementation name="IM_min_float_genmsl" nodedef="ND_min_float" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_color3_genmsl" nodedef="ND_min_color3" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_color3FA_genmsl" nodedef="ND_min_color3FA" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_color4_genmsl" nodedef="ND_min_color4" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_color4FA_genmsl" nodedef="ND_min_color4FA" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_vector2_genmsl" nodedef="ND_min_vector2" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_vector2FA_genmsl" nodedef="ND_min_vector2FA" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_vector3_genmsl" nodedef="ND_min_vector3" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_vector3FA_genmsl" nodedef="ND_min_vector3FA" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_vector4_genmsl" nodedef="ND_min_vector4" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-  <implementation name="IM_min_vector4FA_genmsl" nodedef="ND_min_vector4FA" target="genmsl" sourcecode="min({{in1}}, {{in2}})" />
-
-  <!-- <max> -->
-  <implementation name="IM_max_float_genmsl" nodedef="ND_max_float" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_color3_genmsl" nodedef="ND_max_color3" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_color3FA_genmsl" nodedef="ND_max_color3FA" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_color4_genmsl" nodedef="ND_max_color4" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_color4FA_genmsl" nodedef="ND_max_color4FA" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_vector2_genmsl" nodedef="ND_max_vector2" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_vector2FA_genmsl" nodedef="ND_max_vector2FA" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_vector3_genmsl" nodedef="ND_max_vector3" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_vector3FA_genmsl" nodedef="ND_max_vector3FA" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_vector4_genmsl" nodedef="ND_max_vector4" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-  <implementation name="IM_max_vector4FA_genmsl" nodedef="ND_max_vector4FA" target="genmsl" sourcecode="max({{in1}}, {{in2}})" />
-
-  <!-- <normalize> -->
-  <implementation name="IM_normalize_vector2_genmsl" nodedef="ND_normalize_vector2" target="genmsl" sourcecode="normalize({{in}})" />
-  <implementation name="IM_normalize_vector3_genmsl" nodedef="ND_normalize_vector3" target="genmsl" sourcecode="normalize({{in}})" />
-  <implementation name="IM_normalize_vector4_genmsl" nodedef="ND_normalize_vector4" target="genmsl" sourcecode="normalize({{in}})" />
-
-  <!-- <magnitude> -->
-  <implementation name="IM_magnitude_vector2_genmsl" nodedef="ND_magnitude_vector2" target="genmsl" sourcecode="length({{in}})" />
-  <implementation name="IM_magnitude_vector3_genmsl" nodedef="ND_magnitude_vector3" target="genmsl" sourcecode="length({{in}})" />
-  <implementation name="IM_magnitude_vector4_genmsl" nodedef="ND_magnitude_vector4" target="genmsl" sourcecode="length({{in}})" />
-
-  <!-- <dotproduct> -->
-  <implementation name="IM_dotproduct_vector2_genmsl" nodedef="ND_dotproduct_vector2" target="genmsl" sourcecode="dot({{in1}}, {{in2}})" />
-  <implementation name="IM_dotproduct_vector3_genmsl" nodedef="ND_dotproduct_vector3" target="genmsl" sourcecode="dot({{in1}}, {{in2}})" />
-  <implementation name="IM_dotproduct_vector4_genmsl" nodedef="ND_dotproduct_vector4" target="genmsl" sourcecode="dot({{in1}}, {{in2}})" />
-
-  <!-- <crossproduct> -->
-  <implementation name="IM_crossproduct_vector3_genmsl" nodedef="ND_crossproduct_vector3" target="genmsl" sourcecode="cross({{in1}}, {{in2}})" />
-
   <!-- <transformpoint> -->
   <implementation name="IM_transformpoint_vector3_genmsl" nodedef="ND_transformpoint_vector3" target="genmsl" />
 
@@ -444,87 +126,20 @@
   <!-- <transformnormal> -->
   <implementation name="IM_transformnormal_vector3_genmsl" nodedef="ND_transformnormal_vector3" target="genmsl" />
 
-  <!-- <transformmatrix> -->
-  <implementation name="IM_transformmatrix_vector2M3_genmsl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="../genglsl/mx_transformmatrix_vector2M3.glsl" target="genmsl" />
-  <implementation name="IM_transformmatrix_vector3_genmsl" nodedef="ND_transformmatrix_vector3" target="genmsl" sourcecode="{{mat}} * {{in}}" />
-  <implementation name="IM_transformmatrix_vector3M4_genmsl" nodedef="ND_transformmatrix_vector3M4" function="mx_transformmatrix_vector3M4" file="../genglsl/mx_transformmatrix_vector3M4.glsl" target="genmsl" />
-  <implementation name="IM_transformmatrix_vector4_genmsl" nodedef="ND_transformmatrix_vector4" target="genmsl" sourcecode="{{mat}} * {{in}}" />
-
-  <!-- <transpose> -->
-  <implementation name="IM_transpose_matrix33_genmsl" nodedef="ND_transpose_matrix33" target="genmsl" sourcecode="transpose({{in}})" />
-  <implementation name="IM_transpose_matrix44_genmsl" nodedef="ND_transpose_matrix44" target="genmsl" sourcecode="transpose({{in}})" />
-
-  <!-- <determinant> -->
-  <implementation name="IM_determinant_matrix33_genmsl" nodedef="ND_determinant_matrix33" target="genmsl" sourcecode="determinant({{in}})" />
-  <implementation name="IM_determinant_matrix44_genmsl" nodedef="ND_determinant_matrix44" target="genmsl" sourcecode="determinant({{in}})" />
-
   <!-- <invertmatrix> -->
   <implementation name="IM_invertmatrix_matrix33_genmsl" nodedef="ND_invertmatrix_matrix33" target="genmsl" sourcecode="mx_inverse({{in}})" />
   <implementation name="IM_invertmatrix_matrix44_genmsl" nodedef="ND_invertmatrix_matrix44" target="genmsl" sourcecode="mx_inverse({{in}})" />
-
-  <!-- <rotate2d> -->
-  <implementation name="IM_rotate2d_vector2_genmsl" nodedef="ND_rotate2d_vector2" file="../genglsl/mx_rotate_vector2.glsl" function="mx_rotate_vector2" target="genmsl" />
-
-  <!-- <rotate3d> -->
-  <implementation name="IM_rotate3d_vector3_genmsl" nodedef="ND_rotate3d_vector3" file="../genglsl/mx_rotate_vector3.glsl" function="mx_rotate_vector3" target="genmsl" />
 
   <!-- ======================================================================== -->
   <!-- Adjustment nodes                                                         -->
   <!-- ======================================================================== -->
 
-  <!-- <contrast> -->
-
-  <!-- <remap> -->
-  <implementation name="IM_remap_float_genmsl" nodedef="ND_remap_float" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_color3_genmsl" nodedef="ND_remap_color3" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_color3FA_genmsl" nodedef="ND_remap_color3FA" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_color4_genmsl" nodedef="ND_remap_color4" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_color4FA_genmsl" nodedef="ND_remap_color4FA" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_vector2_genmsl" nodedef="ND_remap_vector2" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_vector2FA_genmsl" nodedef="ND_remap_vector2FA" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_vector3_genmsl" nodedef="ND_remap_vector3" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_vector3FA_genmsl" nodedef="ND_remap_vector3FA" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_vector4_genmsl" nodedef="ND_remap_vector4" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-  <implementation name="IM_remap_vector4FA_genmsl" nodedef="ND_remap_vector4FA" target="genmsl" sourcecode="{{outlow}} + ({{in}} - {{inlow}}) * ({{outhigh}} - {{outlow}}) / ({{inhigh}} - {{inlow}})" />
-
   <!-- <smoothstep> -->
   <implementation name="IM_smoothstep_float_genmsl" nodedef="ND_smoothstep_float" file="mx_smoothstep_float.metal" function="mx_smoothstep_float" target="genmsl" />
-
-  <!-- <luminance> -->
-  <implementation name="IM_luminance_color3_genmsl" nodedef="ND_luminance_color3" file="../genglsl/mx_luminance_color3.glsl" function="mx_luminance_color3" target="genmsl" />
-  <implementation name="IM_luminance_color4_genmsl" nodedef="ND_luminance_color4" file="../genglsl/mx_luminance_color4.glsl" function="mx_luminance_color4" target="genmsl" />
-
-  <!-- <rgbtohsv> -->
-  <implementation name="IM_rgbtohsv_color3_genmsl" nodedef="ND_rgbtohsv_color3" file="../genglsl/mx_rgbtohsv_color3.glsl" function="mx_rgbtohsv_color3" target="genmsl" />
-  <implementation name="IM_rgbtohsv_color4_genmsl" nodedef="ND_rgbtohsv_color4" file="../genglsl/mx_rgbtohsv_color4.glsl" function="mx_rgbtohsv_color4" target="genmsl" />
-
-  <!-- <hsvtorgb> -->
-  <implementation name="IM_hsvtorgb_color3_genmsl" nodedef="ND_hsvtorgb_color3" file="../genglsl/mx_hsvtorgb_color3.glsl" function="mx_hsvtorgb_color3" target="genmsl" />
-  <implementation name="IM_hsvtorgb_color4_genmsl" nodedef="ND_hsvtorgb_color4" file="../genglsl/mx_hsvtorgb_color4.glsl" function="mx_hsvtorgb_color4" target="genmsl" />
 
   <!-- ======================================================================== -->
   <!-- Compositing nodes                                                        -->
   <!-- ======================================================================== -->
-
-  <!-- <premult> -->
-  <implementation name="IM_premult_color4_genmsl" nodedef="ND_premult_color4" file="../genglsl/mx_premult_color4.glsl" function="mx_premult_color4" target="genmsl" />
-  <!-- <unpremult> -->
-  <implementation name="IM_unpremult_color4_genmsl" nodedef="ND_unpremult_color4" file="../genglsl/mx_unpremult_color4.glsl" function="mx_unpremult_color4" target="genmsl" />
-
-  <!-- <plus> -->
-  <implementation name="IM_plus_float_genmsl" nodedef="ND_plus_float" target="genmsl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_plus_color3_genmsl" nodedef="ND_plus_color3" target="genmsl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_plus_color4_genmsl" nodedef="ND_plus_color4" target="genmsl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-
-  <!-- <minus> -->
-  <implementation name="IM_minus_float_genmsl" nodedef="ND_minus_float" target="genmsl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_minus_color3_genmsl" nodedef="ND_minus_color3" target="genmsl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_minus_color4_genmsl" nodedef="ND_minus_color4" target="genmsl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-
-  <!-- <difference> -->
-  <implementation name="IM_difference_float_genmsl" nodedef="ND_difference_float" target="genmsl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_difference_color3_genmsl" nodedef="ND_difference_color3" target="genmsl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_difference_color4_genmsl" nodedef="ND_difference_color4" target="genmsl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
 
   <!-- <burn> -->
   <implementation name="IM_burn_float_genmsl" nodedef="ND_burn_float" file="mx_burn_float.metal" function="mx_burn_float" target="genmsl" />
@@ -536,140 +151,13 @@
   <implementation name="IM_dodge_color3_genmsl" nodedef="ND_dodge_color3" file="mx_dodge_color3.metal" function="mx_dodge_color3" target="genmsl" />
   <implementation name="IM_dodge_color4_genmsl" nodedef="ND_dodge_color4" file="mx_dodge_color4.metal" function="mx_dodge_color4" target="genmsl" />
 
-  <!-- <screen> -->
-  <implementation name="IM_screen_float_genmsl" nodedef="ND_screen_float" target="genmsl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1.0 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_screen_color3_genmsl" nodedef="ND_screen_color3" target="genmsl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1.0 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_screen_color4_genmsl" nodedef="ND_screen_color4" target="genmsl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1.0 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})" />
-
-  <!-- <disjointover> -->
-  <implementation name="IM_disjointover_color4_genmsl" nodedef="ND_disjointover_color4" file="../genglsl/mx_disjointover_color4.glsl" function="mx_disjointover_color4" target="genmsl" />
-
-  <!-- <in> -->
-  <implementation name="IM_in_color4_genmsl" nodedef="ND_in_color4" target="genmsl" sourcecode="({{fg}}*{{bg}}.a  * {{mix}}) + ({{bg}} * (1.0-{{mix}}));" />
-
-  <!-- <mask> -->
-  <implementation name="IM_mask_color4_genmsl" nodedef="ND_mask_color4" target="genmsl" sourcecode="({{bg}}*{{fg}}.a  * {{mix}}) + ({{bg}} * (1.0-{{mix}}));" />
-
-  <!-- <matte> -->
-  <implementation name="IM_matte_color4_genmsl" nodedef="ND_matte_color4" target="genmsl" sourcecode="vec4( {{fg}}.xyz*{{fg}}.w + {{bg}}.xyz*(1.0-{{fg}}.w), {{fg}}.w + ({{bg}}.w*(1.0-{{fg}}.w)) ) * {{mix}} + ({{bg}} * (1.0-{{mix}}));" />
-
-  <!-- <out> -->
-  <implementation name="IM_out_color4_genmsl" nodedef="ND_out_color4" target="genmsl" sourcecode="({{fg}}*(1.0-{{bg}}.a)  * {{mix}}) + ({{bg}} * (1.0-{{mix}}));" />
-
-  <!-- <over> -->
-  <implementation name="IM_over_color4_genmsl" nodedef="ND_over_color4" target="genmsl" sourcecode="({{fg}} + ({{bg}}*(1.0-{{fg}}[3]))) * {{mix}} + {{bg}} * (1.0-{{mix}})" />
-
-  <!-- <inside> -->
-  <implementation name="IM_inside_float_genmsl" nodedef="ND_inside_float" target="genmsl" sourcecode="{{in}} * {{mask}}" />
-  <implementation name="IM_inside_color3_genmsl" nodedef="ND_inside_color3" target="genmsl" sourcecode="{{in}} * {{mask}}" />
-  <implementation name="IM_inside_color4_genmsl" nodedef="ND_inside_color4" target="genmsl" sourcecode="{{in}} * {{mask}}" />
-
-  <!-- <outside> -->
-  <implementation name="IM_outside_float_genmsl" nodedef="ND_outside_float" target="genmsl" sourcecode="{{in}} * (1.0 - {{mask}})" />
-  <implementation name="IM_outside_color3_genmsl" nodedef="ND_outside_color3" target="genmsl" sourcecode="{{in}} * (1.0 - {{mask}})" />
-  <implementation name="IM_outside_color4_genmsl" nodedef="ND_outside_color4" target="genmsl" sourcecode="{{in}} * (1.0 - {{mask}})" />
-
-  <!-- <mix> -->
-  <implementation name="IM_mix_float_genmsl" nodedef="ND_mix_float" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color3_genmsl" nodedef="ND_mix_color3" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color3_color3_genmsl" nodedef="ND_mix_color3_color3" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color4_genmsl" nodedef="ND_mix_color4" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color4_color4_genmsl" nodedef="ND_mix_color4_color4" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector2_genmsl" nodedef="ND_mix_vector2" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector2_vector2_genmsl" nodedef="ND_mix_vector2_vector2" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector3_genmsl" nodedef="ND_mix_vector3" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector3_vector3_genmsl" nodedef="ND_mix_vector3_vector3" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector4_genmsl" nodedef="ND_mix_vector4" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector4_vector4_genmsl" nodedef="ND_mix_vector4_vector4" target="genmsl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_surfaceshader_genmsl" nodedef="ND_mix_surfaceshader" function="mx_mix_surfaceshader" file="../genglsl/mx_mix_surfaceshader.glsl" target="genmsl" />
-
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
   <!-- ======================================================================== -->
 
-  <!-- <ifgreater -->
-  <implementation name="IM_ifgreater_float_genmsl" nodedef="ND_ifgreater_float" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_integer_genmsl" nodedef="ND_ifgreater_integer" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_color3_genmsl" nodedef="ND_ifgreater_color3" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_color4_genmsl" nodedef="ND_ifgreater_color4" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_vector2_genmsl" nodedef="ND_ifgreater_vector2" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_vector3_genmsl" nodedef="ND_ifgreater_vector3" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_vector4_genmsl" nodedef="ND_ifgreater_vector4" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_matrix33_genmsl" nodedef="ND_ifgreater_matrix33" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_matrix44_genmsl" nodedef="ND_ifgreater_matrix44" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_boolean_genmsl" nodedef="ND_ifgreater_boolean" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? true : false" />
-  <implementation name="IM_ifgreater_floatI_genmsl" nodedef="ND_ifgreater_floatI" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_integerI_genmsl" nodedef="ND_ifgreater_integerI" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_color3I_genmsl" nodedef="ND_ifgreater_color3I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_color4I_genmsl" nodedef="ND_ifgreater_color4I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_vector2I_genmsl" nodedef="ND_ifgreater_vector2I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_vector3I_genmsl" nodedef="ND_ifgreater_vector3I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_vector4I_genmsl" nodedef="ND_ifgreater_vector4I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_matrix33I_genmsl" nodedef="ND_ifgreater_matrix33I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_matrix44I_genmsl" nodedef="ND_ifgreater_matrix44I" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreater_booleanI_genmsl" nodedef="ND_ifgreater_booleanI" target="genmsl" sourcecode="({{value1}} > {{value2}}) ? true : false" />
-
-  <!-- <ifgreatereq -->
-  <implementation name="IM_ifgreatereq_float_genmsl" nodedef="ND_ifgreatereq_float" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_integer_genmsl" nodedef="ND_ifgreatereq_integer" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_color3_genmsl" nodedef="ND_ifgreatereq_color3" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_color4_genmsl" nodedef="ND_ifgreatereq_color4" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_vector2_genmsl" nodedef="ND_ifgreatereq_vector2" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_vector3_genmsl" nodedef="ND_ifgreatereq_vector3" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_vector4_genmsl" nodedef="ND_ifgreatereq_vector4" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_matrix33_genmsl" nodedef="ND_ifgreatereq_matrix33" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_matrix44_genmsl" nodedef="ND_ifgreatereq_matrix44" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_boolean_genmsl" nodedef="ND_ifgreatereq_boolean" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? true : false" />
-  <implementation name="IM_ifgreatereq_floatI_genmsl" nodedef="ND_ifgreatereq_floatI" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_integerI_genmsl" nodedef="ND_ifgreatereq_integerI" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_color3I_genmsl" nodedef="ND_ifgreatereq_color3I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_color4I_genmsl" nodedef="ND_ifgreatereq_color4I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_vector2I_genmsl" nodedef="ND_ifgreatereq_vector2I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_vector3I_genmsl" nodedef="ND_ifgreatereq_vector3I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_vector4I_genmsl" nodedef="ND_ifgreatereq_vector4I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_matrix33I_genmsl" nodedef="ND_ifgreatereq_matrix33I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_matrix44I_genmsl" nodedef="ND_ifgreatereq_matrix44I" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifgreatereq_booleanI_genmsl" nodedef="ND_ifgreatereq_booleanI" target="genmsl" sourcecode="({{value1}} >= {{value2}}) ? true : false" />
-
-  <!-- <ifequal -->
-  <implementation name="IM_ifequal_float_genmsl" nodedef="ND_ifequal_float" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_integer_genmsl" nodedef="ND_ifequal_integer" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_color3_genmsl" nodedef="ND_ifequal_color3" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_color4_genmsl" nodedef="ND_ifequal_color4" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector2_genmsl" nodedef="ND_ifequal_vector2" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector3_genmsl" nodedef="ND_ifequal_vector3" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector4_genmsl" nodedef="ND_ifequal_vector4" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_matrix33_genmsl" nodedef="ND_ifequal_matrix33" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_matrix44_genmsl" nodedef="ND_ifequal_matrix44" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_boolean_genmsl" nodedef="ND_ifequal_boolean" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
-  <implementation name="IM_ifequal_floatI_genmsl" nodedef="ND_ifequal_floatI" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_integerI_genmsl" nodedef="ND_ifequal_integerI" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_color3I_genmsl" nodedef="ND_ifequal_color3I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_color4I_genmsl" nodedef="ND_ifequal_color4I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector2I_genmsl" nodedef="ND_ifequal_vector2I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector3I_genmsl" nodedef="ND_ifequal_vector3I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector4I_genmsl" nodedef="ND_ifequal_vector4I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_matrix33I_genmsl" nodedef="ND_ifequal_matrix33I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_matrix44I_genmsl" nodedef="ND_ifequal_matrix44I" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_booleanI_genmsl" nodedef="ND_ifequal_booleanI" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
-  <implementation name="IM_ifequal_floatB_genmsl" nodedef="ND_ifequal_floatB" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_integerB_genmsl" nodedef="ND_ifequal_integerB" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_color3B_genmsl" nodedef="ND_ifequal_color3B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_color4B_genmsl" nodedef="ND_ifequal_color4B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector2B_genmsl" nodedef="ND_ifequal_vector2B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector3B_genmsl" nodedef="ND_ifequal_vector3B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_vector4B_genmsl" nodedef="ND_ifequal_vector4B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_matrix33B_genmsl" nodedef="ND_ifequal_matrix33B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_matrix44B_genmsl" nodedef="ND_ifequal_matrix44B" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? {{in1}} : {{in2}}" />
-  <implementation name="IM_ifequal_booleanB_genmsl" nodedef="ND_ifequal_booleanB" target="genmsl" sourcecode="({{value1}} == {{value2}}) ? true : false" />
-
   <!-- ======================================================================== -->
   <!-- Channel nodes                                                            -->
   <!-- ======================================================================== -->
-
-  <!-- <convert> -->
-  <implementation name="IM_convert_boolean_float_genmsl" nodedef="ND_convert_boolean_float" target="genmsl" sourcecode="float({{in}})" />
-  <implementation name="IM_convert_integer_float_genmsl" nodedef="ND_convert_integer_float" target="genmsl" sourcecode="float({{in}})" />
 
   <!-- <combine2> -->
   <implementation name="IM_combine2_vector2_genmsl" nodedef="ND_combine2_vector2" target="genmsl" sourcecode="{ {{in1}},{{in2}} }" />
@@ -684,18 +172,6 @@
   <!-- <combine4> -->
   <implementation name="IM_combine4_color4_genmsl" nodedef="ND_combine4_color4" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }" />
   <implementation name="IM_combine4_vector4_genmsl" nodedef="ND_combine4_vector4" target="genmsl" sourcecode="{ {{in1}},{{in2}},{{in3}},{{in4}} }" />
-
-  <!-- <creatematrix> -->
-  <implementation name="IM_creatematrix_vector3_matrix33_genmsl" nodedef="ND_creatematrix_vector3_matrix33" file="../genglsl/mx_creatematrix_vector3_matrix33.glsl" function="mx_creatematrix_vector3_matrix33" target="genmsl" />
-  <implementation name="IM_creatematrix_vector3_matrix44_genmsl" nodedef="ND_creatematrix_vector3_matrix44" file="../genglsl/mx_creatematrix_vector3_matrix44.glsl" function="mx_creatematrix_vector3_matrix44" target="genmsl" />
-  <implementation name="IM_creatematrix_vector4_matrix44_genmsl" nodedef="ND_creatematrix_vector4_matrix44" file="../genglsl/mx_creatematrix_vector4_matrix44.glsl" function="mx_creatematrix_vector4_matrix44" target="genmsl" />
-
-  <!-- <extract> -->
-  <implementation name="IM_extract_color3_genmsl" nodedef="ND_extract_color3" sourcecode="{{in}}[{{index}}]" target="genmsl" />
-  <implementation name="IM_extract_color4_genmsl" nodedef="ND_extract_color4" sourcecode="{{in}}[{{index}}]" target="genmsl" />
-  <implementation name="IM_extract_vector2_genmsl" nodedef="ND_extract_vector2" sourcecode="{{in}}[{{index}}]" target="genmsl" />
-  <implementation name="IM_extract_vector3_genmsl" nodedef="ND_extract_vector3" sourcecode="{{in}}[{{index}}]" target="genmsl" />
-  <implementation name="IM_extract_vector4_genmsl" nodedef="ND_extract_vector4" sourcecode="{{in}}[{{index}}]" target="genmsl" />
 
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->
@@ -716,29 +192,8 @@
   <!-- Logical operator nodes                                                   -->
   <!-- ======================================================================== -->
 
-  <implementation name="IM_logical_and_genmsl" nodedef="ND_logical_and" target="genmsl" sourcecode="{{in1}} && {{in2}}"/>
-  <implementation name="IM_logical_or_genmsl" nodedef="ND_logical_or" target="genmsl" sourcecode="{{in1}} || {{in2}}"/>
-  <implementation name="IM_logical_not_genmsl" nodedef="ND_logical_not" target="genmsl" sourcecode="!{{in}}"/>
-
   <!-- ======================================================================== -->
   <!-- Organization nodes                                                       -->
   <!-- ======================================================================== -->
 
-  <!-- <dot> -->
-  <implementation name="IM_dot_float_genmsl" nodedef="ND_dot_float" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_color3_genmsl" nodedef="ND_dot_color3" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_color4_genmsl" nodedef="ND_dot_color4" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_vector2_genmsl" nodedef="ND_dot_vector2" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_vector3_genmsl" nodedef="ND_dot_vector3" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_vector4_genmsl" nodedef="ND_dot_vector4" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_integer_genmsl" nodedef="ND_dot_integer" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_boolean_genmsl" nodedef="ND_dot_boolean" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_matrix33_genmsl" nodedef="ND_dot_matrix33" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_matrix44_genmsl" nodedef="ND_dot_matrix44" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_string_genmsl" nodedef="ND_dot_string" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_filename_genmsl" nodedef="ND_dot_filename" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_surfaceshader_genmsl" nodedef="ND_dot_surfaceshader" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_displacementshader_genmsl" nodedef="ND_dot_displacementshader" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_volumeshader_genmsl" nodedef="ND_dot_volumeshader" target="genmsl" sourcecode="{{in}}" />
-  <implementation name="IM_dot_lightshader_genmsl" nodedef="ND_dot_lightshader" target="genmsl" sourcecode="{{in}}" />
 </materialx>


### PR DESCRIPTION
This changelist removes a number of MSL implementations that duplicate their counterparts in GLSL, instead using the inheritance relationship between these two shader generators to handle code sharing.