### PR TITLE
Remove ClosureContext params storage

### DIFF
--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -109,44 +109,6 @@ void GenContext::getOutputSuffix(const ShaderOutput* output, string& suffix) con
     }
 }
 
-ScopedSetClosureParams::ScopedSetClosureParams(const ClosureContext::ClosureParams* params, const ShaderNode* node, ClosureContext* cct) :
-    _cct(cct),
-    _node(node),
-    _oldParams(nullptr)
-{
-    if (_cct)
-    {
-        _oldParams = _cct->getClosureParams(_node);
-        _cct->setClosureParams(_node, params);
-    }
-}
-
-ScopedSetClosureParams::ScopedSetClosureParams(const ShaderNode* fromNode, const ShaderNode* toNode, ClosureContext* cct) :
-    _cct(cct),
-    _node(toNode),
-    _oldParams(nullptr)
-{
-    // The class must be safe for the cases where a context is not set
-    // so make sure to check for nullptr here.
-    if (_cct)
-    {
-        const ClosureContext::ClosureParams* newParams = _cct->getClosureParams(fromNode);
-        if (newParams)
-        {
-            _oldParams = _cct->getClosureParams(_node);
-            _cct->setClosureParams(_node, newParams);
-        }
-    }
-}
-
-ScopedSetClosureParams::~ScopedSetClosureParams()
-{
-    if (_cct)
-    {
-        _cct->setClosureParams(_node, _oldParams);
-    }
-}
-
 ScopedSetVariableName::ScopedSetVariableName(const string& name, ShaderPort* port) :
     _port(port),
     _oldName(port->getVariable())

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -294,54 +294,13 @@ class MX_GENSHADER_API ClosureContext
     }
     [[deprecated]] const string& getSuffix(const TypeDesc* nodeType) const { return getSuffix(*nodeType); }
 
-    /// Set extra parameters to use for evaluating a closure.
-    void setClosureParams(const ShaderNode* closure, const ClosureParams* params)
-    {
-        if (params)
-        {
-            _params[closure] = params;
-        }
-        else
-        {
-            _params.erase(closure);
-        }
-    }
-
-    /// Return extra parameters to use for evaluating a closure. Or return
-    /// nullptr if no parameters have been set for the given closure.
-    const ClosureParams* getClosureParams(const ShaderNode* closure) const
-    {
-        auto it = _params.find(closure);
-        return it != _params.end() ? it->second : nullptr;
-    }
-
   protected:
     const int _type;
     std::unordered_map<TypeDesc, Arguments, TypeDesc::Hasher> _arguments;
     std::unordered_map<TypeDesc, string, TypeDesc::Hasher> _suffix;
-    std::unordered_map<const ShaderNode*, const ClosureParams*> _params;
+    // std::unordered_map<const ShaderNode*, const ClosureParams*> _params;
 
     static const Arguments EMPTY_ARGUMENTS;
-};
-
-/// A RAII class for setting extra parameters for closure evaluation,
-/// stored in the closure context.
-class MX_GENSHADER_API ScopedSetClosureParams
-{
-  public:
-    /// Constructor for setting explicit parameters for a closure node.
-    ScopedSetClosureParams(const ClosureContext::ClosureParams* params, const ShaderNode* node, ClosureContext* cct);
-
-    /// Constructor for setting parameters from one closure node to another.
-    ScopedSetClosureParams(const ShaderNode* fromNode, const ShaderNode* toNode, ClosureContext* cct);
-
-    /// Destructor restoring the closure parameter state.
-    ~ScopedSetClosureParams();
-
-  private:
-    ClosureContext* _cct;
-    const ShaderNode* _node;
-    const ClosureContext::ClosureParams* _oldParams;
 };
 
 /// A RAII class for overriding port variable names.

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -254,9 +254,6 @@ class MX_GENSHADER_API ClosureContext
     /// An array of arguments
     using Arguments = vector<Argument>;
 
-    /// Extra parameters for closure evaluation.
-    using ClosureParams = std::unordered_map<string, const ShaderInput*>;
-
     /// Constructor
     ClosureContext(int type = 0) :
         _type(type) { }
@@ -298,7 +295,6 @@ class MX_GENSHADER_API ClosureContext
     const int _type;
     std::unordered_map<TypeDesc, Arguments, TypeDesc::Hasher> _arguments;
     std::unordered_map<TypeDesc, string, TypeDesc::Hasher> _suffix;
-    // std::unordered_map<const ShaderNode*, const ClosureParams*> _params;
 
     static const Arguments EMPTY_ARGUMENTS;
 };

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
@@ -169,17 +169,6 @@ void ClosureCompoundNode::emitFunctionCall(const ShaderNode& node, GenContext& c
             const ShaderGraphOutputSocket* outputSocket = _rootGraph->getOutputSocket();
             const TypeDesc closureType = outputSocket->getType();
 
-            // Check if extra parameters has been added for this node.
-            const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
-            if (closureType == Type::BSDF && params)
-            {
-                // Assign the parameters to the BSDF.
-                for (auto it : *params)
-                {
-                    shadergen.emitLine(outputSocket->getVariable() + "." + it.first + " = " + shadergen.getUpstreamResult(it.second, context), stage);
-                }
-            }
-
             // Emit function name.
             shadergen.emitString(_functionName + cct->getSuffix(closureType) + "(", stage);
 

--- a/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureSourceCodeNode.cpp
@@ -39,17 +39,7 @@ void ClosureSourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext&
             ClosureContext* cct = context.getClosureContext();
             if (cct)
             {
-                // Check if extra parameters has been added for this node.
                 const TypeDesc closureType = output->getType();
-                const ClosureContext::ClosureParams* params = cct->getClosureParams(&node);
-                if (closureType == Type::BSDF && params)
-                {
-                    // Assign the parameters to the BSDF.
-                    for (auto it : *params)
-                    {
-                        shadergen.emitLine(output->getVariable() + "." + it.first + " = " + shadergen.getUpstreamResult(it.second, context), stage);
-                    }
-                }
 
                 // Emit function name.
                 shadergen.emitLineBegin(stage);


### PR DESCRIPTION
This does not look to be used anywhere in the current code base.

Anyone who is relying on this external to MaterialX - please could you provide an example of the use-case, and ideally a MaterialX unit-test to demonstrate such. 