### PR TITLE
Align Clang warning settings

### DIFF
--- a/source/MaterialXRenderMsl/CMakeLists.txt
+++ b/source/MaterialXRenderMsl/CMakeLists.txt
@@ -40,7 +40,7 @@ elseif(UNIX)
     target_include_directories(${TARGET_NAME} PRIVATE ${X11_INCLUDE_DIR})
 endif()
 
-# Disable OpenGL deprecation warnings on Clang.
+# Disable deprecation warnings on Clang.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(${TARGET_NAME} PRIVATE -Wno-deprecated-declarations)
 endif()

--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -91,6 +91,11 @@ if(MATERIALX_BUILD_RENDER)
   endif()
 endif()
 
+# Disable deprecation warnings on Clang.
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(MaterialXTest PUBLIC -Wno-deprecated-declarations)
+endif()
+
 # TODO: Only do this stuff when it's relevant
 
 add_custom_command(TARGET MaterialXTest POST_BUILD


### PR DESCRIPTION
This changelist aligns Clang warning settings between MaterialXRenderMsl and MaterialXTest, addressing compilation issues in upcoming MacOS environments.