### PR TITLE
Integrate OSL class improvements

### DIFF
--- a/libraries/stdlib/genosl/include/color4.h
+++ b/libraries/stdlib/genosl/include/color4.h
@@ -1,5 +1,6 @@
-// Open Shading Language : Copyright (c) 2009-2017 Sony Pictures Imageworks Inc., et al.
-// https://github.com/imageworks/OpenShadingLanguage/blob/master/LICENSE
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 #pragma once
 #define COLOR4_H
@@ -105,13 +106,13 @@ color4 __operator__div__(color4 a, color4 b)
 
 color4 __operator__div__(color4 a, int b)
 {
-    float b_inv = 1.0/b;
+    float b_inv = 1.0 / float(b);
     return a * color4(color(b_inv), b_inv);
 }
 
 color4 __operator__div__(color4 a, float b)
 {
-    float b_inv = 1.0/b;
+    float b_inv = 1.0 / b;
     return a * color4(color(b_inv), b_inv);
 }
 
@@ -130,7 +131,7 @@ int __operator__eq__(color4 a, color4 b)
     return (a.rgb == b.rgb) && (a.a == b.a);
 }
 
-int __operator__ne__(color4 a, color4 b)
+int __operator__neq__(color4 a, color4 b)
 {
     return (a.rgb != b.rgb) || (a.a != b.a);
 }
@@ -193,11 +194,6 @@ color4 mix(color4 a, color4 b, color4 x )
                   mix(a.a, b.a, x.a));
 }
 
-float dot(color4 a, color b)
-{
-    return dot(a.rgb, b);
-}
-
 color4 smoothstep(color4 edge0, color4 edge1, color4 c)
 {
     return color4(smoothstep(edge0.rgb, edge1.rgb, c.rgb),
@@ -250,11 +246,6 @@ color4 mod(color4 a, color4 b)
                   mod(a.a, b.a));
 }
 
-color4 mod(color4 a, int b)
-{
-    return mod(a, color4(color(b), b));
-}
-
 color4 mod(color4 a, float b)
 {
     return mod(a, color4(color(b), b));
@@ -278,14 +269,12 @@ color4 fmod(color4 a, float b)
 
 color4 pow(color4 base, color4 power)
 {
-    return color4(pow(base.rgb, power.rgb),
-                  pow(base.a, power.a));
+    return color4(pow(base.rgb, power.rgb), pow(base.a, power.a));
 }
 
 color4 pow(color4 base, float power)
 {
-    return color4(pow(base.rgb, power),
-                  pow(base.a, power));
+    return pow(base, color4(color(power), power));
 }
 
 color4 sign(color4 a)

--- a/libraries/stdlib/genosl/include/matrix33.h
+++ b/libraries/stdlib/genosl/include/matrix33.h
@@ -1,8 +1,7 @@
-// Open Shading Language : Copyright (c) 2009-2017 Sony Pictures Imageworks Inc., et al.
-// https://github.com/imageworks/OpenShadingLanguage/blob/master/LICENSE
-//
-// MaterialX specification (c) 2017 Lucasfilm Ltd.
-// http://www.materialx.org/
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
+
 
 #pragma once
 #define MATRIX33_H
@@ -160,6 +159,3 @@ normal transform(matrix33 a, normal b)
 {
     return transform(a.m, b);
 }
-
-
-

--- a/libraries/stdlib/genosl/include/vector2.h
+++ b/libraries/stdlib/genosl/include/vector2.h
@@ -1,5 +1,6 @@
-// Open Shading Language : Copyright (c) 2009-2017 Sony Pictures Imageworks Inc., et al.
-// https://github.com/imageworks/OpenShadingLanguage/blob/master/LICENSE
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 #pragma once
 #define VECTOR2_H
@@ -104,13 +105,13 @@ vector2 __operator__div__(vector2 a, vector2 b)
 
 vector2 __operator__div__(vector2 a, int b)
 {
-    float b_inv = 1.0/b;
+    float b_inv = 1.0 / float(b);
     return a * vector2(b_inv, b_inv);
 }
 
 vector2 __operator__div__(vector2 a, float b)
 {
-    float b_inv = 1.0/b;
+    float b_inv = 1.0 / b;
     return a * vector2(b_inv, b_inv);
 }
 
@@ -129,7 +130,7 @@ int __operator__eq__(vector2 a, vector2 b)
     return (a.x == b.x) && (a.y == b.y);
 }
 
-int __operator__ne__(vector2 a, vector2 b)
+int __operator__neq__(vector2 a, vector2 b)
 {
     return (a.x != b.x) || (a.y != b.y);
 }
@@ -230,6 +231,17 @@ vector2 max(vector2 a, vector2 b)
                     max(a.y, b.y));
 }
 
+vector2 min(vector2 a, vector2 b)
+{
+    return vector2 (min(a.x, b.x),
+                    min(a.y, b.y));
+}
+
+vector2 min(vector2 a, float b)
+{
+    return min(a, vector2(b, b));
+}
+
 vector2 max(vector2 a, float b)
 {
     return max(a, vector2(b, b));
@@ -238,17 +250,6 @@ vector2 max(vector2 a, float b)
 vector2 normalize(vector2 a)
 {
     return a / length(a);
-}
-
-vector2 min(vector2 a, vector2 b)
-{
-    return vector2 (min(a.x, a.x),
-                    min(b.y, b.y));
-}
-
-vector2 min(vector2 a, float b)
-{
-    return min(a, vector2(b, b));
 }
 
 vector2 mod(vector2 a, vector2 b)
@@ -275,14 +276,12 @@ vector2 fmod(vector2 a, float b)
 
 vector2 pow(vector2 in, vector2 amount)
 {
-    return vector2(pow(in.x, amount.x),
-                   pow(in.y, amount.y));
+    return vector2(pow(in.x, amount.x), pow(in.y, amount.y));
 }
 
 vector2 pow(vector2 in, float amount)
 {
-    return vector2(pow(in.x, amount),
-                   pow(in.y, amount));
+    return pow(in, vector2(amount, amount));
 }
 
 vector2 sign(vector2 a)
@@ -324,13 +323,11 @@ vector2 acos(vector2 a)
 vector2 atan2(vector2 a, float f)
 {
     return vector2(atan2(a.x, f),
-                  atan2(a.y, f));
+                   atan2(a.y, f));
 }
 
 vector2 atan2(vector2 a, vector2 b)
 {
     return vector2(atan2(a.x, b.x),
-                  atan2(a.y, b.y));
+                   atan2(a.y, b.y));
 }
-
-

--- a/libraries/stdlib/genosl/include/vector4.h
+++ b/libraries/stdlib/genosl/include/vector4.h
@@ -1,5 +1,6 @@
-// Open Shading Language : Copyright (c) 2009-2017 Sony Pictures Imageworks Inc., et al.
-// https://github.com/imageworks/OpenShadingLanguage/blob/master/LICENSE
+// Copyright Contributors to the Open Shading Language project.
+// SPDX-License-Identifier: BSD-3-Clause
+// https://github.com/AcademySoftwareFoundation/OpenShadingLanguage
 
 #pragma once
 #define VECTOR4_H
@@ -107,13 +108,13 @@ vector4 __operator__div__(vector4 a, vector4 b)
 
 vector4 __operator__div__(vector4 a, int b)
 {
-    float b_inv = 1.0/b;
+    float b_inv = 1.0 / float(b);
     return a * vector4(b_inv, b_inv, b_inv, b_inv);
 }
 
 vector4 __operator__div__(vector4 a, float b)
 {
-    float b_inv = 1.0/b;
+    float b_inv = 1.0 / b;
     return a * vector4(b_inv, b_inv, b_inv, b_inv);
 }
 
@@ -132,7 +133,7 @@ int __operator__eq__(vector4 a, vector4 b)
     return (a.x == b.x) && (a.y == b.y) && (a.z == b.z) && (a.w == b.w);
 }
 
-int __operator__ne__(vector4 a, vector4 b)
+int __operator__neq__(vector4 a, vector4 b)
 {
     return (a.x != b.x) || (a.y != b.y) || (a.z != b.z) || (a.w != b.w);
 }
@@ -284,11 +285,6 @@ vector4 max(vector4 a, float b)
     return max(a, vector4(b, b, b, b));
 }
 
-vector4 normalize(vector4 a)
-{
-    return a / length(a);
-}
-
 vector4 min(vector4 a, vector4 b)
 {
     return vector4 (min(a.x, b.x),
@@ -300,6 +296,11 @@ vector4 min(vector4 a, vector4 b)
 vector4 min(vector4 a, float b)
 {
     return min(a, vector4(b, b, b, b));
+}
+
+vector4 normalize(vector4 a)
+{
+    return a / length(a);
 }
 
 vector4 mod(vector4 a, vector4 b)


### PR DESCRIPTION
This changelist integrates recent improvements to the color4, vector2, and vector4 classes in the OSL project, including bug fixes for inequality tests.

Further in the future, we can take the step of removing our local copy of these classes in the MaterialX project, relying fully on their OSL definitions.