### PR TITLE
Improve usage of setDataLibrary

### DIFF
--- a/source/MaterialXRender/ShaderMaterial.cpp
+++ b/source/MaterialXRender/ShaderMaterial.cpp
@@ -68,10 +68,8 @@ bool ShaderMaterial::generateEnvironmentShader(GenContext& context,
 {
     // Read in the environment nodegraph.
     DocumentPtr doc = createDocument();
-    doc->importLibrary(stdLib);
-    DocumentPtr envDoc = createDocument();
-    readFromXmlFile(envDoc, filename);
-    doc->importLibrary(envDoc);
+    doc->setDataLibrary(stdLib);
+    readFromXmlFile(doc, filename);
 
     NodeGraphPtr envGraph = doc->getNodeGraph("envMap");
     if (!envGraph)

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -24,7 +24,7 @@ ShaderPtr createConstantShader(GenContext& context,
 {
     // Construct the constant color nodegraph
     DocumentPtr doc = createDocument();
-    doc->importLibrary(stdLib);
+    doc->setDataLibrary(stdLib);
     NodeGraphPtr nodeGraph = doc->addNodeGraph();
     NodePtr constant = nodeGraph->addNode("constant");
     constant->setInputValue("value", color);
@@ -41,7 +41,7 @@ ShaderPtr createDepthShader(GenContext& context,
 {
     // Construct a dummy nodegraph.
     DocumentPtr doc = createDocument();
-    doc->importLibrary(stdLib);
+    doc->setDataLibrary(stdLib);
     NodeGraphPtr nodeGraph = doc->addNodeGraph();
     NodePtr constant = nodeGraph->addNode("constant");
     OutputPtr output = nodeGraph->addOutput();
@@ -61,7 +61,7 @@ ShaderPtr createAlbedoTableShader(GenContext& context,
 {
     // Construct a dummy nodegraph.
     DocumentPtr doc = createDocument();
-    doc->importLibrary(stdLib);
+    doc->setDataLibrary(stdLib);
     NodeGraphPtr nodeGraph = doc->addNodeGraph();
     NodePtr constant = nodeGraph->addNode("constant");
     OutputPtr output = nodeGraph->addOutput();
@@ -82,7 +82,7 @@ ShaderPtr createEnvPrefilterShader(GenContext& context,
 {
     // Construct a dummy nodegraph.
     DocumentPtr doc = createDocument();
-    doc->importLibrary(stdLib);
+    doc->setDataLibrary(stdLib);
     NodeGraphPtr nodeGraph = doc->addNodeGraph();
     NodePtr constant = nodeGraph->addNode("constant");
     OutputPtr output = nodeGraph->addOutput();
@@ -104,7 +104,7 @@ ShaderPtr createBlurShader(GenContext& context,
 {
     // Construct the blur nodegraph
     DocumentPtr doc = createDocument();
-    doc->importLibrary(stdLib);
+    doc->setDataLibrary(stdLib);
     NodeGraphPtr nodeGraph = doc->addNodeGraph();
     NodePtr imageNode = nodeGraph->addNode("image", "image");
     NodePtr blurNode = nodeGraph->addNode("blur", "blur");


### PR DESCRIPTION
This changelist improves the usage of Document::setDataLibrary in MaterialXRender functions, leveraging this more efficient alternative to Document::importLibrary where appropriate.