### PR TITLE
Simplify additional HW closures

### DIFF
--- a/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_burley_diffuse_bsdf.glsl
@@ -1,11 +1,7 @@
 #include "lib/mx_microfacet_diffuse.glsl"
 
-void mx_burley_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, float roughness, vec3 normal, inout BSDF bsdf)
+void mx_burley_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, float roughness, vec3 N, inout BSDF bsdf)
 {
-    vec3 V = closureData.V;
-    vec3 L = closureData.L;
-    float occlusion = closureData.occlusion;
-
     bsdf.throughput = vec3(0.0);
 
     if (weight < M_FLOAT_EPS)
@@ -13,13 +9,16 @@ void mx_burley_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, f
         return;
     }
 
-    normal = mx_forward_facing_normal(normal, V);
+    vec3 V = closureData.V;
+    vec3 L = closureData.L;
+    float occlusion = closureData.occlusion;
 
-    float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
+    N = mx_forward_facing_normal(N, V);
+    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
     if (closureData.closureType == CLOSURE_TYPE_REFLECTION)
     {
-        float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
+        float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
         float LdotH = clamp(dot(L, normalize(L + V)), M_FLOAT_EPS, 1.0);
 
         bsdf.response = color * occlusion * weight * NdotL * M_PI_INV;
@@ -27,7 +26,7 @@ void mx_burley_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, f
     }
     else if (closureData.closureType == CLOSURE_TYPE_INDIRECT)
     {
-        vec3 Li = mx_environment_irradiance(normal) *
+        vec3 Li = mx_environment_irradiance(N) *
                   mx_burley_diffuse_dir_albedo(NdotV, roughness);
         bsdf.response = Li * color * weight;
     }

--- a/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_conductor_bsdf.glsl
@@ -1,72 +1,51 @@
 #include "lib/mx_microfacet_specular.glsl"
 
-void mx_conductor_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 ior_n, vec3 ior_k, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, inout BSDF bsdf)
-{
-    bsdf.throughput = vec3(0.0);
-
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-
-    X = normalize(X - dot(X, N) * N);
-    vec3 Y = cross(N, X);
-    vec3 H = normalize(L + V);
-
-    float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
-    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-    float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
-
-    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgAlpha = mx_average_alpha(safeAlpha);
-    vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
-
-    FresnelData fd = mx_init_fresnel_conductor(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
-    vec3 F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(Ht, safeAlpha);
-    float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
-
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-
-    // Note: NdotL is cancelled out
-    bsdf.response = D * F * G * comp * occlusion * weight / (4.0 * NdotV);
-}
-
-void mx_conductor_bsdf_indirect(vec3 V, float weight, vec3 ior_n, vec3 ior_k, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, inout BSDF bsdf)
-{
-    bsdf.throughput = vec3(0.0);
-
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-
-    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-
-    FresnelData fd = mx_init_fresnel_conductor(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
-    vec3 F = mx_compute_fresnel(NdotV, fd);
-
-    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgAlpha = mx_average_alpha(safeAlpha);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-
-    vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
-
-    bsdf.response = Li * comp * weight;
-}
-
 void mx_conductor_bsdf(ClosureData closureData, float weight, vec3 ior_n, vec3 ior_k, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, inout BSDF bsdf)
 {
+    bsdf.throughput = vec3(0.0);
+
+    if (weight < M_FLOAT_EPS)
+    {
+        return;
+    }
+
+    vec3 V = closureData.V;
+    vec3 L = closureData.L;
+    float occlusion = closureData.occlusion;
+
+    N = mx_forward_facing_normal(N, V);
+    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
+
+    FresnelData fd = mx_init_fresnel_conductor(ior_n, ior_k, thinfilm_thickness, thinfilm_ior);
+
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+
     if (closureData.closureType == CLOSURE_TYPE_REFLECTION)
     {
-        mx_conductor_bsdf_reflection(closureData.L, closureData.V, closureData.P, closureData.occlusion, weight, ior_n, ior_k, roughness, thinfilm_thickness, thinfilm_ior, N, X, distribution, bsdf);
+        X = normalize(X - dot(X, N) * N);
+        vec3 Y = cross(N, X);
+        vec3 H = normalize(L + V);
+
+        float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
+        float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
+
+        vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
+
+        vec3 F = mx_compute_fresnel(VdotH, fd);
+        float D = mx_ggx_NDF(Ht, safeAlpha);
+        float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
+
+        vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+
+        // Note: NdotL is cancelled out
+        bsdf.response = D * F * G * comp * occlusion * weight / (4.0 * NdotV);
     }
     else if (closureData.closureType == CLOSURE_TYPE_INDIRECT)
     {
-        mx_conductor_bsdf_indirect(closureData.V, weight, ior_n, ior_k, roughness, thinfilm_thickness, thinfilm_ior, N, X, distribution, bsdf);
+        vec3 F = mx_compute_fresnel(NdotV, fd);
+        vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+        vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
+        bsdf.response = Li * comp * weight;
     }
 }

--- a/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl
@@ -1,121 +1,73 @@
 #include "lib/mx_microfacet_specular.glsl"
 
-void mx_dielectric_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 tint, float ior, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
-{
-    if (scatter_mode == 1) // BSDF_T (skip reflection - transmission only)
-    {
-        return;
-    }
-
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-
-    X = normalize(X - dot(X, N) * N);
-    vec3 Y = cross(N, X);
-    vec3 H = normalize(L + V);
-
-    float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
-    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-    float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
-
-    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgAlpha = mx_average_alpha(safeAlpha);
-    vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
-
-    vec3 safeTint = max(tint, 0.0);
-    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
-    vec3  F = mx_compute_fresnel(VdotH, fd);
-    float D = mx_ggx_NDF(Ht, safeAlpha);
-    float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
-
-    float F0 = mx_ior_to_f0(ior);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
-    bsdf.throughput = 1.0 - dirAlbedo * weight;
-
-    // Note: NdotL is cancelled out
-    bsdf.response = D * F * G * comp * safeTint * occlusion * weight / (4.0 * NdotV);
-}
-
-void mx_dielectric_bsdf_transmission(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
-{
-    // Note: If scatter_mode is BSDF_R (reflection only) we must still keep evaluating both reflection/transmission
-    // since reflection needs to attenuate the transmission amount in HW shaders when layering is used.
-
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-
-    vec3 safeTint = max(tint, 0.0);
-    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
-    vec3 F = mx_compute_fresnel(NdotV, fd);
-
-    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgAlpha = mx_average_alpha(safeAlpha);
-
-    float F0 = mx_ior_to_f0(ior);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
-    bsdf.throughput = 1.0 - dirAlbedo * weight;
-
-    if (scatter_mode != 0)
-    {
-        bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, safeTint) * weight;
-    }
-}
-
-void mx_dielectric_bsdf_indirect(vec3 V, float weight, vec3 tint, float ior, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
-{
-    if (scatter_mode == 1) // BSDF_T (skip reflection - transmission only)
-    {
-        return;
-    }
-
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    N = mx_forward_facing_normal(N, V);
-
-    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
-
-    vec3 safeTint = max(tint, 0.0);
-    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
-    vec3 F = mx_compute_fresnel(NdotV, fd);
-
-    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
-    float avgAlpha = mx_average_alpha(safeAlpha);
-
-    float F0 = mx_ior_to_f0(ior);
-    vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
-    vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
-    bsdf.throughput = 1.0 - dirAlbedo * weight;
-
-    vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
-    bsdf.response = Li * safeTint * comp * weight;
-}
-
 void mx_dielectric_bsdf(ClosureData closureData, float weight, vec3 tint, float ior, vec2 roughness, float thinfilm_thickness, float thinfilm_ior, vec3 N, vec3 X, int distribution, int scatter_mode, inout BSDF bsdf)
 {
+    if (weight < M_FLOAT_EPS)
+    {
+        return;
+    }
+    if (closureData.closureType != CLOSURE_TYPE_TRANSMISSION && scatter_mode == 1)
+    {
+        return;
+    }
+
+    vec3 V = closureData.V;
+    vec3 L = closureData.L;
+    float occlusion = closureData.occlusion;
+
+    N = mx_forward_facing_normal(N, V);
+    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
+
+    FresnelData fd = mx_init_fresnel_dielectric(ior, thinfilm_thickness, thinfilm_ior);
+    float F0 = mx_ior_to_f0(ior);
+
+    vec2 safeAlpha = clamp(roughness, M_FLOAT_EPS, 1.0);
+    float avgAlpha = mx_average_alpha(safeAlpha);
+    vec3 safeTint = max(tint, 0.0);
+
     if (closureData.closureType == CLOSURE_TYPE_REFLECTION)
     {
-        mx_dielectric_bsdf_reflection(closureData.L, closureData.V, closureData.P, closureData.occlusion, weight, tint, ior, roughness, thinfilm_thickness, thinfilm_ior, N, X, distribution, scatter_mode, bsdf);
+        X = normalize(X - dot(X, N) * N);
+        vec3 Y = cross(N, X);
+        vec3 H = normalize(L + V);
+
+        float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
+        float VdotH = clamp(dot(V, H), M_FLOAT_EPS, 1.0);
+
+        vec3 Ht = vec3(dot(H, X), dot(H, Y), dot(H, N));
+
+        vec3 F = mx_compute_fresnel(VdotH, fd);
+        float D = mx_ggx_NDF(Ht, safeAlpha);
+        float G = mx_ggx_smith_G2(NdotL, NdotV, avgAlpha);
+
+        vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+        vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
+        bsdf.throughput = 1.0 - dirAlbedo * weight;
+
+        bsdf.response = D * F * G * comp * safeTint * occlusion * weight / (4.0 * NdotV);
     }
     else if (closureData.closureType == CLOSURE_TYPE_TRANSMISSION)
     {
-        mx_dielectric_bsdf_transmission(closureData.V, weight, tint, ior, roughness, thinfilm_thickness, thinfilm_ior, N, X, distribution, scatter_mode, bsdf);
+        vec3 F = mx_compute_fresnel(NdotV, fd);
+
+        vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+        vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
+        bsdf.throughput = 1.0 - dirAlbedo * weight;
+
+        if (scatter_mode != 0)
+        {
+            bsdf.response = mx_surface_transmission(N, V, X, safeAlpha, distribution, fd, safeTint) * weight;
+        }
     }
     else if (closureData.closureType == CLOSURE_TYPE_INDIRECT)
     {
-        mx_dielectric_bsdf_indirect(closureData.V, weight, tint, ior, roughness, thinfilm_thickness, thinfilm_ior, N, X, distribution, scatter_mode, bsdf);
+        vec3 F = mx_compute_fresnel(NdotV, fd);
+
+        vec3 comp = mx_ggx_energy_compensation(NdotV, avgAlpha, F);
+        vec3 dirAlbedo = mx_ggx_dir_albedo(NdotV, avgAlpha, F0, 1.0) * comp;
+        bsdf.throughput = 1.0 - dirAlbedo * weight;
+
+        vec3 Li = mx_environment_radiance(N, V, X, safeAlpha, distribution, fd);
+        bsdf.response = Li * safeTint * comp * weight;
     }
 }

--- a/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_oren_nayar_diffuse_bsdf.glsl
@@ -1,6 +1,6 @@
 #include "lib/mx_microfacet_diffuse.glsl"
 
-void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusion, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)
+void mx_oren_nayar_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, float roughness, vec3 N, bool energy_compensation, inout BSDF bsdf)
 {
     bsdf.throughput = vec3(0.0);
 
@@ -9,46 +9,29 @@ void mx_oren_nayar_diffuse_bsdf_reflection(vec3 L, vec3 V, vec3 P, float occlusi
         return;
     }
 
-    normal = mx_forward_facing_normal(normal, V);
+    vec3 V = closureData.V;
+    vec3 L = closureData.L;
+    float occlusion = closureData.occlusion;
 
-    float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
-    float NdotL = clamp(dot(normal, L), M_FLOAT_EPS, 1.0);
-    float LdotV = clamp(dot(L, V), M_FLOAT_EPS, 1.0);
+    N = mx_forward_facing_normal(N, V);
+    float NdotV = clamp(dot(N, V), M_FLOAT_EPS, 1.0);
 
-    vec3 diffuse = energy_compensation ?
-                   mx_oren_nayar_compensated_diffuse(NdotV, NdotL, LdotV, roughness, color) :
-                   mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) * color;
-    bsdf.response = diffuse * occlusion * weight * NdotL * M_PI_INV;
-}
-
-void mx_oren_nayar_diffuse_bsdf_indirect(vec3 V, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)
-{
-    bsdf.throughput = vec3(0.0);
-
-    if (weight < M_FLOAT_EPS)
-    {
-        return;
-    }
-
-    normal = mx_forward_facing_normal(normal, V);
-
-    float NdotV = clamp(dot(normal, V), M_FLOAT_EPS, 1.0);
-
-    vec3 diffuse = energy_compensation ?
-                   mx_oren_nayar_compensated_diffuse_dir_albedo(NdotV, roughness, color) :
-                   mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness) * color;
-    vec3 Li = mx_environment_irradiance(normal);
-    bsdf.response = Li * diffuse * weight;
-}
-
-void mx_oren_nayar_diffuse_bsdf(ClosureData closureData, float weight, vec3 color, float roughness, vec3 normal, bool energy_compensation, inout BSDF bsdf)
-{
     if (closureData.closureType == CLOSURE_TYPE_REFLECTION)
     {
-        mx_oren_nayar_diffuse_bsdf_reflection(closureData.L, closureData.V, closureData.P, closureData.occlusion, weight, color, roughness, normal, energy_compensation, bsdf);
+        float NdotL = clamp(dot(N, L), M_FLOAT_EPS, 1.0);
+        float LdotV = clamp(dot(L, V), M_FLOAT_EPS, 1.0);
+
+        vec3 diffuse = energy_compensation ?
+                       mx_oren_nayar_compensated_diffuse(NdotV, NdotL, LdotV, roughness, color) :
+                       mx_oren_nayar_diffuse(NdotV, NdotL, LdotV, roughness) * color;
+        bsdf.response = diffuse * occlusion * weight * NdotL * M_PI_INV;
     }
     else if (closureData.closureType == CLOSURE_TYPE_INDIRECT)
     {
-        mx_oren_nayar_diffuse_bsdf_indirect(closureData.V, weight, color, roughness, normal, energy_compensation, bsdf);
+        vec3 diffuse = energy_compensation ?
+                       mx_oren_nayar_compensated_diffuse_dir_albedo(NdotV, roughness, color) :
+                       mx_oren_nayar_diffuse_dir_albedo(NdotV, roughness) * color;
+        vec3 Li = mx_environment_irradiance(N);
+        bsdf.response = Li * diffuse * weight;
     }
 }


### PR DESCRIPTION
Building upon recent work in https://github.com/AcademySoftwareFoundation/MaterialX/pull/2205, this changelist simplifies the implementations of the `conductor_bsdf`, `dielectric_bsdf`, and `oren_nayar_diffuse_bsdf` closures in hardware shading languages, using a single function to handle all closure types.

Additionally, it harmonizes on the name `N` for normal inputs in HW closures, making it more straightforward to compare code across implementations.