### PR TITLE
Fix handling of missing scenes in the Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -90,14 +90,14 @@ export class Scene
         }
 
         this.#_rootNode = null;
-        const model = gltfData.scene;
+        let model = gltfData.scene;
         if (!model)
         {
             const geometry = new THREE.BoxGeometry(1, 1, 1);
             const material = new THREE.MeshBasicMaterial({ color: 0xdddddd });
             const cube = new THREE.Mesh(geometry, material);
-            obj = new Group();
-            obj.add(geometry);
+            model = new Group();
+            model.add(cube);
         }
         else
         {


### PR DESCRIPTION
JsViewerX attempted to use a cube when the selected GLTF file contained no model, but the code never added it to the scene.