### PR TITLE
Update MacOS version in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -389,7 +389,7 @@ jobs:
       fail-fast: false
       matrix:
         python-minor: ['7', '8', '9', '10', '11', '12']
-        os: ['ubuntu-22.04', 'windows-2022', 'macos-13']
+        os: ['ubuntu-22.04', 'windows-2022', 'macos-14-large']
 
     steps:
     - name: Sync Repository


### PR DESCRIPTION
This changelist updates Python wheel generation to the `macos-14-large` environment in GitHub CI, as Python versions before 3.11 have been removed from the `macos-13` environment.