### PR TITLE
Add defaultgeomprop support for nodegraph inputs

### DIFF
--- a/resources/Materials/TestSuite/stdlib/defaultgeomprop/defaultgeomprop.mtlx
+++ b/resources/Materials/TestSuite/stdlib/defaultgeomprop/defaultgeomprop.mtlx
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <surfacematerial name="defaultgeomprop" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface1" />
+  </surfacematerial>
+  <standard_surface name="standard_surface1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" output="out" nodegraph="checkerboard1" />
+  </standard_surface>
+  <nodegraph name="checkerboard1">
+    <input name="color1" type="color3" uiname="Color 1" value="1, 1, 1" doc="The first color used in the checkerboard pattern." />
+    <input name="color2" type="color3" uiname="Color 2" value="0.0, 0.0, 0.0" doc="The second color used in the checkerboard pattern." />
+    <input name="uvtiling" type="vector2" uiname="UV Tiling" value="8, 8" doc="The tiling of the checkerboard pattern along each axis, with higher values producing smaller squares. Default is (8, 8)." />
+    <input name="uvoffset" type="vector2" uiname="UV Offset" value="0, 0" doc="The offset of the checkerboard pattern along each axis. Default is (0, 0)." />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" doc="The input 2d space. Default is the first texture coordinates." />
+    <multiply name="N_mtlxmult" type="vector2">
+      <input name="in1" type="vector2" interfacename="texcoord" />
+      <input name="in2" type="vector2" interfacename="uvtiling" />
+    </multiply>
+    <subtract name="N_mtlxsubtract" type="vector2">
+      <input name="in1" type="vector2" nodename="N_mtlxmult" />
+      <input name="in2" type="vector2" interfacename="uvoffset" />
+    </subtract>
+    <floor name="N_mtlxfloor" type="vector2">
+      <input name="in" type="vector2" nodename="N_mtlxsubtract" />
+    </floor>
+    <dotproduct name="N_mtlxdotproduct" type="float">
+      <input name="in1" type="vector2" nodename="N_mtlxfloor" />
+      <input name="in2" type="vector2" value="1, 1" />
+    </dotproduct>
+    <modulo name="N_modulo" type="float">
+      <input name="in1" type="float" nodename="N_mtlxdotproduct" />
+      <input name="in2" type="float" value="2" />
+    </modulo>
+    <mix name="N_mtlxmix" type="color3">
+      <input name="bg" type="color3" interfacename="color2" />
+      <input name="fg" type="color3" interfacename="color1" />
+      <input name="mix" type="float" nodename="N_modulo" />
+    </mix>
+    <output name="out" type="color3" nodename="N_mtlxmix" />
+  </nodegraph>
+</materialx>

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -295,7 +295,7 @@ bool Input::validate(string* message) const
 
     if (hasDefaultGeomPropString())
     {
-        validateRequire(parent->isA<NodeDef>(), res, message, "Invalid defaultgeomprop on non-definition input");
+        validateRequire(parent->isA<NodeDef>() || parent->isA<NodeGraph>(), res, message, "Invalid defaultgeomprop on non-definition and non-nodegraph input");
         validateRequire(getDefaultGeomProp() != nullptr, res, message, "Invalid defaultgeomprop string");
     }
     if (parent->isA<Node>())

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -81,7 +81,7 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
                                        ElementPtr connectingElement,
                                        GenContext& context)
 {
-    // Create the node if it doesn't exists
+    // Create the node if it doesn't exist.
     NodePtr upstreamNode = upstreamElement->asA<Node>();
     if (!upstreamNode)
     {
@@ -95,10 +95,7 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
         newNode = createNode(upstreamNode, context);
     }
 
-    //
-    // Handle defaultgeomprops
-    //
-
+    // Handle interface inputs with default geometric properties.
     for (InputPtr activeInput : upstreamNode->getActiveInputs())
     {
         if (!activeInput->hasInterfaceName() || activeInput->getConnectedNode())
@@ -106,7 +103,6 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
             continue;
         }
         
-        // Handle interface inputs with default geometric properties.
         InputPtr graphInput = activeInput->getInterfaceInput();
         if (graphInput && graphInput->hasDefaultGeomPropString())
         {

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -99,15 +99,15 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
     // Handle defaultgeomprops
     //
 
-    const vector<InputPtr> activeInputs = upstreamNode->getActiveInputs();
-    for (const InputPtr& activeInput : activeInputs)
+    for (InputPtr activeInput : upstreamNode->getActiveInputs())
     {
         if (!activeInput->hasInterfaceName() || activeInput->getConnectedNode())
         {
             continue;
         }
-        const auto graphInput = activeInput->getInterfaceInput();
-        // We have an input connected to an interface. See if it has defaultgeomprop
+        
+        // Handle interface inputs with default geometric properties.
+        InputPtr graphInput = activeInput->getInterfaceInput();
         if (graphInput && graphInput->hasDefaultGeomPropString())
         {
             ShaderInput* shaderInput = getNode(upstreamNode->getName())->getInput(activeInput->getName());

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -96,6 +96,24 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
     }
 
     //
+    // Handle defaultgeomprops
+    //
+
+    const vector<InputPtr> activeInputs = upstreamNode->getActiveInputs();
+    for (const InputPtr& activeInput : activeInputs)
+    {
+        if (!activeInput->hasInterfaceName() || activeInput->getConnectedNode()) {
+            continue;
+        }
+        const auto graphInput = activeInput->getInterfaceInput();
+        // We have an input connected to an interface. See if it has defaultgeomprop
+        if (graphInput && graphInput->hasDefaultGeomPropString()) {
+            ShaderInput* shaderInput = getNode(upstreamNode->getName())->getInput(activeInput->getName());
+            addDefaultGeomNode(shaderInput, *graphInput->getDefaultGeomProp(), context);
+        }
+    }
+
+    //
     // Make connections
     //
 

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -102,12 +102,14 @@ void ShaderGraph::createConnectedNodes(const ElementPtr& downstreamElement,
     const vector<InputPtr> activeInputs = upstreamNode->getActiveInputs();
     for (const InputPtr& activeInput : activeInputs)
     {
-        if (!activeInput->hasInterfaceName() || activeInput->getConnectedNode()) {
+        if (!activeInput->hasInterfaceName() || activeInput->getConnectedNode())
+        {
             continue;
         }
         const auto graphInput = activeInput->getInterfaceInput();
         // We have an input connected to an interface. See if it has defaultgeomprop
-        if (graphInput && graphInput->hasDefaultGeomPropString()) {
+        if (graphInput && graphInput->hasDefaultGeomPropString())
+        {
             ShaderInput* shaderInput = getNode(upstreamNode->getName())->getInput(activeInput->getName());
             addDefaultGeomNode(shaderInput, *graphInput->getDefaultGeomProp(), context);
         }


### PR DESCRIPTION
This PR makes it so that defaultgeomprop values can be used with nodegraph inputs as opposed to solely used on nodedef inputs. Includes a test file that is a nodegraph version of a checkerboard nodegraph implementation. The nodegraph exposes a defaultgeomprop value on the nodegraph's texcoord input of "UV0". Attached is what the rendered test result looks like. Without the fix it would be black.
![defaultgeomprop_glsl copy](https://github.com/user-attachments/assets/9b8f681a-f336-4442-a3d4-ee60fe68fb94)
