### PR TITLE
Update translateshader for data library referencing

### DIFF
--- a/python/Scripts/translateshader.py
+++ b/python/Scripts/translateshader.py
@@ -24,19 +24,12 @@ def main():
     parser.add_argument('--writeDocumentPerMaterial', dest='writeDocumentPerMaterial', type=mx.stringToBoolean, default=True, help='Specify whether to write baked materials to seprate MaterialX documents. Default is True')
     if platform == "darwin":
         parser.add_argument("--glsl", dest="useGlslBackend", default=False, type=bool, help="Set to True to use GLSL backend (default = Metal).")
-
     parser.add_argument(dest="inputFilename", help="Filename of the input document.")
     parser.add_argument(dest="outputFilename", help="Filename of the output document.")
     parser.add_argument(dest="destShader", help="Destination shader for translation")
     opts = parser.parse_args()
 
-    doc = mx.createDocument()
-    try:
-        mx.readFromXmlFile(doc, opts.inputFilename)
-    except mx.ExceptionFileMissing as err:
-        print(err)
-        sys.exit(0)
-
+    # Load standard and custom data libraries.
     stdlib = mx.createDocument()
     searchPath = mx.getDefaultDataSearchPath()
     searchPath.append(os.path.dirname(opts.inputFilename))
@@ -51,8 +44,15 @@ def main():
                 libraryFolders.append(library)
     libraryFolders.extend(mx.getDefaultDataLibraryFolders())
     mx.loadLibraries(libraryFolders, searchPath, stdlib)
-    doc.importLibrary(stdlib)
 
+    # Read and validate the source document.
+    doc = mx.createDocument()
+    try:
+        mx.readFromXmlFile(doc, opts.inputFilename)
+        doc.setDataLibrary(stdlib)
+    except mx.ExceptionFileMissing as err:
+        print(err)
+        sys.exit(0)
     valid, msg = doc.validate()
     if not valid:
         print("Validation warnings for input document:")


### PR DESCRIPTION
This changelist updates the translateshader.py script to take advantage of data library referencing. i.e. `Document::setDataLibrary`.