### PR TITLE
Update UsdPreviewSurface Nodegraph

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -6,7 +6,7 @@
   <!-- ======================================================================== -->
 
   <!-- Node: UsdPreviewSurface -->
-  <nodedef name="ND_UsdPreviewSurface_surfaceshader" node="UsdPreviewSurface" nodegroup="pbr" doc="USD preview surface shader" version="2.3" isdefaultversion="true">
+  <nodedef name="ND_UsdPreviewSurface_surfaceshader" node="UsdPreviewSurface" nodegroup="pbr" doc="USD preview surface shader" version="2.6" isdefaultversion="true">
     <input name="diffuseColor" type="color3" value="0.18, 0.18, 0.18" uimin="0,0,0" uimax="1,1,1" />
     <input name="emissiveColor" type="color3" value="0, 0, 0" uimin="0,0,0" uisoftmax="1,1,1" />
     <input name="useSpecularWorkflow" type="integer" value="0" uimin="0" uimax="1" uistep="1" />
@@ -152,10 +152,16 @@
       <input name="normal" type="vector3" nodename="surface_normal" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
+    <ifgreater name="transmission_mix_amount" type="float">
+      <input name="value1" type="float" interfacename="opacityThreshold" />
+      <input name="value2" type="float" value="0" />
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" interfacename="opacity" />
+    </ifgreater>
     <mix name="transmission_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="diffuse_bsdf" />
       <input name="bg" type="BSDF" nodename="transmission_bsdf" />
-      <input name="mix" type="float" interfacename="opacity" />
+      <input name="mix" type="float" nodename="transmission_mix_amount" />
     </mix>
 
     <!-- Specular Workflow -->
@@ -170,8 +176,12 @@
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
     </generalized_schlick_bsdf>
+    <mix name="specular_bsdf1_mix" type="BSDF">
+      <input name="bg" type="BSDF" nodename="specular_bsdf1" />
+      <input name="mix" type="float" nodename="transmission_mix_amount" />
+    </mix>
     <layer name="specular_workflow_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="specular_bsdf1" />
+      <input name="top" type="BSDF" nodename="specular_bsdf1_mix" />
       <input name="base" type="BSDF" nodename="transmission_mix" />
     </layer>
 
@@ -213,8 +223,12 @@
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
     </generalized_schlick_bsdf>
+    <mix name="specular_bsdf2_mix" type="BSDF">
+      <input name="bg" type="BSDF" nodename="specular_bsdf2" />
+      <input name="mix" type="float" nodename="transmission_mix_amount" />
+    </mix>
     <layer name="metalness_specular_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="specular_bsdf2" />
+      <input name="top" type="BSDF" nodename="specular_bsdf2_mix" />
       <input name="base" type="BSDF" nodename="transmission_mix" />
     </layer>
     <artistic_ior name="artistic_ior" type="multioutput">


### PR DESCRIPTION
This PR fixes the cutout issue described in gitIssue #2044. It also updates the nodegraph to reflect the recently updated PreviewSurface v2.6 which removes specular highlights for fully transparent materials.