### PR TITLE
Improvements to heighttonormal node

### DIFF
--- a/documents/Specification/MaterialX.Specification.md
+++ b/documents/Specification/MaterialX.Specification.md
@@ -1776,7 +1776,7 @@ Convolution nodes have one input named "in", and apply a defined convolution fun
 
 <a id="node-heighttonormal"> </a>
 
-* **`heighttonormal`**: convert a scalar height map to a normal map of type vector3.
+* **`heighttonormal`**: convert a scalar height map to a tangent-space normal map of type vector3.  The output normal map is encoded with all channels in the [0-1] range, enabling its storage in unsigned image formats.
     * `in` (float): the input value or nodename
     * `scale` (float): the scale of normal map deflections relative to the gradient of the height map.  Default is 1.0.
 

--- a/libraries/stdlib/genosl/mx_heighttonormal_vector3.osl
+++ b/libraries/stdlib/genosl/mx_heighttonormal_vector3.osl
@@ -1,5 +1,8 @@
 void mx_heighttonormal_vector3(float in, float scale, output vector result)
 {
-    point htP = P + normalize(N) * in * scale;
-    result = normalize(calculatenormal(htP));
+    float dx = -Dx(in);
+    float dy = Dy(in);
+    float dz = max(scale, 1.0E-05) * sqrt(max(1.0 - dx*dx - dy*dy, 1.0E-05));
+    vector dir = normalize(vector(dx, dy, dz));
+    result = dir * vector(0.5) + vector(0.5);
 }

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -62,7 +62,7 @@
     <input name="extraLibraryPaths" type="string" value="" />
 
     <!-- List of document paths for render tests -->
-    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib/surfaceshader,resources/Materials/TestSuite/nprlib" />
+    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/pbrlib/surfaceshader,resources/Materials/TestSuite/nprlib" />
 
     <!-- Enable reference quality rendering.
          This option enables higher sample counts and supersampling in render tests,

--- a/resources/Materials/TestSuite/stdlib/convolution/blur.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/blur.mtlx
@@ -12,7 +12,7 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
-    <output name="blur_color3_out" type="color3" nodename="blur_color3" />
+    <output name="out" type="color3" nodename="blur_color3" />
   </nodegraph>
   <nodegraph name="blur_color4">
     <tiledimage name="tiledimage1" type="color4">
@@ -23,7 +23,7 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
-    <output name="blur_color4_out" type="color4" nodename="blur_color4" />
+    <output name="out" type="color4" nodename="blur_color4" />
   </nodegraph>
   <nodegraph name="blur_float">
     <image name="image1" type="float">
@@ -34,7 +34,7 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-    <output name="blur_float_out" type="float" nodename="blur_float" />
+    <output name="out" type="float" nodename="blur_float" />
   </nodegraph>
   <nodegraph name="blur_vector2">
     <tiledimage name="tiledimage1" type="vector2">
@@ -45,7 +45,7 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-    <output name="blur_vector2_out" type="vector2" nodename="blur_vector2" />
+    <output name="out" type="vector2" nodename="blur_vector2" />
   </nodegraph>
   <nodegraph name="blur_vector3">
     <tiledimage name="tiledimage1" type="vector3">
@@ -56,7 +56,7 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-    <output name="blur_vector3_out" type="vector3" nodename="blur_vector3" />
+    <output name="out" type="vector3" nodename="blur_vector3" />
   </nodegraph>
   <nodegraph name="blur_vector4">
     <tiledimage name="tiledimage1" type="vector4">
@@ -67,7 +67,7 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="box" />
     </blur>
-    <output name="blur_vector4_out" type="vector4" nodename="blur_vector4" />
+    <output name="out" type="vector4" nodename="blur_vector4" />
   </nodegraph>
   <nodegraph name="blur_cellnoise">
     <texcoord name="texcoord1" type="vector2" />
@@ -83,6 +83,6 @@
       <input name="size" type="float" value="0.5" />
       <input name="filtertype" type="string" value="gaussian" />
     </blur>
-    <output name="blur_cellnoise_out" type="float" nodename="blur_cellnoise" />
+    <output name="out" type="float" nodename="blur_cellnoise" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
+++ b/resources/Materials/TestSuite/stdlib/convolution/heighttonormal.mtlx
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
-  <nodegraph name="height_to_normal">
+  <nodegraph name="heighttonormal">
     <input name="file" type="filename" uniform="true" value="resources/Images/plain_heightmap.png" />
     <tiledimage name="tiledimage" type="float">
       <input name="file" type="filename" uniform="true" interfacename="file" />
@@ -27,8 +27,8 @@
     <UsdPreviewSurface name="UsdPreviewSurface" type="surfaceshader">
       <input name="normal" type="vector3" nodename="bias" />
     </UsdPreviewSurface>
-    <output name="height_to_normal_out" type="vector3" nodename="heighttonormal" />
-    <output name="standard_surface_out" type="surfaceshader" nodename="standard_surface" />
-    <output name="usd_preview_surface_out" type="surfaceshader" nodename="UsdPreviewSurface" />
+    <output name="vector3_out" type="vector3" nodename="heighttonormal" />
+    <output name="surface1_out" type="surfaceshader" nodename="standard_surface" />
+    <output name="surface2_out" type="surfaceshader" nodename="UsdPreviewSurface" />
   </nodegraph>
 </materialx>


### PR DESCRIPTION
- Improve the specification of the `heighttonormal` node, clarifying that its output contains tangent-space vectors encoded in the [0-1] range.
- Improve the OSL implementation of the `heighttonormal` node, leveraging the built-in partial derivative instructions to compute the gradient at each surface point.
- Simplify example material filenames to improve layout in render tests.
- Add convolution nodes to the list of standard render tests.