### PR TITLE
Updates to GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,14 +68,6 @@ jobs:
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
           python: 3.9
 
-        - name: MacOS_Xcode_15_Python311
-          os: macos-14
-          compiler: xcode
-          compiler_version: "15.1"
-          python: 3.11
-          static_analysis: ON
-          cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
         - name: MacOS_Xcode_15_Python312
           os: macos-14
           compiler: xcode
@@ -83,18 +75,26 @@ jobs:
           python: 3.12
           test_shaders: ON
 
-        - name: MacOS_Xcode_DynamicAnalysis
-          os: macos-14
+        - name: MacOS_Xcode_16_Python313
+          os: macos-15
           compiler: xcode
-          compiler_version: "15.4"
+          compiler_version: "16.1"
+          python: 3.13
+          static_analysis: ON
+          cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+        - name: MacOS_Xcode_DynamicAnalysis
+          os: macos-15
+          compiler: xcode
+          compiler_version: "16.1"
           python: None
           dynamic_analysis: ON
           cmake_config: -DMATERIALX_DYNAMIC_ANALYSIS=ON
 
-        - name: iOS_Xcode_15
-          os: macos-14
+        - name: iOS_Xcode_16
+          os: macos-15
           compiler: xcode
-          compiler_version: "15.4"
+          compiler_version: "16.1"
           python: None
           cmake_config: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=`xcrun --sdk iphoneos --show-sdk-path` -DCMAKE_OSX_ARCHITECTURES=arm64
 
@@ -104,19 +104,19 @@ jobs:
           python: 3.7
           cmake_config: -G "Visual Studio 16 2019" -A "Win32" -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Windows_VS2022_x64_Python311
-          os: windows-2022
-          architecture: x64
-          python: 3.11
-          cmake_config: -G "Visual Studio 17 2022" -A "x64"
-          test_shaders: ON
-
         - name: Windows_VS2022_x64_Python312
           os: windows-2022
           architecture: x64
           python: 3.12
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           upload_shaders: ON
+
+        - name: Windows_VS2022_x64_Python313
+          os: windows-2025
+          architecture: x64
+          python: 3.13
+          cmake_config: -G "Visual Studio 17 2022" -A "x64"
+          test_shaders: ON
 
     steps:
     - name: Sync Repository


### PR DESCRIPTION
This changelist updates GitHub CI to include the recently added MacOS 15 and Windows 2025 environments, taking advantage of the new support for Python 3.13.