### PR TITLE
Add filtering properties to OSL textures

### DIFF
--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -12,5 +12,9 @@ void mx_image_color3(textureresource file, string layer, color default_value, ve
 
     color missingColor = default_value;
     vector2 st = mx_transform_uv(texcoord);
-    out = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode, "colorspace", file.colorspace);
+    out = texture(file.filename, st.x, st.y,
+                  "subimage", layer, "interp", filtertype,
+                  "missingcolor", missingColor,
+                  "swrap", uaddressmode, "twrap", vaddressmode,
+                  "colorspace", file.colorspace);
 }

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -14,8 +14,11 @@ void mx_image_color4(textureresource file, string layer, color4 default_value, v
     float missingAlpha = default_value.a;
     vector2 st = mx_transform_uv(texcoord);
     float alpha;
-    color rgb = texture(file.filename, st.x, st.y, "alpha", alpha, "subimage", layer,
-                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode, "colorspace", file.colorspace);
+    color rgb = texture(file.filename, st.x, st.y, "alpha", alpha,
+                        "subimage", layer, "interp", filtertype,
+                        "missingcolor", missingColor, "missingalpha", missingAlpha,
+                        "swrap", uaddressmode, "twrap", vaddressmode,
+                        "colorspace", file.colorspace);
 
     out = color4(rgb, alpha);
 }

--- a/libraries/stdlib/genosl/mx_image_float.osl
+++ b/libraries/stdlib/genosl/mx_image_float.osl
@@ -12,6 +12,9 @@ void mx_image_float(textureresource file, string layer, float default_value, vec
 
     color missingColor = color(default_value);
     vector2 st = mx_transform_uv(texcoord);
-    color rgb = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    color rgb = texture(file.filename, st.x, st.y,
+                        "subimage", layer, "interp", filtertype,
+                        "missingcolor", missingColor,
+                        "swrap", uaddressmode, "twrap", vaddressmode);
     out = rgb[0];
 }

--- a/libraries/stdlib/genosl/mx_image_vector2.osl
+++ b/libraries/stdlib/genosl/mx_image_vector2.osl
@@ -12,7 +12,10 @@ void mx_image_vector2(textureresource file, string layer, vector2 default_value,
 
     color missingColor = color(default_value.x, default_value.y, 0.0);
     vector2 st = mx_transform_uv(texcoord);
-    color rgb = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    color rgb = texture(file.filename, st.x, st.y,
+                        "subimage", layer, "interp", filtertype,
+                        "missingcolor", missingColor,
+                        "swrap", uaddressmode, "twrap", vaddressmode);
     out.x = rgb[0];
     out.y = rgb[1];
 }

--- a/libraries/stdlib/genosl/mx_image_vector3.osl
+++ b/libraries/stdlib/genosl/mx_image_vector3.osl
@@ -12,5 +12,8 @@ void mx_image_vector3(textureresource file, string layer, vector default_value, 
 
     color missingColor = default_value;
     vector2 st = mx_transform_uv(texcoord);
-    out = texture(file.filename, st.x, st.y, "subimage", layer, "missingcolor", missingColor, "swrap", uaddressmode, "twrap", vaddressmode);
+    out = texture(file.filename, st.x, st.y,
+                  "subimage", layer, "interp", filtertype,
+                  "missingcolor", missingColor,
+                  "swrap", uaddressmode, "twrap", vaddressmode);
 }

--- a/libraries/stdlib/genosl/mx_image_vector4.osl
+++ b/libraries/stdlib/genosl/mx_image_vector4.osl
@@ -14,8 +14,10 @@ void mx_image_vector4(textureresource file, string layer, vector4 default_value,
     float missingAlpha = default_value.w;
     vector2 st = mx_transform_uv(texcoord);
     float alpha;
-    color rgb = texture(file.filename, st.x, st.y, "alpha", alpha, "subimage", layer,
-                        "missingcolor", missingColor, "missingalpha", missingAlpha, "swrap", uaddressmode, "twrap", vaddressmode);
+    color rgb = texture(file.filename, st.x, st.y, "alpha", alpha,
+                        "subimage", layer, "interp", filtertype,
+                        "missingcolor", missingColor, "missingalpha", missingAlpha,
+                        "swrap", uaddressmode, "twrap", vaddressmode);
 
     out = vector4(rgb[0], rgb[1], rgb[2], alpha);
 }


### PR DESCRIPTION
This changelist adds filtering properties to texture calls in OSL shader generation, improving the visual consistency between generated OSL and other shading languages.

Previously, the "interp" property was omitted from texture calls in generated OSL, causing the default "smartcubic" filtering mode to be used.