### PR TITLE
WIP: MDL 1.9 updates

### DIFF
--- a/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
+++ b/libraries/pbrlib/genmdl/pbrlib_genmdl_impl.mtlx
@@ -2,7 +2,7 @@
 <materialx version="1.39">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genmdl" nodedef="ND_oren_nayar_diffuse_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_oren_nayar_diffuse_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_roughness:{{roughness}}, mxp_normal:{{normal}})" target="genmdl" />
+  <implementation name="IM_oren_nayar_diffuse_bsdf_genmdl" nodedef="ND_oren_nayar_diffuse_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_oren_nayar_diffuse_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_roughness:{{roughness}}, mxp_normal:{{normal}}, mxp_energy_compensation:{{energy_compensation}})" target="genmdl" />
 
   <!-- <burley_diffuse_bsdf> -->
   <implementation name="IM_burley_diffuse_bsdf_genmdl" nodedef="ND_burley_diffuse_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_burley_diffuse_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_roughness:{{roughness}}, mxp_normal:{{normal}})" target="genmdl" />
@@ -11,13 +11,13 @@
   <implementation name="IM_translucent_bsdf_genmdl" nodedef="ND_translucent_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_translucent_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_normal:{{normal}})" target="genmdl" />
 
   <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genmdl" nodedef="ND_dielectric_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_dielectric_bsdf(mxp_weight:{{weight}}, mxp_tint:{{tint}}, mxp_ior:{{ior}}, mxp_roughness:{{roughness}}, mxp_thinfilm_thickness:{{thinfilm_thickness}}, mxp_thinfilm_ior:{{thinfilm_ior}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}}, mxp_distribution:{{distribution}}, mxp_scatter_mode:{{scatter_mode}}, mxp_base:{{base}})" target="genmdl" />
+  <implementation name="IM_dielectric_bsdf_genmdl" nodedef="ND_dielectric_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_dielectric_bsdf(mxp_weight:{{weight}}, mxp_tint:{{tint}}, mxp_ior:{{ior}}, mxp_roughness:{{roughness}}, mxp_thinfilm_thickness:{{thinfilm_thickness}}, mxp_thinfilm_ior:{{thinfilm_ior}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}}, mxp_distribution:{{distribution}}, mxp_scatter_mode:{{scatter_mode}}, mxp_base:{{base}}, mxp_top_weight:{{top_weight}})" target="genmdl" />
 
   <!-- <conductor_bsdf> -->
   <implementation name="IM_conductor_bsdf_genmdl" nodedef="ND_conductor_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_conductor_bsdf(mxp_weight:{{weight}}, mxp_ior:{{ior}}, mxp_extinction:{{extinction}}, mxp_roughness:{{roughness}}, mxp_thinfilm_thickness:{{thinfilm_thickness}}, mxp_thinfilm_ior:{{thinfilm_ior}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}}, mxp_distribution:{{distribution}})" target="genmdl" />
 
   <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genmdl" nodedef="ND_generalized_schlick_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_generalized_schlick_bsdf(mxp_weight:{{weight}}, mxp_color0:{{color0}}, mxp_color90:{{color90}}, mxp_exponent:{{exponent}},mxp_roughness:{{roughness}}, mxp_thinfilm_thickness:{{thinfilm_thickness}}, mxp_thinfilm_ior:{{thinfilm_ior}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}}, mxp_distribution:{{distribution}}, mxp_scatter_mode:{{scatter_mode}}, mxp_base:{{base}})" target="genmdl" />
+  <implementation name="IM_generalized_schlick_bsdf_genmdl" nodedef="ND_generalized_schlick_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_generalized_schlick_bsdf(mxp_weight:{{weight}}, mxp_color0:{{color0}}, mxp_color82:{{color82}}, mxp_color90:{{color90}}, mxp_exponent:{{exponent}},mxp_roughness:{{roughness}}, mxp_thinfilm_thickness:{{thinfilm_thickness}}, mxp_thinfilm_ior:{{thinfilm_ior}}, mxp_normal:{{normal}}, mxp_tangent:{{tangent}}, mxp_distribution:{{distribution}}, mxp_scatter_mode:{{scatter_mode}}, mxp_base:{{base}}, mxp_top_weight:{{top_weight}})" target="genmdl" />
 
   <!-- <subsurface_bsdf> -->
   <implementation name="IM_subsurface_bsdf_genmdl" nodedef="ND_subsurface_bsdf" sourcecode="materialx::pbrlib_{{MDL_VERSION_SUFFIX}}::mx_subsurface_bsdf(mxp_weight:{{weight}}, mxp_color:{{color}}, mxp_radius:{{radius}}, mxp_anisotropy:{{anisotropy}}, mxp_normal:{{normal}})" target="genmdl" />

--- a/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
+++ b/libraries/stdlib/genmdl/stdlib_genmdl_impl.mtlx
@@ -695,7 +695,7 @@
   <implementation name="IM_combine3_vector3_genmdl" nodedef="ND_combine3_vector3" target="genmdl" sourcecode="float3( {{in1}},{{in2}},{{in3}} )" />
 
   <!-- <combine4> -->
-  <implementation name="IM_combine4_color4_genmdl" nodedef="ND_combine4_color4" target="genmdl" sourcecode="color4( {{in1}},{{in2}},{{in3}},{{in4}} )" />
+  <implementation name="IM_combine4_color4_genmdl" nodedef="ND_combine4_color4" target="genmdl" sourcecode="materialx::core::mk_color4( {{in1}},{{in2}},{{in3}},{{in4}} )" />
   <implementation name="IM_combine4_vector4_genmdl" nodedef="ND_combine4_vector4" target="genmdl" sourcecode="float4( {{in1}},{{in2}},{{in3}},{{in4}} )" />
 
   <!-- <creatematrix> -->

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -52,9 +52,11 @@ const string IMPORT_ALL = " import *";
 const string MDL_VERSION_1_6 = "1.6";
 const string MDL_VERSION_1_7 = "1.7";
 const string MDL_VERSION_1_8 = "1.8";
+const string MDL_VERSION_1_9 = "1.9";
 const string MDL_VERSION_SUFFIX_1_6 = "1_6";
 const string MDL_VERSION_SUFFIX_1_7 = "1_7";
 const string MDL_VERSION_SUFFIX_1_8 = "1_8";
+const string MDL_VERSION_SUFFIX_1_9 = "1_9";
 
 } // anonymous namespace
 
@@ -215,6 +217,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
     const string result = getUpstreamResult(outputSocket, context);
 
     const TypeDesc outputType = outputSocket->getType();
+    // Try to return some meaningful color in case the output is not a material
     if (graph.hasClassification(ShaderNode::Classification::TEXTURE))
     {
         if (outputType == Type::DISPLACEMENTSHADER)
@@ -229,7 +232,25 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
         else
         {
             emitLine("float3 displacement__ = float3(0.0)", stage);
-            emitLine("color finalOutput__ = mk_color3(" + result + ")", stage);
+            std::string finalOutput = "mk_color3(0.0)";
+            if (outputType == Type::BOOLEAN)
+                finalOutput = result + " ? mk_color3(0.0, 1.0, 0.0) : mk_color3(1.0, 0.0, 0.0)";
+            else if (outputType == Type::INTEGER)
+                finalOutput = "mk_color3(" + result + " / 100)"; // arbitrary
+            else if (outputType == Type::FLOAT)
+                finalOutput = "mk_color3(" + result + ")";
+            else if (outputType == Type::VECTOR2)
+                finalOutput = "mk_color3(" + result + ".x, " + result + ".y, 0.0)";
+            else if (outputType == Type::VECTOR3)
+                finalOutput = "mk_color3(" + result + ")";
+            else if (outputType == Type::COLOR3)
+                finalOutput = result;
+            else if (outputType == Type::COLOR4)
+                finalOutput = result + ".rgb";
+            else if (outputType == Type::MATRIX33 || outputType == Type::MATRIX44)
+                finalOutput = "mk_color3(" + result + "[0][0], " + result + "[1][1], " + result + "[2][2])";
+
+            emitLine("color finalOutput__ = " + finalOutput, stage);
         }
 
         // End shader body
@@ -537,7 +558,7 @@ ShaderPtr MdlShaderGenerator::createShader(const string& name, ElementPtr elemen
         outputs->add(outputSocket->getSelf());
     }
 
-    // MDL does not allow varying data connected to transmission IOR.
+    // MDL does not allow varying data connected to transmission IOR until MDL 1.9.
     // We must find all uses of transmission IOR and make sure we don't
     // have a varying connection to it. If a varying connection is found
     // we break that connection and revert to using default value on that
@@ -552,8 +573,14 @@ ShaderPtr MdlShaderGenerator::createShader(const string& name, ElementPtr elemen
     // this fix will disconnect the transmission IOR on the inside, but
     // still support the connection to reflection IOR.
     //
-    if (graph->hasClassification(ShaderNode::Classification::SHADER) ||
-        graph->hasClassification(ShaderNode::Classification::CLOSURE))
+    GenMdlOptions::MdlVersion version = getMdlVersion(context);
+    bool uniformIorRequired =
+        version == GenMdlOptions::MdlVersion::MDL_1_6 ||
+        version == GenMdlOptions::MdlVersion::MDL_1_7 ||
+        version == GenMdlOptions::MdlVersion::MDL_1_8;
+    if (uniformIorRequired && (
+        graph->hasClassification(ShaderNode::Classification::SHADER) ||
+        graph->hasClassification(ShaderNode::Classification::CLOSURE)))
     {
         // Find dependencies on transmission IOR.
         std::set<ShaderGraph*> graphsWithIorDependency;
@@ -641,10 +668,15 @@ void MdlShaderGenerator::emitShaderInputs(const DocumentPtr doc, const VariableB
     }
 }
 
-void MdlShaderGenerator::emitMdlVersionNumber(GenContext& context, ShaderStage& stage) const
+GenMdlOptions::MdlVersion MdlShaderGenerator::getMdlVersion(GenContext& context) const
 {
     GenMdlOptionsPtr options = context.getUserData<GenMdlOptions>(GenMdlOptions::GEN_CONTEXT_USER_DATA_KEY);
-    GenMdlOptions::MdlVersion version = options ? options->targetVersion : GenMdlOptions::MdlVersion::MDL_LATEST;
+    return options ? options->targetVersion : GenMdlOptions::MdlVersion::MDL_LATEST;
+}
+
+void MdlShaderGenerator::emitMdlVersionNumber(GenContext& context, ShaderStage& stage) const
+{
+    GenMdlOptions::MdlVersion version = getMdlVersion(context);
 
     emitLineBegin(stage);
     emitString("mdl ", stage);
@@ -656,19 +688,22 @@ void MdlShaderGenerator::emitMdlVersionNumber(GenContext& context, ShaderStage& 
         case GenMdlOptions::MdlVersion::MDL_1_7:
             emitString(MDL_VERSION_1_7, stage);
             break;
-        default:
-            // GenMdlOptions::MdlVersion::MDL_1_8
-            // GenMdlOptions::MdlVersion::MDL_LATEST
+        case GenMdlOptions::MdlVersion::MDL_1_8:
             emitString(MDL_VERSION_1_8, stage);
+            break;
+        default:
+            // GenMdlOptions::MdlVersion::MDL_1_9
+            // GenMdlOptions::MdlVersion::MDL_LATEST
+            emitString(MDL_VERSION_1_9, stage);
             break;
     }
     emitLineEnd(stage, true);
 }
 
+
 const string& MdlShaderGenerator::getMdlVersionFilenameSuffix(GenContext& context) const
 {
-    GenMdlOptionsPtr options = context.getUserData<GenMdlOptions>(GenMdlOptions::GEN_CONTEXT_USER_DATA_KEY);
-    GenMdlOptions::MdlVersion version = options ? options->targetVersion : GenMdlOptions::MdlVersion::MDL_LATEST;
+    GenMdlOptions::MdlVersion version = getMdlVersion(context);
 
     switch (version)
     {
@@ -676,10 +711,12 @@ const string& MdlShaderGenerator::getMdlVersionFilenameSuffix(GenContext& contex
             return MDL_VERSION_SUFFIX_1_6;
         case GenMdlOptions::MdlVersion::MDL_1_7:
             return MDL_VERSION_SUFFIX_1_7;
-        default:
-            // GenMdlOptions::MdlVersion::MDL_1_8
-            // GenMdlOptions::MdlVersion::MDL_LATEST
+        case GenMdlOptions::MdlVersion::MDL_1_8:
             return MDL_VERSION_SUFFIX_1_8;
+        default:
+            // GenMdlOptions::MdlVersion::MDL_1_9
+            // GenMdlOptions::MdlVersion::MDL_LATEST
+            return MDL_VERSION_SUFFIX_1_9;
     }
 }
 

--- a/source/MaterialXGenMdl/MdlShaderGenerator.h
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.h
@@ -25,7 +25,8 @@ class MX_GENMDL_API GenMdlOptions : public GenUserData
         MDL_1_6,
         MDL_1_7,
         MDL_1_8,
-        MDL_LATEST = MDL_1_8
+        MDL_1_9,
+        MDL_LATEST = MDL_1_9
     };
 
     /// Create MDL code generator options with default values.
@@ -76,7 +77,11 @@ class MX_GENMDL_API MdlShaderGenerator : public ShaderGenerator
     /// Map of code snippets for geomprops in MDL.
     static const std::unordered_map<string, string> GEOMPROP_DEFINITIONS;
 
-    /// Add the MDL file header containing the version number of the generated module..
+    /// Get the selected MDL target language version number from the context option.
+    /// If not set, the latest version supported by GenMdl is returned.
+    GenMdlOptions::MdlVersion getMdlVersion(GenContext& context) const;
+
+    /// Add the MDL file header containing the version number of the generated module.
     void emitMdlVersionNumber(GenContext& context, ShaderStage& stage) const;
 
     /// Add the version number suffix appended to MDL modules that use versions.

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
@@ -16,6 +16,10 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string StringConstantsMdl::TOP = "top";
 const string StringConstantsMdl::BASE = "base";
+const string StringConstantsMdl::FG = "fg";
+const string StringConstantsMdl::BG = "bg";
+const string StringConstantsMdl::MIX = "mix";
+const string StringConstantsMdl::TOP_WEIGHT = "top_weight";
 
 ShaderNodeImplPtr ClosureLayerNodeMdl::create()
 {
@@ -101,6 +105,7 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
 
     // Transport the base bsdf further than one layer
     ShaderNode* baseReceiverNode = top;
+    ShaderNode* mixTopWeightNode = nullptr;
     while (true)
     {
         // If the top node is again a layer, we don't want to override the base
@@ -111,6 +116,26 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
         }
         else
         {
+            // TODO is there a more efficient way to check if the node is a mix_bsdf?
+            std::string name = top->getImplementation().getName();
+            if (name == "IM_mix_bsdf_genmdl")
+            {
+                // handle one special case: the top node is a mix where either fg or bg is empty
+                // so basically a scale factor
+                ShaderOutput* fgOutput = top->getInput(StringConstantsMdl::FG)->getConnection();
+                ShaderOutput* bgOutput = top->getInput(StringConstantsMdl::BG)->getConnection();
+                ShaderOutput* mixOutput = top->getInput(StringConstantsMdl::MIX)->getConnection();
+                ShaderNode* fg = fgOutput ? fgOutput->getNode() : nullptr;
+                ShaderNode* bg = bgOutput ? bgOutput->getNode() : nullptr;
+                ShaderNode* mix = mixOutput ? mixOutput->getNode() : nullptr;
+                if ((fg && !bg) || (!fg && bg))
+                {
+                    baseReceiverNode = fg ? fg : bg; // take the node that is valid
+                    top = baseReceiverNode;
+                    mixTopWeightNode = mix;
+                }
+                break;
+            }
             // we stop at elemental bsdfs
             // TODO handle mix, add, and multiply
             break;
@@ -150,6 +175,11 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
     // base BSDF connection and output variable name from the
     // layer operator itself.
     topNodeBaseInput->makeConnection(base->getOutput());
+    if (mixTopWeightNode)
+    {
+        ShaderInput* topNodeTopWeightInput = baseReceiverNode->getInput(StringConstantsMdl::TOP_WEIGHT);
+        topNodeTopWeightInput->makeConnection(mixTopWeightNode->getOutput());
+    }
     ScopedSetVariableName setVariable(output->getVariable(), top->getOutput());
 
     // Make the call.
@@ -171,6 +201,21 @@ void LayerableNodeMdl::addInputs(ShaderNode& node, GenContext& /*context*/) cons
 {
     // Add the input to hold base layer BSDF.
     node.addInput(StringConstantsMdl::BASE, Type::BSDF);
+
+    // Set the top level weight default to 1.0
+    ShaderInput* topWeightNode = node.addInput(StringConstantsMdl::TOP_WEIGHT, Type::FLOAT);
+    ValuePtr value = TypedValue<float>::createValue(1.0f);
+    topWeightNode->setValue(value);
+}
+
+bool LayerableNodeMdl::isEditable(const ShaderInput& input) const
+{
+    if (input.getName() == StringConstantsMdl::BASE ||
+        input.getName() == StringConstantsMdl::TOP_WEIGHT)
+    {
+        return false;
+    }
+    return BASE::isEditable(input);
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h
@@ -23,6 +23,10 @@ class MX_GENMDL_API StringConstantsMdl
     /// String constants
     static const string TOP;  ///< layer parameter name of the top component
     static const string BASE; ///< layer parameter name of the base component
+    static const string FG;   ///< mix parameter name of the foreground
+    static const string BG;   ///< mix parameter name of the background
+    static const string MIX;  ///< mix parameter name of the amount
+    static const string TOP_WEIGHT; ///< mix amount forwarded into layer top component
 };
 
 /// Closure layer node implementation for MDL.
@@ -40,11 +44,14 @@ class MX_GENMDL_API ClosureLayerNodeMdl : public ShaderNodeImpl
 /// Note, not all elemental bsdfs support this kind of transformation.
 class MX_GENMDL_API LayerableNodeMdl : public SourceCodeNodeMdl
 {
+    using BASE = SourceCodeNodeMdl;
+
   public:
     virtual ~LayerableNodeMdl() = default;
     static ShaderNodeImplPtr create();
 
     void addInputs(ShaderNode& node, GenContext&) const override;
+    bool isEditable(const ShaderInput& input) const override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
@@ -82,7 +82,8 @@ export material mx_oren_nayar_diffuse_bsdf(
     float  mxp_weight    = 1.0,
     color  mxp_color     = color(0.18),
     float  mxp_roughness = 0.0,
-    float3 mxp_normal    = state::normal()
+    float3 mxp_normal    = state::normal(),
+    uniform bool mxp_energy_compensation = false [[ anno::unused() ]] // MDL 1.10
 ) [[ 
     anno::usage( "materialx:bsdf") 
 ]]
@@ -152,7 +153,8 @@ export material mx_dielectric_bsdf(
     float3 mxp_tangent   = state::texture_tangent_u(0),
     uniform core::mx_distribution_type mxp_distribution = core::mx_distribution_type_ggx [[ anno::unused() ]],
     uniform mx_scatter_mode mxp_scatter_mode = mx_scatter_mode_R,
-    material mxp_base = material() [[ anno::usage( "materialx:bsdf") ]],
+    material mxp_base = material() [[ anno::usage( "materialx:bsdf") ]], // layering
+    float mxp_top_weight = 1.0, // layering for cases where top is scaled using a mix
     float mxp_thinfilm_thickness = 0.0,
     float mxp_thinfilm_ior = 1.0
 ) [[ 
@@ -174,8 +176,8 @@ export material mx_dielectric_bsdf(
             layer: df::microfacet_ggx_smith_bsdf(
                 roughness_u: mxp_roughness.x,
                 roughness_v: mxp_roughness.y,
-                tint: mxp_tint,
-                multiscatter_tint: mxp_tint,
+                tint: mxp_tint * mxp_top_weight,
+                multiscatter_tint: mxp_tint * mxp_top_weight,
                 tangent_u: mxp_tangent,
                 mode: df::scatter_reflect),
             base: mxp_base.surface.scattering,
@@ -186,8 +188,8 @@ export material mx_dielectric_bsdf(
         layer: df::microfacet_ggx_smith_bsdf(
             roughness_u: mxp_roughness.x,
             roughness_v: mxp_roughness.y,
-            tint: mxp_tint,
-            multiscatter_tint: mxp_tint,
+            tint: mxp_tint * mxp_top_weight,
+            multiscatter_tint: mxp_tint * mxp_top_weight,
             tangent_u: mxp_tangent,
             mode: df::scatter_transmit),
         normal: mxp_normal);
@@ -200,8 +202,8 @@ export material mx_dielectric_bsdf(
             base: df::microfacet_ggx_smith_bsdf(
                 roughness_u: mxp_roughness.x,
                 roughness_v: mxp_roughness.y,
-                tint: mxp_tint,
-                multiscatter_tint: mxp_tint,
+                tint: mxp_tint * mxp_top_weight,
+                multiscatter_tint: mxp_tint * mxp_top_weight,
                 tangent_u: mxp_tangent,
                 mode: df::scatter_reflect_transmit)),
         normal: mxp_normal);
@@ -258,12 +260,13 @@ export material mx_conductor_bsdf(
     )
 );
 
-// TODO MDL 1.8 
+// MDL 1.8 
 // * will add support for thin film above a color_custom_curve_layer node until then, thin_film will have no effect
 // * thin_film(thickness: 0.0, ior: < 1.0) will be handled properly
 export material mx_generalized_schlick_bsdf(
     float  mxp_weight    = 1.0,
     color  mxp_color0    = color(1.0),
+    color  mxp_color82   = color(1.0) [[ anno::unused() ]], // MDL 1.10
     color  mxp_color90   = color(1.0),
     float  mxp_exponent  = 5.0,
     float2 mxp_roughness = float2(0.05),
@@ -271,7 +274,8 @@ export material mx_generalized_schlick_bsdf(
     float3 mxp_tangent   = state::texture_tangent_u(0),
     uniform core::mx_distribution_type mxp_distribution = core::mx_distribution_type_ggx [[ anno::unused() ]],
     uniform mx_scatter_mode mxp_scatter_mode = mx_scatter_mode_R,
-    material mxp_base = material() [[ anno::usage( "materialx:bsdf") ]],
+    material mxp_base = material() [[ anno::usage( "materialx:bsdf") ]], // layering
+    float mxp_top_weight = 1.0, // layering for cases where top is scaled using a mix
     float mxp_thinfilm_thickness = 0.0,
     float mxp_thinfilm_ior = 1.0
 ) [[ 
@@ -283,8 +287,8 @@ export material mx_generalized_schlick_bsdf(
     bsdf ggx_model_R = df::microfacet_ggx_smith_bsdf(
         roughness_u: mxp_roughness.x,
         roughness_v: mxp_roughness.y,
-        tint: color(1.0),
-        multiscatter_tint: color(1.0),
+        tint: color(1.0) * mxp_top_weight,
+        multiscatter_tint: color(1.0) * mxp_top_weight,
         tangent_u: mxp_tangent,
         mode: df::scatter_reflect);
 
@@ -440,7 +444,7 @@ export material mx_chiang_hair_bsdf(
     float mxp_cuticle_angle = 0.5,
     float3 mxp_absorption_coefficient = float3(0.0),
     // TODO: MDL's chiang_hair BSDF has no support user tangent vector
-    float3 mxp_curve_direction = state::texture_tangent_u(0)
+    float3 mxp_curve_direction = state::texture_tangent_u(0) [[ anno::unused() ]]
 ) [[
     anno::usage( "materialx:bsdf")
 ]]

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_9.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_9.mdl
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// MDL implementation of all types and nodes of
+//     MaterialX Physically-Based Shading Nodes
+//     Document v1.37 REV2, July 16, 2019 (Revised October 17, 2019)
+//     see www.materialx.org 
+// in
+//     NVIDIA Material Definition Language 1.9
+//     Language Specification
+//     Document version 1.9.2, September 16, 2024
+//     www.nvidia.com/mdl
+
+mdl 1.9;
+
+import ::anno::*;
+import ::df::*;
+import ::math::*;
+import ::state::*;
+
+import .::core::*;
+
+// Changes since MDL 1.8
+// - lift the restriction of uniform IORs
+
+// forward unchanged definitions from the previous versions
+export using .::pbrlib_1_6 import mx_scatter_mode;
+export using .::pbrlib_1_6 import mx_map_scatter_mode;
+export using .::pbrlib_1_6 import mx_oren_nayar_diffuse_bsdf;
+export using .::pbrlib_1_6 import mx_burley_diffuse_bsdf;
+export using .::pbrlib_1_6 import mx_translucent_bsdf;
+export using .::pbrlib_1_6 import mx_subsurface_bsdf;
+export using .::pbrlib_1_6 import mx_thin_film_bsdf;
+export using .::pbrlib_1_6 import mx_chiang_hair_bsdf;
+export using .::pbrlib_1_6 import mx_uniform_edf;
+export using .::pbrlib_1_6 import mx_conical_edf;
+export using .::pbrlib_1_6 import mx_measured_edf;
+export using .::pbrlib_1_6 import mx_absorption_vdf;
+export using .::pbrlib_1_6 import mx_anisotropic_vdf;
+export using .::pbrlib_1_6 import mx_light;
+export using .::pbrlib_1_6 import mx_displacement_float;
+export using .::pbrlib_1_6 import mx_displacement_vector3;
+export using .::pbrlib_1_6 import volume_mix_return;
+export using .::pbrlib_1_6 import volume_mix;
+export using .::pbrlib_1_6 import mx_multiply_bsdf_color3;
+export using .::pbrlib_1_6 import mx_multiply_bsdf_float;
+export using .::pbrlib_1_6 import mx_multiply_edf_color3;
+export using .::pbrlib_1_6 import mx_multiply_edf_float;
+export using .::pbrlib_1_6 import mx_multiply_vdf_color3;
+export using .::pbrlib_1_6 import mx_multiply_vdf_float;
+export using .::pbrlib_1_6 import mx_roughness_anisotropy;
+export using .::pbrlib_1_6 import mx_roughness_dual;
+export using .::pbrlib_1_6 import mx_blackbody;
+export using .::pbrlib_1_6 import mx_artistic_ior__result;
+export using .::pbrlib_1_6 import mx_artistic_ior;
+export using .::pbrlib_1_6 import mx_deon_hair_absorption_from_melanin;
+export using .::pbrlib_1_6 import mx_chiang_hair_absorption_from_color;
+export using .::pbrlib_1_6 import mx_chiang_hair_roughness__result;
+export using .::pbrlib_1_6 import mx_chiang_hair_roughness;
+
+export using .::pbrlib_1_7 import mx_sheen_bsdf;
+export using .::pbrlib_1_7 import mx_add_bsdf;
+export using .::pbrlib_1_7 import mx_add_edf;
+export using .::pbrlib_1_7 import mx_mix_edf;
+export using .::pbrlib_1_7 import mx_add_vdf;
+export using .::pbrlib_1_7 import mx_generalized_schlick_edf;
+export using .::pbrlib_1_7 import mx_volume;
+
+export material mx_mix_bsdf(
+    material mxp_fg = material() [[ anno::usage( "materialx:bsdf") ]],
+    material mxp_bg = material() [[ anno::usage( "materialx:bsdf") ]],
+    float    mxp_mix = 0.0
+) [[ 
+    anno::usage( "materialx:bsdf") 
+]]
+= let {
+    float mix = math::saturate(mxp_mix);
+    volume_mix_return v = volume_mix(
+        mxp_fg.volume.scattering_coefficient, mix,
+        mxp_bg.volume.scattering_coefficient, (1.0f - mix));
+} in material(
+    surface: material_surface( 
+        scattering: df::weighted_layer(
+            weight: mix,
+            layer:  mxp_fg.surface.scattering,
+            base:   mxp_bg.surface.scattering
+        )
+    ),
+    // we need to carry volume properties along for SSS
+    ior: mix * mxp_fg.ior + (1.0f - mix) * mxp_bg.ior,
+    volume: material_volume(
+        scattering: df::clamped_mix( 
+            df::vdf_component[]( 
+                df::vdf_component(v.mix_weight1, mxp_fg.volume.scattering), 
+                df::vdf_component(1.0 - v.mix_weight1, mxp_bg.volume.scattering))
+        ),
+        absorption_coefficient: mix * mxp_fg.volume.absorption_coefficient + 
+                    (1.0 - mix) * mxp_bg.volume.absorption_coefficient,
+        scattering_coefficient: v.scattering_coefficient
+    )
+);
+
+export material mx_mix_vdf(
+    material mxp_fg = material() [[ anno::usage( "materialx:vdf") ]],
+    material mxp_bg = material() [[ anno::usage( "materialx:vdf") ]],
+    float    mxp_mix = 0.0
+) [[ 
+    anno::usage( "materialx:vdf") 
+]]
+= let {
+    float mix = math::saturate(mxp_mix);
+    volume_mix_return v = volume_mix(
+        mxp_fg.volume.scattering_coefficient, mix,
+        mxp_bg.volume.scattering_coefficient, (1.0f - mix));
+} in material(
+    ior: mix * mxp_fg.ior + (1.0f - mix) * mxp_bg.ior,
+    volume: material_volume(
+        scattering: df::clamped_mix(
+        df::vdf_component[](
+            df::vdf_component( v.mix_weight1, mxp_fg.volume.scattering),
+            df::vdf_component( 1.0 - v.mix_weight1, mxp_bg.volume.scattering))
+        ),
+        absorption_coefficient: mix * mxp_fg.volume.absorption_coefficient +
+                   (1.0 - mix) * mxp_bg.volume.absorption_coefficient,
+        scattering_coefficient: v.scattering_coefficient
+    )
+);
+
+// helper to compute ior for generalized_schlick
+color mx_f0_to_ior(color F0)
+{
+    float3 sqrtF0 = math::sqrt(math::clamp(float3(F0), 0.01, 0.99));
+    return color((float3(1.0) + sqrtF0) / (float3(1.0) - sqrtF0));
+}
+
+export material mx_generalized_schlick_bsdf(
+    float  mxp_weight    = 1.0,
+    color  mxp_color0    = color(1.0),
+    color  mxp_color82   = color(1.0) [[ anno::unused() ]], // MDL 1.10
+    color  mxp_color90   = color(1.0),
+    float  mxp_exponent  = 5.0,
+    float2 mxp_roughness = float2(0.05),
+    float3 mxp_normal    = state::normal(),
+    float3 mxp_tangent   = state::texture_tangent_u(0),
+    uniform core::mx_distribution_type mxp_distribution = core::mx_distribution_type_ggx [[ anno::unused() ]],
+    uniform mx_scatter_mode mxp_scatter_mode = mx_scatter_mode_R,
+    material mxp_base = material() [[ anno::usage( "materialx:bsdf") ]], // layering
+    float mxp_top_weight = 1.0, // layering for cases where top is scaled using a mix
+    float mxp_thinfilm_thickness = 0.0,
+    float mxp_thinfilm_ior = 1.0
+) [[ 
+    anno::usage( "materialx:bsdf") 
+]]
+= let {
+    float coatIor = mxp_thinfilm_ior <= 0.0 ? 1.0 : mxp_thinfilm_ior;
+    bsdf ggx_model_R = df::microfacet_ggx_smith_bsdf(
+        roughness_u: mxp_roughness.x,
+        roughness_v: mxp_roughness.y,
+        tint: color(1.0) * mxp_top_weight,
+        multiscatter_tint: color(1.0) * mxp_top_weight,
+        tangent_u: mxp_tangent,
+        mode: df::scatter_reflect);
+
+    bsdf ggx_model_T = df::microfacet_ggx_smith_bsdf(
+        roughness_u: mxp_roughness.x,
+        roughness_v: mxp_roughness.y,
+        tint: color(1.0) * mxp_top_weight,
+        multiscatter_tint: color(1.0) * mxp_top_weight,
+        tangent_u: mxp_tangent,
+        mode: df::scatter_transmit);
+
+} in material(
+    surface: material_surface(
+        scattering: df::unbounded_mix(
+            df::bsdf_component[](
+            df::bsdf_component(
+                mxp_weight,
+                mxp_scatter_mode == mx_scatter_mode_T
+                ? df::color_custom_curve_layer(
+                    normal_reflectivity: mxp_color0,
+                    grazing_reflectivity: mxp_color90,
+                    exponent: mxp_exponent,
+                    layer: bsdf(),
+                    base: ggx_model_T,
+                    normal: mxp_normal)
+                : df::thin_film(
+                    thickness: mxp_thinfilm_thickness,
+                    ior: color(coatIor),
+                    base: df::color_custom_curve_layer(
+                        normal_reflectivity: mxp_color0,
+                        grazing_reflectivity: mxp_color90,
+                        exponent: mxp_exponent,
+                        layer: ggx_model_R,
+                        base: mxp_scatter_mode == mx_scatter_mode_R 
+                            ? mxp_base.surface.scattering 
+                            : ggx_model_T,
+                        normal: mxp_normal))
+                ),
+            df::bsdf_component(
+                1.0 - mxp_weight, 
+                mxp_base.surface.scattering)
+            )
+        )
+    ),
+    ior: mx_f0_to_ior(mxp_color0),
+    // we need to carry volume properties along for SSS
+    volume: mxp_base.volume
+);
+
+
+// TODO MDL 1.8 
+// * will add support for thin film above a color_custom_curve_layer node until then, thin_film will have no effect
+// * thin_film(thickness: 0.0, ior: < 1.0) will be handled properly
+export material mx_dielectric_bsdf(
+    float  mxp_weight    = 1.0,
+    color  mxp_tint      = color(1.0),
+    float  mxp_ior       = 1.5,
+    float2 mxp_roughness = float2(0.0),
+    float3 mxp_normal    = state::normal(),
+    float3 mxp_tangent   = state::texture_tangent_u(0),
+    uniform core::mx_distribution_type mxp_distribution = core::mx_distribution_type_ggx [[ anno::unused() ]],
+    uniform mx_scatter_mode mxp_scatter_mode = mx_scatter_mode_R,
+    material mxp_base = material() [[ anno::usage( "materialx:bsdf") ]], // layering
+    float mxp_top_weight = 1.0, // layering for cases where top is scaled using a mix
+    float mxp_thinfilm_thickness = 0.0,
+    float mxp_thinfilm_ior = 1.0
+) [[ 
+    anno::usage( "materialx:bsdf") 
+]]
+= let {
+    float coatIor = mxp_thinfilm_ior <= 0.0 ? 1.0 : mxp_thinfilm_ior;
+    float grazing_refl = math::max((1.0 - math::average(mxp_roughness)), 0.0);
+    float root_r = (mxp_ior-1)/(mxp_ior+1);
+    bsdf bsdf_R = df::thin_film(
+        thickness: mxp_thinfilm_thickness,
+        ior: color(coatIor),
+        // fresnel layer has issues if base is a diffuse transmission, use custom curve for now
+        // this will break thin_film but improves standard_surface with diffuse transmission
+        base: df::custom_curve_layer(
+            normal_reflectivity: root_r*root_r,
+            grazing_reflectivity: grazing_refl,
+            weight: mxp_weight,
+            layer: df::microfacet_ggx_smith_bsdf(
+                roughness_u: mxp_roughness.x,
+                roughness_v: mxp_roughness.y,
+                tint: mxp_tint * mxp_top_weight,
+                multiscatter_tint: mxp_tint * mxp_top_weight,
+                tangent_u: mxp_tangent,
+                mode: df::scatter_reflect),
+            base: mxp_base.surface.scattering,
+            normal: mxp_normal));
+
+    bsdf bsdf_T = df::weighted_layer(
+        weight: mxp_weight,
+        layer: df::microfacet_ggx_smith_bsdf(
+            roughness_u: mxp_roughness.x,
+            roughness_v: mxp_roughness.y,
+            tint: mxp_tint * mxp_top_weight,
+            multiscatter_tint: mxp_tint * mxp_top_weight,
+            tangent_u: mxp_tangent,
+            mode: df::scatter_transmit),
+        normal: mxp_normal);
+
+    bsdf bsdf_RT = df::weighted_layer(
+        weight: mxp_weight,
+        layer: df::thin_film(
+            thickness: mxp_thinfilm_thickness,
+            ior: color(coatIor),
+            base: df::microfacet_ggx_smith_bsdf(
+                roughness_u: mxp_roughness.x,
+                roughness_v: mxp_roughness.y,
+                tint: mxp_tint * mxp_top_weight,
+                multiscatter_tint: mxp_tint * mxp_top_weight,
+                tangent_u: mxp_tangent,
+                mode: df::scatter_reflect_transmit)),
+        normal: mxp_normal);
+
+    bsdf bsdf_selected = (mxp_scatter_mode == mx_scatter_mode_R) ? bsdf_R :
+                         ((mxp_scatter_mode == mx_scatter_mode_T) ? bsdf_T : bsdf_RT);
+} in material(
+    surface: material_surface(
+        scattering: bsdf_selected
+    ),
+    // we need to carry volume properties along for SSS
+    ior: color(mxp_ior),
+    volume: mxp_base.volume
+);
+
+export material mx_conductor_bsdf(
+    float  mxp_weight     = 1.0,
+    color  mxp_ior        = color(0.18, 0.42, 1.37),
+    color  mxp_extinction = color(3.42, 2.35, 1.77),
+    float2 mxp_roughness  = float2(0.0),
+    float3 mxp_normal     = state::normal(),
+    float3 mxp_tangent    = state::texture_tangent_u(0),
+    uniform core::mx_distribution_type mxp_distribution = core::mx_distribution_type_ggx [[ anno::unused() ]],
+    float mxp_thinfilm_thickness = 0.0,
+    float mxp_thinfilm_ior = 1.0
+) [[ 
+    anno::usage( "materialx:bsdf") 
+]]
+= let {
+    float coatIor = mxp_thinfilm_ior <= 0.0 ? 1.0 : mxp_thinfilm_ior;
+    bsdf ggx_model = df::microfacet_ggx_smith_bsdf(
+        roughness_u: mxp_roughness.x,
+        roughness_v: mxp_roughness.y,
+        tint: color(1.0),
+        multiscatter_tint: color(1.0),
+        tangent_u: mxp_tangent);
+    bsdf conductor = df::fresnel_factor(
+        ior: mxp_ior,
+        extinction_coefficient: mxp_extinction, 
+        base: ggx_model);
+    bsdf thin_film_conductor = df::thin_film(
+        thickness: mxp_thinfilm_thickness,
+        ior: color(coatIor),
+        base: conductor);
+} in material(
+    surface: material_surface(
+        scattering: df::weighted_layer(
+            weight: mxp_weight,
+            layer: thin_film_conductor,
+            normal: mxp_normal
+        )
+    ),
+    ior: mxp_ior,
+);
+
+// Shader Nodes
+
+// NOTE: The MDL material with thin_walled == false uses the same material_surface
+//       properties for the front- and backface, the material will not be black
+//       from the backside as mandated by the MaterialX spec.
+export material mx_surface(
+    material mxp_bsdf = material() [[ anno::usage( "materialx:bsdf") ]],
+    material mxp_edf  = material() [[ anno::usage( "materialx:edf") ]],
+    float mxp_opacity = 1.0,
+    uniform bool mxp_thin_walled = false,
+    float mxp_transmission_ior = 0.0 // extra parameter for setting transmission IOR
+) [[
+    anno::usage( "materialx:surfaceshader")
+]]
+= let {
+    bsdf              bsdf_node = mxp_bsdf.surface.scattering;
+    material_emission edf_node  = mxp_edf.surface.emission;
+    // we need to carry volume properties along for SSS
+    material_volume   bsdf_volume = mxp_bsdf.volume;
+} in material(
+    thin_walled: mxp_thin_walled,
+    surface: material_surface(
+        scattering: bsdf_node,
+        emission: edf_node
+    ),
+    ior: mxp_transmission_ior > 0.0 ? color(mxp_transmission_ior) : mxp_bsdf.ior,
+    volume: bsdf_volume,
+    geometry: material_geometry(
+        cutout_opacity: mxp_opacity
+    )
+);

--- a/source/MaterialXGenMdl/mdl/materialx/sampling.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/sampling.mdl
@@ -5,7 +5,9 @@
 
 mdl 1.6;
 
+import ::anno::*;
 import ::math::*;
+import ::state::*;
 
 import .::core::*;
 
@@ -15,14 +17,14 @@ export const int MX_MAX_SAMPLE_COUNT = 49;
 export const int MX_WEIGHT_ARRAY_SIZE = 84;
 
 // This is not available in MDL so just use a "small" number
-float2 dFdx(float2 uv)
+float2 dFdx(float2 uv [[anno::unused()]])
 {
-    return uv+0.0001;
+    return float2(0.001, 0);
 }
 
-float2 dFdy(float2 uv)
+float2 dFdy(float2 uv [[anno::unused()]])
 {
-    return uv+0.0001;
+    return float2(0, 0.001);
 }
 
 //
@@ -49,11 +51,13 @@ export float2 mx_compute_sample_size_uv(float2 uv, float filterSize, float filte
 //
 export float3 mx_normal_from_samples_sobel(float[9] S, float scale)
 {
-   float nx = S[0] - S[2] + (2.0*S[3]) - (2.0*S[5]) + S[6] - S[8];
-   float ny = S[0] + (2.0*S[1]) + S[2] - S[6] - (2.0*S[7]) - S[8];
-   float nz = scale * ::math::sqrt(1.0 - nx*nx - ny*ny);
-   float3 norm = ::math::normalize(float3(nx, ny, nz));
-   return (norm + 1.0) * 0.5;
+    // this produces NaN
+    float nx = S[0] - S[2] + (2.0*S[3]) - (2.0*S[5]) + S[6] - S[8];
+    float ny = S[0] + (2.0*S[1]) + S[2] - S[6] - (2.0*S[7]) - S[8];
+    // float nz = scale * ::math::sqrt(1.0 - nx*nx - ny*ny);
+    // float3 norm = ::math::normalize(float3(nx, ny, nz));
+    float3 norm = math::normalize(float3(nx * scale, ny * scale, 0.125));
+    return (norm + 1.0) * 0.5;
 }
 
 // Kernel weights for box filter

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_9.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_9.mdl
@@ -1,0 +1,387 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// MDL implementation of all Standard Source Nodes of
+//     MaterialX: An Open Standard for Network-Based CG Object Looks
+//     Document v1.37 REV2, January 19, 2020
+//     www.materialx.org 
+// in
+//     NVIDIA Material Definition Language 1.9
+//     Language Specification
+//     Document version 1.9.2, September 16, 2024
+//     www.nvidia.com/mdl
+
+mdl 1.9;
+
+import ::anno::*;
+import ::df::*;
+import ::math::*;
+import ::scene::*;
+import ::state::*;
+
+import .::core::*;
+import .::noise::*;
+import .::hsv::*;
+
+// Changes since MDL 1.8
+// - lift the restriction of uniform IORs
+
+// forward unchanged definitions from the previous version
+export using .::stdlib_1_7 import mx_surfacematerial;
+export using .::stdlib_1_7 import mx_surface_unlit;
+export using .::stdlib_1_7 import mx_image_float;
+export using .::stdlib_1_7 import mx_image_color3;
+export using .::stdlib_1_7 import mx_image_color4;
+export using .::stdlib_1_7 import mx_image_vector2;
+export using .::stdlib_1_7 import mx_image_vector3;
+export using .::stdlib_1_7 import mx_image_vector4;
+export using .::stdlib_1_7 import mx_constant_float;
+export using .::stdlib_1_7 import mx_constant_color3;
+export using .::stdlib_1_7 import mx_constant_color4;
+export using .::stdlib_1_7 import mx_constant_vector2;
+export using .::stdlib_1_7 import mx_constant_vector3;
+export using .::stdlib_1_7 import mx_constant_vector4;
+export using .::stdlib_1_7 import mx_constant_boolean;
+export using .::stdlib_1_7 import mx_constant_integer;
+export using .::stdlib_1_7 import mx_constant_matrix33;
+export using .::stdlib_1_7 import mx_constant_matrix44;
+export using .::stdlib_1_7 import mx_constant_string;
+export using .::stdlib_1_7 import mx_constant_filename;
+export using .::stdlib_1_7 import mx_ramplr_float;
+export using .::stdlib_1_7 import mx_ramplr_color3;
+export using .::stdlib_1_7 import mx_ramplr_color4;
+export using .::stdlib_1_7 import mx_ramplr_vector2;
+export using .::stdlib_1_7 import mx_ramplr_vector3;
+export using .::stdlib_1_7 import mx_ramplr_vector4;
+export using .::stdlib_1_7 import mx_ramptb_float;
+export using .::stdlib_1_7 import mx_ramptb_color3;
+export using .::stdlib_1_7 import mx_ramptb_color4;
+export using .::stdlib_1_7 import mx_ramptb_vector2;
+export using .::stdlib_1_7 import mx_ramptb_vector3;
+export using .::stdlib_1_7 import mx_ramptb_vector4;
+export using .::stdlib_1_7 import mx_splitlr_float;
+export using .::stdlib_1_7 import mx_splitlr_color3;
+export using .::stdlib_1_7 import mx_splitlr_color4;
+export using .::stdlib_1_7 import mx_splitlr_vector2;
+export using .::stdlib_1_7 import mx_splitlr_vector3;
+export using .::stdlib_1_7 import mx_splitlr_vector4;
+export using .::stdlib_1_7 import mx_splittb_float;
+export using .::stdlib_1_7 import mx_splittb_color3;
+export using .::stdlib_1_7 import mx_splittb_color4;
+export using .::stdlib_1_7 import mx_splittb_vector2;
+export using .::stdlib_1_7 import mx_splittb_vector3;
+export using .::stdlib_1_7 import mx_splittb_vector4;
+export using .::stdlib_1_7 import mx_position_vector3;
+export using .::stdlib_1_7 import mx_normal_vector3;
+export using .::stdlib_1_7 import mx_tangent_vector3;
+export using .::stdlib_1_7 import mx_bitangent_vector3;
+export using .::stdlib_1_7 import mx_texcoord_vector2;
+export using .::stdlib_1_7 import mx_texcoord_vector3;
+export using .::stdlib_1_7 import mx_geomcolor_float;
+export using .::stdlib_1_7 import mx_geomcolor_color3;
+export using .::stdlib_1_7 import mx_geomcolor_color4;
+export using .::stdlib_1_7 import mx_ambientocclusion_float;
+export using .::stdlib_1_7 import mx_frame_float;
+export using .::stdlib_1_7 import mx_time_float;
+export using .::stdlib_1_7 import mx_modulo_color3;
+export using .::stdlib_1_7 import mx_modulo_color4;
+export using .::stdlib_1_7 import mx_modulo_color3FA;
+export using .::stdlib_1_7 import mx_modulo_color4FA;
+export using .::stdlib_1_7 import mx_invert_color4;
+export using .::stdlib_1_7 import mx_invert_color4FA;
+export using .::stdlib_1_7 import mx_absval_color4;
+export using .::stdlib_1_7 import mx_floor_color3;
+export using .::stdlib_1_7 import mx_floor_color4;
+export using .::stdlib_1_7 import mx_ceil_color3;
+export using .::stdlib_1_7 import mx_ceil_color4;
+export using .::stdlib_1_7 import mx_round_color3;
+export using .::stdlib_1_7 import mx_round_color4;
+export using .::stdlib_1_7 import mx_power_color4;
+export using .::stdlib_1_7 import mx_power_color4FA;
+export using .::stdlib_1_7 import mx_sin_float;
+export using .::stdlib_1_7 import mx_cos_float;
+export using .::stdlib_1_7 import mx_tan_float;
+export using .::stdlib_1_7 import mx_asin_float;
+export using .::stdlib_1_7 import mx_acos_float;
+export using .::stdlib_1_7 import mx_atan2_float;
+export using .::stdlib_1_7 import mx_sin_vector2;
+export using .::stdlib_1_7 import mx_cos_vector2;
+export using .::stdlib_1_7 import mx_tan_vector2;
+export using .::stdlib_1_7 import mx_asin_vector2;
+export using .::stdlib_1_7 import mx_acos_vector2;
+export using .::stdlib_1_7 import mx_atan2_vector2;
+export using .::stdlib_1_7 import mx_sin_vector3;
+export using .::stdlib_1_7 import mx_cos_vector3;
+export using .::stdlib_1_7 import mx_tan_vector3;
+export using .::stdlib_1_7 import mx_asin_vector3;
+export using .::stdlib_1_7 import mx_acos_vector3;
+export using .::stdlib_1_7 import mx_atan2_vector3;
+export using .::stdlib_1_7 import mx_sin_vector4;
+export using .::stdlib_1_7 import mx_cos_vector4;
+export using .::stdlib_1_7 import mx_tan_vector4;
+export using .::stdlib_1_7 import mx_asin_vector4;
+export using .::stdlib_1_7 import mx_acos_vector4;
+export using .::stdlib_1_7 import mx_atan2_vector4;
+export using .::stdlib_1_7 import mx_sqrt_float;
+export using .::stdlib_1_7 import mx_ln_float;
+export using .::stdlib_1_7 import mx_exp_float;
+export using .::stdlib_1_7 import mx_sqrt_vector2;
+export using .::stdlib_1_7 import mx_ln_vector2;
+export using .::stdlib_1_7 import mx_exp_vector2;
+export using .::stdlib_1_7 import mx_sqrt_vector3;
+export using .::stdlib_1_7 import mx_ln_vector3;
+export using .::stdlib_1_7 import mx_exp_vector3;
+export using .::stdlib_1_7 import mx_sqrt_vector4;
+export using .::stdlib_1_7 import mx_ln_vector4;
+export using .::stdlib_1_7 import mx_exp_vector4;
+export using .::stdlib_1_7 import mx_sign_color3;
+export using .::stdlib_1_7 import mx_sign_color4;
+export using .::stdlib_1_7 import mx_clamp_color4;
+export using .::stdlib_1_7 import mx_clamp_color4FA;
+export using .::stdlib_1_7 import mx_min_color4;
+export using .::stdlib_1_7 import mx_min_color4;
+export using .::stdlib_1_7 import mx_max_color4;
+export using .::stdlib_1_7 import mx_max_color4;
+export using .::stdlib_1_7 import mx_transformpoint_vector3;
+export using .::stdlib_1_7 import mx_transformvector_vector3;
+export using .::stdlib_1_7 import mx_transformnormal_vector3;
+export using .::stdlib_1_7 import mx_transformmatrix_vector2M3;
+export using .::stdlib_1_7 import mx_transformmatrix_vector3;
+export using .::stdlib_1_7 import mx_transformmatrix_vector3M4;
+export using .::stdlib_1_7 import mx_transformmatrix_vector4;
+export using .::stdlib_1_7 import mx_normalmap_float;
+export using .::stdlib_1_7 import mx_normalmap_vector2;
+export using .::stdlib_1_7 import mx_transpose_matrix33;
+export using .::stdlib_1_7 import mx_transpose_matrix44;
+export using .::stdlib_1_7 import mx_determinant_matrix33;
+export using .::stdlib_1_7 import mx_determinant_matrix44;
+export using .::stdlib_1_7 import mx_invertmatrix_matrix33;
+export using .::stdlib_1_7 import mx_invertmatrix_matrix44;
+export using .::stdlib_1_7 import mx_rotate2d_vector2;
+export using .::stdlib_1_7 import mx_rotate3d_vector3;
+export using .::stdlib_1_7 import mx_remap_float;
+export using .::stdlib_1_7 import mx_remap_color3;
+export using .::stdlib_1_7 import mx_remap_color4;
+export using .::stdlib_1_7 import mx_remap_vector2;
+export using .::stdlib_1_7 import mx_remap_vector3;
+export using .::stdlib_1_7 import mx_remap_vector4;
+export using .::stdlib_1_7 import mx_remap_color3FA;
+export using .::stdlib_1_7 import mx_remap_color4FA;
+export using .::stdlib_1_7 import mx_remap_vector2FA;
+export using .::stdlib_1_7 import mx_remap_vector3FA;
+export using .::stdlib_1_7 import mx_remap_vector4FA;
+export using .::stdlib_1_7 import mx_smoothstep_float;
+export using .::stdlib_1_7 import mx_smoothstep_color3;
+export using .::stdlib_1_7 import mx_smoothstep_color4;
+export using .::stdlib_1_7 import mx_smoothstep_vector2;
+export using .::stdlib_1_7 import mx_smoothstep_vector3;
+export using .::stdlib_1_7 import mx_smoothstep_vector4;
+export using .::stdlib_1_7 import mx_smoothstep_color3FA;
+export using .::stdlib_1_7 import mx_smoothstep_color4FA;
+export using .::stdlib_1_7 import mx_smoothstep_vector2FA;
+export using .::stdlib_1_7 import mx_smoothstep_vector3FA;
+export using .::stdlib_1_7 import mx_smoothstep_vector4FA;
+export using .::stdlib_1_7 import mx_curveadjust_float;
+export using .::stdlib_1_7 import mx_curveadjust_color3;
+export using .::stdlib_1_7 import mx_curveadjust_color4;
+export using .::stdlib_1_7 import mx_curveadjust_vector2;
+export using .::stdlib_1_7 import mx_curveadjust_vector3;
+export using .::stdlib_1_7 import mx_curveadjust_vector4;
+export using .::stdlib_1_7 import mx_luminance_color3;
+export using .::stdlib_1_7 import mx_luminance_color4;
+export using .::stdlib_1_7 import mx_rgbtohsv_color3;
+export using .::stdlib_1_7 import mx_rgbtohsv_color4;
+export using .::stdlib_1_7 import mx_hsvtorgb_color3;
+export using .::stdlib_1_7 import mx_hsvtorgb_color4;
+export using .::stdlib_1_7 import mx_premult_color4;
+export using .::stdlib_1_7 import mx_unpremult_color4;
+export using .::stdlib_1_7 import mx_plus_color4;
+export using .::stdlib_1_7 import mx_minus_color4;
+export using .::stdlib_1_7 import mx_difference_color4;
+export using .::stdlib_1_7 import mx_burn_float;
+export using .::stdlib_1_7 import mx_burn_color3;
+export using .::stdlib_1_7 import mx_burn_color4;
+export using .::stdlib_1_7 import mx_dodge_float;
+export using .::stdlib_1_7 import mx_dodge_color3;
+export using .::stdlib_1_7 import mx_dodge_color4;
+export using .::stdlib_1_7 import mx_screen_color4;
+export using .::stdlib_1_7 import mx_disjointover_color4;
+export using .::stdlib_1_7 import mx_in_color4;
+export using .::stdlib_1_7 import mx_mask_color4;
+export using .::stdlib_1_7 import mx_matte_color4;
+export using .::stdlib_1_7 import mx_out_color4;
+export using .::stdlib_1_7 import mx_over_color4;
+export using .::stdlib_1_7 import mx_mix_color4;
+export using .::stdlib_1_7 import mx_mix_color4_color4;
+export using .::stdlib_1_7 import mx_mix_volumeshader;
+export using .::stdlib_1_7 import mx_mix_displacementshader;
+export using .::stdlib_1_7 import mx_ifgreater_float;
+export using .::stdlib_1_7 import mx_ifgreater_integer;
+export using .::stdlib_1_7 import mx_ifgreater_color3;
+export using .::stdlib_1_7 import mx_ifgreater_color4;
+export using .::stdlib_1_7 import mx_ifgreater_vector2;
+export using .::stdlib_1_7 import mx_ifgreater_vector3;
+export using .::stdlib_1_7 import mx_ifgreater_vector4;
+export using .::stdlib_1_7 import mx_ifgreater_matrix33;
+export using .::stdlib_1_7 import mx_ifgreater_matrix44;
+export using .::stdlib_1_7 import mx_ifgreater_boolean;
+export using .::stdlib_1_7 import mx_ifgreater_floatI;
+export using .::stdlib_1_7 import mx_ifgreater_integerI;
+export using .::stdlib_1_7 import mx_ifgreater_color3I;
+export using .::stdlib_1_7 import mx_ifgreater_color4I;
+export using .::stdlib_1_7 import mx_ifgreater_vector2I;
+export using .::stdlib_1_7 import mx_ifgreater_vector3I;
+export using .::stdlib_1_7 import mx_ifgreater_vector4I;
+export using .::stdlib_1_7 import mx_ifgreater_matrix33I;
+export using .::stdlib_1_7 import mx_ifgreater_matrix44I;
+export using .::stdlib_1_7 import mx_ifgreater_booleanI;
+export using .::stdlib_1_7 import mx_ifgreatereq_float;
+export using .::stdlib_1_7 import mx_ifgreatereq_integer;
+export using .::stdlib_1_7 import mx_ifgreatereq_color3;
+export using .::stdlib_1_7 import mx_ifgreatereq_color4;
+export using .::stdlib_1_7 import mx_ifgreatereq_vector2;
+export using .::stdlib_1_7 import mx_ifgreatereq_vector3;
+export using .::stdlib_1_7 import mx_ifgreatereq_vector4;
+export using .::stdlib_1_7 import mx_ifgreatereq_matrix33;
+export using .::stdlib_1_7 import mx_ifgreatereq_matrix44;
+export using .::stdlib_1_7 import mx_ifgreatereq_boolean;
+export using .::stdlib_1_7 import mx_ifgreatereq_floatI;
+export using .::stdlib_1_7 import mx_ifgreatereq_integerI;
+export using .::stdlib_1_7 import mx_ifgreatereq_color3I;
+export using .::stdlib_1_7 import mx_ifgreatereq_color4I;
+export using .::stdlib_1_7 import mx_ifgreatereq_vector2I;
+export using .::stdlib_1_7 import mx_ifgreatereq_vector3I;
+export using .::stdlib_1_7 import mx_ifgreatereq_vector4I;
+export using .::stdlib_1_7 import mx_ifgreatereq_matrix33I;
+export using .::stdlib_1_7 import mx_ifgreatereq_matrix44I;
+export using .::stdlib_1_7 import mx_ifgreatereq_booleanI;
+export using .::stdlib_1_7 import mx_ifequal_float;
+export using .::stdlib_1_7 import mx_ifequal_integer;
+export using .::stdlib_1_7 import mx_ifequal_color3;
+export using .::stdlib_1_7 import mx_ifequal_color4;
+export using .::stdlib_1_7 import mx_ifequal_vector2;
+export using .::stdlib_1_7 import mx_ifequal_vector3;
+export using .::stdlib_1_7 import mx_ifequal_vector4;
+export using .::stdlib_1_7 import mx_ifequal_matrix33;
+export using .::stdlib_1_7 import mx_ifequal_matrix44;
+export using .::stdlib_1_7 import mx_ifequal_boolean;
+export using .::stdlib_1_7 import mx_ifequal_floatI;
+export using .::stdlib_1_7 import mx_ifequal_integerI;
+export using .::stdlib_1_7 import mx_ifequal_color3I;
+export using .::stdlib_1_7 import mx_ifequal_color4I;
+export using .::stdlib_1_7 import mx_ifequal_vector2I;
+export using .::stdlib_1_7 import mx_ifequal_vector3I;
+export using .::stdlib_1_7 import mx_ifequal_vector4I;
+export using .::stdlib_1_7 import mx_ifequal_matrix33I;
+export using .::stdlib_1_7 import mx_ifequal_matrix44I;
+export using .::stdlib_1_7 import mx_ifequal_booleanI;
+export using .::stdlib_1_7 import mx_ifequal_floatB;
+export using .::stdlib_1_7 import mx_ifequal_integerB;
+export using .::stdlib_1_7 import mx_ifequal_color3B;
+export using .::stdlib_1_7 import mx_ifequal_color4B;
+export using .::stdlib_1_7 import mx_ifequal_vector2B;
+export using .::stdlib_1_7 import mx_ifequal_vector3B;
+export using .::stdlib_1_7 import mx_ifequal_vector4B;
+export using .::stdlib_1_7 import mx_ifequal_matrix33B;
+export using .::stdlib_1_7 import mx_ifequal_matrix44B;
+export using .::stdlib_1_7 import mx_ifequal_booleanB;
+export using .::stdlib_1_7 import mx_creatematrix_vector3_matrix33;
+export using .::stdlib_1_7 import mx_creatematrix_vector3_matrix44;
+export using .::stdlib_1_7 import mx_creatematrix_vector4_matrix44;
+export using .::stdlib_1_7 import mx_extract_color3;
+export using .::stdlib_1_7 import mx_extract_color4;
+export using .::stdlib_1_7 import mx_extract_vector2;
+export using .::stdlib_1_7 import mx_extract_vector3;
+export using .::stdlib_1_7 import mx_extract_vector4;
+export using .::stdlib_1_7 import mx_blur_float;
+export using .::stdlib_1_7 import mx_blur_color3;
+export using .::stdlib_1_7 import mx_blur_color4;
+export using .::stdlib_1_7 import mx_blur_vector2;
+export using .::stdlib_1_7 import mx_blur_vector3;
+export using .::stdlib_1_7 import mx_blur_vector4;
+export using .::stdlib_1_7 import mx_heighttonormal_vector3;
+export using .::stdlib_1_7 import mx_noise2d_float;
+export using .::stdlib_1_7 import mx_noise2d_float2;
+export using .::stdlib_1_7 import mx_noise2d_float3;
+export using .::stdlib_1_7 import mx_noise2d_float4;
+export using .::stdlib_1_7 import mx_noise3d_float;
+export using .::stdlib_1_7 import mx_noise3d_float2;
+export using .::stdlib_1_7 import mx_noise3d_float3;
+export using .::stdlib_1_7 import mx_noise3d_float4;
+export using .::stdlib_1_7 import mx_fractal3d_float;
+export using .::stdlib_1_7 import mx_fractal3d_float2;
+export using .::stdlib_1_7 import mx_fractal3d_float3;
+export using .::stdlib_1_7 import mx_fractal3d_float4;
+export using .::stdlib_1_7 import mx_cellnoise2d_float;
+export using .::stdlib_1_7 import mx_cellnoise3d_float;
+export using .::stdlib_1_7 import mx_worleynoise2d_float;
+export using .::stdlib_1_7 import mx_worleynoise2d_float2;
+export using .::stdlib_1_7 import mx_worleynoise2d_float3;
+export using .::stdlib_1_7 import mx_worleynoise3d_float;
+export using .::stdlib_1_7 import mx_worleynoise3d_float2;
+export using .::stdlib_1_7 import mx_worleynoise3d_float3;
+export using .::stdlib_1_7 import mx_combine2_color4CF;
+
+export using .::stdlib_1_7 import mx_geompropvalue_string;
+export using .::stdlib_1_8 import mx_geompropvalue_boolean;
+export using .::stdlib_1_8 import mx_geompropvalue_integer;
+export using .::stdlib_1_8 import mx_geompropvalue_float;
+export using .::stdlib_1_8 import mx_geompropvalue_color3;
+export using .::stdlib_1_8 import mx_geompropvalue_color4;
+export using .::stdlib_1_8 import mx_geompropvalue_vector2;
+export using .::stdlib_1_8 import mx_geompropvalue_vector3;
+export using .::stdlib_1_8 import mx_geompropvalue_vector4;
+export using .::stdlib_1_8 import mx_viewdirection_vector3;
+
+
+
+// mix all parts of the material, bsdf, edf, and vdf, geometry
+export material mx_mix_surfaceshader(
+    material mxp_fg = material() [[ anno::usage( "materialx:surfaceshader") ]],
+    material mxp_bg = material() [[ anno::usage( "materialx:surfaceshader") ]],
+    float    mxp_mix = 0.0
+) [[
+    anno::description("Node Group: compositing"),
+    anno::usage( "materialx:surfaceshader") 
+]]
+= material(
+    surface: material_surface( 
+        scattering: df::weighted_layer(
+            weight: mxp_mix,
+            layer:  mxp_fg.surface.scattering,
+            base:   mxp_bg.surface.scattering
+        ),
+        emission: material_emission(
+            emission: df::clamped_mix(
+            df::edf_component[]( 
+                df::edf_component( mxp_mix, mxp_fg.surface.emission.emission), 
+                df::edf_component( 1.0 - mxp_mix, mxp_bg.surface.emission.emission))
+            ),
+            intensity: mxp_mix * mxp_fg.surface.emission.intensity +
+                       (1.0 - mxp_mix) * mxp_bg.surface.emission.intensity
+        )
+    ),
+
+    // we need to carry volume properties along for SSS
+    ior: mxp_mix * mxp_fg.ior + (1.0 - mxp_mix) * mxp_bg.ior,
+    volume: material_volume(
+        scattering: df::clamped_mix(
+            df::vdf_component[]( 
+                df::vdf_component( mxp_mix, mxp_fg.volume.scattering), 
+                df::vdf_component( 1.0 - mxp_mix, mxp_bg.volume.scattering))
+        ),
+        absorption_coefficient: mxp_mix * mxp_fg.volume.absorption_coefficient + 
+                    (1.0 - mxp_mix) * mxp_bg.volume.absorption_coefficient,
+        scattering_coefficient: mxp_mix * mxp_fg.volume.scattering_coefficient + 
+                    (1.0 - mxp_mix) * mxp_bg.volume.scattering_coefficient
+    ),
+    geometry: material_geometry(
+        displacement: mxp_mix * mxp_fg.geometry.displacement + 
+                    (1.0 - mxp_mix) * mxp_bg.geometry.displacement,
+        cutout_opacity: mxp_mix * mxp_fg.geometry.cutout_opacity + 
+                    (1.0 - mxp_mix) * mxp_bg.geometry.cutout_opacity,
+        normal: mxp_mix * mxp_fg.geometry.normal + 
+                    (1.0 - mxp_mix) * mxp_bg.geometry.normal
+    )
+);

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -225,15 +225,9 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
     moduleToTest = moduleToTest.substr(0, moduleToTest.size() - sourceCodePaths[0].getExtension().length() - 1);
 
     std::string renderExec(MATERIALX_MDL_RENDER_EXECUTABLE);
-    bool testMDLC = renderExec.empty();
-    if (testMDLC)
+    std::string mdlcExec(MATERIALX_MDLC_EXECUTABLE);
+    if (!mdlcExec.empty()) // always run compiler
     {
-        std::string mdlcExec(MATERIALX_MDLC_EXECUTABLE);
-        if (mdlcExec.empty())
-        {
-            return;
-        }
-
         std::string mdlcCommand = mdlcExec;
 
         // use the same paths as the resolver
@@ -264,12 +258,19 @@ void MdlShaderGeneratorTester::compileSource(const std::vector<mx::FilePath>& so
                 _logFile << "\tReturn code: " << std::to_string(returnValue) << std::endl;
                 writeErrorCode = true;
             }
-            _logFile << "\tError: " << line << std::endl;
+            if (line.find(": Warning ") != std::string::npos)
+            {
+                _logFile << "\tWarning: " << line << std::endl;
+            }
+            else
+            {
+                _logFile << "\tError: " << line << std::endl;
+            }
         }
 
         CHECK(returnValue == 0);
     }
-    else
+    if (!renderExec.empty()) // render if renderer is availabe
     {
         std::string renderCommand = renderExec;
 
@@ -358,6 +359,7 @@ TEST_CASE("GenShader: MDL Shader Generation", "[genmdl]")
     mx::FilePathVec testRootPaths;
     testRootPaths.push_back(searchPath.find("resources/Materials/TestSuite"));
     testRootPaths.push_back(searchPath.find("resources/Materials/Examples/StandardSurface"));
+    testRootPaths.push_back(searchPath.find("resources/Materials/Examples/UsdPreviewSurface"));
 
     const mx::FilePath logPath("genmdl_mdl_generate_test.txt");
 


### PR DESCRIPTION
add new version to GenMDL and remove uniform restriction from material IOR

Minor updates:
- improve MDL printing by adding named parameters
- handle 1-element mixes (basically scale) above layers
- improve blur and hight to normal to return something meaningful (before totally broken)
- improve non-material outputs that can be rendered, e.g. float3x3 and float4x4
- preparations for MDL 1.10