### PR TITLE
Node editor traversal

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3494,8 +3494,39 @@ void Graph::propertyEditor()
                             }
                             else
                             {
-                                std::string typeText = " [" + input->_input->getType() + "]";
-                                ImGui::Text("%s", typeText.c_str());
+                                std::string displayString = input->_input->getType();
+
+                                const std::vector<UiPinPtr>& connections = input->getConnections();
+                                std::shared_ptr<UiNode> pinNode = nullptr;
+                                if (!connections.empty())
+                                {
+                                    UiPinPtr pin = connections[0];
+                                    std::string pinName = std::string(pin->_name);
+
+                                    pinNode = pin->_pinNode;
+                                    if (pinNode)
+                                    {
+                                        pinName = std::string(pinNode->getName()) + "." + pinName;
+                                    }
+                                    displayString = pinName;
+                                }
+
+                                //ImGui::PushItemWidth(-100);
+                                //ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(.15f, .15f, .15f, 1.0f));
+                                //ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(.2f, .4f, .6f, 1.0f));
+
+                                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f)); 
+                                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f)); 
+                                ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
+                                if (ImGui::Button(displayString.c_str()))
+                                {
+                                    if (pinNode)
+                                    {
+                                        ed::SelectNode(pinNode->getId());
+                                        ed::NavigateToSelection();
+                                    }
+                                }
+                                ImGui::PopStyleColor(3);
                             }
 
                             ImGui::PopID();

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3516,6 +3516,7 @@ void Graph::propertyEditor()
                                 ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f)); 
                                 ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f)); 
                                 ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
+                                ImGui::PushItemWidth(-1);
                                 if (ImGui::Button(displayString.c_str()))
                                 {
                                     if (pinNode)
@@ -3524,6 +3525,7 @@ void Graph::propertyEditor()
                                         ed::NavigateToSelection();
                                     }
                                 }
+                                ImGui::PopItemWidth();
                                 ImGui::PopStyleColor(3);
                             }
 
@@ -3543,13 +3545,25 @@ void Graph::propertyEditor()
 
                 if (pinCount > 0)
                 {
-                    ImVec2 tableSize(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, (int)pinCount+1));
+                    if (pinCount > 1)
+                    {
+                        pinCount++;
+                    }
+                    ImVec2 tableSize(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, (int)pinCount));
                     bool haveTable = ImGui::BeginTable("outputs_node_table", 2, tableFlags, tableSize);
                     if (haveTable)
                     {
                         ImGui::SetWindowFontScale(_fontScale);
                         for (UiPinPtr outputPin : _currUiNode->outputPins)
                         {
+                            bool firstPin = true;
+                            std::string outputPinName = outputPin->_name;
+                            std::string blankPinName;
+                            for (size_t i = 0; i < outputPinName.length(); i++) 
+                            {
+                                blankPinName += ' ';
+                            }
+
                             for (UiPinPtr connectedPin : outputPin->getConnections())
                             {
                                 ImGui::TableNextRow();
@@ -3562,18 +3576,28 @@ void Graph::propertyEditor()
                                 }
                                 // Display outputPin name, and connectedPinName in same row
                                 //
-                                ImGui::Text(outputPin->_name.c_str());
-                                ImGui::SameLine();
-                                std::string displayString = connectedPinName;
+                                if (firstPin)
+                                {
+                                    ImGui::Text(outputPinName.c_str());
+                                    firstPin = false;
+                                }
+                                else
+                                {
+                                    ImGui::Text(blankPinName.c_str());
+                                }
 
+                                std::string displayString = connectedPinName;
+                                ImGui::SameLine();
                                 ImGui::TableNextColumn();
-                                std::shared_ptr<UiNode> pinNode = connectedPin->_pinNode;
+                                ImGui::PushItemWidth(-1);
 
                                 ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
                                 ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f));
                                 ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
+
                                 if (ImGui::Button(displayString.c_str()))
                                 {
+                                    std::shared_ptr<UiNode> pinNode = connectedPin->_pinNode;
                                     if (pinNode)
                                     {
                                         ed::SelectNode(pinNode->getId());
@@ -3581,11 +3605,8 @@ void Graph::propertyEditor()
                                     }
                                 }
                                 ImGui::PopStyleColor(3);
-
-                                //ImGui::Text("%s", displayString.c_str());
+                                ImGui::PopItemWidth();
                             }
-                            //std::string dispayString = " [" + outputPin->_name + "]";
-                            //ImGui::Text("%s", dispayString.c_str());
                         }
                         ImGui::EndTable();
                         ImGui::SetWindowFontScale(1.0f);

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3545,10 +3545,6 @@ void Graph::propertyEditor()
 
                 if (pinCount > 0)
                 {
-                    if (pinCount > 1)
-                    {
-                        pinCount++;
-                    }
                     ImVec2 tableSize(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, (int)pinCount));
                     bool haveTable = ImGui::BeginTable("outputs_node_table", 2, tableFlags, tableSize);
                     if (haveTable)
@@ -3578,12 +3574,12 @@ void Graph::propertyEditor()
                                 //
                                 if (firstPin)
                                 {
-                                    ImGui::Text(outputPinName.c_str());
+                                    ImGui::Text("%s", outputPinName.c_str());
                                     firstPin = false;
                                 }
                                 else
                                 {
-                                    ImGui::Text(blankPinName.c_str());
+                                    ImGui::Text("%s", blankPinName.c_str());
                                 }
 
                                 std::string displayString = connectedPinName;

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -912,7 +912,7 @@ void Graph::updateMaterials(mx::InputPtr input /* = nullptr */, mx::ValuePtr val
     }
 }
 
-void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIProperties& uiProperties)
+void Graph::showPropertyEditorValue(UiNodePtr node, mx::InputPtr& input, const mx::UIProperties& uiProperties)
 {
     ImGui::PushItemWidth(-1);
 
@@ -3287,6 +3287,123 @@ void Graph::graphButtons()
     }
 }
 
+void Graph::showPropertyEditorOutputConnections(UiNodePtr node)
+{
+    if (node->_showOutputsInEditor)
+    {
+        std::vector<UiPinPtr> pinList = node->outputPins;
+        size_t pinCount = pinList.size();
+
+        if (pinCount > 0)
+        {
+            const float TEXT_BASE_HEIGHT = ImGui::GetTextLineHeightWithSpacing() * 1.3f;
+            const int SCROLL_LINE_COUNT = 20;
+            ImGuiTableFlags tableFlags = ImGuiTableFlags_ScrollY | ImGuiTableFlags_Resizable | ImGuiTableFlags_NoSavedSettings |
+                ImGuiTableFlags_BordersOuterH | ImGuiTableFlags_NoBordersInBody;
+
+            ImVec2 tableSize(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, (int)pinCount));
+            bool haveTable = ImGui::BeginTable("outputs_node_table", 2, tableFlags, tableSize);
+            if (haveTable)
+            {
+                ImGui::SetWindowFontScale(_fontScale);
+                for (UiPinPtr outputPin : node->outputPins)
+                {
+                    bool firstPin = true;
+                    std::string outputPinName = outputPin->_name;
+                    std::string blankPinName;
+                    for (size_t i = 0; i < outputPinName.length(); i++)
+                    {
+                        blankPinName += ' ';
+                    }
+
+                    for (UiPinPtr connectedPin : outputPin->getConnections())
+                    {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+
+                        std::string connectedPinName = connectedPin->_name;
+                        if (connectedPin->_pinNode)
+                        {
+                            connectedPinName = connectedPin->_pinNode->getName() + "." + connectedPinName;
+                        }
+                        // Display outputPin name, and connectedPinName in same row
+                        //
+                        if (firstPin)
+                        {
+                            ImGui::Text("%s", outputPinName.c_str());
+                            firstPin = false;
+                        }
+                        else
+                        {
+                            ImGui::Text("%s", blankPinName.c_str());
+                        }
+
+                        std::string displayString = connectedPinName;
+                        ImGui::SameLine();
+                        ImGui::TableNextColumn();
+                        ImGui::PushItemWidth(-1);
+
+                        ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+                        ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f));
+                        ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
+
+                        if (ImGui::Button(displayString.c_str()))
+                        {
+                            std::shared_ptr<UiNode> pinNode = connectedPin->_pinNode;
+                            if (pinNode)
+                            {
+                                ed::SelectNode(pinNode->getId());
+                                ed::NavigateToSelection();
+                            }
+                        }
+                        ImGui::PopStyleColor(3);
+                        ImGui::PopItemWidth();
+                    }
+                }
+                ImGui::EndTable();
+                ImGui::SetWindowFontScale(1.0f);
+            }
+        }
+    }
+
+}
+
+void Graph::showPropertyEditorInputConnection(UiPinPtr displayPin)
+{
+    // Allow for upstream traversal via button
+    //
+    std::string displayString = displayPin->_input->getType();
+    const std::vector<UiPinPtr>& connections = displayPin->getConnections();
+    std::shared_ptr<UiNode> pinNode = nullptr;
+    if (!connections.empty())
+    {
+        UiPinPtr pin = connections[0];
+        std::string pinName = std::string(pin->_name);
+
+        pinNode = pin->_pinNode;
+        if (pinNode)
+        {
+            pinName = std::string(pinNode->getName()) + "." + pinName;
+        }
+        displayString = pinName;
+    }
+
+    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
+    ImGui::PushItemWidth(-1);
+    if (ImGui::Button(displayString.c_str()))
+    {
+        if (pinNode)
+        {
+            ed::SelectNode(pinNode->getId());
+            ed::NavigateToSelection();
+        }
+    }
+    ImGui::PopItemWidth();
+    ImGui::PopStyleColor(3);
+}
+
 void Graph::propertyEditor()
 {
     // Get parent dimensions
@@ -3442,7 +3559,7 @@ void Graph::propertyEditor()
             }
 
             ImGui::Checkbox("Show all inputs", &_currUiNode->_showAllInputs);
-            ImGui::Checkbox("Show outputs", &_currUiNode->_showOutputsInEditor);
+            ImGui::Checkbox("Show output connections", &_currUiNode->_showOutputsInEditor);
 
             int count = 0;
             for (UiPinPtr input : _currUiNode->inputPins)
@@ -3491,42 +3608,11 @@ void Graph::propertyEditor()
                             ImGui::TableNextColumn();
                             if (!input->getConnected())
                             {
-                                setConstant(_currUiNode, input->_input, uiProperties);
+                                showPropertyEditorValue(_currUiNode, input->_input, uiProperties);
                             }
                             else
                             {
-                                // Allow for upstream traversal via button
-                                //
-                                std::string displayString = input->_input->getType();
-                                const std::vector<UiPinPtr>& connections = input->getConnections();
-                                std::shared_ptr<UiNode> pinNode = nullptr;
-                                if (!connections.empty())
-                                {
-                                    UiPinPtr pin = connections[0];
-                                    std::string pinName = std::string(pin->_name);
-
-                                    pinNode = pin->_pinNode;
-                                    if (pinNode)
-                                    {
-                                        pinName = std::string(pinNode->getName()) + "." + pinName;
-                                    }
-                                    displayString = pinName;
-                                }
-
-                                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f)); 
-                                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f)); 
-                                ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
-                                ImGui::PushItemWidth(-1);
-                                if (ImGui::Button(displayString.c_str()))
-                                {
-                                    if (pinNode)
-                                    {
-                                        ed::SelectNode(pinNode->getId());
-                                        ed::NavigateToSelection();
-                                    }
-                                }
-                                ImGui::PopItemWidth();
-                                ImGui::PopStyleColor(3);
+                                showPropertyEditorInputConnection(input);
                             }
 
                             ImGui::PopID();
@@ -3538,77 +3624,7 @@ void Graph::propertyEditor()
                 }
             }
 
-            if (_currUiNode->_showOutputsInEditor)
-            {
-                std::vector<UiPinPtr> pinList = _currUiNode->outputPins;
-                size_t pinCount = pinList.size();
-
-                if (pinCount > 0)
-                {
-                    ImVec2 tableSize(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, (int)pinCount));
-                    bool haveTable = ImGui::BeginTable("outputs_node_table", 2, tableFlags, tableSize);
-                    if (haveTable)
-                    {
-                        ImGui::SetWindowFontScale(_fontScale);
-                        for (UiPinPtr outputPin : _currUiNode->outputPins)
-                        {
-                            bool firstPin = true;
-                            std::string outputPinName = outputPin->_name;
-                            std::string blankPinName;
-                            for (size_t i = 0; i < outputPinName.length(); i++) 
-                            {
-                                blankPinName += ' ';
-                            }
-
-                            for (UiPinPtr connectedPin : outputPin->getConnections())
-                            {
-                                ImGui::TableNextRow();
-                                ImGui::TableNextColumn();
-
-                                std::string connectedPinName = connectedPin->_name;
-                                if (connectedPin->_pinNode)
-                                {
-                                    connectedPinName = connectedPin->_pinNode->getName() + "." + connectedPinName;
-                                }
-                                // Display outputPin name, and connectedPinName in same row
-                                //
-                                if (firstPin)
-                                {
-                                    ImGui::Text("%s", outputPinName.c_str());
-                                    firstPin = false;
-                                }
-                                else
-                                {
-                                    ImGui::Text("%s", blankPinName.c_str());
-                                }
-
-                                std::string displayString = connectedPinName;
-                                ImGui::SameLine();
-                                ImGui::TableNextColumn();
-                                ImGui::PushItemWidth(-1);
-
-                                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-                                ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.2f, 0.4f, 0.6f, 1.0f));
-                                ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.1f, 0.2f, 0.4f, 1.0f));
-
-                                if (ImGui::Button(displayString.c_str()))
-                                {
-                                    std::shared_ptr<UiNode> pinNode = connectedPin->_pinNode;
-                                    if (pinNode)
-                                    {
-                                        ed::SelectNode(pinNode->getId());
-                                        ed::NavigateToSelection();
-                                    }
-                                }
-                                ImGui::PopStyleColor(3);
-                                ImGui::PopItemWidth();
-                            }
-                        }
-                        ImGui::EndTable();
-                        ImGui::SetWindowFontScale(1.0f);
-                    }
-                }
-            }
+            showPropertyEditorOutputConnections(_currUiNode);;
         }
 
         else if (_currUiNode->getInput() != nullptr)
@@ -3643,12 +3659,11 @@ void Graph::propertyEditor()
                         // Set constant sliders for input values
                         if (!inputs[i]->getConnected())
                         {
-                            setConstant(_currUiNode, inputs[i]->_input, uiProperties);
+                            showPropertyEditorValue(_currUiNode, inputs[i]->_input, uiProperties);
                         }
                         else
                         {
-                            std::string typeText = " [" + inputs[i]->_input->getType() + "]";
-                            ImGui::Text("%s", typeText.c_str());
+                            showPropertyEditorInputConnection(inputs[i]);
                         }
                         ImGui::PopID();
                     }
@@ -3656,6 +3671,8 @@ void Graph::propertyEditor()
                     ImGui::SetWindowFontScale(1.0f);
                 }
             }
+
+            showPropertyEditorOutputConnections(_currUiNode);;
         }
         else if (_currUiNode->getOutput() != nullptr)
         {
@@ -3668,6 +3685,7 @@ void Graph::propertyEditor()
             ImGui::Text("%s", _currUiNode->getCategory().c_str());
 
             ImGui::Checkbox("Show all inputs", &_currUiNode->_showAllInputs);
+            ImGui::Checkbox("Show output connections", &_currUiNode->_showOutputsInEditor);
 
             int count = 0;
             for (UiPinPtr input : inputs)
@@ -3705,12 +3723,11 @@ void Graph::propertyEditor()
                             ImGui::TableNextColumn();
                             if (!input->_input->getConnectedNode() && _currUiNode->getNodeGraph()->getActiveInput(input->_input->getName()))
                             {
-                                setConstant(_currUiNode, input->_input, uiProperties);
+                                showPropertyEditorValue(_currUiNode, input->_input, uiProperties);
                             }
                             else
                             {
-                                std::string typeText = " [" + input->_input->getType() + "]";
-                                ImGui::Text("%s", typeText.c_str());
+                                showPropertyEditorInputConnection(input);
                             }
 
                             ImGui::PopID();
@@ -3720,6 +3737,8 @@ void Graph::propertyEditor()
                     ImGui::SetWindowFontScale(1.0f);
                 }
             }
+
+            showPropertyEditorOutputConnections(_currUiNode);;
         }
         ImGui::PopStyleColor();
         ImGui::PopStyleColor();

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -184,9 +184,13 @@ class Graph
 
     void upNodeGraph();
 
-    // Set the value of the selected node constants in the node property editor
-    void setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIProperties& uiProperties);
-
+    // Show input values in property editor for a given input
+    void showPropertyEditorValue(UiNodePtr node, mx::InputPtr& input, const mx::UIProperties& uiProperties);
+    // Show input connections in property editor for a given node
+    void showPropertyEditorOutputConnections(UiNodePtr node);
+    // Show output connections in property editor for a given output pin
+    void showPropertyEditorInputConnection(UiPinPtr pin);
+    // Show property editor for a given node
     void propertyEditor();
     void setDefaults(mx::InputPtr input);
 

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -72,6 +72,7 @@ int main(int argc, char* const argv[])
     std::string fontFilename;
     int fontSize = 18;
     std::string captureFilename;
+    ImColor graphBackgroundColor(0.2f, 0.2f, 0.2f, 1.0f);
 
     for (size_t i = 0; i < tokens.size(); i++)
     {
@@ -117,6 +118,12 @@ int main(int argc, char* const argv[])
         else if (token == "--captureFilename")
         {
             parseToken(nextToken, "string", captureFilename);
+        }
+        else if (token == "--graphBackground")
+        {
+            mx::Color3 mxColor;
+            parseToken(nextToken, "color3", mxColor);
+            graphBackgroundColor = ImColor(mxColor[0], mxColor[1], mxColor[2], 1.0f);
         }
         else if (token == "--help")
         {
@@ -243,6 +250,7 @@ int main(int argc, char* const argv[])
         config.CustomZoomLevels.push_back(level);
     }
     ed::SetCurrentEditor(editorContext);
+    ed::PushStyleColor(ed::StyleColor_Bg, graphBackgroundColor);
 
     // Main loop
     while (!glfwWindowShouldClose(window))

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -15,6 +15,7 @@ const int INVALID_POS = -10000;
 UiNode::UiNode() :
     _level(-1),
     _showAllInputs(false),
+    _showOutputsInEditor(true),
     _id(0),
     _nodePos(INVALID_POS, INVALID_POS),
     _inputNodeNum(0)
@@ -24,6 +25,7 @@ UiNode::UiNode() :
 UiNode::UiNode(const std::string& name, int id) :
     _level(-1),
     _showAllInputs(false),
+    _showOutputsInEditor(true),
     _id(id),
     _nodePos(INVALID_POS, INVALID_POS),
     _name(name),

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -265,6 +265,7 @@ class UiNode
     mx::ElementPtr getElement();
     int _level;
     bool _showAllInputs;
+    bool _showOutputsInEditor;
 
   private:
     int _id;


### PR DESCRIPTION
## Proposal

- Add in clickable links to traverse through pin connections (inputs / outputs)
- This gives an easy way to move through a graph and also provide information on what is being routed in and out of a node
- Useful for diagnosis (see bugs section below)
- Options: Allow for output connections to be displayed with a per node toggle.
- Did not add hotkeys as selection of what to traverse to up / downstream is ambiguous for multiple input / output connections on a node. Can consider later and hook to keys like left/right arrow for instance.

- Aside: Add in background graph color option as it's pretty hard to see selected outlines, and better contrast with graph elements, grid etc. (`--graphBackground "r,g,b")

### Details
- Currently pin connections show the type which gives no information as to what is connected to it. You can hover over the pins in the graph but this just gives you pin names w/o node names
- Instead add in clickable buttons to traverse between pins.
- Traversal includes selecting the centering around selected node
- There are some existing bugs found in the code:
  - Deletion does not refresh connections properly
  - Inputs to graphs are not properly updating.
- Prevent a possible crash when deleting. Didn't fix the issue
- Fix positioning of "Show all inputs" for `nodegraph`s. (missed from a previous submission)
  
### Results 

https://github.com/user-attachments/assets/9b3f157e-dbca-44f4-a156-2706a2d0928e

1. Fan-out from an output:
![image](https://github.com/user-attachments/assets/870fccbf-a7af-4c0b-b5c4-db6ea40a4dd8)

2. Upstream connections:
![image](https://github.com/user-attachments/assets/ef0b9785-df9c-4d4b-8910-589c7d8b1edd)

3. Hide output connections: 
![image](https://github.com/user-attachments/assets/c2c96631-af63-481c-9ce9-cce619d17452)

---
Pinging @lfl-eholthouser  and @jstone-lucasfilm for comments.
