### PR TITLE
Move templated accessors to Element.cpp

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -284,6 +284,27 @@ ElementPtr Element::changeChildCategory(ElementPtr child, const string& category
     return newChild;
 }
 
+template <class T> shared_ptr<T> Element::getChildOfType(const string& name) const
+{
+    ElementPtr child = getChild(name);
+    return child ? child->asA<T>() : shared_ptr<T>();
+}
+
+template <class T> vector<shared_ptr<T>> Element::getChildrenOfType(const string& category) const
+{
+    vector<shared_ptr<T>> children;
+    for (ElementPtr child : _childOrder)
+    {
+        shared_ptr<T> instance = child->asA<T>();
+        if (!instance)
+            continue;
+        if (!category.empty() && child->getCategory() != category)
+            continue;
+        children.push_back(instance);
+    }
+    return children;
+}
+
 ElementPtr Element::getRoot()
 {
     ElementPtr root = _root.lock();
@@ -866,9 +887,11 @@ template <class T> class ElementRegistry
 // Template instantiations
 //
 
-#define INSTANTIATE_SUBCLASS(T)                           \
-    template MX_CORE_API shared_ptr<T> Element::asA<T>(); \
-    template MX_CORE_API shared_ptr<const T> Element::asA<T>() const;
+#define INSTANTIATE_SUBCLASS(T)                                                                             \
+    template MX_CORE_API shared_ptr<T> Element::asA<T>();                                                   \
+    template MX_CORE_API shared_ptr<const T> Element::asA<T>() const;                                       \
+    template MX_CORE_API shared_ptr<T> Element::getChildOfType<T>(const string& name) const;                \
+    template MX_CORE_API vector<shared_ptr<T>> Element::getChildrenOfType<T>(const string& category) const;
 
 INSTANTIATE_SUBCLASS(Element)
 INSTANTIATE_SUBCLASS(GeomElement)

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -439,11 +439,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return the child element, if any, with the given name and subclass.
     /// If a child with the given name exists, but belongs to a different
     /// subclass, then an empty shared pointer is returned.
-    template <class T> shared_ptr<T> getChildOfType(const string& name) const
-    {
-        ElementPtr child = getChild(name);
-        return child ? child->asA<T>() : shared_ptr<T>();
-    }
+    template <class T> shared_ptr<T> getChildOfType(const string& name) const;
 
     /// Return a constant vector of all child elements.
     /// The returned vector maintains the order in which children were added.
@@ -455,20 +451,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// Return a vector of all child elements that are instances of the given
     /// subclass, optionally filtered by the given category string.  The returned
     /// vector maintains the order in which children were added.
-    template <class T> vector<shared_ptr<T>> getChildrenOfType(const string& category = EMPTY_STRING) const
-    {
-        vector<shared_ptr<T>> children;
-        for (ElementPtr child : _childOrder)
-        {
-            shared_ptr<T> instance = child->asA<T>();
-            if (!instance)
-                continue;
-            if (!category.empty() && child->getCategory() != category)
-                continue;
-            children.push_back(instance);
-        }
-        return children;
-    }
+    template <class T> vector<shared_ptr<T>> getChildrenOfType(const string& category = EMPTY_STRING) const;
 
     /// Set the index of the child, if any, with the given name.
     /// If the given index is out of bounds, then an exception is thrown.


### PR DESCRIPTION
This changelist moves the templated accessors `getChildOfType` and `getChildrenOfType` from Element.h to Element.cpp, allowing upcoming features to be implemented in a more straightforward fashion.