### PR TITLE
Add fallbacks for findUniform methods

### DIFF
--- a/source/MaterialXRenderGlsl/GlslMaterial.cpp
+++ b/source/MaterialXRenderGlsl/GlslMaterial.cpp
@@ -331,6 +331,13 @@ ShaderPort* GlslMaterial::findUniform(const std::string& path) const
         {
             return (port && stringEndsWith(port->getPath(), path));
         });
+        if (!port)
+        {
+            port = publicUniforms->find([path](ShaderPort* port)
+            {
+                return (port && stringEndsWith(path, port->getName()));
+            });
+        }
 
         // Check if the uniform exists in the shader program
         if (port && !_glProgram->getUniformsList().count(port->getVariable()))

--- a/source/MaterialXRenderMsl/MslMaterial.mm
+++ b/source/MaterialXRenderMsl/MslMaterial.mm
@@ -292,6 +292,13 @@ ShaderPort* MslMaterial::findUniform(const std::string& path) const
         {
             return (port && stringEndsWith(port->getPath(), path));
         });
+        if (!port)
+        {
+            port = publicUniforms->find([path](ShaderPort* port)
+            {
+                return (port && stringEndsWith(path, port->getName()));
+            });
+        }
 
         // Check if the uniform exists in the shader program
         if (port && !_glProgram->getUniformsList().count(


### PR DESCRIPTION
This changelist adds fallbacks to the GlslMaterial::findUniform and MslMaterial::findUniform methods, allowing them to find matches for uniforms that don't yet have a full path.

This addresses issue https://github.com/AcademySoftwareFoundation/MaterialX/issues/1782.