### PR TITLE
Reduce verbosity of unit tests

### DIFF
--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -10,8 +10,6 @@
 #include <MaterialXFormat/Util.h>
 #include <MaterialXFormat/XmlIo.h>
 
-#include <iostream>
-
 namespace mx = MaterialX;
 
 TEST_CASE("Document", "[document]")
@@ -123,16 +121,6 @@ TEST_CASE("Document", "[document]")
     REQUIRE(doc->validate());
 }
 
-void printDifferences(const mx::ElementEquivalenceResultVec& results, const std::string& label)
-{
-    for (const mx::ElementEquivalenceResult& result : results)
-    {
-        std::cout << label << ": " << "Element: " << result.path1 << 
-            ", Element: " << result.path2 << ", Difference Type: " << result.differenceType
-            << ", Value: " << result.attributeName << std::endl;
-    }
-}
-
 TEST_CASE("Document equivalence", "[document]")
 {
     mx::DocumentPtr doc = mx::createDocument();
@@ -224,44 +212,18 @@ TEST_CASE("Document equivalence", "[document]")
     // Check skipping all value compares
     options.skipValueComparisons = true;
     bool equivalent = doc->isEquivalent(doc2, options, &results);
-    if (equivalent)
-    {
-        std::cout << "Unexpected skip value equivalence:" << std::endl;
-        std::cout << "Document 1: " << mx::prettyPrint(doc) << std::endl;
-        std::cout << "Document 2: " << mx::prettyPrint(doc2) << std::endl;
-    }
-    else
-    {
-        printDifferences(results, "Expected value differences");
-    }
     REQUIRE(!equivalent);
 
     // Check attibute values 
     options.skipValueComparisons = false;
     results.clear();
     equivalent = doc->isEquivalent(doc2, options, &results);
-    if (!equivalent)
-    {
-        printDifferences(results, "Unexpected value difference");
-        std::cout << "Document 1: " << mx::prettyPrint(doc) << std::endl;
-        std::cout << "Document 2: " << mx::prettyPrint(doc2) << std::endl;
-    }
     REQUIRE(equivalent);
 
     unsigned int currentPrecision = mx::Value::getFloatPrecision();
     // This will compare 0.012345608 versus: 1, 0.012345611 for input10
     options.precision = 8;
     equivalent = doc->isEquivalent(doc2, options);
-    if (equivalent)
-    {
-        std::cout << "Unexpected precision equivalence:" << std::endl;
-        std::cout << "Document 1: " << mx::prettyPrint(doc) << std::endl;
-        std::cout << "Document 2: " << mx::prettyPrint(doc2) << std::endl;
-    }
-    else
-    {
-        printDifferences(results, "Expected precision difference");
-    }
     REQUIRE(!equivalent);
     options.precision = currentPrecision;
 
@@ -274,12 +236,6 @@ TEST_CASE("Document equivalence", "[document]")
         floatInput->setAttribute(mx::ValueElement::UI_MAX_ATTRIBUTE, "100.0");
     }
     equivalent = doc->isEquivalent(doc2, options, &results);
-    if (!equivalent)
-    {
-        printDifferences(results, "Unexpected filtering differences");
-        std::cout << "Document 1: " << mx::prettyPrint(doc) << std::endl;
-        std::cout << "Document 2: " << mx::prettyPrint(doc2) << std::endl;
-    }
     REQUIRE(equivalent);
     for (mx::InputPtr floatInput : floatInputs)
     {
@@ -293,16 +249,6 @@ TEST_CASE("Document equivalence", "[document]")
     mismatchElement->setName("mismatch_color4");
     results.clear();
     equivalent = doc->isEquivalent(doc2, options, &results);
-    if (!equivalent)
-    {
-        printDifferences(results, "Expected name mismatch differences");
-    }
-    else
-    {
-        std::cout << "Unexpected name match equivalence:" << std::endl;
-        std::cout << "Document 1: " << mx::prettyPrint(doc) << std::endl;
-        std::cout << "Document 2: " << mx::prettyPrint(doc2) << std::endl;
-    }
     REQUIRE(!equivalent);
     mismatchElement->setName(previousName);
     results.clear();
@@ -320,15 +266,5 @@ TEST_CASE("Document equivalence", "[document]")
     nodeGraph2->setNodeDefString("ND_mygraph");
     results.clear();
     equivalent = doc->isEquivalent(doc2, options, &results);
-    if (!equivalent)
-    {
-        printDifferences(results, "Expected functional graph differences");
-    }
-    else
-    {
-        std::cout << "Unexpected functional graph equivalence:" << std::endl;
-        std::cout << "Document 1: " << mx::prettyPrint(doc) << std::endl;
-        std::cout << "Document 2: " << mx::prettyPrint(doc2) << std::endl;
-    }
     REQUIRE(!equivalent);
 }


### PR DESCRIPTION
This changelist reduces the verbosity of our unit tests for element equivalence, focusing on REQUIRE statements to provide coverage.