### PR TITLE
Improvements to render tests

### DIFF
--- a/python/MaterialXTest/tests_to_html.bat
+++ b/python/MaterialXTest/tests_to_html.bat
@@ -1,2 +1,2 @@
 @echo off
-python tests_to_html.py -i1 ../../build %*
+python tests_to_html.py -i1 ../../build %* -d

--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -6,13 +6,13 @@ import datetime
 import argparse
 
 try:
-    # Use pip to install Pillow and Image to enable image diffs
-    from PIL import Image, ImageChops
+    # Install pillow via pip to enable image differencing and statistics.
+    from PIL import Image, ImageChops, ImageStat
     DIFF_ENABLED = True
 except Exception:
     DIFF_ENABLED = False
 
-def createDiff(image1Path, image2Path, imageDiffPath):
+def computeDiff(image1Path, image2Path, imageDiffPath):
     try:
         if os.path.exists(imageDiffPath):
             os.remove(imageDiffPath)
@@ -29,6 +29,8 @@ def createDiff(image1Path, image2Path, imageDiffPath):
         image2 = Image.open(image2Path).convert('RGB')
         diff = ImageChops.difference(image1, image2)
         diff.save(imageDiffPath)
+        diffStat = ImageStat.Stat(diff)
+        return sum(diffStat.rms) / (3.0 * 255.0)
     except Exception:
         if os.path.exists(imageDiffPath):
             os.remove(imageDiffPath)
@@ -144,9 +146,8 @@ def main(args=None):
             fullPath1 = os.path.join(path1, file1) if file1 else None
             fullPath2 = os.path.join(path2, file2) if file2 else None
             fullPath3 = os.path.join(path3, file3) if file3 else None
-            diffPath1 = None
-            diffPath2 = None
-            diffPath3 = None
+            diffPath1 = diffPath2 = diffPath3 = None
+            diffRms1 = diffRms2 = diffRms3 = None
 
             if curPath != path1:
                 if curPath != "":
@@ -157,13 +158,13 @@ def main(args=None):
 
             if file1 and file2 and DIFF_ENABLED and args.CREATE_DIFF:
                 diffPath1 = fullPath1[0:-8] + "_" + args.lang1 + "-1_vs_" + args.lang2 + "-2_diff.png"
-                createDiff(fullPath1, fullPath2, diffPath1)
+                diffRms1 = computeDiff(fullPath1, fullPath2, diffPath1)
 
             if useThirdLang and file1 and file3 and DIFF_ENABLED and args.CREATE_DIFF:
                 diffPath2 = fullPath1[0:-8] + "_" + args.lang1 + "-1_vs_" + args.lang3 + "-3_diff.png"
-                createDiff(fullPath1, fullPath3, diffPath2)
+                diffRms2 = computeDiff(fullPath1, fullPath3, diffPath2)
                 diffPath3 = fullPath1[0:-8] + "_" + args.lang2 + "-2_vs_" + args.lang3 + "-3_diff.png"
-                createDiff(fullPath2, fullPath3, diffPath3)
+                diffRms3 = computeDiff(fullPath2, fullPath3, diffPath3)
 
             def prependFileUri(filepath: str) -> str:
                 if os.path.isabs(filepath):
@@ -203,11 +204,11 @@ def main(args=None):
                     fh.write("<br>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullPath3))) + ")")
                 fh.write("</td>\n")
             if diffPath1:
-                fh.write("<td align='center'>Difference " + args.lang1 + " vs. " + args.lang2 + " </td>\n")
+                fh.write("<td align='center'>" + args.lang1.upper() + " vs. " + args.lang2.upper() + " (RMS " + "%.5f" % diffRms1 + ") </td>\n")
             if diffPath2:
-                fh.write("<td align='center'>Difference " + args.lang1 + " vs. " + args.lang3 + " </td>\n")
+                fh.write("<td align='center'>" + args.lang1.upper() + " vs. " + args.lang3.upper() + " (RMS " + "%.5f" % diffRms2 + ") </td>\n")
             if diffPath3:
-                fh.write("<td align='center'>Difference " + args.lang2 + " vs. " + args.lang3 + " </td>\n")
+                fh.write("<td align='center'>" + args.lang2.upper() + " vs. " + args.lang3.upper() + " (RMS " + "%.5f" % diffRms3 + ") </td>\n")
             fh.write("</tr>\n")
 
     fh.write("</table>\n")

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -33,20 +33,8 @@
     -->
     <input name="shaderInterfaces" type="integer" value="2" />
 
-    <!-- Validate element before attempting to generate code. Default is false  -->
-    <input name="validateElementToRender" type="boolean" value="false" />
-
-    <!-- Perform source code compilation validation test -->
-    <input name="compileCode" type="boolean" value="true" />
-
-    <!-- Perform rendering validation test -->
-    <input name="renderImages" type="boolean" value="true" />
-
     <!-- Rendered image size if render validation test enabled -->
     <input name="renderSize" type="vector2" value="512, 512" />
-
-    <!-- Perform saving of image. Can only be disabled for GLSL tests -->
-    <input name="saveImages" type="boolean" value="true" />
 
     <!-- Set this to be true if it is desired to dump out uniform and attribut information to the logging file -->
     <input name="dumpUniformsAndAttributes" type="boolean" value="true" />
@@ -76,7 +64,11 @@
     <!-- List of document paths for render tests -->
     <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/stdlib/geometric,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib,resources/Materials/TestSuite/nprlib" />
 
-    <!-- Enable reference quality rendering. Default is false. -->
+    <!-- Enable reference quality rendering.
+         This option enables higher sample counts and supersampling in render tests,
+         allowing for visual comparisons and differencing across shading languages,
+         but requiring a more powerful GPU and longer CPU render times.
+    -->
     <input name="enableReferenceQuality" type="boolean" value="false" />
   </nodedef>
 </materialx>

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -921,11 +921,7 @@ void TestSuiteOptions::print(std::ostream& output) const
     output << "\tCheck Implementation Usage Count: " << checkImplCount << std::endl;
     output << "\tDump Generated Code: " << dumpGeneratedCode << std::endl;
     output << "\tShader Interfaces: " << shaderInterfaces << std::endl;
-    output << "\tValidate Element To Render: " << validateElementToRender << std::endl;
-    output << "\tCompile code: " << compileCode << std::endl;
-    output << "\tRender Images: " << renderImages << std::endl;
     output << "\tRender Size: " << renderSize[0] << "," << renderSize[1] << std::endl;
-    output << "\tSave Images: " << saveImages << std::endl;
     output << "\tDump uniforms and Attributes  " << dumpUniformsAndAttributes << std::endl;
     output << "\tRender Geometry: " << renderGeometry.asString() << std::endl;
     output << "\tEnable Direct Lighting: " << enableDirectLighting << std::endl;
@@ -947,11 +943,7 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
     const std::string TARGETS_STRING("targets");
     const std::string LIGHT_FILES_STRING("lightFiles");
     const std::string SHADER_INTERFACES_STRING("shaderInterfaces");
-    const std::string VALIDATE_ELEMENT_TO_RENDER_STRING("validateElementToRender");
-    const std::string COMPILE_CODE_STRING("compileCode");
-    const std::string RENDER_IMAGES_STRING("renderImages");
     const std::string RENDER_SIZE_STRING("renderSize");
-    const std::string SAVE_IMAGES_STRING("saveImages");
     const std::string DUMP_UNIFORMS_AND_ATTRIBUTES_STRING("dumpUniformsAndAttributes");
     const std::string CHECK_IMPL_COUNT_STRING("checkImplCount");
     const std::string DUMP_GENERATED_CODE_STRING("dumpGeneratedCode");
@@ -998,25 +990,9 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
                     {
                         shaderInterfaces = val->asA<int>();
                     }
-                    else if (name == VALIDATE_ELEMENT_TO_RENDER_STRING)
-                    {
-                        validateElementToRender = val->asA<bool>();
-                    }
-                    else if (name == COMPILE_CODE_STRING)
-                    {
-                        compileCode = val->asA<bool>();
-                    }
-                    else if (name == RENDER_IMAGES_STRING)
-                    {
-                        renderImages = val->asA<bool>();
-                    }
                     else if (name == RENDER_SIZE_STRING)
                     {
                         renderSize = val->asA<mx::Vector2>();
-                    }
-                    else if (name == SAVE_IMAGES_STRING)
-                    {
-                        saveImages = val->asA<bool>();
                     }
                     else if (name == DUMP_UNIFORMS_AND_ATTRIBUTES_STRING)
                     {
@@ -1082,23 +1058,11 @@ bool TestSuiteOptions::readOptions(const std::string& optionFile)
             }
         }
 
-        // Disable render and save of images if not compiled code will be generated
-        if (!compileCode)
-        {
-            renderImages = false;
-            saveImages = false;
-        }
-        // Disable saving images, if no images are to be produced
-        if (!renderImages)
-        {
-            saveImages = false;
-        }
-        // Disable direct lighting
+        // Handle direct and indirect lighting toggles.
         if (!enableDirectLighting)
         {
             lightFiles.clear();
         }
-        // Disable indirect lighting
         if (!enableIndirectLighting)
         {
             radianceIBLPath.assign(mx::EMPTY_STRING);

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -88,20 +88,8 @@ class TestSuiteOptions
     // - 1 = run reduced only.
     int shaderInterfaces = 2;
 
-    // Validate element before attempting to generate code. Default is false.
-    bool validateElementToRender = false;
-
-    // Perform source code compilation validation test
-    bool compileCode = true;
-
-    // Perform rendering validation test
-    bool renderImages = true;
-
     // Render size
     mx::Vector2 renderSize = { 512, 512 };
-
-    // Perform saving of image.
-    bool saveImages = true;
 
     // Set this to be true if it is desired to dump out uniform and attribut information to the logging file.
     bool dumpUniformsAndAttributes = true;

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -192,17 +192,6 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
 
     mx::ShaderGenerator& shadergen = context.getShaderGenerator();
 
-    // Perform validation if requested
-    if (testOptions.validateElementToRender)
-    {
-        std::string message;
-        if (!element->validate(&message))
-        {
-            log << "Element is invalid: " << message << std::endl;
-            return false;
-        }
-    }
-
     std::vector<mx::GenOptions> optionsList;
     getGenerationOptions(testOptions, context.getOptions(), optionsList);
 
@@ -267,11 +256,6 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                 file.close();
             }
 
-            if (!testOptions.compileCode)
-            {
-                return false;
-            }
-
             // Validate
             bool validated = false;
             try
@@ -288,55 +272,52 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                     _renderer->createProgram(shader);
                 }
 
-                if (testOptions.renderImages)
+                _renderer->setSize(static_cast<unsigned int>(testOptions.renderSize[0]), static_cast<unsigned int>(testOptions.renderSize[1]));
+
+                const mx::ShaderStage& stage = shader->getStage(mx::Stage::PIXEL);
+
+                // Bind IBL image name overrides.
+                mx::StringVec envOverrides;
+                std::string envmap_filename("string envmap_filename \"");
+                envmap_filename += testOptions.radianceIBLPath;
+                envmap_filename += "\";\n";                    
+                envOverrides.push_back(envmap_filename);
+
+                _renderer->setEnvShaderParameterOverrides(envOverrides);
+
+                const mx::VariableBlock& outputs = stage.getOutputBlock(mx::OSL::OUTPUTS);
+                if (outputs.size() > 0)
                 {
-                    _renderer->setSize(static_cast<unsigned int>(testOptions.renderSize[0]), static_cast<unsigned int>(testOptions.renderSize[1]));
+                    const mx::ShaderPort* output = outputs[0];
+                    const mx::TypeSyntax& typeSyntax = shadergen.getSyntax().getTypeSyntax(output->getType());
 
-                    const mx::ShaderStage& stage = shader->getStage(mx::Stage::PIXEL);
+                    const std::string& outputName = output->getVariable();
+                    const std::string& outputType = typeSyntax.getTypeAlias().empty() ? typeSyntax.getName() : typeSyntax.getTypeAlias();
+                    const std::string& sceneTemplateFile = "scene_template.xml";
 
-                    // Bind IBL image name overrides.
-                    mx::StringVec envOverrides;
-                    std::string envmap_filename("string envmap_filename \"");
-                    envmap_filename += testOptions.radianceIBLPath;
-                    envmap_filename += "\";\n";                    
-                    envOverrides.push_back(envmap_filename);
+                    // Set shader output name and type to use
+                    _renderer->setOslShaderOutput(outputName, outputType);
 
-                    _renderer->setEnvShaderParameterOverrides(envOverrides);
+                    // Set scene template file. For now we only have the constant color scene file
+                    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+                    mx::FilePath sceneTemplatePath = searchPath.find("resources/Utilities/");
+                    sceneTemplatePath = sceneTemplatePath / sceneTemplateFile;
+                    _renderer->setOslTestRenderSceneTemplateFile(sceneTemplatePath.asString());
 
-                    const mx::VariableBlock& outputs = stage.getOutputBlock(mx::OSL::OUTPUTS);
-                    if (outputs.size() > 0)
+                    // Validate rendering
                     {
-                        const mx::ShaderPort* output = outputs[0];
-                        const mx::TypeSyntax& typeSyntax = shadergen.getSyntax().getTypeSyntax(output->getType());
-
-                        const std::string& outputName = output->getVariable();
-                        const std::string& outputType = typeSyntax.getTypeAlias().empty() ? typeSyntax.getName() : typeSyntax.getTypeAlias();
-                        const std::string& sceneTemplateFile = "scene_template.xml";
-
-                        // Set shader output name and type to use
-                        _renderer->setOslShaderOutput(outputName, outputType);
-
-                        // Set scene template file. For now we only have the constant color scene file
-                        mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
-                        mx::FilePath sceneTemplatePath = searchPath.find("resources/Utilities/");
-                        sceneTemplatePath = sceneTemplatePath / sceneTemplateFile;
-                        _renderer->setOslTestRenderSceneTemplateFile(sceneTemplatePath.asString());
-
-                        // Validate rendering
+                        mx::ScopedTimer renderTimer(&profileTimes.languageTimes.renderTime);
+                        _renderer->render();
+                        if (imageVec)
                         {
-                            mx::ScopedTimer renderTimer(&profileTimes.languageTimes.renderTime);
-                            _renderer->render();
-                            if (imageVec)
-                            {
-                                imageVec->push_back(_renderer->captureImage());
-                            }
+                            imageVec->push_back(_renderer->captureImage());
                         }
                     }
-                    else
-                    {
-                        CHECK(false);
-                        log << ">> Shader has no output to render from\n";
-                    }
+                }
+                else
+                {
+                    CHECK(false);
+                    log << ">> Shader has no output to render from\n";
                 }
 
                 validated = true;

--- a/source/MaterialXTest/MaterialXRenderOsl/Utilities/scene_template.xml
+++ b/source/MaterialXTest/MaterialXRenderOsl/Utilities/scene_template.xml
@@ -1,6 +1,6 @@
 <!-- Template for a lit scene in testrender -->
 <World>
-   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.3" />
+   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.335" />
 
    <!-- Background environment map. -->
    <ShaderGroup>


### PR DESCRIPTION
- Display image statistics when image differencing is enabled in render tests.
- Add supersampling to hardware shading languages when reference quality is enabled.
- Improve camera alignment across shading languages.
- Remove legacy render test options for clarity.