### PR TITLE
Draft : Named value experiment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ option(MATERIALX_BUILD_VIEWER "Build the MaterialX Viewer." OFF)
 option(MATERIALX_BUILD_GRAPH_EDITOR "Build the MaterialX Graph Editor." OFF)
 option(MATERIALX_BUILD_DOCS "Create HTML documentation using Doxygen. Requires that Doxygen be installed." OFF)
 
+option(MATERIALX_BUILD_BAKE_NAMED_VALUES "Process the data library files at build time to bake out the named values." ON)
+
 option(MATERIALX_BUILD_GEN_GLSL "Build the GLSL shader generator back-end." ON)
 option(MATERIALX_BUILD_GEN_OSL "Build the OSL shader generator back-end." ON)
 option(MATERIALX_BUILD_GEN_MDL "Build the MDL shader generator back-end." ON)
@@ -439,6 +441,7 @@ endif()
 # Add core subdirectories
 add_subdirectory(source/MaterialXCore)
 add_subdirectory(source/MaterialXFormat)
+add_subdirectory(source/MaterialXBuildTools/buildLibrary)
 
 # Add shader generation subdirectories
 add_subdirectory(source/MaterialXGenShader)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,7 +1,39 @@
+
+set(MATERIALX_DATA_LIBRARY_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/data_library)
+
+function(build_data_library TARGET_NAME SOURCE_DIR DEST_DIR)
+
+    if (${MATERIALX_BUILD_BAKE_NAMED_VALUES})
+        add_custom_target(${TARGET_NAME} ALL
+                COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+            ${SOURCE_DIR}/
+            ${DEST_DIR}
+                COMMAND MaterialXBuildLibrary --sourceLibraryRoot ${SOURCE_DIR} --destLibraryRoot ${DEST_DIR}
+                COMMAND ${CMAKE_COMMAND} -E rm ${DEST_DIR}/CmakeLists.txt
+        )
+    else()
+        add_custom_target(${TARGET_NAME} ALL
+                COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+                    ${SOURCE_DIR}/
+                    ${DEST_DIR}
+                COMMAND ${CMAKE_COMMAND} -E rm ${DEST_DIR}/CmakeLists.txt
+        )
+    endif()
+
+endfunction(build_data_library)
+
+build_data_library(buildDataLibrary ${CMAKE_CURRENT_SOURCE_DIR} ${MATERIALX_DATA_LIBRARY_BUILD_DIR})
+
+if(MATERIALX_BUILD_TESTS)
+    build_data_library(buildTestDataLibrary ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libraries)
+endif()
+
+
+
 if(NOT SKBUILD)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-            DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}"
-            PATTERN "CMakeLists.txt" EXCLUDE)
+    install(DIRECTORY ${MATERIALX_DATA_LIBRARY_BUILD_DIR}/
+        DESTINATION "${MATERIALX_INSTALL_STDLIB_PATH}"
+    )
 endif()
 
 set(MATERIALX_PYTHON_LIBRARIES_PATH "${MATERIALX_PYTHON_FOLDER_NAME}/${MATERIALX_INSTALL_STDLIB_PATH}")
@@ -10,7 +42,6 @@ if(SKBUILD)
 endif()
 
 if(MATERIALX_BUILD_PYTHON)
-    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-            DESTINATION "${MATERIALX_PYTHON_LIBRARIES_PATH}"
-            PATTERN "CMakeLists.txt" EXCLUDE)
+    install(DIRECTORY ${MATERIALX_DATA_LIBRARY_BUILD_DIR}/
+            DESTINATION "${MATERIALX_PYTHON_LIBRARIES_PATH}")
 endif()

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -9,14 +9,14 @@ function(build_data_library TARGET_NAME SOURCE_DIR DEST_DIR)
             ${SOURCE_DIR}/
             ${DEST_DIR}
                 COMMAND MaterialXBuildLibrary --sourceLibraryRoot ${SOURCE_DIR} --destLibraryRoot ${DEST_DIR}
-                COMMAND ${CMAKE_COMMAND} -E rm ${DEST_DIR}/CmakeLists.txt
+                COMMAND ${CMAKE_COMMAND} -E rm -f ${DEST_DIR}/CmakeLists.txt
         )
     else()
         add_custom_target(${TARGET_NAME} ALL
                 COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
                     ${SOURCE_DIR}/
                     ${DEST_DIR}
-                COMMAND ${CMAKE_COMMAND} -E rm ${DEST_DIR}/CmakeLists.txt
+                COMMAND ${CMAKE_COMMAND} -E rm -f ${DEST_DIR}/CmakeLists.txt
         )
     endif()
 

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -12,15 +12,15 @@
   <!-- ======================================================================== -->
 
   <typedef name="boolean" />
-  <typedef name="integer" />
-  <typedef name="float" />
-  <typedef name="color3" semantic="color" />
-  <typedef name="color4" semantic="color" />
-  <typedef name="vector2" />
-  <typedef name="vector3" />
-  <typedef name="vector4" />
-  <typedef name="matrix33" />
-  <typedef name="matrix44" />
+  <typedef name="integer" zero="0" one="1"/>
+  <typedef name="float" zero="0.0" one="1.0"/>
+  <typedef name="color3" semantic="color" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
+  <typedef name="color4" semantic="color" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
+  <typedef name="vector2" zero="0.0,0.0" one="1.0,1.0"/>
+  <typedef name="vector3" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
+  <typedef name="vector4" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
+  <typedef name="matrix33" zero="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" identity="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+  <typedef name="matrix44" zero="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" identity="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   <typedef name="string" />
   <typedef name="filename" />
   <typedef name="geomname" />
@@ -1451,83 +1451,83 @@
     Add "in2" value/stream to the incoming float/integer/color/vector/matrix.
   -->
   <nodedef name="ND_add_float" node="add" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_integer" node="add" nodegroup="math">
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="in1" type="integer" value="Value:zero" />
+    <input name="in2" type="integer" value="Value:zero" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color3" node="add" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="color3" value="Value:zero" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color4" node="add" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="color4" value="Value:zero" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector2" node="add" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="vector2" value="Value:zero" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector3" node="add" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="vector3" value="Value:zero" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector4" node="add" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="vector4" value="Value:zero" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix33" node="add" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" />
+    <input name="in1" type="matrix33" value="Value:identity" />
+    <input name="in2" type="matrix33" value="Value:zero" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix44" node="add" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" />
+    <input name="in1" type="matrix44" value="Value:identity" />
+    <input name="in2" type="matrix44" value="Value:zero" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color3FA" node="add" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color4FA" node="add" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector2FA" node="add" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector3FA" node="add" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector4FA" node="add" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix33FA" node="add" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix33" value="Value:identity" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix44FA" node="add" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix44" value="Value:identity" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
 
@@ -1536,83 +1536,83 @@
     Subtract "in2" value/stream from the incoming float/integer/color/vector/matrix.
   -->
   <nodedef name="ND_subtract_float" node="subtract" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_integer" node="subtract" nodegroup="math">
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="in1" type="integer" value="Value:zero" />
+    <input name="in2" type="integer" value="Value:zero" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color3" node="subtract" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="color3" value="Value:zero" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color4" node="subtract" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="color4" value="Value:zero" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector2" node="subtract" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="vector2" value="Value:zero" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector3" node="subtract" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="vector3" value="Value:zero" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector4" node="subtract" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="vector4" value="Value:zero" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix33" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" />
+    <input name="in1" type="matrix33" value="Value:identity" />
+    <input name="in2" type="matrix33" value="Value:zero" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix44" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" />
+    <input name="in1" type="matrix44" value="Value:identity" />
+    <input name="in2" type="matrix44" value="Value:zero" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color3FA" node="subtract" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color4FA" node="subtract" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector2FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector3FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector4FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix33FA" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix33" value="Value:identity" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix44FA" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix44" value="Value:identity" />
+    <input name="in2" type="float" value="Value:zero" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
 
@@ -1622,68 +1622,68 @@
     two matrices.
   -->
   <nodedef name="ND_multiply_float" node="multiply" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color3" node="multiply" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="color3" value="Value:one" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color4" node="multiply" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="color4" value="Value:one" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector2" node="multiply" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="vector2" value="Value:one" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector3" node="multiply" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="vector3" value="Value:one" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector4" node="multiply" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="vector4" value="Value:one" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_matrix33" node="multiply" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in1" type="matrix33" value="Value:identity" />
+    <input name="in2" type="matrix33" value="Value:identity" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_matrix44" node="multiply" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in1" type="matrix44" value="Value:identity" />
+    <input name="in2" type="matrix44" value="Value:identity" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color3FA" node="multiply" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color4FA" node="multiply" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector2FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector3FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector4FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -1694,68 +1694,68 @@
     inverse of a second matrix.
   -->
   <nodedef name="ND_divide_float" node="divide" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color3" node="divide" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="color3" value="Value:one" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color4" node="divide" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="color4" value="Value:one" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector2" node="divide" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="vector2" value="Value:one" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector3" node="divide" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="vector3" value="Value:one" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector4" node="divide" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="vector4" value="Value:one" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_matrix33" node="divide" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in1" type="matrix33" value="Value:identity" />
+    <input name="in2" type="matrix33" value="Value:identity" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_matrix44" node="divide" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in1" type="matrix44" value="Value:identity" />
+    <input name="in2" type="matrix44" value="Value:identity" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color3FA" node="divide" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color4FA" node="divide" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector2FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector3FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector4FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="Value:zero" />
+    <input name="in2" type="float" value="Value:one" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -3795,11 +3795,11 @@
       <input name="in" type="float" interfacename="in" />
       <input name="inlow" type="float" interfacename="inlow" />
       <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="Value:zero" />
+      <input name="outhigh" type="float" value="Value:one" />
     </remap>
     <divide name="N_recip_float" type="float">
-      <input name="in1" type="float" value="1.0" />
+      <input name="in1" type="float" value="Value:one" />
       <input name="in2" type="float" interfacename="gamma" />
     </divide>
     <absval name="N_abs_float" type="float">
@@ -3818,8 +3818,8 @@
     </multiply>
     <remap name="N_remap2_float" type="float">
       <input name="in" type="float" nodename="N_gamma_float" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
+      <input name="inlow" type="float" value="Value:zero" />
+      <input name="inhigh" type="float" value="Value:one" />
       <input name="outlow" type="float" interfacename="outlow" />
       <input name="outhigh" type="float" interfacename="outhigh" />
     </remap>
@@ -3841,11 +3841,11 @@
       <input name="in" type="color3" interfacename="in" />
       <input name="inlow" type="color3" interfacename="inlow" />
       <input name="inhigh" type="color3" interfacename="inhigh" />
-      <input name="outlow" type="color3" value="0.0, 0.0, 0.0" />
-      <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="outlow" type="color3" value="Value:zero" />
+      <input name="outhigh" type="color3" value="Value:one" />
     </remap>
     <divide name="N_recip_color3" type="color3">
-      <input name="in1" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="in1" type="color3" value="Value:one" />
       <input name="in2" type="color3" interfacename="gamma" />
     </divide>
     <absval name="N_abs_color3" type="color3">
@@ -3864,8 +3864,8 @@
     </multiply>
     <remap name="N_remap2_color3" type="color3">
       <input name="in" type="color3" nodename="N_gamma_color3" />
-      <input name="inlow" type="color3" value="0.0, 0.0, 0.0" />
-      <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="inlow" type="color3" value="Value:zero" />
+      <input name="inhigh" type="color3" value="Value:one" />
       <input name="outlow" type="color3" interfacename="outlow" />
       <input name="outhigh" type="color3" interfacename="outhigh" />
     </remap>
@@ -3887,11 +3887,11 @@
       <input name="in" type="color4" interfacename="in" />
       <input name="inlow" type="color4" interfacename="inlow" />
       <input name="inhigh" type="color4" interfacename="inhigh" />
-      <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="outlow" type="color4" value="Value:zero" />
+      <input name="outhigh" type="color4" value="Value:one" />
     </remap>
     <divide name="N_recip_color4" type="color4">
-      <input name="in1" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="in1" type="color4" value="Value:one" />
       <input name="in2" type="color4" interfacename="gamma" />
     </divide>
     <absval name="N_abs_color4" type="color4">
@@ -3910,8 +3910,8 @@
     </multiply>
     <remap name="N_remap2_color4" type="color4">
       <input name="in" type="color4" nodename="N_gamma_color4" />
-      <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="inlow" type="color4" value="Value:zero" />
+      <input name="inhigh" type="color4" value="Value:one" />
       <input name="outlow" type="color4" interfacename="outlow" />
       <input name="outhigh" type="color4" interfacename="outhigh" />
     </remap>
@@ -3933,11 +3933,11 @@
       <input name="in" type="vector2" interfacename="in" />
       <input name="inlow" type="vector2" interfacename="inlow" />
       <input name="inhigh" type="vector2" interfacename="inhigh" />
-      <input name="outlow" type="vector2" value="0.0, 0.0" />
-      <input name="outhigh" type="vector2" value="1.0, 1.0" />
+      <input name="outlow" type="vector2" value="Value:zero" />
+      <input name="outhigh" type="vector2" value="Value:one" />
     </remap>
     <divide name="N_recip_vector2" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0" />
+      <input name="in1" type="vector2" value="Value:one" />
       <input name="in2" type="vector2" interfacename="gamma" />
     </divide>
     <absval name="N_abs_vector2" type="vector2">
@@ -3956,8 +3956,8 @@
     </multiply>
     <remap name="N_remap2_vector2" type="vector2">
       <input name="in" type="vector2" nodename="N_gamma_vector2" />
-      <input name="inlow" type="vector2" value="0.0, 0.0" />
-      <input name="inhigh" type="vector2" value="1.0, 1.0" />
+      <input name="inlow" type="vector2" value="Value:zero" />
+      <input name="inhigh" type="vector2" value="Value:one" />
       <input name="outlow" type="vector2" interfacename="outlow" />
       <input name="outhigh" type="vector2" interfacename="outhigh" />
     </remap>
@@ -3979,11 +3979,11 @@
       <input name="in" type="vector3" interfacename="in" />
       <input name="inlow" type="vector3" interfacename="inlow" />
       <input name="inhigh" type="vector3" interfacename="inhigh" />
-      <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" />
+      <input name="outlow" type="vector3" value="Value:zero" />
+      <input name="outhigh" type="vector3" value="Value:one" />
     </remap>
     <divide name="N_recip_vector3" type="vector3">
-      <input name="in1" type="vector3" value="1.0, 1.0, 1.0" />
+      <input name="in1" type="vector3" value="Value:one" />
       <input name="in2" type="vector3" interfacename="gamma" />
     </divide>
     <absval name="N_abs_vector3" type="vector3">
@@ -4002,8 +4002,8 @@
     </multiply>
     <remap name="N_remap2_vector3" type="vector3">
       <input name="in" type="vector3" nodename="N_gamma_vector3" />
-      <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" />
+      <input name="inlow" type="vector3" value="Value:zero" />
+      <input name="inhigh" type="vector3" value="Value:one" />
       <input name="outlow" type="vector3" interfacename="outlow" />
       <input name="outhigh" type="vector3" interfacename="outhigh" />
     </remap>
@@ -4025,11 +4025,11 @@
       <input name="in" type="vector4" interfacename="in" />
       <input name="inlow" type="vector4" interfacename="inlow" />
       <input name="inhigh" type="vector4" interfacename="inhigh" />
-      <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="outlow" type="vector4" value="Value:zero" />
+      <input name="outhigh" type="vector4" value="Value:one" />
     </remap>
     <divide name="N_recip_vector4" type="vector4">
-      <input name="in1" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="in1" type="vector4" value="Value:one" />
       <input name="in2" type="vector4" interfacename="gamma" />
     </divide>
     <absval name="N_abs_vector4" type="vector4">
@@ -4048,8 +4048,8 @@
     </multiply>
     <remap name="N_remap2_vector4" type="vector4">
       <input name="in" type="vector4" nodename="N_gamma_vector4" />
-      <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+      <input name="inlow" type="vector4" value="Value:zero" />
+      <input name="inhigh" type="vector4" value="Value:one" />
       <input name="outlow" type="vector4" interfacename="outlow" />
       <input name="outhigh" type="vector4" interfacename="outhigh" />
     </remap>
@@ -4071,11 +4071,11 @@
       <input name="in" type="color3" interfacename="in" />
       <input name="inlow" type="float" interfacename="inlow" />
       <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="Value:zero" />
+      <input name="outhigh" type="float" value="Value:one" />
     </remap>
     <divide name="N_recip_color3FA" type="float">
-      <input name="in1" type="float" value="1.0" />
+      <input name="in1" type="float" value="Value:one" />
       <input name="in2" type="float" interfacename="gamma" />
     </divide>
     <absval name="N_abs_color3FA" type="color3">
@@ -4094,8 +4094,8 @@
     </multiply>
     <remap name="N_remap2_color3FA" type="color3">
       <input name="in" type="color3" nodename="N_gamma_color3FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
+      <input name="inlow" type="float" value="Value:zero" />
+      <input name="inhigh" type="float" value="Value:one" />
       <input name="outlow" type="float" interfacename="outlow" />
       <input name="outhigh" type="float" interfacename="outhigh" />
     </remap>
@@ -4117,11 +4117,11 @@
       <input name="in" type="color4" interfacename="in" />
       <input name="inlow" type="float" interfacename="inlow" />
       <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="Value:zero" />
+      <input name="outhigh" type="float" value="Value:one" />
     </remap>
     <divide name="N_recip_color4FA" type="float">
-      <input name="in1" type="float" value="1.0" />
+      <input name="in1" type="float" value="Value:one" />
       <input name="in2" type="float" interfacename="gamma" />
     </divide>
     <absval name="N_abs_color4FA" type="color4">
@@ -4140,8 +4140,8 @@
     </multiply>
     <remap name="N_remap2_color4FA" type="color4">
       <input name="in" type="color4" nodename="N_gamma_color4FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
+      <input name="inlow" type="float" value="Value:zero" />
+      <input name="inhigh" type="float" value="Value:one" />
       <input name="outlow" type="float" interfacename="outlow" />
       <input name="outhigh" type="float" interfacename="outhigh" />
     </remap>
@@ -4163,11 +4163,11 @@
       <input name="in" type="vector2" interfacename="in" />
       <input name="inlow" type="float" interfacename="inlow" />
       <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="Value:zero" />
+      <input name="outhigh" type="float" value="Value:one" />
     </remap>
     <divide name="N_recip_vector2FA" type="float">
-      <input name="in1" type="float" value="1.0" />
+      <input name="in1" type="float" value="Value:one" />
       <input name="in2" type="float" interfacename="gamma" />
     </divide>
     <absval name="N_abs_vector2FA" type="vector2">
@@ -4186,8 +4186,8 @@
     </multiply>
     <remap name="N_remap2_vector2FA" type="vector2">
       <input name="in" type="vector2" nodename="N_gamma_vector2FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
+      <input name="inlow" type="float" value="Value:zero" />
+      <input name="inhigh" type="float" value="Value:one" />
       <input name="outlow" type="float" interfacename="outlow" />
       <input name="outhigh" type="float" interfacename="outhigh" />
     </remap>
@@ -4209,11 +4209,11 @@
       <input name="in" type="vector3" interfacename="in" />
       <input name="inlow" type="float" interfacename="inlow" />
       <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="Value:zero" />
+      <input name="outhigh" type="float" value="Value:one" />
     </remap>
     <divide name="N_recip_vector3FA" type="float">
-      <input name="in1" type="float" value="1.0" />
+      <input name="in1" type="float" value="Value:one" />
       <input name="in2" type="float" interfacename="gamma" />
     </divide>
     <absval name="N_abs_vector3FA" type="vector3">
@@ -4232,8 +4232,8 @@
     </multiply>
     <remap name="N_remap2_vector3FA" type="vector3">
       <input name="in" type="vector3" nodename="N_gamma_vector3FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
+      <input name="inlow" type="float" value="Value:zero" />
+      <input name="inhigh" type="float" value="Value:one" />
       <input name="outlow" type="float" interfacename="outlow" />
       <input name="outhigh" type="float" interfacename="outhigh" />
     </remap>
@@ -4255,11 +4255,11 @@
       <input name="in" type="vector4" interfacename="in" />
       <input name="inlow" type="float" interfacename="inlow" />
       <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
+      <input name="outlow" type="float" value="Value:zero" />
+      <input name="outhigh" type="float" value="Value:one" />
     </remap>
     <divide name="N_recip_vector4FA" type="float">
-      <input name="in1" type="float" value="1.0" />
+      <input name="in1" type="float" value="Value:one" />
       <input name="in2" type="float" interfacename="gamma" />
     </divide>
     <absval name="N_abs_vector4FA" type="vector4">
@@ -4278,8 +4278,8 @@
     </multiply>
     <remap name="N_remap2_vector4FA" type="vector4">
       <input name="in" type="vector4" nodename="N_gamma_vector4FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
+      <input name="inlow" type="float" value="Value:zero" />
+      <input name="inhigh" type="float" value="Value:one" />
       <input name="outlow" type="float" interfacename="outlow" />
       <input name="outhigh" type="float" interfacename="outhigh" />
     </remap>

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -25,10 +25,13 @@ _testValues = (1,
                [1.0, 2.0, 3.0],
                ['one', 'two', 'three'])
 
+_defaultSearchPath = mx.getDefaultDataSearchPath().asString()
 _fileDir = os.path.dirname(os.path.abspath(__file__))
-_libraryDir = os.path.join(_fileDir, '../../libraries/stdlib/')
+_libraryDir = os.path.join(_defaultSearchPath, 'libraries/stdlib/')
 _exampleDir = os.path.join(_fileDir, '../../resources/Materials/Examples/')
 _searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
+
+print(_searchPath)
 
 _libraryFilenames = ('stdlib_defs.mtlx',
                      'stdlib_ng.mtlx')

--- a/source/MaterialXBuildTools/buildLibrary/CMakeLists.txt
+++ b/source/MaterialXBuildTools/buildLibrary/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+file(GLOB materialx_source       "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB materialx_headers      "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
+
+set(TARGET_NAME MaterialXBuildLibrary)
+
+set(MATERIALX_LIBRARIES
+        MaterialXFormat
+        MaterialXCore)
+
+add_executable(${TARGET_NAME} ${materialx_source} ${materialx_headers})
+
+target_link_libraries(
+        ${TARGET_NAME}
+        ${MATERIALX_LIBRARIES})

--- a/source/MaterialXBuildTools/buildLibrary/Main.cpp
+++ b/source/MaterialXBuildTools/buildLibrary/Main.cpp
@@ -1,0 +1,176 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXFormat/Util.h>
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/XmlIo.h>
+#include <MaterialXCore/Exception.h>
+
+namespace mx = MaterialX;
+
+#include <iostream>
+
+const std::string options =
+    " Options: \n"
+    "    --sourceLibraryRoot [FILEPATH]     Directory containing the source data library files.\n"
+    "    --destLibraryRoot [FILEPATH]       Directory to write the modified data library files.\n"
+    "    --help                             Display the complete list of command-line options\n";
+
+template <class T> void parseToken(std::string token, std::string type, T& res)
+{
+    if (token.empty())
+    {
+        return;
+    }
+
+    mx::ValuePtr value = mx::Value::createValueFromStrings(token, type);
+    if (!value)
+    {
+        std::cout << "Unable to parse token " << token << " as type " << type << std::endl;
+        return;
+    }
+
+    res = value->asA<T>();
+}
+
+mx::FilePathVec getMaterialXFiles(const mx::FilePath& libraryRoot)
+{
+    mx::FilePathVec result;
+
+    auto subDirs = libraryRoot.getSubDirectories();
+    for (const auto& subDir : subDirs)
+    {
+        for (const auto& file : subDir.getFilesInDirectory("mtlx"))
+        {
+            auto absFile = subDir / file;
+            std::string absFileStr = absFile.asString();
+            std::string relFileStr = absFileStr.substr(libraryRoot.asString().size()+1);
+            result.emplace_back(mx::FilePath(relFileStr));
+        }
+    }
+    return result;
+}
+
+int main(int argc, char* const argv[])
+{
+    std::vector<std::string> tokens;
+    for (int i = 1; i < argc; i++)
+    {
+        tokens.emplace_back(argv[i]);
+    }
+
+    std::string sourceLibraryRootStr = "";
+    std::string destLibraryRootStr = "";
+
+    for (size_t i = 0; i < tokens.size(); i++)
+    {
+        const std::string& token = tokens[i];
+        const std::string& nextToken = i + 1 < tokens.size() ? tokens[i + 1] : mx::EMPTY_STRING;
+
+        if (token == "--sourceLibraryRoot")
+        {
+            sourceLibraryRootStr = nextToken;
+        }
+        else if (token == "--destLibraryRoot")
+        {
+            destLibraryRootStr = nextToken;
+        }
+        else if (token == "--help")
+        {
+            std::cout << " MaterialXBuildLibrary version " << mx::getVersionString() << std::endl;
+            std::cout << options << std::endl;
+            return 0;
+        }
+        else
+        {
+            std::cout << "Unrecognized command-line option: " << token << std::endl;
+            std::cout << "Launch the viewer with '--help' for a complete list of supported options." << std::endl;
+            continue;
+        }
+
+        if (nextToken.empty())
+        {
+            std::cout << "Expected another token following command-line option: " << token << std::endl;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::loadLibraries({}, mx::FileSearchPath(sourceLibraryRootStr), stdlib);
+
+    mx::FilePath sourceLibraryRoot = mx::FilePath(sourceLibraryRootStr);
+    mx::FilePath destLibrarayRoot = mx::FilePath(destLibraryRootStr);
+
+    if (!sourceLibraryRoot.isDirectory()) {
+        std::cerr << "Source Library Root is not a directory" << std::endl;
+        return 1;
+    }
+
+    if (!destLibrarayRoot.isDirectory()) {
+        std::cerr << "Destination Library Root is not a directory" << std::endl;
+        return 1;
+    }
+
+    mx::FilePathVec mtlxFiles = getMaterialXFiles(sourceLibraryRoot);
+
+    mx::XmlReadOptions readOptions;
+    readOptions.readComments = true;
+    readOptions.readNewlines = true;
+
+    mx::XmlWriteOptions writeOptions;
+    writeOptions.createDirectories = true;
+
+    const std::string typeValuePrefix = "Value:";
+
+    for (const auto& mtlxFile : mtlxFiles)
+    {
+        mx::DocumentPtr doc = mx::createDocument();
+
+        mx::FilePath sourceFile = sourceLibraryRoot / mtlxFile;
+        mx::FilePath destFile = destLibrarayRoot / mtlxFile;
+
+        mx::readFromXmlFile(doc, sourceFile, mx::FileSearchPath(), &readOptions);
+
+        for (auto elem : doc->traverseTree())
+        {
+            auto port = elem->asA<mx::PortElement>();
+            if (!port)
+            {
+                continue;
+            }
+
+            if (!port->hasValueString())
+            {
+                continue;
+            }
+
+            auto valueStr = port->getValueString();
+            if (mx::stringStartsWith(valueStr, typeValuePrefix))
+            {
+                auto valueNameStr = valueStr.substr(typeValuePrefix.size());
+
+                auto typeDef = stdlib->getTypeDef(port->getType());
+                if (!typeDef)
+                {
+                    throw mx::Exception("Unable to find typeDef '"+port->getType()+"'");
+                }
+
+                if (!typeDef->hasAttribute(valueNameStr))
+                {
+                    throw mx::Exception("Unable to find named value '"+valueNameStr+"' for type '"+typeDef->getName()+"'");
+                }
+
+                port->setValueString(typeDef->getAttribute(valueNameStr));
+            }
+        }
+
+        mx::writeToXmlFile(doc, destFile, &writeOptions);
+    }
+
+    return 0;
+}

--- a/source/MaterialXCore/CMakeLists.txt
+++ b/source/MaterialXCore/CMakeLists.txt
@@ -15,3 +15,15 @@ mx_add_library(MaterialXCore
 target_include_directories(${TARGET_NAME}
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>)
+
+if (${MATERIALX_BUILD_BAKE_NAMED_VALUES})
+    target_compile_definitions(${TARGET_NAME}
+        PRIVATE
+            MATERIALX_BUILD_BAKE_NAMED_VALUES=1
+    )
+else()
+    target_compile_definitions(${TARGET_NAME}
+            PRIVATE
+            MATERIALX_BUILD_BAKE_NAMED_VALUES=0
+    )
+endif()

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -644,6 +644,38 @@ TypeDefPtr TypedElement::getTypeDef() const
 //
 // ValueElement methods
 //
+/// Get the value string of a element.
+const string ValueElement::getValueString() const
+{
+#if MATERIALX_BUILD_BAKE_NAMED_VALUES
+    return getAttribute(VALUE_ATTRIBUTE);
+#else
+
+    static string typeValuePrefix = "Value:";
+
+    auto valueStr = getAttribute(VALUE_ATTRIBUTE);
+    if (!stringStartsWith(valueStr, typeValuePrefix))
+    {
+        return valueStr;
+    }
+
+    auto valueNameStr = valueStr.substr(typeValuePrefix.size());
+
+    auto typeDef = getTypeDef();
+    if (!typeDef)
+    {
+        throw Exception("Unable to find typeDef '"+getType()+"'");
+    }
+
+    if (!typeDef->hasAttribute(valueNameStr))
+    {
+        throw Exception("Unable to find named value '"+valueNameStr+"' for type '"+typeDef->getName()+"'");
+    }
+
+    return typeDef->getAttribute(valueNameStr);
+#endif
+}
+
 
 string ValueElement::getResolvedValueString(StringResolverPtr resolver) const
 {

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -951,10 +951,7 @@ class MX_CORE_API ValueElement : public TypedElement
     }
 
     /// Get the value string of a element.
-    const string& getValueString() const
-    {
-        return getAttribute(VALUE_ATTRIBUTE);
-    }
+    const string getValueString() const;
 
     /// Return the resolved value string of an element, applying any string
     /// substitutions that are defined at the element's scope.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -301,7 +301,7 @@ XmlReadOptions::XmlReadOptions() :
 //
 
 XmlWriteOptions::XmlWriteOptions() :
-    writeXIncludeEnable(true)
+    writeXIncludeEnable(true), createDirectories(false)
 {
 }
 
@@ -373,6 +373,13 @@ void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const XmlWriteOptio
 
 void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOptions* writeOptions)
 {
+    if (writeOptions->createDirectories)
+    {
+        if (!filename.getParentPath().isDirectory())
+        {
+            filename.getParentPath().createDirectory();
+        }
+    }
     std::ofstream ofs(filename.asString());
     writeToXmlStream(doc, ofs, writeOptions);
 }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -373,7 +373,7 @@ void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const XmlWriteOptio
 
 void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOptions* writeOptions)
 {
-    if (writeOptions->createDirectories)
+    if (writeOptions && writeOptions->createDirectories)
     {
         if (!filename.getParentPath().isDirectory())
         {

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -70,6 +70,10 @@ class MX_FORMAT_API XmlWriteOptions
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
+
+    /// If true, any necessary directories will be created to write the
+    /// file.
+    bool createDirectories;
 };
 
 /// @class ExceptionParseError

--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -93,10 +93,6 @@ endif()
 
 # TODO: Only do this stuff when it's relevant
 
-add_custom_command(TARGET MaterialXTest POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../libraries ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/libraries)
-
 if(MATERIALX_BUILD_GEN_MDL)
     install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../source/MaterialXGenMdl/mdl/"
         DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${MATERIALX_INSTALL_MDL_MODULE_PATH}/mdl)


### PR DESCRIPTION
This PR not currently in a mergable state, but is posted to help promote conversation around the recent proposals posted #2148 #2149 related to generic types and named values.

Here we see one possible implementation of the named values proposal, that offers both build time and run-time options.  

Named values are added to the `<typedef>` elements, with the names `zero`, `one` and `identity`. (Note perhaps `identity` for a matrix should just be called `one`?). 

There are then a number of example uses of `Value:zero`, `Value:one` etc. in place of the respective concrete values.

The cmake argument `MATERIALX_BUILD_BAKE_NAMED_VALUES` is used to control if the named values are baked out concretely at build time. If they are then a new tool `MaterialXBuildLibrary` is called that loads each `mtlx` file in the library and mutates the value to the concrete one, and writes the file out.

If `MATERIALX_BUILD_BAKE_NAMED_VALUES` is set to `OFF` then the data library is installed unmodified, and instead `Value::getValueString()` has been updated to apply the corresponding logic. This logic is only included in the library if the cmake flag is disabled.

This is only one possible route this proposal could take, but I wanted to post it as having a concrete example can make discussion easier. 
