### PR TITLE
Make ClosureData struct and CLOSURE_TYPE defines data-driven

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_closure_type.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_closure_type.glsl
@@ -1,0 +1,17 @@
+// These are defined based on the HwShaderGenerator::ClosureContextType enum
+// if that changes - these need to be updated accordingly.
+
+#define CLOSURE_TYPE_DEFAULT 0
+#define CLOSURE_TYPE_REFLECTION 1
+#define CLOSURE_TYPE_TRANSMISSION 2
+#define CLOSURE_TYPE_INDIRECT 3
+#define CLOSURE_TYPE_EMISSION 4
+
+struct ClosureData {
+    int closureType;
+    vec3 L;
+    vec3 V;
+    vec3 N;
+    vec3 P;
+    float occlusion;
+};

--- a/libraries/pbrlib/genglsl/mx_add_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_add_bsdf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_add_bsdf(ClosureData closureData, BSDF in1, BSDF in2, out BSDF result)
 {
     result.response = in1.response + in2.response;

--- a/libraries/pbrlib/genglsl/mx_add_edf.glsl
+++ b/libraries/pbrlib/genglsl/mx_add_edf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_add_edf(ClosureData closureData, EDF in1, EDF in2, out EDF result)
 {
     result = in1 + in2;

--- a/libraries/pbrlib/genglsl/mx_anisotropic_vdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_anisotropic_vdf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_anisotropic_vdf(ClosureData closureData, vec3 absorption, vec3 scattering, float anisotropy, inout BSDF bsdf)
 {
     // TODO: Add some approximation for volumetric light absorption.

--- a/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_diffuse.glsl"
 
 void mx_burley_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_specular.glsl"
 
 // https://eugenedeon.com/pdfs/egsrhair.pdf

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_specular.glsl"
 
 void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 ior_n, vec3 ior_k, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_specular.glsl"
 
 void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 tint, float ior, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_specular.glsl"
 
 void mx_generalized_schlick_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color0, vec3 color82, vec3 color90, float exponent, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_generalized_schlick_edf.glsl
+++ b/libraries/pbrlib/genglsl/mx_generalized_schlick_edf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet.glsl"
 
 void mx_generalized_schlick_edf(ClosureData closureData, vec3 color0, vec3 color90, float exponent, EDF base, out EDF result)

--- a/libraries/pbrlib/genglsl/mx_layer_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_layer_bsdf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_layer_bsdf(ClosureData closureData, BSDF top, BSDF base, out BSDF result)
 {
     result.response = top.response + base.response * top.throughput;

--- a/libraries/pbrlib/genglsl/mx_layer_vdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_layer_vdf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_layer_vdf(ClosureData closureData, BSDF top, BSDF base, out BSDF result)
 {
     result.response = top.response + base.response;

--- a/libraries/pbrlib/genglsl/mx_mix_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_mix_bsdf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_mix_bsdf(ClosureData closureData, BSDF fg, BSDF bg, float mixValue, out BSDF result)
 {
     result.response = mix(bg.response, fg.response, mixValue);

--- a/libraries/pbrlib/genglsl/mx_mix_edf.glsl
+++ b/libraries/pbrlib/genglsl/mx_mix_edf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_mix_edf(ClosureData closureData, EDF fg, EDF bg, float mixValue, out EDF result)
 {
     result = mix(bg, fg, mixValue);

--- a/libraries/pbrlib/genglsl/mx_multiply_bsdf_color3.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_bsdf_color3.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_multiply_bsdf_color3(ClosureData closureData, BSDF in1, vec3 in2, out BSDF result)
 {
     vec3 tint = clamp(in2, 0.0, 1.0);

--- a/libraries/pbrlib/genglsl/mx_multiply_bsdf_float.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_bsdf_float.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_multiply_bsdf_float(ClosureData closureData, BSDF in1, float in2, out BSDF result)
 {
     float weight = clamp(in2, 0.0, 1.0);

--- a/libraries/pbrlib/genglsl/mx_multiply_edf_color3.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_edf_color3.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_multiply_edf_color3(ClosureData closureData, EDF in1, vec3 in2, out EDF result)
 {
     result = in1 * in2;

--- a/libraries/pbrlib/genglsl/mx_multiply_edf_float.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_edf_float.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_multiply_edf_float(ClosureData closureData, EDF in1, float in2, out EDF result)
 {
     result = in1 * in2;

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_diffuse.glsl"
 
 void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_sheen_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_sheen.glsl"
 
 void mx_sheen_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 N, int mode, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_subsurface_bsdf.glsl
@@ -1,3 +1,4 @@
+#include "lib/mx_closure_type.glsl"
 #include "lib/mx_microfacet_diffuse.glsl"
 
 void mx_subsurface_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, vec3 radius, float anisotropy, vec3 normal, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_translucent_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_translucent_bsdf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 // We fake diffuse transmission by using diffuse reflection from the opposite side.
 // So this BTDF is really a BRDF.
 void mx_translucent_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, vec3 normal, inout BSDF bsdf)

--- a/libraries/pbrlib/genglsl/mx_uniform_edf.glsl
+++ b/libraries/pbrlib/genglsl/mx_uniform_edf.glsl
@@ -1,3 +1,5 @@
+#include "lib/mx_closure_type.glsl"
+
 void mx_uniform_edf(ClosureData closureData, vec3 color, out EDF result)
 {
     if (closureData.closureType == CLOSURE_TYPE_EMISSION)

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
@@ -28,11 +28,6 @@ void EsslShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
     emitLineBreak(stage);
     emitLine("precision mediump float", stage);
     emitLineBreak(stage);
-    emitLine("#define CLOSURE_TYPE_REFLECTION "+std::to_string(HwShaderGenerator::ClosureContextType::REFLECTION), stage, false);
-    emitLine("#define CLOSURE_TYPE_TRANSMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::TRANSMISSION), stage, false);
-    emitLine("#define CLOSURE_TYPE_INDIRECT "+std::to_string(HwShaderGenerator::ClosureContextType::INDIRECT), stage, false);
-    emitLine("#define CLOSURE_TYPE_EMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::EMISSION), stage, false);
-    emitLineBreak(stage);
 }
 
 void EsslShaderGenerator::emitUniforms(GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -252,11 +252,6 @@ void GlslShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
 {
     emitLine("#version " + getVersion(), stage, false);
     emitLineBreak(stage);
-    emitLine("#define CLOSURE_TYPE_REFLECTION "+std::to_string(HwShaderGenerator::ClosureContextType::REFLECTION), stage, false);
-    emitLine("#define CLOSURE_TYPE_TRANSMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::TRANSMISSION), stage, false);
-    emitLine("#define CLOSURE_TYPE_INDIRECT "+std::to_string(HwShaderGenerator::ClosureContextType::INDIRECT), stage, false);
-    emitLine("#define CLOSURE_TYPE_EMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::EMISSION), stage, false);
-    emitLineBreak(stage);
 }
 
 void GlslShaderGenerator::emitConstants(GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -330,15 +330,6 @@ GlslSyntax::GlslSyntax()
             EMPTY_STRING,
             "surfaceshader",
             "#define material surfaceshader"));
-
-    registerTypeSyntax(
-        HW::ClosureDataType,
-        std::make_shared<AggregateTypeSyntax>(
-            "ClosureData",
-            EMPTY_STRING,
-            EMPTY_STRING,
-            EMPTY_STRING,
-            "struct ClosureData {int closureType; vec3 L; vec3 V; vec3 N; vec3 P; float occlusion;};"));
 }
 
 bool GlslSyntax::typeSupported(const TypeDesc* type) const

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.cpp
@@ -23,8 +23,8 @@ const string LIGHT_DIRECTION_CALCULATION =
 LightNodeGlsl::LightNodeGlsl()
 {
     // Emission context
-    _callEmission.addArgument(ClosureContext::Argument(Type::VECTOR3, "light.direction"));
-    _callEmission.addArgument(ClosureContext::Argument(Type::VECTOR3, "-L"));
+    _callEmission.addArgument(ClosureContext::Argument("vec3", "light.direction"));
+    _callEmission.addArgument(ClosureContext::Argument("vec3", "-L"));
 }
 
 ShaderNodeImplPtr LightNodeGlsl::create()

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.cpp
@@ -14,7 +14,7 @@ MATERIALX_NAMESPACE_BEGIN
 SurfaceNodeGlsl::SurfaceNodeGlsl()
 {
     // Create closure context for calling closure functions.
-    _callClosure.addArgument(ClosureContext::Argument(HW::ClosureDataType, HW::CLOSURE_DATA));
+    _callClosure.addArgument(ClosureContext::Argument(HW::CLOSURE_DATA_TYPE, HW::CLOSURE_DATA_ARG));
 }
 
 ShaderNodeImplPtr SurfaceNodeGlsl::create()

--- a/source/MaterialXGenGlsl/VkShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/VkShaderGenerator.cpp
@@ -27,12 +27,6 @@ void VkShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
 {
     emitLine("#version " + getVersion(), stage, false);
     emitLineBreak(stage);
-    emitLineBreak(stage);
-    emitLine("#define CLOSURE_TYPE_REFLECTION "+std::to_string(HwShaderGenerator::ClosureContextType::REFLECTION), stage, false);
-    emitLine("#define CLOSURE_TYPE_TRANSMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::TRANSMISSION), stage, false);
-    emitLine("#define CLOSURE_TYPE_INDIRECT "+std::to_string(HwShaderGenerator::ClosureContextType::INDIRECT), stage, false);
-    emitLine("#define CLOSURE_TYPE_EMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::EMISSION), stage, false);
-    emitLineBreak(stage);
 }
 
 void VkShaderGenerator::emitInputs(GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -676,11 +676,6 @@ void MslShaderGenerator::emitDirectives(GenContext&, ShaderStage& stage) const
     emitLine("#define mat4 float4x4", stage, false);
 
     emitLineBreak(stage);
-    emitLine("#define CLOSURE_TYPE_REFLECTION "+std::to_string(HwShaderGenerator::ClosureContextType::REFLECTION), stage, false);
-    emitLine("#define CLOSURE_TYPE_TRANSMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::TRANSMISSION), stage, false);
-    emitLine("#define CLOSURE_TYPE_INDIRECT "+std::to_string(HwShaderGenerator::ClosureContextType::INDIRECT), stage, false);
-    emitLine("#define CLOSURE_TYPE_EMISSION "+std::to_string(HwShaderGenerator::ClosureContextType::EMISSION), stage, false);
-    emitLineBreak(stage);
 }
 
 void MslShaderGenerator::emitConstants(GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -312,15 +312,6 @@ MslSyntax::MslSyntax()
             EMPTY_STRING,
             "surfaceshader",
             "#define material surfaceshader"));
-
-    registerTypeSyntax(
-        HW::ClosureDataType,
-        std::make_shared<AggregateTypeSyntax>(
-            "ClosureData",
-            EMPTY_STRING,
-            EMPTY_STRING,
-            EMPTY_STRING,
-            "struct ClosureData {int closureType; vec3 L; vec3 V; vec3 N; vec3 P; float occlusion;};"));
 }
 
 string MslSyntax::getOutputTypeName(TypeDesc type) const

--- a/source/MaterialXGenMsl/Nodes/LightNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/LightNodeMsl.cpp
@@ -23,8 +23,8 @@ const string LIGHT_DIRECTION_CALCULATION =
 LightNodeMsl::LightNodeMsl()
 {
     // Emission context
-    _callEmission.addArgument(ClosureContext::Argument(Type::VECTOR3, "light.direction"));
-    _callEmission.addArgument(ClosureContext::Argument(Type::VECTOR3, "-L"));
+    _callEmission.addArgument(ClosureContext::Argument("float3", "light.direction"));
+    _callEmission.addArgument(ClosureContext::Argument("float3", "-L"));
 }
 
 ShaderNodeImplPtr LightNodeMsl::create()

--- a/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.cpp
@@ -14,7 +14,7 @@ MATERIALX_NAMESPACE_BEGIN
 SurfaceNodeMsl::SurfaceNodeMsl()
 {
     // Create closure context for calling closure functions.
-    _callClosure.addArgument(ClosureContext::Argument(HW::ClosureDataType, HW::CLOSURE_DATA));
+    _callClosure.addArgument(ClosureContext::Argument(HW::CLOSURE_DATA_TYPE, HW::CLOSURE_DATA_ARG));
 }
 
 ShaderNodeImplPtr SurfaceNodeMsl::create()

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -249,8 +249,8 @@ class MX_GENSHADER_API ClosureContext
   public:
     /// An extra argument for closure functions.
     /// An argument is a pair of strings holding the
-    /// 'type' and 'name' of the argument.
-    using Argument = std::pair<TypeDesc, string>;
+    /// 'typename' and 'name' of the argument.
+    using Argument = std::pair<string, string>;
     /// An array of arguments
     using Arguments = vector<Argument>;
 

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -153,7 +153,8 @@ const string PUBLIC_UNIFORMS                  = "PublicUniforms";
 const string LIGHT_DATA                       = "LightData";
 const string PIXEL_OUTPUTS                    = "PixelOutputs";
 const string DIR_N                            = "N";
-const string CLOSURE_DATA                     = "closureData";
+const string CLOSURE_DATA_TYPE                = "ClosureData";
+const string CLOSURE_DATA_ARG                 = "closureData";
 const string DIR_L                            = "L";
 const string DIR_V                            = "V";
 const string WORLD_POSITION                   = "P";
@@ -242,7 +243,7 @@ HwShaderGenerator::HwShaderGenerator(SyntaxPtr syntax) :
 
     // Setup closure contexts for defining closure functions
     //
-    _defClosure.addArgument(ClosureContext::Argument(HW::ClosureDataType, "closureData"));
+    _defClosure.addArgument(ClosureContext::Argument(HW::CLOSURE_DATA_TYPE, HW::CLOSURE_DATA_ARG));
 }
 
 ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -207,7 +207,8 @@ extern MX_GENSHADER_API const string LIGHT_DATA;       // Uniform inputs for lig
 extern MX_GENSHADER_API const string PIXEL_OUTPUTS;    // Outputs from the main/pixel stage.
 
 /// Variable names for lighting parameters.
-extern MX_GENSHADER_API const string CLOSURE_DATA;
+extern MX_GENSHADER_API const string CLOSURE_DATA_TYPE;
+extern MX_GENSHADER_API const string CLOSURE_DATA_ARG;
 extern MX_GENSHADER_API const string DIR_N;
 extern MX_GENSHADER_API const string DIR_L;
 extern MX_GENSHADER_API const string DIR_V;
@@ -314,6 +315,9 @@ class MX_GENSHADER_API HwShaderGenerator : public ShaderGenerator
 
     /// Determine the prefix of vertex data variables.
     virtual string getVertexDataPrefix(const VariableBlock& vertexData) const = 0;
+
+    // Note : the order must match the order defined in libraries/pbrlib/genglsl/lib/mx_closure_type.glsl
+    // TODO : investigate build time mechanism for ensuring these stay in sync.
 
     /// Types of closure contexts for HW.
     enum ClosureContextType

--- a/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ClosureCompoundNode.cpp
@@ -64,8 +64,7 @@ void ClosureCompoundNode::emitFunctionDefinition(ClosureContext* cct, GenContext
         // Add any extra argument inputs first
         for (const ClosureContext::Argument& arg : cct->getArguments())
         {
-            const string& type = syntax.getTypeName(arg.first);
-            shadergen.emitString(delim + type + " " + arg.second, stage);
+            shadergen.emitString(delim + arg.first + " " + arg.second, stage);
             delim = ", ";
         }
     }


### PR DESCRIPTION
While testing the latest dev branch with the latest USD branch I realized that the recent PR #2205 doesn't work without similar changes to the HdStorm shader generator.  Taking this data driven approach should mean it works without any changes on the HdStorm side. 