### PR TITLE
Fix mxvalidate to check for stdlib usage

### DIFF
--- a/python/Scripts/mxvalidate.py
+++ b/python/Scripts/mxvalidate.py
@@ -17,6 +17,7 @@ def main():
     opts = parser.parse_args()
 
     # Load standard libraries if requested.
+    stdlib = None
     if opts.stdlib:
         stdlib = mx.createDocument()
         try:
@@ -29,7 +30,8 @@ def main():
     doc = mx.createDocument()
     try:
         mx.readFromXmlFile(doc, opts.inputFilename)
-        doc.setDataLibrary(stdlib)
+        if stdlib:
+            doc.setDataLibrary(stdlib)
     except mx.ExceptionFileMissing as err:
         print(err)
         sys.exit(0)


### PR DESCRIPTION
## Change

Patch `mxvalidate.py` script to avoid trying to access an undefined object `stdlib`
if not specified from the command line (default).

```
doc.setDataLibrary(stdlib)
                       ^^^^^^
UnboundLocalError: cannot access local variable 'stdlib' where it is not associated with a value
```