### PR TITLE
Fix edge case with editor pasting

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -4045,8 +4045,8 @@ void Graph::drawGraph(ImVec2 mousePos)
                     for (std::map<UiNodePtr, UiNodePtr>::iterator iter = _copiedNodes.begin(); iter != _copiedNodes.end(); iter++)
                     {
                         copyUiNode(iter->first);
+                        _addNewNode = true;
                     }
-                    _addNewNode = true;
                 }
                 else
                 {


### PR DESCRIPTION
This changelist fixes the edge case of pasting with an empty copy buffer in the Graph Editor.

Previously, this action would have an unintended effect on node positions, and it now has no impact on the graph.