### PR TITLE
Add API to allow input reordering on node graphs

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -700,6 +700,41 @@ void NodeGraph::modifyInterfaceName(const string& inputPath, const string& inter
     }
 }
 
+void NodeGraph::setInputOrdering(const StringVec& inputNames)
+{
+    vector<InputPtr> inputs;
+    StringSet childInputNames;
+    std::vector<unsigned int> childInputIndicies;
+        
+    for (ElementPtr child : _childOrder)
+    {
+        InputPtr input = child->asA<Input>();
+        if (!input)
+            continue;
+
+        inputs.push_back(input);
+        const string& inputName = input->getName();
+        childInputNames.insert(inputName);
+        childInputIndicies.push_back(getChildIndex(inputName));
+    }
+
+    // Check that all names exist in the inputs
+    StringSet orderedNameSet(inputNames.begin(), inputNames.end());
+    if (childInputNames != orderedNameSet)
+    {
+        throw Exception("The set of names provided does not match the existing set of input names");
+    }
+
+    // Use the existing input child indices to set the locations for the
+    // named list. Pre-sort to add from lowest index to highest
+    std::sort(childInputIndicies.begin(), childInputIndicies.end());
+    for (size_t i = 0; i < childInputIndicies.size(); i++)
+    {
+        unsigned int newLocation = childInputIndicies[i];
+        setChildIndex(inputNames[i], newLocation);
+    }
+}
+
 NodeDefPtr NodeGraph::getNodeDef() const
 {
     NodeDefPtr nodedef = resolveNameReference<NodeDef>(getNodeDefString());

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -702,7 +702,6 @@ void NodeGraph::modifyInterfaceName(const string& inputPath, const string& inter
 
 void NodeGraph::setInputOrdering(const StringVec& inputNames)
 {
-    vector<InputPtr> inputs;
     StringSet childInputNames;
     std::vector<unsigned int> childInputIndicies;
         
@@ -712,15 +711,14 @@ void NodeGraph::setInputOrdering(const StringVec& inputNames)
         if (!input)
             continue;
 
-        inputs.push_back(input);
         const string& inputName = input->getName();
         childInputNames.insert(inputName);
         childInputIndicies.push_back(getChildIndex(inputName));
     }
 
     // Check that all names exist in the inputs
-    StringSet orderedNameSet(inputNames.begin(), inputNames.end());
-    if (childInputNames != orderedNameSet)
+    StringSet orderedInputNames(inputNames.begin(), inputNames.end());
+    if (childInputNames != orderedInputNames)
     {
         throw Exception("The set of names provided does not match the existing set of input names");
     }
@@ -730,8 +728,7 @@ void NodeGraph::setInputOrdering(const StringVec& inputNames)
     std::sort(childInputIndicies.begin(), childInputIndicies.end());
     for (size_t i = 0; i < childInputIndicies.size(); i++)
     {
-        unsigned int newLocation = childInputIndicies[i];
-        setChildIndex(inputNames[i], newLocation);
+        setChildIndex(inputNames[i], childInputIndicies[i]);
     }
 }
 

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -379,6 +379,10 @@ class MX_CORE_API NodeGraph : public GraphElement
     /// @param interfaceName The new interface name.
     void modifyInterfaceName(const string& inputPath, const string& interfaceName);
 
+    /// Set the ordering of inputs
+    /// @param inputNames List of names of all inputs in the desired order from start to end.
+    void setInputOrdering(const StringVec& inputNames);
+
     /// @}
     /// @name Validation
     /// @{

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -809,7 +809,7 @@ TEST_CASE("Input Ordering", "[nodegraph]")
 
     mx::StringVec desiredChildOrdering = { "two", "node_0", "one", "node_1", "four", "node_3", "three" };
     mx::StringVec resultingChildOrdering;
-    for (const mx::ElementPtr child : graph->getChildren())
+    for (auto child : graph->getChildren())
     {
         resultingChildOrdering.push_back(child->getName());
     }

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -777,3 +777,41 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
     
     REQUIRE(doc->validate());
 }
+
+TEST_CASE("Input Ordering", "[nodegraph]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::NodeGraphPtr graph = doc->addNodeGraph("graph1");
+    mx::StringVec childNames = { "one", "node_0", "two", "node_1", "three", "node_3", "four" };
+    for (const std::string& childName : childNames)
+    {
+        if (childName.rfind("node", 0) == 0)
+            graph->addNode("constant", childName);
+        else
+            graph->addInput(childName, "color3");
+    }
+
+    mx::StringVec incorrectInputOrdering = { "two2", "one", "four", "three" };
+    bool haveIncorrectNames = true;
+    try
+    {
+        graph->setInputOrdering(incorrectInputOrdering);
+        haveIncorrectNames = false;
+    }
+    catch (mx::Exception& e)
+    {
+        INFO(e.what())
+    }
+    REQUIRE(haveIncorrectNames);
+
+    mx::StringVec desiredInputOrdering = { "two", "one", "four", "three" };
+    graph->setInputOrdering(desiredInputOrdering);
+
+    mx::StringVec desiredChildOrdering = { "two", "node_0", "one", "node_1", "four", "node_3", "three" };
+    mx::StringVec resultingChildOrdering;
+    for (const mx::ElementPtr child : graph->getChildren())
+    {
+        resultingChildOrdering.push_back(child->getName());
+    }
+    REQUIRE((resultingChildOrdering == desiredChildOrdering));
+}


### PR DESCRIPTION
## Workflow Motivation

In order for users to specify interface ordering for node graphs they need to re-order the storage order of child inputs. Additionally, when creating new definitions (`nodedef`) they may which to specify the ordering of child inputs as part of definition publishing.

## Proposal

Provide a simple atomic API to allow for inputs on node graphs to be re-ordered without affecting non-input child ordering.
The proposed API name is: `NodeGraph::setInputOrdering()` where a list all input names specifies the desired ordering.
