### PR TITLE
Restore specular terms of UsdPreviewSurface

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -152,16 +152,10 @@
       <input name="normal" type="vector3" nodename="surface_normal" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
-    <ifgreater name="transmission_mix_amount" type="float">
-      <input name="value1" type="float" interfacename="opacityThreshold" />
-      <input name="value2" type="float" value="0" />
-      <input name="in1" type="float" value="1" />
-      <input name="in2" type="float" interfacename="opacity" />
-    </ifgreater>
     <mix name="transmission_mix" type="BSDF">
       <input name="fg" type="BSDF" nodename="diffuse_bsdf" />
       <input name="bg" type="BSDF" nodename="transmission_bsdf" />
-      <input name="mix" type="float" nodename="transmission_mix_amount" />
+      <input name="mix" type="float" interfacename="opacity" />
     </mix>
 
     <!-- Specular Workflow -->
@@ -176,12 +170,8 @@
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
     </generalized_schlick_bsdf>
-    <mix name="specular_bsdf1_mix" type="BSDF">
-      <input name="bg" type="BSDF" nodename="specular_bsdf1" />
-      <input name="mix" type="float" nodename="transmission_mix_amount" />
-    </mix>
     <layer name="specular_workflow_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="specular_bsdf1_mix" />
+      <input name="top" type="BSDF" nodename="specular_bsdf1" />
       <input name="base" type="BSDF" nodename="transmission_mix" />
     </layer>
 
@@ -223,12 +213,8 @@
       <input name="roughness" type="vector2" nodename="specular_roughness" />
       <input name="normal" type="vector3" nodename="surface_normal" />
     </generalized_schlick_bsdf>
-    <mix name="specular_bsdf2_mix" type="BSDF">
-      <input name="bg" type="BSDF" nodename="specular_bsdf2" />
-      <input name="mix" type="float" nodename="transmission_mix_amount" />
-    </mix>
     <layer name="metalness_specular_bsdf" type="BSDF">
-      <input name="top" type="BSDF" nodename="specular_bsdf2_mix" />
+      <input name="top" type="BSDF" nodename="specular_bsdf2" />
       <input name="base" type="BSDF" nodename="transmission_mix" />
     </layer>
     <artistic_ior name="artistic_ior" type="multioutput">


### PR DESCRIPTION
This changelist restores the interpretation of the reflective and transmissive specular terms of UsdPreviewSurface, reverting some unintended changes in PR #2081.