### PR TITLE
Simplify element equivalence interface

### DIFF
--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -72,8 +72,6 @@ using ElementMap = std::unordered_map<string, ElementPtr>;
 using ElementPredicate = std::function<bool(ConstElementPtr)>;
 
 class ElementEquivalenceOptions;
-class ElementEquivalenceResult;
-using ElementEquivalenceResultVec = vector<ElementEquivalenceResult>;
 
 /// @class Element
 /// The base class for MaterialX elements.
@@ -610,8 +608,8 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @param options Equivalence criteria
     /// @param results Results of comparison if argument is specified.
     /// @return True if the elements are equivalent. False otherwise.
-    bool isEquivalent(ConstElementPtr rhs, const ElementEquivalenceOptions& options, 
-                      ElementEquivalenceResultVec* results = nullptr) const;
+    bool isEquivalent(ConstElementPtr rhs, const ElementEquivalenceOptions& options,
+                      string* message = nullptr) const;
 
     /// Return true if the attribute on a given element is equivalent
     /// based on the equivalence criteria provided.
@@ -622,7 +620,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @return True if the attribute on the elements are equivalent. False otherwise.
     virtual bool isAttributeEquivalent(ConstElementPtr rhs, const string& attributeName,
                                        const ElementEquivalenceOptions& options, 
-                                       ElementEquivalenceResultVec* results = nullptr) const;
+                                       string* message = nullptr) const;
 
     /// @}
     /// @name Traversal
@@ -1129,7 +1127,7 @@ class MX_CORE_API ValueElement : public TypedElement
     /// @return True if the attribute on the elements are equivalent. False otherwise.
     bool isAttributeEquivalent(ConstElementPtr rhs, const string& attributeName,
                                const ElementEquivalenceOptions& options, 
-                               ElementEquivalenceResultVec* results = nullptr) const override;
+                               string* message = nullptr) const override;
 
     /// @}
     /// @name Validation
@@ -1351,35 +1349,6 @@ class MX_CORE_API StringResolver
     string _geomPrefix;
     StringMap _filenameMap;
     StringMap _geomNameMap;
-};
-
-/// @class ElementEquivalenceResult
-/// A comparison result for the functional equivalence of two elements.
-class MX_CORE_API ElementEquivalenceResult
-{
-  public:
-    ElementEquivalenceResult(const string& p1, const string& p2, const string& type,
-                             const string& attrName = EMPTY_STRING)
-    {
-        path1 = p1;
-        path2 = p2;
-        differenceType = type;
-        attributeName = attrName;
-    }
-    ElementEquivalenceResult() = delete;
-    ~ElementEquivalenceResult() = default;
-
-    string path1;
-    string path2;
-    string differenceType;
-    string attributeName;
-
-    static const string ATTRIBUTE;
-    static const string ATTRIBUTE_NAMES;
-    static const string CHILD_COUNT;
-    static const string CHILD_NAME;
-    static const string NAME;
-    static const string CATEGORY;
 };
 
 /// @class ElementEquivalenceOptions

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -215,17 +215,16 @@ TEST_CASE("Document equivalence", "[document]")
     comment->setDocString("Comment 3");
 
     mx::ElementEquivalenceOptions options;
-    mx::ElementEquivalenceResultVec results;
+    std::string message;
 
     // Check that this fails when not performing value comparisons
     options.performValueComparisons = false;
-    bool equivalent = doc->isEquivalent(doc2, options, &results);
+    bool equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(!equivalent);
 
     // Check attibute values 
     options.performValueComparisons = true;
-    results.clear();
-    equivalent = doc->isEquivalent(doc2, options, &results);
+    equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(equivalent);
 
     unsigned int currentPrecision = mx::Value::getFloatPrecision();
@@ -236,14 +235,13 @@ TEST_CASE("Document equivalence", "[document]")
     options.floatPrecision = currentPrecision;
 
     // Check attribute filtering of inputs
-    results.clear();
     options.attributeExclusionList = { mx::ValueElement::UI_MIN_ATTRIBUTE, mx::ValueElement::UI_MAX_ATTRIBUTE };
     for (mx::InputPtr floatInput : floatInputs)
     {
         floatInput->setAttribute(mx::ValueElement::UI_MIN_ATTRIBUTE, "0.9");
         floatInput->setAttribute(mx::ValueElement::UI_MAX_ATTRIBUTE, "100.0");
     }
-    equivalent = doc->isEquivalent(doc2, options, &results);
+    equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(equivalent);
     for (mx::InputPtr floatInput : floatInputs)
     {
@@ -255,12 +253,10 @@ TEST_CASE("Document equivalence", "[document]")
     mx::ElementPtr mismatchElement = doc->getDescendant("mygraph/input_color4");
     std::string previousName = mismatchElement->getName();
     mismatchElement->setName("mismatch_color4");
-    results.clear();
-    equivalent = doc->isEquivalent(doc2, options, &results);
+    equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(!equivalent);
     mismatchElement->setName(previousName);
-    results.clear();
-    equivalent = doc->isEquivalent(doc2, options, &results);
+    equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(equivalent);
 
     // Check for functional nodegraphs
@@ -272,7 +268,6 @@ TEST_CASE("Document equivalence", "[document]")
     REQUIRE(nodeGraph2);
     doc2->addNodeDef("ND_mygraph");
     nodeGraph2->setNodeDefString("ND_mygraph");
-    results.clear();
-    equivalent = doc->isEquivalent(doc2, options, &results);
+    equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(!equivalent);
 }

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -31,9 +31,9 @@ void bindPyElement(py::module& mod)
         .def(py::self != py::self)
         .def("isEquivalent", [](const mx::Element& elem, mx::ConstElementPtr& rhs, const mx::ElementEquivalenceOptions& options)
         {
-            mx::ElementEquivalenceResultVec results;
-            bool res = elem.isEquivalent(rhs, options, &results);
-            return std::pair<bool, mx::ElementEquivalenceResultVec>(res, results);
+            std::string message;
+            bool res = elem.isEquivalent(rhs, options, &message);
+            return std::pair<bool, std::string>(res, message);
         })        
         .def("setCategory", &mx::Element::setCategory)
         .def("getCategory", &mx::Element::getCategory)
@@ -210,18 +210,6 @@ void bindPyElement(py::module& mod)
 
     py::class_<mx::GenericElement, mx::GenericElementPtr, mx::Element>(mod, "GenericElement")
         .def_readonly_static("CATEGORY", &mx::GenericElement::CATEGORY);
-
-    py::class_<mx::ElementEquivalenceResult>(mod, "ElementEquivalenceResult")
-        .def_readonly_static("ATTRIBUTE", &mx::ElementEquivalenceResult::ATTRIBUTE)
-        .def_readonly_static("ATTRIBUTE_NAMES", &mx::ElementEquivalenceResult::ATTRIBUTE_NAMES)
-        .def_readonly_static("CHILD_COUNT", &mx::ElementEquivalenceResult::CHILD_COUNT)
-        .def_readonly_static("CHILD_NAME", &mx::ElementEquivalenceResult::CHILD_NAME)
-        .def_readonly_static("NAME", &mx::ElementEquivalenceResult::NAME)
-        .def_readonly_static("CATEGORY", &mx::ElementEquivalenceResult::CATEGORY)
-        .def_readwrite("path1", &mx::ElementEquivalenceResult::path1)
-        .def_readwrite("path2", &mx::ElementEquivalenceResult::path2)
-        .def_readwrite("differenceType", &mx::ElementEquivalenceResult::differenceType)
-        .def_readwrite("attributeName", &mx::ElementEquivalenceResult::attributeName);
 
     py::class_<mx::ElementEquivalenceOptions>(mod, "ElementEquivalenceOptions")
         .def_readwrite("performValueComparisons", &mx::ElementEquivalenceOptions::performValueComparisons)


### PR DESCRIPTION
This changelist simplifies the interface of the Element::isEquivalent method in MaterialX C++, aligning it with the behavior of Element::validate and proposed use cases for element equivalence in JavaScript.