### PR TITLE
Simplify BSDF switches in OSL

### DIFF
--- a/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl
@@ -1,15 +1,6 @@
 void mx_dielectric_bsdf(float weight, color tint, float ior, vector2 roughness, float thinfilm_thickness, float thinfilm_ior, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {
-    if (scatter_mode == "R")
-    {
-        bsdf = weight * dielectric_bsdf(N, U, tint, color(0.0), roughness.x, roughness.y, ior, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
-    }
-    else if (scatter_mode == "T")
-    {
-        bsdf = weight * dielectric_bsdf(N, U, color(0.0), tint, roughness.x, roughness.y, ior, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
-    }
-    else
-    {
-        bsdf = weight * dielectric_bsdf(N, U, tint, tint, roughness.x, roughness.y, ior, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
-    }
+    color reflection_tint = (scatter_mode == "T") ? color(0.0) : tint;
+    color transmission_tint = (scatter_mode == "R") ? color(0.0) : tint;
+    bsdf = weight * dielectric_bsdf(N, U, reflection_tint, transmission_tint, roughness.x, roughness.y, ior, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
 }

--- a/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_generalized_schlick_bsdf.osl
@@ -1,15 +1,6 @@
 void mx_generalized_schlick_bsdf(float weight, color color0, color color82, color color90, float exponent, vector2 roughness, float thinfilm_thickness, float thinfilm_ior, normal N, vector U, string distribution, string scatter_mode, output BSDF bsdf)
 {
-    if (scatter_mode == "R")
-    {
-        bsdf = weight * generalized_schlick_bsdf(N, U, color(1.0), color(0.0), roughness.x, roughness.y, color0, color90, exponent, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
-    }
-    else if (scatter_mode == "T")
-    {
-        bsdf = weight * generalized_schlick_bsdf(N, U, color(0.0), color(1.0), roughness.x, roughness.y, color0, color90, exponent, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
-    }
-    else
-    {
-        bsdf = weight * generalized_schlick_bsdf(N, U, color(1.0), color(1.0), roughness.x, roughness.y, color0, color90, exponent, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
-    }
+    color reflection_tint = (scatter_mode == "T") ? color(0.0) : color(1.0);
+    color transmission_tint = (scatter_mode == "R") ? color(0.0) : color(1.0);
+    bsdf = weight * generalized_schlick_bsdf(N, U, reflection_tint, transmission_tint, roughness.x, roughness.y, color0, color90, exponent, distribution, "thinfilm_thickness", thinfilm_thickness, "thinfilm_ior", thinfilm_ior);
 }


### PR DESCRIPTION
This changelist simplifies the logic for reflection/transmission switches in the OSL implementations of `dielectric_bsdf` and `generalized_schlick_bsdf`.