### PR TITLE
Fix hair nodes in MDL backend

### DIFF
--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -26,7 +26,7 @@
   <implementation name="IM_sheen_bsdf_genmdl" nodedef="ND_sheen_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_sheen_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_roughness:{{roughness}}, mxp_normal:{{normal}}, mxp_base:{{base}})" target="genmdl" />
 
   <!-- <chiang_hair_bsdf> -->
-  <implementation name="IM_chiang_hair_bsdf_genmdl" nodedef="ND_chiang_hair_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_chiang_hairbsdf(mxp_tint_R:{{tint_R}}, mxp_tint_TT:{{tint_TT}}, mxp_tint_TRT:{{tint_TRT}}, mxp_ior:{{ior}}, mxp_roughness_R:{{roughness_R}}, mxp_roughness_TT:{{roughness_TT}}, mxp_roughness_TRT:{{roughness_TRT}}, mxp_cuticle_angle:{{cuticle_angle}}, mxp_absorption_coefficient:{{absorption_coefficient}}, mxp_curve_direction:{{curve_direction}})" target="genmdl" />
+  <implementation name="IM_chiang_hair_bsdf_genmdl" nodedef="ND_chiang_hair_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_chiang_hair_bsdf(mxp_tint_R:{{tint_R}}, mxp_tint_TT:{{tint_TT}}, mxp_tint_TRT:{{tint_TRT}}, mxp_ior:{{ior}}, mxp_roughness_R:{{roughness_R}}, mxp_roughness_TT:{{roughness_TT}}, mxp_roughness_TRT:{{roughness_TRT}}, mxp_cuticle_angle:{{cuticle_angle}}, mxp_absorption_coefficient:{{absorption_coefficient}}, mxp_curve_direction:{{curve_direction}})" target="genmdl" />
 
   <!-- <uniform_edf> -->
   <implementation name="IM_uniform_edf_genmdl" nodedef="ND_uniform_edf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_uniform_edf(mxp_color:{{color}})" target="genmdl" />

--- a/resources/Materials/Examples/SimpleHair/simple_hair_default.mtlx
+++ b/resources/Materials/Examples/SimpleHair/simple_hair_default.mtlx
@@ -45,6 +45,7 @@
       <input name="tint_R" type="color3" interfacename="tint_R" />
       <input name="tint_TT" type="color3" interfacename="tint_TT" />
       <input name="tint_TRT" type="color3" interfacename="tint_TRT" />
+      <input name="ior" type="float" interfacename="ior" />
       <input name="roughness_R" type="vector2" nodename="spec_roughness" output="roughness_R" />
       <input name="roughness_TT" type="vector2" nodename="spec_roughness" output="roughness_TT" />
       <input name="roughness_TRT" type="vector2" nodename="spec_roughness" output="roughness_TRT" />

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
@@ -430,9 +430,9 @@ export material mx_thin_film_bsdf(
 
 export material mx_chiang_hair_bsdf(
     // TODO: MDL's chiang_hair BSDF has no support tinting each lobes
-    color mxp_tint_R = color(1.0),
-    color mxp_tint_TT = color(1.0),
-    color mxp_tint_TRT = color(1.0),
+    color mxp_tint_R = color(1.0) [[ anno::unused() ]],
+    color mxp_tint_TT = color(1.0) [[ anno::unused() ]],
+    color mxp_tint_TRT = color(1.0) [[ anno::unused() ]],
     float mxp_ior = 1.55,
     float2 mxp_roughness_R = float2(0.1, 0.1),
     float2 mxp_roughness_TT = float2(0.05, 0.05),
@@ -452,7 +452,7 @@ export material mx_chiang_hair_bsdf(
         roughness_TT: mxp_roughness_TT,
         roughness_TRT: mxp_roughness_TRT,
         cuticle_angle: mxp_cuticle_angle,
-        absorption_coefficient: mxp_absorption_coefficient,
+        absorption_coefficient: color(mxp_absorption_coefficient),
         ior: mxp_ior
     )
 );
@@ -590,6 +590,7 @@ export material mx_surface(
         scattering: bsdf_node,
         emission: edf_node
     ),
+    hair: mxp_bsdf.hair,
     ior: mxp_transmission_ior > 0.0 ? color(mxp_transmission_ior) : mxp_bsdf.ior,
     volume: bsdf_volume,
     geometry: material_geometry(
@@ -1010,17 +1011,17 @@ export mx_artistic_ior__result mx_artistic_ior(
     return mx_artistic_ior__result(n,k);
 }
 
-export float3 mx_dion_hair_absorption_from_melanin(
+export float3 mx_deon_hair_absorption_from_melanin(
     float mxp_melanin_concentration = 0.25,
     float mxp_melanin_redness = 0.5,
     color mxp_eumelanin_color = color(0.657704, 0.498077, 0.254107),
     color mxp_pheomelanin_color = color(0.829444, 0.67032, 0.349938)
 ) {
     float melanin = -math::log(math::max(1.0 - mxp_melanin_concentration, 0.0001));
-    float eumelanin = melanin * (1.0 = mxp_melanin_redness);
+    float eumelanin = melanin * (1.0 - mxp_melanin_redness);
     float pheomelanin = melanin * mxp_melanin_redness;
     return math::max(
-        eumelanin * -math::log(mxp_eumelanin_color) + pheomelanin * -math::log(mxp_pheomelanin_color),
+        eumelanin * -math::log(float3(mxp_eumelanin_color)) + pheomelanin * -math::log(float3(mxp_pheomelanin_color)),
         float3(0.0)
     );
 }
@@ -1038,7 +1039,7 @@ export float3 mx_chiang_hair_absorption_from_color(
     (10.73 * r2 * mxp_azimuthal_roughness) + 
     (5.574 * r4) +
     (0.245 * r4 * mxp_azimuthal_roughness);
-    float3 sigma = math::log(math::min(math::max(mxp_color, 0.001), float3(1.0))) / r_fac;
+    float3 sigma = math::log(math::min(math::max(float3(mxp_color), 0.001), float3(1.0))) / r_fac;
     return (sigma * sigma);
 }
 

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_7.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_7.mdl
@@ -48,6 +48,7 @@ export using .::pbrlib_1_6 import mx_conductor_bsdf;
 export using .::pbrlib_1_6 import mx_generalized_schlick_bsdf;
 export using .::pbrlib_1_6 import mx_subsurface_bsdf;
 export using .::pbrlib_1_6 import mx_thin_film_bsdf;
+export using .::pbrlib_1_6 import mx_chiang_hair_bsdf;
 export using .::pbrlib_1_6 import mx_uniform_edf;
 export using .::pbrlib_1_6 import mx_conical_edf;
 export using .::pbrlib_1_6 import mx_measured_edf;
@@ -72,6 +73,10 @@ export using .::pbrlib_1_6 import mx_roughness_dual;
 export using .::pbrlib_1_6 import mx_blackbody;
 export using .::pbrlib_1_6 import mx_artistic_ior__result ;
 export using .::pbrlib_1_6 import mx_artistic_ior;
+export using .::pbrlib_1_6 import mx_deon_hair_absorption_from_melanin;
+export using .::pbrlib_1_6 import mx_chiang_hair_absorption_from_color;
+export using .::pbrlib_1_6 import mx_chiang_hair_roughness__result;
+export using .::pbrlib_1_6 import mx_chiang_hair_roughness;
 
 
 

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -42,6 +42,7 @@ export material mx_surfacematerial(
 = material(
     thin_walled: mxp_surfaceshader.thin_walled || mxp_backsurfaceshader.thin_walled,
     surface: mxp_surfaceshader.surface,
+	hair: mxp_surfaceshader.hair,
     backface: mxp_backsurfaceshader.surface,
     geometry: material_geometry(
         cutout_opacity: mxp_surfaceshader.geometry.cutout_opacity,


### PR DESCRIPTION
Fix the issue where the generated MDL code with hair nodes does not compile.

Also address warnings for unused parameters.