### PR TITLE
Add None check to RMS output in test report

### DIFF
--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -204,11 +204,14 @@ def main(args=None):
                     fh.write("<br>(" + str(datetime.datetime.fromtimestamp(os.path.getmtime(fullPath3))) + ")")
                 fh.write("</td>\n")
             if diffPath1:
-                fh.write("<td align='center'>" + args.lang1.upper() + " vs. " + args.lang2.upper() + " (RMS " + "%.5f" % diffRms1 + ") </td>\n")
+                rms: str = f" (RMS {diffRms1:.5})" if diffRms1 else ""  # diff will be None if one of the images is not found
+                fh.write("<td align='center'>" + args.lang1.upper() + " vs. " + args.lang2.upper() + rms + "</td>\n")
             if diffPath2:
-                fh.write("<td align='center'>" + args.lang1.upper() + " vs. " + args.lang3.upper() + " (RMS " + "%.5f" % diffRms2 + ") </td>\n")
+                rms: str = f" (RMS {diffRms2:.5})" if diffRms2 else ""
+                fh.write("<td align='center'>" + args.lang1.upper() + " vs. " + args.lang3.upper() + rms + "</td>\n")
             if diffPath3:
-                fh.write("<td align='center'>" + args.lang2.upper() + " vs. " + args.lang3.upper() + " (RMS " + "%.5f" % diffRms3 + ") </td>\n")
+                rms: str = f" (RMS {diffRms3:.5})" if diffRms3 else ""
+                fh.write("<td align='center'>" + args.lang2.upper() + " vs. " + args.lang3.upper() + rms + "</td>\n")
             fh.write("</tr>\n")
 
     fh.write("</table>\n")


### PR DESCRIPTION
Add None check to RMS output in the html test page script.
In case one of the two images for a diff is not present, the rms value is None and causes the next string concatenation to crash.