### PR TITLE
Additional refinements to render tests

### DIFF
--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -23,7 +23,7 @@
   <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
 
   <!-- <chiang_hair_bsdf> -->
-  <implementation name="IM_chiang_hair_bsdf_genosl" nodedef="ND_chiang_hair_bsdf" sourcecode="oren_nayar_diffuse_bsdf({{normal}}, {{tint_R}}, 0.0)" target="genosl" />
+  <implementation name="IM_chiang_hair_bsdf_genosl" nodedef="ND_chiang_hair_bsdf" sourcecode="dielectric_bsdf({{normal}}, {{curve_direction}}, color(1), color(0), 0.1, 0.1, {{ior}}, &quot;ggx&quot;)" target="genosl" />
 
   <!-- <sheen_bsdf> -->
   <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" sourcecode="{{weight}} * sheen_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/normalmapped_surfaceshader.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/normalmapped_surfaceshader.mtlx
@@ -7,7 +7,7 @@
     <input name="coat" type="float" value="1" />
     <input name="normal" type="vector3" nodegraph="NormalMapGraph" />
   </standard_surface>
-  <surfacematerial name="NormalMappedShaderMaterial" type="material">
+  <surfacematerial name="NormalMappedMaterial" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="NormalMappedShader" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>
@@ -31,7 +31,7 @@
     <input name="coat" type="float" value="1" />
     <input name="normal" type="vector3" nodegraph="NormalMapGraph2" />
   </standard_surface>
-  <surfacematerial name="NormalMappedShaderMaterial2" type="material">
+  <surfacematerial name="NormalMappedMaterial2" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="NormalMappedShader2" />
     <input name="displacementshader" type="displacementshader" value="" />
   </surfacematerial>

--- a/resources/Materials/TestSuite/stdlib/color_management/color3_vec3_cm_test.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color3_vec3_cm_test.mtlx
@@ -13,7 +13,7 @@
       <input name="in" type="float" nodename="extract1" />
       <input name="scale" type="float" value="1.0" />
     </heighttonormal>
-    <output name="height_normal_map_output" type="vector3" nodename="impl_heighttonormalmap" />
+    <output name="out" type="vector3" nodename="impl_heighttonormalmap" />
   </nodegraph>
   <!-- create nodegraph to test cm conversion on image node before feeding to normalmap  -->
   <nodegraph name="normalmap_cm">
@@ -27,6 +27,6 @@
       <input name="in" type="vector3" nodename="c3tov3" />
       <input name="scale" type="float" value="1.5" />
     </normalmap>
-    <output name="normal_map_output" type="vector3" nodename="impl_normalmap" />
+    <output name="out" type="vector3" nodename="impl_normalmap" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -7,77 +7,77 @@
     <standard_surface name="image_lin_rec709_standard_surface" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_lin_rec709" />
     </standard_surface>
-    <output name="image_lin_rec709_output" type="surfaceshader" nodename="image_lin_rec709_standard_surface" />
+    <output name="image_lin_rec709_out" type="surfaceshader" nodename="image_lin_rec709_standard_surface" />
     <image name="image_gamma18" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma18" />
     </image>
     <standard_surface name="image_gamma18_standard_surface2" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_gamma18" />
     </standard_surface>
-    <output name="image_gamma18_output" type="surfaceshader" nodename="image_gamma18_standard_surface2" />
+    <output name="image_gamma18_out" type="surfaceshader" nodename="image_gamma18_standard_surface2" />
     <image name="image_gamma22" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma22" />
     </image>
     <standard_surface name="image_gamma22_standard_surface3" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_gamma22" />
     </standard_surface>
-    <output name="image_gamma22_output" type="surfaceshader" nodename="image_gamma22_standard_surface3" />
+    <output name="image_gamma22_out" type="surfaceshader" nodename="image_gamma22_standard_surface3" />
     <image name="image_gamma24" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="gamma24" />
     </image>
     <standard_surface name="image_gamma24_standard_surface4" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_gamma24" />
     </standard_surface>
-    <output name="image_gamma24_output" type="surfaceshader" nodename="image_gamma24_standard_surface4" />
+    <output name="image_gamma24_out" type="surfaceshader" nodename="image_gamma24_standard_surface4" />
     <image name="image_acescg" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="acescg" />
     </image>
     <standard_surface name="image_acescg_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_acescg" />
     </standard_surface>
-    <output name="image_acescg_output" type="surfaceshader" nodename="image_acescg_standard_surface5" />
+    <output name="image_acescg_out" type="surfaceshader" nodename="image_acescg_standard_surface5" />
     <image name="image_g22_ap1" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="g22_ap1" />
     </image>
     <standard_surface name="image_g22_ap1_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_g22_ap1" />
     </standard_surface>
-    <output name="image_g22_ap1_output" type="surfaceshader" nodename="image_g22_ap1_standard_surface5" />
+    <output name="image_g22_ap1_out" type="surfaceshader" nodename="image_g22_ap1_standard_surface5" />
     <image name="image_srgb_texture" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_texture" />
     </image>
     <standard_surface name="image_srgb_texture_standard_surface6" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_srgb_texture" />
     </standard_surface>
-    <output name="image_srgb_texture_output" type="surfaceshader" nodename="image_srgb_texture_standard_surface6" />
+    <output name="image_srgb_texture_out" type="surfaceshader" nodename="image_srgb_texture_standard_surface6" />
     <image name="image_adobergb" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="adobergb" />
     </image>
     <standard_surface name="image_adobergb_standard_surface7" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_adobergb" />
     </standard_surface>
-    <output name="image_adobergb_output" type="surfaceshader" nodename="image_adobergb_standard_surface7" />
+    <output name="image_adobergb_out" type="surfaceshader" nodename="image_adobergb_standard_surface7" />
     <image name="image_lin_adobergb" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_adobergb" />
     </image>
     <standard_surface name="image_lin_adobergb_standard_surface8" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_lin_adobergb" />
     </standard_surface>
-    <output name="image_lin_adobergb_output" type="surfaceshader" nodename="image_lin_adobergb_standard_surface8" />
+    <output name="image_lin_adobergb_out" type="surfaceshader" nodename="image_lin_adobergb_standard_surface8" />
     <image name="image_srgb_displayp3" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="srgb_displayp3" />
     </image>
     <standard_surface name="image_srgb_displayp3_standard_surface9" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_srgb_displayp3" />
     </standard_surface>
-    <output name="image_srgb_displayp3_output" type="surfaceshader" nodename="image_srgb_displayp3_standard_surface9" />
+    <output name="image_srgb_displayp3_out" type="surfaceshader" nodename="image_srgb_displayp3_standard_surface9" />
     <image name="image_lin_displayp3" type="color3">
       <input name="file" type="filename" value="resources/Images/grid.png" colorspace="lin_displayp3" />
     </image>
     <standard_surface name="image_lin_displayp3_standard_surface10" type="surfaceshader">
       <input name="base_color" type="color3" nodename="image_lin_displayp3" />
     </standard_surface>
-    <output name="image_lin_displayp3_output" type="surfaceshader" nodename="image_lin_displayp3_standard_surface10" />
+    <output name="image_lin_displayp3_out" type="surfaceshader" nodename="image_lin_displayp3_standard_surface10" />
     <constant name="color_lin_rec709" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_rec709" />
     </constant>
@@ -87,7 +87,7 @@
     <standard_surface name="color_lin_rec709_standard_surface" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_lin_rec709_color3" />
     </standard_surface>
-    <output name="color_lin_rec709_output" type="surfaceshader" nodename="color_lin_rec709_standard_surface" />
+    <output name="color_lin_rec709_out" type="surfaceshader" nodename="color_lin_rec709_standard_surface" />
     <constant name="color_gamma18" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma18" />
     </constant>
@@ -97,7 +97,7 @@
     <standard_surface name="color_gamma18_standard_surface2" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_gamma18_color3" />
     </standard_surface>
-    <output name="color_gamma18_output" type="surfaceshader" nodename="color_gamma18_standard_surface2" />
+    <output name="color_gamma18_out" type="surfaceshader" nodename="color_gamma18_standard_surface2" />
     <constant name="color_gamma22" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma22" />
     </constant>
@@ -107,7 +107,7 @@
     <standard_surface name="color_gamma22_standard_surface3" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_gamma22_color3" />
     </standard_surface>
-    <output name="color_gamma22_output" type="surfaceshader" nodename="color_gamma22_standard_surface3" />
+    <output name="color_gamma22_out" type="surfaceshader" nodename="color_gamma22_standard_surface3" />
     <constant name="color_gamma24" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="gamma24" />
     </constant>
@@ -117,7 +117,7 @@
     <standard_surface name="color_gamma24_standard_surface4" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_gamma24_color3" />
     </standard_surface>
-    <output name="color_gamma24_output" type="surfaceshader" nodename="color_gamma24_standard_surface4" />
+    <output name="color_gamma24_out" type="surfaceshader" nodename="color_gamma24_standard_surface4" />
     <constant name="color_acescg" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="acescg" />
     </constant>
@@ -127,7 +127,7 @@
     <standard_surface name="color_acescg_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_acescg_color3" />
     </standard_surface>
-    <output name="color_acescg_output" type="surfaceshader" nodename="color_acescg_standard_surface5" />
+    <output name="color_acescg_out" type="surfaceshader" nodename="color_acescg_standard_surface5" />
     <constant name="color_g22_ap1" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="g22_ap1" />
     </constant>
@@ -137,7 +137,7 @@
     <standard_surface name="color_g22_ap1_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_g22_ap1_color3" />
     </standard_surface>
-    <output name="color_g22_ap1_output" type="surfaceshader" nodename="color_g22_ap1_standard_surface5" />
+    <output name="color_g22_ap1_out" type="surfaceshader" nodename="color_g22_ap1_standard_surface5" />
     <constant name="color_srgb_texture" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="srgb_texture" />
     </constant>
@@ -147,7 +147,7 @@
     <standard_surface name="color_srgb_texture_standard_surface6" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_srgb_texture_color3" />
     </standard_surface>
-    <output name="color_srgb_texture_output" type="surfaceshader" nodename="color_srgb_texture_standard_surface6" />
+    <output name="color_srgb_texture_out" type="surfaceshader" nodename="color_srgb_texture_standard_surface6" />
     <constant name="color_adobergb" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="adobergb" />
     </constant>
@@ -157,7 +157,7 @@
     <standard_surface name="color_adobergb_standard_surface7" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_adobergb_color3" />
     </standard_surface>
-    <output name="color_adobergb_output" type="surfaceshader" nodename="color_adobergb_standard_surface7" />
+    <output name="color_adobergb_out" type="surfaceshader" nodename="color_adobergb_standard_surface7" />
     <constant name="color_lin_adobergb" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_adobergb" />
     </constant>
@@ -167,7 +167,7 @@
     <standard_surface name="color_lin_adobergb_standard_surface8" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_lin_adobergb_color3" />
     </standard_surface>
-    <output name="color_lin_adobergb_output" type="surfaceshader" nodename="color_lin_adobergb_standard_surface8" />
+    <output name="color_lin_adobergb_out" type="surfaceshader" nodename="color_lin_adobergb_standard_surface8" />
     <constant name="color_srgb_displayp3" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="srgb_displayp3" />
     </constant>
@@ -177,7 +177,7 @@
     <standard_surface name="color_srgb_displayp3_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_srgb_displayp3_color3" />
     </standard_surface>
-    <output name="color_srgb_displayp3_output" type="surfaceshader" nodename="color_srgb_displayp3_standard_surface5" />
+    <output name="color_srgb_displayp3_out" type="surfaceshader" nodename="color_srgb_displayp3_standard_surface5" />
     <constant name="color_lin_displayp3" type="color4">
       <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_displayp3" />
     </constant>
@@ -187,6 +187,6 @@
     <standard_surface name="color_lin_displayp3_standard_surface5" type="surfaceshader">
       <input name="base_color" type="color3" nodename="color_lin_displayp3_color3" />
     </standard_surface>
-    <output name="color_lin_displayp3_output" type="surfaceshader" nodename="color_lin_displayp3_standard_surface5" />
+    <output name="color_lin_displayp3_out" type="surfaceshader" nodename="color_lin_displayp3_standard_surface5" />
   </nodegraph>
 </materialx>

--- a/source/MaterialXTest/MaterialXRenderOsl/Utilities/scene_template.xml
+++ b/source/MaterialXTest/MaterialXRenderOsl/Utilities/scene_template.xml
@@ -1,6 +1,6 @@
 <!-- Template for a lit scene in testrender -->
 <World>
-   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.335" />
+   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.334" />
 
    <!-- Background environment map. -->
    <ShaderGroup>


### PR DESCRIPTION
- Simplify example material names to improve PDF layout for render tests.
- Slightly adjust the OSL camera to improve parity with hardware shading languages.
- Select a more appropriate fallback for the Chiang Hair BSDF in OSL.