### PR TITLE
Updates for OSL v1.14

### DIFF
--- a/libraries/README.md
+++ b/libraries/README.md
@@ -69,8 +69,8 @@ This folder contains the standard data libraries for MaterialX, providing declar
 
 ### Target Support
 - GLSL target support is for version 4.0 or higher.
-- OSL target support is for version 1.9.10 or higher.
-- MDL target support is for version 1.7.
+- OSL target support is for version 1.12.6 or higher.
+- MDL target support is for version 1.6 or higher.
 - Basic GLSL and MSL `lightshader` node definitions and implementations are provided for the following light types:
     - point, directional, spot
 - Shader generation does not currently support:

--- a/libraries/pbrlib/genosl/mx_chiang_hair_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_chiang_hair_bsdf.osl
@@ -1,0 +1,12 @@
+void mx_chiang_hair_bsdf(color tint_R, color tint_TT, color tint_TRT, float ior,
+                         vector2 roughness_R, vector2 roughness_TT, vector2 roughness_TRT,
+                         float cuticle_angle, vector absorption_coefficient, normal N, vector U, output BSDF bsdf)
+{
+#if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
+    bsdf = chiang_hair_bsdf(N, U, tint_R, tint_TT, tint_TRT, ior,
+                            roughness_R.x, roughness_TT.x, roughness_TRT.x, roughness_R.y, roughness_TT.y, roughness_TRT.y,
+                            cuticle_angle, absorption_coefficient);
+#else
+    bsdf = dielectric_bsdf(N, U, color(1), color(0), 0.1, 0.1, ior, "ggx");
+#endif
+}

--- a/libraries/pbrlib/genosl/mx_displacement_float.osl
+++ b/libraries/pbrlib/genosl/mx_displacement_float.osl
@@ -1,4 +1,0 @@
-void mx_displacement_float(float displacement, float scale, output displacementshader result)
-{
-    result = vector(displacement * scale);
-}

--- a/libraries/pbrlib/genosl/mx_displacement_vector3.osl
+++ b/libraries/pbrlib/genosl/mx_displacement_vector3.osl
@@ -1,4 +1,0 @@
-void mx_displacement_vector3(vector displacement, float scale, output displacementshader result)
-{
-    result = displacement * scale;
-}

--- a/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
@@ -1,5 +1,8 @@
-void mx_subsurface_bsdf(float weight, color _color, color radius, float anisotropy, normal N, output BSDF bsdf)
+void mx_subsurface_bsdf(float weight, color albedo, color radius, float anisotropy, normal N, output BSDF bsdf)
 {
-    // TODO: Subsurface closure is not supported by vanilla OSL.
-    bsdf = _color * weight * diffuse(N);
+#if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
+    bsdf = subsurface_bssrdf(N, weight * albedo, radius, anisotropy);
+#else
+    bsdf = subsurface_bssrdf(N, weight * albedo, 1.0, radius, anisotropy);
+#endif
 }

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -23,7 +23,7 @@
   <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
 
   <!-- <chiang_hair_bsdf> -->
-  <implementation name="IM_chiang_hair_bsdf_genosl" nodedef="ND_chiang_hair_bsdf" sourcecode="dielectric_bsdf({{normal}}, {{curve_direction}}, color(1), color(0), 0.1, 0.1, {{ior}}, &quot;ggx&quot;)" target="genosl" />
+  <implementation name="IM_chiang_hair_bsdf_genosl" nodedef="ND_chiang_hair_bsdf" file="mx_chiang_hair_bsdf.osl" function="mx_chiang_hair_bsdf" target="genosl" />
 
   <!-- <sheen_bsdf> -->
   <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" sourcecode="{{weight}} * sheen_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl" />
@@ -59,8 +59,8 @@
   <implementation name="IM_surface_genosl" nodedef="ND_surface" file="mx_surface.osl" function="mx_surface" target="genosl" />
 
   <!-- <displacement> -->
-  <implementation name="IM_displacement_float_genosl" nodedef="ND_displacement_float" file="mx_displacement_float.osl" function="mx_displacement_float" target="genosl" />
-  <implementation name="IM_displacement_vector3_genosl" nodedef="ND_displacement_vector3" file="mx_displacement_vector3.osl" function="mx_displacement_vector3" target="genosl" />
+  <implementation name="IM_displacement_float_genosl" nodedef="ND_displacement_float" sourcecode="vector({{displacement}} * {{scale}})" target="genosl" />
+  <implementation name="IM_displacement_vector3_genosl" nodedef="ND_displacement_vector3" sourcecode="({{displacement}} * {{scale}})" target="genosl" />
 
   <!-- <roughness_anisotropy> -->
   <implementation name="IM_roughness_anisotropy_genosl" nodedef="ND_roughness_anisotropy" file="mx_roughness_anisotropy.osl" function="mx_roughness_anisotropy" target="genosl" />


### PR DESCRIPTION
- Call the new subsurface_bssrdf closure in OSL v1.14 and above, falling back to the original closure signature in earlier versions.
- Call the new chiang_hair_bsdf closure in OSL v1.14 and above, falling back to a dielectric_bsdf approximation in earlier versions.
- Inline the OSL implementations of displacement nodes for simplicity.
- Update the minimum OSL and MDL versions in libraries documentation.