### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -730,10 +730,9 @@ bool ValueElement::isAttributeEquivalent(ConstElementPtr rhs, const string& attr
         // Get precision and format options
         ScopedFloatFormatting fmt(options.floatFormat, options.floatPrecision);
 
-        ConstValueElementPtr rhsValueElement = rhs->asA<ValueElement>();
-
         // Check value equality
-        if (attributeName == ValueElement::VALUE_ATTRIBUTE)
+        ConstValueElementPtr rhsValueElement = rhs->asA<ValueElement>();
+        if (rhsValueElement && attributeName == ValueElement::VALUE_ATTRIBUTE)
         {
             ValuePtr thisValue = getValue();
             ValuePtr rhsValue = rhsValueElement->getValue();

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -235,7 +235,7 @@ StringVec parseStructValueString(const string& value)
         {
             // When we hit a separator we store the currently accumulated part, and clear to start collecting the next.
             split.emplace_back(part);
-            part = "";
+            part.clear();
         }
         else
         {

--- a/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/GlslResourceBindingContext.cpp
@@ -137,12 +137,12 @@ void GlslResourceBindingContext::emitStructuredResourceBindings(GenContext& cont
         if (it == alignmentMap.end())
         {
             structSize += baseAlignment;
-            memberOrder.push_back(std::make_pair(baseAlignment, i));
+            memberOrder.emplace_back(baseAlignment, i);
         }
         else
         {
             structSize += it->second;
-            memberOrder.push_back(std::make_pair(it->second, i));
+            memberOrder.emplace_back(it->second, i);
         }
     }
 

--- a/source/MaterialXGenGlsl/VkResourceBindingContext.cpp
+++ b/source/MaterialXGenGlsl/VkResourceBindingContext.cpp
@@ -124,12 +124,12 @@ void VkResourceBindingContext::emitStructuredResourceBindings(GenContext& contex
         if (it == alignmentMap.end())
         {
             structSize += baseAlignment;
-            memberOrder.push_back(std::make_pair(baseAlignment, i));
+            memberOrder.emplace_back(baseAlignment, i);
         }
         else
         {
             structSize += it->second;
-            memberOrder.push_back(std::make_pair(it->second, i));
+            memberOrder.emplace_back(it->second, i);
         }
     }
 

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -692,7 +692,7 @@ ShaderPtr MdlShaderGenerator::createShader(const string& name, ElementPtr elemen
 namespace
 {
 
-void emitInputAnnotations(const MdlShaderGenerator& _this, const DocumentPtr doc, const ShaderPort* variable, ShaderStage& stage)
+void emitInputAnnotations(const MdlShaderGenerator& _this, ConstDocumentPtr doc, const ShaderPort* variable, ShaderStage& stage)
 {
     // allows to relate between MaterialX and MDL parameters when looking at the MDL code.
     const std::string mtlxParameterPathAnno = "materialx::core::origin(\"" + variable->getPath() + "\")";
@@ -706,7 +706,7 @@ void emitInputAnnotations(const MdlShaderGenerator& _this, const DocumentPtr doc
 
 } // anonymous namespace
 
-void MdlShaderGenerator::emitShaderInputs(const DocumentPtr doc, const VariableBlock& inputs, ShaderStage& stage) const
+void MdlShaderGenerator::emitShaderInputs(ConstDocumentPtr doc, const VariableBlock& inputs, ShaderStage& stage) const
 {
     const string uniformPrefix = _syntax->getUniformQualifier() + " ";
     for (size_t i = 0; i < inputs.size(); ++i)

--- a/source/MaterialXGenMdl/MdlShaderGenerator.h
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.h
@@ -95,7 +95,7 @@ class MX_GENMDL_API MdlShaderGenerator : public ShaderGenerator
     ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;
 
     // Emit a block of shader inputs.
-    void emitShaderInputs(const DocumentPtr doc, const VariableBlock& inputs, ShaderStage& stage) const;
+    void emitShaderInputs(ConstDocumentPtr doc, const VariableBlock& inputs, ShaderStage& stage) const;
 };
 
 namespace MDL

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -587,7 +587,7 @@ string MdlSyntax::replaceSourceCodeMarkers(const string& nodeName, const string&
     return joinStrings(code, EMPTY_STRING);
 }
 
-const string MdlSyntax::getMdlVersionSuffixMarker() const
+const string& MdlSyntax::getMdlVersionSuffixMarker() const
 {
     return MARKER_MDL_VERSION_SUFFIX;
 }

--- a/source/MaterialXGenMdl/MdlSyntax.h
+++ b/source/MaterialXGenMdl/MdlSyntax.h
@@ -73,7 +73,7 @@ class MX_GENMDL_API MdlSyntax : public Syntax
     string replaceSourceCodeMarkers(const string& nodeName, const string& soureCode, std::function<string(const string&)> lambda) const;
 
     /// Get the MDL language versing marker: {{MDL_VERSION_SUFFIX}}.
-    const string getMdlVersionSuffixMarker() const;
+    const string& getMdlVersionSuffixMarker() const;
 };
 
 namespace Type

--- a/source/MaterialXGenMsl/MslResourceBindingContext.cpp
+++ b/source/MaterialXGenMsl/MslResourceBindingContext.cpp
@@ -95,12 +95,12 @@ void MslResourceBindingContext::emitStructuredResourceBindings(GenContext& conte
         if (it == alignmentMap.end())
         {
             structSize += baseAlignment;
-            memberOrder.push_back(std::make_pair(baseAlignment, i));
+            memberOrder.emplace_back(baseAlignment, i);
         }
         else
         {
             structSize += it->second;
-            memberOrder.push_back(std::make_pair(it->second, i));
+            memberOrder.emplace_back(it->second, i);
         }
     }
 

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -230,7 +230,7 @@ void ShaderStage::beginScope(Syntax::Punctuation punc)
     }
 
     ++_indentations;
-    _scopes.push_back(Scope(punc));
+    _scopes.emplace_back(punc);
 }
 
 void ShaderStage::endScope(bool semicolon, bool newline)

--- a/source/MaterialXGenShader/Util.cpp
+++ b/source/MaterialXGenShader/Util.cpp
@@ -125,11 +125,11 @@ bool isTransparentShaderNode(NodePtr node, NodePtr interfaceNode)
         string inputName = item.first;
         if (item.second == Input::TRANSPARENCY_HINT)
         {
-            inputPairList.push_back(std::make_pair(inputName, 0.0f) );
+            inputPairList.emplace_back(inputName, 0.0f);
         }
         else if (item.second == Input::OPACITY_HINT)
         {
-            inputPairList.push_back(std::make_pair(inputName, 1.0f));
+            inputPairList.emplace_back(inputName, 1.0f);
         }
     }
 
@@ -145,7 +145,7 @@ bool isTransparentShaderNode(NodePtr node, NodePtr interfaceNode)
                 const string& interfaceName = checkInput->getInterfaceName();
                 if (!interfaceName.empty())
                 {
-                    interfaceNames.push_back(std::make_pair(interfaceName, inputPair.second));
+                    interfaceNames.emplace_back(interfaceName, inputPair.second);
                 }
             }
         }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -455,8 +455,8 @@ int Graph::findLinkPosition(int id)
 
 bool Graph::checkPosition(UiNodePtr node)
 {
-    return node->getMxElement() &&
-           !node->getMxElement()->getAttribute(mx::Element::XPOS_ATTRIBUTE).empty();
+    mx::ElementPtr elem = node->getElement();
+    return elem && !elem->getAttribute(mx::Element::XPOS_ATTRIBUTE).empty();
 }
 
 // Calculate the total vertical space the node level takes up
@@ -549,12 +549,13 @@ ImVec2 Graph::layoutPosition(UiNodePtr layoutNode, ImVec2 startingPos, bool init
                 // Don't set position of group nodes
                 if (node->getMessage().empty())
                 {
-                    if (node->getMxElement()->hasAttribute(mx::Element::XPOS_ATTRIBUTE))
+                    mx::ElementPtr elem = node->getElement();
+                    if (elem && elem->hasAttribute(mx::Element::XPOS_ATTRIBUTE))
                     {
-                        float x = std::stof(node->getMxElement()->getAttribute(mx::Element::XPOS_ATTRIBUTE));
-                        if (node->getMxElement()->hasAttribute(mx::Element::YPOS_ATTRIBUTE))
+                        float x = std::stof(elem->getAttribute(mx::Element::XPOS_ATTRIBUTE));
+                        if (elem->hasAttribute(mx::Element::YPOS_ATTRIBUTE))
                         {
-                            float y = std::stof(node->getMxElement()->getAttribute(mx::Element::YPOS_ATTRIBUTE));
+                            float y = std::stof(elem->getAttribute(mx::Element::YPOS_ATTRIBUTE));
                             x *= DEFAULT_NODE_SIZE.x;
                             y *= DEFAULT_NODE_SIZE.y;
                             ed::SetNodePosition(node->getId(), ImVec2(x, y));
@@ -695,38 +696,38 @@ void Graph::layoutInputs()
 
 void Graph::setPinColor()
 {
-    _pinColor.insert(std::make_pair("integer", ImColor(255, 255, 28, 255)));
-    _pinColor.insert(std::make_pair("boolean", ImColor(255, 0, 255, 255)));
-    _pinColor.insert(std::make_pair("float", ImColor(50, 100, 255, 255)));
-    _pinColor.insert(std::make_pair("color3", ImColor(178, 34, 34, 255)));
-    _pinColor.insert(std::make_pair("color4", ImColor(50, 10, 255, 255)));
-    _pinColor.insert(std::make_pair("vector2", ImColor(100, 255, 100, 255)));
-    _pinColor.insert(std::make_pair("vector3", ImColor(0, 255, 0, 255)));
-    _pinColor.insert(std::make_pair("vector4", ImColor(100, 0, 100, 255)));
-    _pinColor.insert(std::make_pair("matrix33", ImColor(0, 100, 100, 255)));
-    _pinColor.insert(std::make_pair("matrix44", ImColor(50, 255, 100, 255)));
-    _pinColor.insert(std::make_pair("filename", ImColor(255, 184, 28, 255)));
-    _pinColor.insert(std::make_pair("string", ImColor(100, 100, 50, 255)));
-    _pinColor.insert(std::make_pair("geomname", ImColor(121, 60, 180, 255)));
-    _pinColor.insert(std::make_pair("BSDF", ImColor(10, 181, 150, 255)));
-    _pinColor.insert(std::make_pair("EDF", ImColor(255, 50, 100, 255)));
-    _pinColor.insert(std::make_pair("VDF", ImColor(0, 100, 151, 255)));
-    _pinColor.insert(std::make_pair(mx::SURFACE_SHADER_TYPE_STRING, ImColor(150, 255, 255, 255)));
-    _pinColor.insert(std::make_pair(mx::MATERIAL_TYPE_STRING, ImColor(255, 255, 255, 255)));
-    _pinColor.insert(std::make_pair(mx::DISPLACEMENT_SHADER_TYPE_STRING, ImColor(155, 50, 100, 255)));
-    _pinColor.insert(std::make_pair(mx::VOLUME_SHADER_TYPE_STRING, ImColor(155, 250, 100, 255)));
-    _pinColor.insert(std::make_pair(mx::LIGHT_SHADER_TYPE_STRING, ImColor(100, 150, 100, 255)));
-    _pinColor.insert(std::make_pair("none", ImColor(140, 70, 70, 255)));
-    _pinColor.insert(std::make_pair(mx::MULTI_OUTPUT_TYPE_STRING, ImColor(70, 70, 70, 255)));
-    _pinColor.insert(std::make_pair("integerarray", ImColor(200, 10, 100, 255)));
-    _pinColor.insert(std::make_pair("floatarray", ImColor(25, 250, 100)));
-    _pinColor.insert(std::make_pair("color3array", ImColor(25, 200, 110)));
-    _pinColor.insert(std::make_pair("color4array", ImColor(50, 240, 110)));
-    _pinColor.insert(std::make_pair("vector2array", ImColor(50, 200, 75)));
-    _pinColor.insert(std::make_pair("vector3array", ImColor(20, 200, 100)));
-    _pinColor.insert(std::make_pair("vector4array", ImColor(100, 200, 100)));
-    _pinColor.insert(std::make_pair("geomnamearray", ImColor(150, 200, 100)));
-    _pinColor.insert(std::make_pair("stringarray", ImColor(120, 180, 100)));
+    _pinColor.emplace("integer", ImColor(255, 255, 28, 255));
+    _pinColor.emplace("boolean", ImColor(255, 0, 255, 255));
+    _pinColor.emplace("float", ImColor(50, 100, 255, 255));
+    _pinColor.emplace("color3", ImColor(178, 34, 34, 255));
+    _pinColor.emplace("color4", ImColor(50, 10, 255, 255));
+    _pinColor.emplace("vector2", ImColor(100, 255, 100, 255));
+    _pinColor.emplace("vector3", ImColor(0, 255, 0, 255));
+    _pinColor.emplace("vector4", ImColor(100, 0, 100, 255));
+    _pinColor.emplace("matrix33", ImColor(0, 100, 100, 255));
+    _pinColor.emplace("matrix44", ImColor(50, 255, 100, 255));
+    _pinColor.emplace("filename", ImColor(255, 184, 28, 255));
+    _pinColor.emplace("string", ImColor(100, 100, 50, 255));
+    _pinColor.emplace("geomname", ImColor(121, 60, 180, 255));
+    _pinColor.emplace("BSDF", ImColor(10, 181, 150, 255));
+    _pinColor.emplace("EDF", ImColor(255, 50, 100, 255));
+    _pinColor.emplace("VDF", ImColor(0, 100, 151, 255));
+    _pinColor.emplace(mx::SURFACE_SHADER_TYPE_STRING, ImColor(150, 255, 255, 255));
+    _pinColor.emplace(mx::MATERIAL_TYPE_STRING, ImColor(255, 255, 255, 255));
+    _pinColor.emplace(mx::DISPLACEMENT_SHADER_TYPE_STRING, ImColor(155, 50, 100, 255));
+    _pinColor.emplace(mx::VOLUME_SHADER_TYPE_STRING, ImColor(155, 250, 100, 255));
+    _pinColor.emplace(mx::LIGHT_SHADER_TYPE_STRING, ImColor(100, 150, 100, 255));
+    _pinColor.emplace("none", ImColor(140, 70, 70, 255));
+    _pinColor.emplace(mx::MULTI_OUTPUT_TYPE_STRING, ImColor(70, 70, 70, 255));
+    _pinColor.emplace("integerarray", ImColor(200, 10, 100, 255));
+    _pinColor.emplace("floatarray", ImColor(25, 250, 100));
+    _pinColor.emplace("color3array", ImColor(25, 200, 110));
+    _pinColor.emplace("color4array", ImColor(50, 240, 110));
+    _pinColor.emplace("vector2array", ImColor(50, 200, 75));
+    _pinColor.emplace("vector3array", ImColor(20, 200, 100));
+    _pinColor.emplace("vector4array", ImColor(100, 200, 100));
+    _pinColor.emplace("geomnamearray", ImColor(150, 200, 100));
+    _pinColor.emplace("stringarray", ImColor(120, 180, 100));
 }
 
 void Graph::setRenderMaterial(UiNodePtr node)
@@ -1759,7 +1760,7 @@ void Graph::copyUiNode(UiNodePtr node)
 {
     UiNodePtr copyNode = std::make_shared<UiNode>(mx::EMPTY_STRING, int(_graphTotalSize + 1));
     ++_graphTotalSize;
-    if (node->getMxElement())
+    if (node->getElement())
     {
         std::string newName = _currGraphElem->createValidChildName(node->getName());
         if (node->getNode())
@@ -1785,7 +1786,7 @@ void Graph::copyUiNode(UiNodePtr node)
             mxOutput->setName(newName);
             copyNode->setOutput(mxOutput);
         }
-        copyNode->getMxElement()->setName(newName);
+        copyNode->getElement()->setName(newName);
         copyNode->setName(newName);
     }
     else if (node->getNodeGraph())
@@ -2590,14 +2591,14 @@ void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
         // If the accepting node already has a link, remove it
         if (inputPin->_connected)
         {
-            for (auto linksItr = _currLinks.begin(); linksItr != _currLinks.end(); linksItr++)
+            for (auto iter = _currLinks.begin(); iter != _currLinks.end(); ++iter)
             {
-                if (linksItr->_endAttr == end_attr)
+                if (iter->_endAttr == end_attr)
                 {
                     // Found existing link - remove it; adapted from deleteLink
                     // note: ed::BreakLinks doesn't work as the order ends up inaccurate
-                    deleteLinkInfo(linksItr->_startAttr, linksItr->_endAttr);
-                    _currLinks.erase(linksItr);
+                    deleteLinkInfo(iter->_startAttr, iter->_endAttr);
+                    _currLinks.erase(iter);
                     break;
                 }
             }
@@ -4042,7 +4043,7 @@ void Graph::drawGraph(ImVec2 mousePos)
             {
                 if (!readOnly())
                 {
-                    for (std::map<UiNodePtr, UiNodePtr>::iterator iter = _copiedNodes.begin(); iter != _copiedNodes.end(); iter++)
+                    for (auto iter = _copiedNodes.begin(); iter != _copiedNodes.end(); ++iter)
                     {
                         copyUiNode(iter->first);
                         _addNewNode = true;
@@ -4096,7 +4097,7 @@ void Graph::drawGraph(ImVec2 mousePos)
             if (_graphNodes.size() > 0)
             {
 
-                if (outputNum.size() == 0 && _graphNodes[0]->getMxElement())
+                if (outputNum.size() == 0 && _graphNodes[0]->getElement())
                 {
                     for (UiNodePtr node : _graphNodes)
                     {
@@ -4436,16 +4437,17 @@ void Graph::savePosition()
 {
     for (UiNodePtr node : _graphNodes)
     {
-        if (node->getMxElement())
+        mx::ElementPtr elem = node->getElement();
+        if (elem)
         {
             ImVec2 pos = ed::GetNodePosition(node->getId());
             pos.x /= DEFAULT_NODE_SIZE.x;
             pos.y /= DEFAULT_NODE_SIZE.y;
-            node->getMxElement()->setAttribute(mx::Element::XPOS_ATTRIBUTE, std::to_string(pos.x));
-            node->getMxElement()->setAttribute(mx::Element::YPOS_ATTRIBUTE, std::to_string(pos.y));
-            if (node->getMxElement()->hasAttribute("nodedef"))
+            elem->setAttribute(mx::Element::XPOS_ATTRIBUTE, std::to_string(pos.x));
+            elem->setAttribute(mx::Element::YPOS_ATTRIBUTE, std::to_string(pos.y));
+            if (elem->hasAttribute("nodedef"))
             {
-                node->getMxElement()->removeAttribute("nodedef");
+                elem->removeAttribute("nodedef");
             }
         }
     }

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -114,7 +114,7 @@ void UiNode::removeOutputConnection(const std::string& name)
     }
 }
 
-mx::ElementPtr UiNode::getMxElement()
+mx::ElementPtr UiNode::getElement()
 {
     if (_currNode != nullptr)
     {

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -262,7 +262,7 @@ class UiNode
     std::vector<UiPinPtr> inputPins;
     std::vector<UiPinPtr> outputPins;
     void removeOutputConnection(const std::string& name);
-    mx::ElementPtr getMxElement();
+    mx::ElementPtr getElement();
     int _level;
     bool _showAllInputs;
 


### PR DESCRIPTION
This changelist addresses a handful of static analysis warnings flagged by PVS-Studio:

- Add missing null check to `ValueElement::isElementEquivalent`.
- Use `std::string::clear` instead of empty string assignment in `parseStructValueString`.
- Use `std::vector::emplace_back` instead of `std::vector::push_back(std::make_pair)` in MaterialXGen modules.
- Minor const-correctness improvements in `MdlShaderGenerator` and `MdlSyntax` methods.
- Minor efficiency and clarity improvements in `Graph` and `UiNode` methods.