### PR TITLE
Add second null check in getShaderNodes

### DIFF
--- a/source/MaterialXCore/Material.cpp
+++ b/source/MaterialXCore/Material.cpp
@@ -92,23 +92,26 @@ vector<NodePtr> getShaderNodes(NodePtr materialNode, const string& nodeType, con
                     if (defOutput->getType() == MATERIAL_TYPE_STRING)
                     {
                         OutputPtr implGraphOutput = implGraph->getOutput(defOutput->getName());
-                        for (GraphIterator it = implGraphOutput->traverseGraph().begin(); it != GraphIterator::end(); ++it)
+                        if (implGraphOutput)
                         {
-                            ElementPtr upstreamElem = it.getUpstreamElement();
-                            if (!upstreamElem)
+                            for (GraphIterator it = implGraphOutput->traverseGraph().begin(); it != GraphIterator::end(); ++it)
                             {
-                                it.setPruneSubgraph(true);
-                                continue;
-                            }
-                            NodePtr upstreamNode = upstreamElem->asA<Node>();
-                            if (upstreamNode && upstreamNode->getType() == MATERIAL_TYPE_STRING)
-                            {
-                                for (NodePtr shaderNode : getShaderNodes(upstreamNode, nodeType, target))
+                                ElementPtr upstreamElem = it.getUpstreamElement();
+                                if (!upstreamElem)
                                 {
-                                    if (!shaderNodeSet.count(shaderNode))
+                                    it.setPruneSubgraph(true);
+                                    continue;
+                                }
+                                NodePtr upstreamNode = upstreamElem->asA<Node>();
+                                if (upstreamNode && upstreamNode->getType() == MATERIAL_TYPE_STRING)
+                                {
+                                    for (NodePtr shaderNode : getShaderNodes(upstreamNode, nodeType, target))
                                     {
-                                        shaderNodeVec.push_back(shaderNode);
-                                        shaderNodeSet.insert(shaderNode);
+                                        if (!shaderNodeSet.count(shaderNode))
+                                        {
+                                            shaderNodeVec.push_back(shaderNode);
+                                            shaderNodeSet.insert(shaderNode);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This changelist adds a second missing null check in getShaderNodes, handling the edge case of a mismatch in output names.  Previously, this edge case would trigger a crash in MaterialXCore, and now it correctly generates validation warnings and proceeds.