### PR TITLE
Improve invalid material handling in viewer

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -2412,7 +2412,7 @@ void Viewer::updateCameras()
     _envCamera->setViewMatrix(_viewCamera->getViewMatrix());
     _envCamera->setProjectionMatrix(_viewCamera->getProjectionMatrix());
 
-    mx::NodePtr dirLight = _lightHandler->getFirstLightOfCategory(DIR_LIGHT_NODE_CATEGORY);
+    mx::NodePtr dirLight = !_materialAssignments.empty() ? _lightHandler->getFirstLightOfCategory(DIR_LIGHT_NODE_CATEGORY) : nullptr;
     if (dirLight)
     {
         mx::Vector3 sphereCenter = (_geometryHandler->getMaximumBounds() + _geometryHandler->getMinimumBounds()) * 0.5;


### PR DESCRIPTION
This changelist improves the handling of invalid materials in the MaterialX Viewer, where the application would sometimes search for lights in a non-existent scene.  Previously, this situation would trigger a crash in the viewer, and now it correctly displays a warning to the user.