### PR TITLE
Update mxvalidate for data library referencing

### DIFF
--- a/python/Scripts/mxvalidate.py
+++ b/python/Scripts/mxvalidate.py
@@ -16,13 +16,7 @@ def main():
     parser.add_argument(dest="inputFilename", help="Filename of the input document.")
     opts = parser.parse_args()
 
-    doc = mx.createDocument()
-    try:
-        mx.readFromXmlFile(doc, opts.inputFilename)
-    except mx.ExceptionFileMissing as err:
-        print(err)
-        sys.exit(0)
-
+    # Load standard libraries if requested.
     if opts.stdlib:
         stdlib = mx.createDocument()
         try:
@@ -30,15 +24,23 @@ def main():
         except Exception as err:
             print(err)
             sys.exit(0)
-        doc.importLibrary(stdlib)
 
-    (valid, message) = doc.validate()
+    # Read and validate the source document.
+    doc = mx.createDocument()
+    try:
+        mx.readFromXmlFile(doc, opts.inputFilename)
+        doc.setDataLibrary(stdlib)
+    except mx.ExceptionFileMissing as err:
+        print(err)
+        sys.exit(0)
+    valid, message = doc.validate()
     if (valid):
         print("%s is a valid MaterialX document in v%s" % (opts.inputFilename, mx.getVersionString()))
     else:
         print("%s is not a valid MaterialX document in v%s" % (opts.inputFilename, mx.getVersionString()))
         print(message)
 
+    # Generate verbose output if requested.
     if opts.verbose:
         nodegraphs = doc.getNodeGraphs()
         materials = doc.getMaterialNodes()


### PR DESCRIPTION
This changelist updates the mxvalidate.py script to take advantage of data library referencing. i.e. `Document::setDataLibrary`.