### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -749,7 +749,7 @@ bool ValueElement::isAttributeEquivalent(ConstElementPtr rhs, const string& attr
         else if (uiAttributes.find(attributeName) != uiAttributes.end())
         {
             const string& uiAttribute = getAttribute(attributeName);
-            const string& rhsUiAttribute = getAttribute(attributeName);
+            const string& rhsUiAttribute = rhs->getAttribute(attributeName);
             ValuePtr uiValue = !rhsUiAttribute.empty() ? Value::createValueFromStrings(uiAttribute, getType()) : nullptr;
             ValuePtr rhsUiValue = !rhsUiAttribute.empty() ? Value::createValueFromStrings(rhsUiAttribute, getType()) : nullptr;
             if (uiValue && rhsUiValue)

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -400,8 +400,8 @@ string GlslStructTypeSyntax::getValue(const Value& value, bool /* uniform */) co
         result += separator;
         separator = ",";
 
-        auto memberTypeName = memberValue->getTypeString();
-        auto memberTypeDesc = TypeDesc::get(memberTypeName);
+        const string& memberTypeName = memberValue->getTypeString();
+        TypeDesc memberTypeDesc = TypeDesc::get(memberTypeName);
 
         // Recursively use the syntax to generate the output, so we can supported nested structs.
         result += _parentSyntax->getValue(memberTypeDesc, *memberValue, true);

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
@@ -128,7 +128,7 @@ void ClosureLayerNodeMdl::emitFunctionCall(const ShaderNode& _node, GenContext& 
                 ShaderNode* fg = fgOutput ? fgOutput->getNode() : nullptr;
                 ShaderNode* bg = bgOutput ? bgOutput->getNode() : nullptr;
                 ShaderNode* mix = mixOutput ? mixOutput->getNode() : nullptr;
-                if ((fg && !bg) || (!fg && bg))
+                if ((bool) fg != (bool) bg)
                 {
                     baseReceiverNode = fg ? fg : bg; // take the node that is valid
                     top = baseReceiverNode;

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -286,9 +286,6 @@ string StructTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
 {
     const AggregateValue& aggValue = static_cast<const AggregateValue&>(value);
 
-    auto typeDesc = TypeDesc::get(aggValue.getTypeString());
-    auto structTypeDesc = StructTypeDesc::get(typeDesc.getStructIndex());
-
     string result = "{";
 
     string separator = "";
@@ -297,8 +294,8 @@ string StructTypeSyntax::getValue(const Value& value, bool /*uniform*/) const
         result += separator;
         separator = ";";
 
-        auto memberTypeName = memberValue->getTypeString();
-        auto memberTypeDesc = TypeDesc::get(memberTypeName);
+        const string& memberTypeName = memberValue->getTypeString();
+        TypeDesc memberTypeDesc = TypeDesc::get(memberTypeName);
 
         // Recursively use the syntax to generate the output, so we can support nested structs.
         const string valueStr = _parentSyntax->getValue(memberTypeDesc, *memberValue, true);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -702,7 +702,7 @@ void Viewer::createDocumentationInterface(ng::ref<Widget> parent)
                                                              ng::Alignment::Minimum, 2, 2);
     gridLayout2->set_col_alignment({ ng::Alignment::Minimum, ng::Alignment::Maximum });
 
-    const std::vector<std::pair<std::string, std::string>> KEYBOARD_SHORTCUTS =
+    const std::array<std::pair<std::string, std::string>, 16> KEYBOARD_SHORTCUTS =
     {
         std::make_pair("R", "Reload the current material from file. "
                             "Hold SHIFT to reload all standard libraries as well."),


### PR DESCRIPTION
This changelist addresses a handful of static analysis warnings flagged by PVS-Studio:

- Add a missing reference to `rhs` in `ValueElement::isAttributeEquivalent`.
- Remove unused variables and unneeded string copies in `StructTypeSyntax::getValue` and `GlslStructTypeSyntax::getValue`.
- Simplify boolean logic in `ClosureLayerNodeMdl::emitFunctionCall`.
- Declare an immutable array as a `std::array` in `Viewer::createDocumentationInterface`.