### PR TITLE
Add bitangent input to `bump` node

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1419,6 +1419,7 @@
     <input name="scale" type="float" uiname="Scale" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Scalar to adjust the height amount." />
     <input name="normal" type="vector3" uiname="Normal" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
     <input name="tangent" type="vector3" uiname="Tangent" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />
+    <input name="bitangent" type="vector3" uiname="Bitangent" defaultgeomprop="Bworld" doc="Surface bitangent vector, defaults to the current world-space bitangent vector." />
     <output name="out" type="vector3" doc="Offset surface normal; connect this to a shader's 'normal' input." />
   </nodedef>
 

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2895,6 +2895,7 @@
       <input name="normal" type="vector3" interfacename="normal" />
       <input name="scale" type="float" interfacename="scale" />
       <input name="tangent" type="vector3" interfacename="tangent" />
+      <input name="bitangent" type="vector3" interfacename="bitangent" />
     </normalmap>
     <output name="out" type="vector3" nodename="N_normalmap" />
   </nodegraph>


### PR DESCRIPTION
Starting with MaterialX 1.39, the `normalmap` node now has a bitangent input. It needs to be exposed for the bump node, because otherwise the tangent frame can't be set correctly.