### PR TITLE
Updates for OSL shader generation

### DIFF
--- a/libraries/stdlib/genosl/mx_worleynoise2d_float.osl
+++ b/libraries/stdlib/genosl/mx_worleynoise2d_float.osl
@@ -1,4 +1,4 @@
-void mx_worleynoise2d_float(vector2 texcoord, float jitter, output float result)
+void mx_worleynoise2d_float(vector2 texcoord, float jitter, int style, output float result)
 {
     result = mx_worley_noise_float(texcoord, jitter, 0);
 }

--- a/libraries/stdlib/genosl/mx_worleynoise2d_vector2.osl
+++ b/libraries/stdlib/genosl/mx_worleynoise2d_vector2.osl
@@ -1,4 +1,4 @@
-void mx_worleynoise2d_vector2(vector2 texcoord, float jitter, output vector2 result)
+void mx_worleynoise2d_vector2(vector2 texcoord, float jitter, int style, output vector2 result)
 {
     result = mx_worley_noise_vector2(texcoord, jitter, 0);
 }

--- a/libraries/stdlib/genosl/mx_worleynoise2d_vector3.osl
+++ b/libraries/stdlib/genosl/mx_worleynoise2d_vector3.osl
@@ -1,4 +1,4 @@
-void mx_worleynoise2d_vector3(vector2 texcoord, float jitter, output vector result)
+void mx_worleynoise2d_vector3(vector2 texcoord, float jitter, int style, output vector result)
 {
     result = mx_worley_noise_vector3(texcoord, jitter, 0);
 }

--- a/libraries/stdlib/genosl/mx_worleynoise3d_float.osl
+++ b/libraries/stdlib/genosl/mx_worleynoise3d_float.osl
@@ -1,4 +1,4 @@
-void mx_worleynoise3d_float(vector position, float jitter, output float result)
+void mx_worleynoise3d_float(vector position, float jitter, int style, output float result)
 {
     result = mx_worley_noise_float(position, jitter, 0);
 }

--- a/libraries/stdlib/genosl/mx_worleynoise3d_vector2.osl
+++ b/libraries/stdlib/genosl/mx_worleynoise3d_vector2.osl
@@ -1,4 +1,4 @@
-void mx_worleynoise3d_vector2(vector position, float jitter, output vector2 result)
+void mx_worleynoise3d_vector2(vector position, float jitter, int style, output vector2 result)
 {
     result = mx_worley_noise_vector2(position, jitter, 0);
 }

--- a/libraries/stdlib/genosl/mx_worleynoise3d_vector3.osl
+++ b/libraries/stdlib/genosl/mx_worleynoise3d_vector3.osl
@@ -1,4 +1,4 @@
-void mx_worleynoise3d_vector3(vector position, float jitter, output vector result)
+void mx_worleynoise3d_vector3(vector position, float jitter, int style, output vector result)
 {
     result = mx_worley_noise_vector3(position, jitter, 0);
 }

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -65,7 +65,8 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     // Generate reference shaders.
     // Ignore the following nodes:
     const mx::StringSet ignoreNodeList = { "surfacematerial", "volumematerial",
-                                           "constant_filename", "dot_filename"};
+                                           "constant_filename", "dot_filename",
+                                           "geompropvalueuniform_filename" };
 
     bool failedGeneration = false;
     for (const mx::NodeDefPtr& nodedef : stdlib->getNodeDefs())


### PR DESCRIPTION
This changelist updates OSL shader generation to account for recent feature contributions (e.g. worleynoise, geompropvalueuniform), allowing render comparisons to complete successfully.