### PR TITLE
Add <latlongimage> node

### DIFF
--- a/documents/Specification/MaterialX.Specification.md
+++ b/documents/Specification/MaterialX.Specification.md
@@ -708,6 +708,14 @@ The type of the &lt;image> node determines the number of channels output, which 
     * `realworldtilesize` (vector2): the real-world size of a single square 0-1 UV tile, with unittype "distance".  A `unit` attribute may be provided to indicate the units that `realworldtilesize` is expressed in.
     * `filtertype` (uniform string): the type of texture filtering to use; standard values include "closest" (nearest-neighbor single-sample), "linear", and "cubic".  If not specified, an application may use its own default texture filtering method.
 
+<a id="node-latlongimage"> </a>
+
+* **`latlongimage`** (NG): samples an equiangular map along a view direction with adjustable latitudinal offset.
+    * `file` (uniform filename): the URI of an image file.  The filename can include one or more substitutions to change the file name (including frame number) that is accessed, as described in the [Filename Substitutions](#filename-substitutions) section above.
+    * `default` (float or color<em>N</em> or vector<em>N</em>): a default value to use if the `file` reference can not be resolved (e.g. if a &lt;_geometry token_>, [_interface token_] or {_hostattr_} is included in the filename but no substitution value or default is defined, or if the resolved `file` URI cannot be read), or if the specified `layer` does not exist in the file.  The `default` value must be the same type as the `<image>` element itself.  If `default` is not defined, the default color value will be 0.0 in all channels.
+    * `viewdir` (vector3): the view direction determining the value sampled from the projected equiangular map.
+    * `rotation` (float): the latitudinal sampling offset.
+
 <a id="node-triplanarprojection"> </a>
 
 * **`triplanarprojection`** (NG): samples data from three images (or layers within multi-layer images), and projects a tiled representation of the images along each of the three respective coordinate axes, computing a weighted blend of the three samples using the geometric normal.

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -293,6 +293,18 @@
   </nodedef>
 
   <!--
+    Node: <latlongimage> Supplemental Node
+    Samples an equiangular map with adjustable rotation offset.
+  -->
+  <nodedef name="ND_latlongimage" node="latlongimage" nodegroup="texture2d">
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color" />
+    <input name="viewdir" type="vector3" value="0.0, 0.0, 1.0" uiname="View Direction" />
+    <input name="rotation" type="float" value="0.0" unittype="angle" unit="degree" uimin="0" uimax="360" uiname="Latitude Offset" />
+    <output name="out" type="color3" default="0.0, 0.0, 0.0" />
+  </nodedef>
+
+  <!--
     Node: <triplanarprojection> Supplemental Node
     Samples data from three images, or layers within multi-layer images, and projects a tiled
     representation of the images along each of the three respective coordinate axes, computing

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -196,6 +196,59 @@
   </nodegraph>
 
   <!--
+    Node: <latlongimage>
+  -->
+  <nodegraph name="NG_latlongimage" nodedef="ND_latlongimage">
+    <separate3 name="viewDirChannels" type="multioutput">
+      <input name="in" type="vector3" interfacename="viewdir" />
+    </separate3>
+    <atan2 name="angleXZ" type="float">
+      <input name="iny" type="float" nodename="viewDirChannels" output="outx" />
+      <input name="inx" type="float" nodename="viewDirChannels" output="outz" />
+    </atan2>
+    <multiply name="scaleXZ" type="float">
+      <input name="in1" type="float" nodename="angleXZ" />
+      <input name="in2" type="float" value="-0.15915494" />
+    </multiply>
+    <add name="longitude" type="float">
+      <input name="in1" type="float" nodename="scaleXZ" />
+      <input name="in2" type="float" value="0.5" />
+    </add>
+    <multiply name="rotationDegrees" type="float">
+      <input name="in1" type="float" interfacename="rotation" />
+      <input name="in2" type="float" value="0.00277778" />
+    </multiply>
+    <add name="offsettedLongitude" type="float">
+      <input name="in1" type="float" nodename="rotationDegrees" />
+      <input name="in2" type="float" nodename="longitude" />
+    </add>
+    <asin name="angleY" type="float">
+      <input name="in" type="float" nodename="viewDirChannels" output="outy" />
+    </asin>
+    <multiply name="scaleY" type="float">
+      <input name="in1" type="float" nodename="angleY" />
+      <input name="in2" type="float" value="0.31830989" />
+    </multiply>
+    <add name="latitude" type="float">
+      <input name="in1" type="float" nodename="scaleY" />
+      <input name="in2" type="float" value="0.5" />
+    </add>
+    <combine2 name="mapUvs" type="vector2">
+      <input name="in1" type="float" nodename="offsettedLongitude" />
+      <input name="in2" type="float" nodename="latitude" />
+    </combine2>
+    <image name="envImage" type="color3">
+      <input name="file" type="filename" interfacename="file" />
+      <input name="default" type="color3" interfacename="default" />
+      <input name="texcoord" type="vector2" nodename="mapUvs" />
+      <input name="uaddressmode" type="string" value="periodic" />
+      <input name="vaddressmode" type="string" value="periodic" />
+      <input name="filtertype" type="string" value="linear" />
+    </image>
+    <output name="out" type="color3" nodename="envImage" />
+  </nodegraph>
+
+  <!--
     Node: <triplanarprojection>
     Samples data from three images, or layers within multi-layer images, and projects a tiled
     representation of the images along each of the three respective coordinate axes, computing


### PR DESCRIPTION
This PR proposes an initial version of a node that samples equiangular images.

Question: should the image framerange/frameoffset/frameendaction inputs be forwarded?