### PR TITLE
Add `ElementVec` type alias

### DIFF
--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -64,8 +64,8 @@ bool Element::operator==(const Element& rhs) const
     }
 
     // Compare children.
-    const vector<ElementPtr>& c1 = getChildren();
-    const vector<ElementPtr>& c2 = rhs.getChildren();
+    const ElementVec& c1 = getChildren();
+    const ElementVec& c2 = rhs.getChildren();
     if (c1.size() != c2.size())
         return false;
     for (size_t i = 0; i < c1.size(); i++)
@@ -153,7 +153,7 @@ void Element::unregisterChildElement(ElementPtr child)
 int Element::getChildIndex(const string& name) const
 {
     ElementPtr child = getChild(name);
-    vector<ElementPtr>::const_iterator it = std::find(_childOrder.begin(), _childOrder.end(), child);
+    ElementVec::const_iterator it = std::find(_childOrder.begin(), _childOrder.end(), child);
     if (it == _childOrder.end())
     {
         return -1;
@@ -164,7 +164,7 @@ int Element::getChildIndex(const string& name) const
 void Element::setChildIndex(const string& name, int index)
 {
     ElementPtr child = getChild(name);
-    vector<ElementPtr>::iterator it = std::find(_childOrder.begin(), _childOrder.end(), child);
+    ElementVec::iterator it = std::find(_childOrder.begin(), _childOrder.end(), child);
     if (it == _childOrder.end())
     {
         return;
@@ -426,7 +426,7 @@ bool Element::isEquivalent(ConstElementPtr rhs, const ElementEquivalenceOptions&
     }
 
     // Compare all child elements that affect functional equivalence.
-    vector<ElementPtr> children;
+    ElementVec children;
     for (ElementPtr child : getChildren())
     {
         if (child->getCategory() == CommentElement::CATEGORY)
@@ -435,7 +435,7 @@ bool Element::isEquivalent(ConstElementPtr rhs, const ElementEquivalenceOptions&
         }
         children.push_back(child);
     }
-    vector <ElementPtr> rhsChildren;
+    ElementVec rhsChildren;
     for (ElementPtr child : rhs->getChildren())
     {
         if (child->getCategory() == CommentElement::CATEGORY)

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -65,6 +65,9 @@ using ConstGenericElementPtr = shared_ptr<const GenericElement>;
 /// A shared pointer to a StringResolver
 using StringResolverPtr = shared_ptr<StringResolver>;
 
+/// A vector of elements.
+using ElementVec = vector<ElementPtr>;
+
 /// A hash map from strings to elements
 using ElementMap = std::unordered_map<string, ElementPtr>;
 
@@ -441,7 +444,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
 
     /// Return a constant vector of all child elements.
     /// The returned vector maintains the order in which children were added.
-    const vector<ElementPtr>& getChildren() const
+    const ElementVec& getChildren() const
     {
         return _childOrder;
     }
@@ -837,7 +840,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     string _sourceUri;
 
     ElementMap _childMap;
-    vector<ElementPtr> _childOrder;
+    ElementVec _childOrder;
 
     StringMap _attributeMap;
     StringVec _attributeOrder;

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -375,14 +375,14 @@ void GraphElement::flattenSubgraphs(const string& target, NodePredicate filter)
     }
 }
 
-vector<ElementPtr> GraphElement::topologicalSort() const
+ElementVec GraphElement::topologicalSort() const
 {
     // Calculate a topological order of the children, using Kahn's algorithm
     // to avoid recursion.
     //
     // Running time: O(numNodes + numEdges).
 
-    const vector<ElementPtr>& children = getChildren();
+    const ElementVec& children = getChildren();
 
     // Calculate in-degrees for all children.
     std::unordered_map<ElementPtr, size_t> inDegree(children.size());
@@ -415,7 +415,7 @@ vector<ElementPtr> GraphElement::topologicalSort() const
         }
     }
 
-    vector<ElementPtr> result;
+    ElementVec result;
     while (!childQueue.empty())
     {
         // Pop the queue and add to topological order.
@@ -470,7 +470,7 @@ string GraphElement::asStringDot() const
     string dot = "digraph {\n";
 
     // Create a unique name for each child element.
-    vector<ElementPtr> children = topologicalSort();
+    ElementVec children = topologicalSort();
     StringMap nameMap;
     StringSet nameSet;
     for (ElementPtr elem : children)

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -299,7 +299,7 @@ class MX_CORE_API GraphElement : public InterfaceElement
 
     /// Return a vector of all children (nodes and outputs) sorted in
     /// topological order.
-    vector<ElementPtr> topologicalSort() const;
+    ElementVec topologicalSort() const;
 
     /// If not yet present, add a geometry node to this graph matching the given property
     /// definition and name prefix.

--- a/source/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXCore/Traversal.cpp
@@ -66,7 +66,7 @@ TreeIterator& TreeIterator::operator++()
 
         // Traverse to our siblings.
         StackFrame& parentFrame = _stack.back();
-        const vector<ElementPtr>& siblings = parentFrame.first->getChildren();
+        const ElementVec& siblings = parentFrame.first->getChildren();
         if (parentFrame.second + 1 < siblings.size())
         {
             _elem = siblings[++parentFrame.second];

--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -139,7 +139,7 @@ void Document::upgradeVersion()
         // Upgrade elements in place.
         for (ElementPtr elem : traverseTree())
         {
-            vector<ElementPtr> origChildren = elem->getChildren();
+            ElementVec origChildren = elem->getChildren();
             for (ElementPtr child : origChildren)
             {
                 if (child->getCategory() == "opgraph")
@@ -215,7 +215,7 @@ void Document::upgradeVersion()
         }
 
         // Move connections from nodedef inputs to bindinputs.
-        vector<ElementPtr> materials = getChildrenOfType<Element>("material");
+        ElementVec materials = getChildrenOfType<Element>("material");
         for (NodeDefPtr nodeDef : getNodeDefs())
         {
             for (InputPtr input : nodeDef->getActiveInputs())
@@ -328,7 +328,7 @@ void Document::upgradeVersion()
                 elem->setAttribute(ValueElement::VALUE_ATTRIBUTE, replaceSubstrings(elem->getAttribute(ValueElement::VALUE_ATTRIBUTE), stringMap));
             }
 
-            vector<ElementPtr> origChildren = elem->getChildren();
+            ElementVec origChildren = elem->getChildren();
             for (ElementPtr child : origChildren)
             {
                 if (elem->getCategory() == "material" && child->getCategory() == "override")

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -115,7 +115,7 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
                 elem->setFilePrefix(filePrefix + modifiers.filePrefixTerminator);
             }
         }
-        std::vector<mx::ElementPtr> children = elem->getChildren();
+        mx::ElementVec children = elem->getChildren();
         for (mx::ElementPtr child : children)
         {
             if (modifiers.skipElements.count(child->getCategory()) ||


### PR DESCRIPTION
This changelist adds `mx::ElementVec` as a type alias for `std::vector<mx::ElementPtr>` in MaterialX C++, allowing certain patterns to be expressed more clearly and concisely.