### PR TITLE
Use setDataLibrary in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -171,7 +171,7 @@ Graph::Graph(const std::string& materialFilename,
     // Create a renderer using the initial startup document.
     mx::FilePath captureFilename = "resources/Materials/Examples/example.png";
     std::string envRadianceFilename = "resources/Lights/san_giuseppe_bridge_split.hdr";
-    _renderer = std::make_shared<RenderView>(_graphDoc, meshFilename, envRadianceFilename,
+    _renderer = std::make_shared<RenderView>(_graphDoc, _stdLib, meshFilename, envRadianceFilename,
                                              _searchPath, viewWidth, viewHeight);
     _renderer->initialize();
     for (const std::string& ext : _renderer->getImageHandler()->supportedExtensions())
@@ -249,7 +249,7 @@ mx::DocumentPtr Graph::loadDocument(const mx::FilePath& filename)
         if (!filename.isEmpty())
         {
             mx::readFromXmlFile(doc, filename, _searchPath, &readOptions);
-            doc->importLibrary(_stdLib);
+            doc->setDataLibrary(_stdLib);
             std::string message;
             if (!doc->validate(&message))
             {
@@ -3050,7 +3050,7 @@ void Graph::clearGraph()
     _newLinks.clear();
     _currPins.clear();
     _graphDoc = mx::createDocument();
-    _graphDoc->importLibrary(_stdLib);
+    _graphDoc->setDataLibrary(_stdLib);
     _currGraphElem = _graphDoc;
 
     if (_currUiNode != nullptr)

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -108,6 +108,7 @@ void RenderView::setDocument(mx::DocumentPtr document)
 }
 
 RenderView::RenderView(mx::DocumentPtr doc,
+                       mx::DocumentPtr stdLib,
                        const std::string& meshFilename,
                        const std::string& envRadianceFilename,
                        const mx::FileSearchPath& searchPath,
@@ -162,6 +163,7 @@ RenderView::RenderView(mx::DocumentPtr doc,
     _genContext.getOptions().shaderInterfaceType = mx::SHADER_INTERFACE_COMPLETE;
 
     setDocument(doc);
+    _stdLib = stdLib;
 }
 
 void RenderView::initialize()
@@ -212,18 +214,6 @@ void RenderView::assignMaterial(mx::MeshPartitionPtr geometry, mx::GlslMaterialP
     {
         _materialAssignments.erase(geometry);
     }
-}
-
-mx::ElementPredicate RenderView::getElementPredicate()
-{
-    return [this](mx::ConstElementPtr elem)
-    {
-        if (elem->hasSourceUri())
-        {
-            return (_xincludeFiles.count(elem->getSourceUri()) == 0);
-        }
-        return true;
-    };
 }
 
 void RenderView::updateGeometrySelections()
@@ -935,7 +925,7 @@ mx::ImagePtr RenderView::getShadowMap()
         {
             try
             {
-                mx::ShaderPtr hwShader = mx::createDepthShader(_genContext, _document, "__SHADOW_SHADER__");
+                mx::ShaderPtr hwShader = mx::createDepthShader(_genContext, _stdLib, "__SHADOW_SHADER__");
                 _shadowMaterial = mx::GlslMaterial::create();
                 _shadowMaterial->generateShader(hwShader);
             }
@@ -949,7 +939,7 @@ mx::ImagePtr RenderView::getShadowMap()
         {
             try
             {
-                mx::ShaderPtr hwShader = mx::createBlurShader(_genContext, _document, "__SHADOW_BLUR_SHADER__", "gaussian", 1.0f);
+                mx::ShaderPtr hwShader = mx::createBlurShader(_genContext, _stdLib, "__SHADOW_BLUR_SHADER__", "gaussian", 1.0f);
                 _shadowBlurMaterial = mx::GlslMaterial::create();
                 _shadowBlurMaterial->generateShader(hwShader);
             }

--- a/source/MaterialXGraphEditor/RenderView.h
+++ b/source/MaterialXGraphEditor/RenderView.h
@@ -29,6 +29,7 @@ class RenderView
 {
   public:
     RenderView(mx::DocumentPtr doc,
+               mx::DocumentPtr stdLib,
                const std::string& meshFilename,
                const std::string& envRadianceFilename,
                const mx::FileSearchPath& searchPath,
@@ -159,7 +160,6 @@ class RenderView
     {
         return _xincludeFiles;
     }
-    mx::ElementPredicate getElementPredicate();
 
     // Request a capture of the current frame, writing it to the given filename.
     void requestFrameCapture(const mx::FilePath& filename)
@@ -232,7 +232,6 @@ class RenderView
     void updateGeometrySelections();
 
     mx::ImagePtr getShadowMap();
-    mx::ImagePtr _renderMap;
 
     void renderFrame();
     void renderScreenSpaceQuad(mx::GlslMaterialPtr material);
@@ -268,6 +267,7 @@ class RenderView
 
     // Document management
     mx::DocumentPtr _document;
+    mx::DocumentPtr _stdLib;
     DocumentModifiers _modifiers;
     mx::StringSet _xincludeFiles;
 


### PR DESCRIPTION
This changelist updates the Graph Editor to use `Document::setDataLibrary` rather than `Document::importLibrary`, improving the efficiency of document loading.

Additionally, it removes an unused method and member variable from the `RenderView` class.