### PR TITLE
Additional cleanup from OSL legacy closure removal

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,10 +1,7 @@
 if(NOT SKBUILD)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
             DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}"
-            PATTERN "CMakeLists.txt" EXCLUDE
-            PATTERN "pbrlib_genosl_impl.*" EXCLUDE)
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/pbrlib/genosl/pbrlib_genosl_impl.mtlx"
-            DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}/pbrlib/genosl/" RENAME pbrlib_genosl_impl.mtlx)
+            PATTERN "CMakeLists.txt" EXCLUDE)
 endif()
 
 set(MATERIALX_PYTHON_LIBRARIES_PATH "${MATERIALX_PYTHON_FOLDER_NAME}/${MATERIALX_INSTALL_STDLIB_PATH}")
@@ -15,8 +12,5 @@ endif()
 if(MATERIALX_BUILD_PYTHON)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
             DESTINATION "${MATERIALX_PYTHON_LIBRARIES_PATH}"
-            PATTERN "CMakeLists.txt" EXCLUDE
-            PATTERN "pbrlib_genosl_impl.*" EXCLUDE)
-    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/pbrlib/genosl/pbrlib_genosl_impl.mtlx"
-            DESTINATION "${MATERIALX_PYTHON_LIBRARIES_PATH}/pbrlib/genosl/" RENAME pbrlib_genosl_impl.mtlx)
+            PATTERN "CMakeLists.txt" EXCLUDE)
 endif()


### PR DESCRIPTION
#2121 removed the OSL legacy closures - but we can simplify the data library installation a little more now they are gone.