### PR TITLE
Add null check in getShaderNodes

### DIFF
--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -50,7 +50,11 @@ vector<NodePtr> getShaderNodes(NodePtr materialNode, const string& nodeType, con
             vector<OutputPtr> outputs;
             if (input->hasOutputString())
             {
-                outputs.push_back(nodeGraph->getOutput(input->getOutputString()));
+                OutputPtr connectedOutput = nodeGraph->getOutput(input->getOutputString());
+                if (connectedOutput)
+                {
+                    outputs.push_back(connectedOutput);
+                }
             }
             else
             {


### PR DESCRIPTION
This changelist adds a missing null check in getShaderNodes, handling the edge case of an invalid output string.  Previously, this edge case would trigger a crash in MaterialXCore, and now it correctly generates validation warnings and proceeds.