### PR TITLE
Add abbe number to dielectric BSDF

### DIFF
--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -70,6 +70,7 @@
     <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
     <input name="distribution" type="string" value="ggx" enum="ggx" uniform="true" />
     <input name="scatter_mode" type="string" value="R" enum="R,T,RT" uniform="true" />
+    <input name="abbe_number" type="float" value="0" uimin="0.0" uisoftmin="9.0" uisoftmax="91.0" />
     <output name="out" type="BSDF" />
   </nodedef>
 


### PR DESCRIPTION
This PR addresses the limitation described in #2202 and makes it possible to implement support for dispersion in the OpenPBR and Standard Surface node graphs. 