### PR TITLE
Increase OSL samples in reference renders

### DIFF
--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -62,7 +62,7 @@
     <input name="extraLibraryPaths" type="string" value="" />
 
     <!-- List of document paths for render tests -->
-    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib,resources/Materials/TestSuite/nprlib" />
+    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib/surfaceshader,resources/Materials/TestSuite/nprlib" />
 
     <!-- Enable reference quality rendering.
          This option enables higher sample counts and supersampling in render tests,

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -62,7 +62,7 @@
     <input name="extraLibraryPaths" type="string" value="" />
 
     <!-- List of document paths for render tests -->
-    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/stdlib/geometric,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib,resources/Materials/TestSuite/nprlib" />
+    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib,resources/Materials/TestSuite/nprlib" />
 
     <!-- Enable reference quality rendering.
          This option enables higher sample counts and supersampling in render tests,

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -263,8 +263,8 @@ bool OslShaderRenderTester::runRenderer(const std::string& shaderName,
                 // Set renderer properties.
                 _renderer->setOslOutputFilePath(outputFilePath);
                 _renderer->setOslShaderName(shaderName);
-                _renderer->setRaysPerPixelLit(testOptions.enableReferenceQuality ? 8 : 4);
-                _renderer->setRaysPerPixelUnlit(testOptions.enableReferenceQuality ? 2 : 1);
+                _renderer->setRaysPerPixelLit(testOptions.enableReferenceQuality ? 32 : 4);
+                _renderer->setRaysPerPixelUnlit(testOptions.enableReferenceQuality ? 8 : 1);
 
                 // Validate compilation
                 {


### PR DESCRIPTION
This changelist increases the number of OSL samples in reference-quality renders, improving the visual parity between OSL and other languages in MaterialX render tests.

Additionally, it pares down the list of document paths for MaterialX render tests, reducing the resulting PDF document to a size that can be directly shared on Slack.