### PR TITLE
Promote Worley style control to Unified Noise nodes

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1070,6 +1070,7 @@
     <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" doc="The exponential scale between successive octaves of Fractal noise. Default is 2.0." />
     <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="The rate at which noise amplitude is diminished for each octave of Fractal noise. Default is 0.5." />
     <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Perlin,Cell,Worley,Fractal" enumvalues="0,1,2,3" doc="Menu to select the type of noise: Perlin, Cell, Worley, or Fractal. Default is Perlin." />
+    <input name="style" uiname="Worley Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" doc="Sets the style of cell used when Noise Type is set to Worley." />
     <output name="out" type="float" />
   </nodedef>
 
@@ -1089,6 +1090,7 @@
     <input name="lacunarity" type="float" uiname="Lacunarity" uifolder="Fractal" value="2" doc="The exponential scale between successive octaves of Fractal noise. Default is 2.0." />
     <input name="diminish" type="float" uiname="Diminish" uifolder="Fractal" uisoftmin="0.0" uisoftmax="1.0" value="0.5" doc="The rate at which noise amplitude is diminished for each octave of Fractal noise. Default is 0.5." />
     <input name="type" type="integer" uiname="Noise Type" uifolder="Common" uisoftmin="0" uisoftmax="3" value="0" enum="Perlin,Cell,Worley,Fractal" enumvalues="0,1,2,3" doc="Menu to select the type of noise: Perlin, Cell, Worley, or Fractal. Default is Perlin." />
+    <input name="style" uiname="Worley Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" doc="Sets the style of cell used when Noise Type is set to Worley." />
     <output name="out" type="float" />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1818,6 +1818,7 @@
     <worleynoise2d name="N_worleynoise2d" type="float">
       <input name="texcoord" type="vector2" nodename="N_apply_offset" />
       <input name="jitter" type="float" interfacename="jitter" />
+      <input name="style" type="integer" interfacename="style" />
     </worleynoise2d>
     <fractal3d name="N_fractal3d" type="float">
       <input name="octaves" type="integer" interfacename="octaves" />
@@ -1888,6 +1889,7 @@
     <worleynoise3d name="N_worleynoise3d" type="float">
       <input name="position" type="vector3" nodename="N_apply_offset" />
       <input name="jitter" type="float" interfacename="jitter" />
+      <input name="style" type="integer" interfacename="style" />
     </worleynoise3d>
     <fractal3d name="N_fractal3d" type="float">
       <input name="octaves" type="integer" interfacename="octaves" />


### PR DESCRIPTION
In PR #2119 I'd forgotten to include Worley's new cell styles on the Unified Noise node graphs.

![image](https://github.com/user-attachments/assets/bd7e0983-ed37-4883-b33d-b369cc2b3aac)
