### PR TITLE
Simplify shader generator exclusions

### DIFF
--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.h
@@ -51,10 +51,9 @@ class GlslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "screen", "displacementshader", "volumeshader", 
-            "IM_constant_", "IM_dot_", "IM_geompropvalue_boolean", "IM_geompropvalue_string",
-            "IM_light_genglsl", "IM_point_light_genglsl", "IM_spot_light_genglsl", "IM_directional_light_genglsl",
-            "IM_angle", "volumematerial", "ND_volumematerial"
+            "volumeshader", "volumematerial",
+            "IM_constant_", "IM_dot_", "IM_angle", "IM_geompropvalue_boolean", "IM_geompropvalue_string",
+            "IM_light_", "IM_point_light_", "IM_spot_light_", "IM_directional_light_"
         };
         ShaderGeneratorTester::getImplementationWhiteList(whiteList);
     }

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
@@ -76,9 +76,8 @@ class MdlShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "backfacing", "screen", "displacementshader",
-            "volumeshader", "IM_constant_", "IM_dot_", "IM_geomattrvalue", "IM_angle",
-            "geompropvalue", "surfacematerial", "volumematerial", 
+            "displacementshader", "volumeshader", "surfacematerial", "volumematerial", "geompropvalue",
+            "IM_constant_", "IM_dot_", "IM_angle", "IM_geomattrvalue",
             "IM_absorption_vdf_", "IM_mix_vdf_", "IM_add_vdf_", "IM_multiply_vdf",
             "IM_measured_edf_", "IM_blackbody_", "IM_conical_edf_", 
             "IM_displacement_", "IM_volume_", "IM_light_"

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
@@ -70,10 +70,10 @@ class MslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "backfacing", "screen", "displacementshader",
-            "volumeshader", "IM_constant_", "IM_dot_", "IM_geompropvalue_boolean", "IM_geompropvalue_string",
-            "IM_light_genmsl", "IM_point_light_genmsl", "IM_spot_light_genmsl", "IM_directional_light_genmsl",
-            "IM_angle", "surfacematerial", "volumematerial", "ND_surfacematerial", "ND_volumematerial", "ND_backface_util", "IM_backface_util_genmsl"
+            "displacementshader", "volumeshader", "surfacematerial", "volumematerial",
+            "IM_constant_", "IM_dot_", "IM_angle", "IM_geompropvalue_boolean", "IM_geompropvalue_string",
+            "IM_light_", "IM_point_light_", "IM_spot_light_", "IM_directional_light_",
+            "ND_surfacematerial", "ND_volumematerial"
         };
     }
 };

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.h
@@ -63,8 +63,8 @@ class OslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         whiteList =
         {
-            "backfacing", "screen", "displacementshader",
-            "volumeshader", "IM_constant_", "IM_dot_", "IM_geompropvalue", "IM_angle", "ND_backface_util"
+            "displacementshader", "volumeshader",
+            "IM_constant_", "IM_dot_", "IM_angle", "IM_geompropvalue"
         };
         ShaderGeneratorTester::getImplementationWhiteList(whiteList);
     }


### PR DESCRIPTION
This changelist simplifies the shader generator exclusion lists used in unit testing, removing legacy exclusions that are no longer needed with the current data libraries.