### PR TITLE
Validate tree depth in XML parsing

### DIFF
--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -19,7 +19,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string MTLX_EXTENSION = "mtlx";
 
-const int MAX_XML_ELEMENT_TREE_DEPTH = 256;
+const int MAX_XML_TREE_DEPTH = 256;
 
 namespace
 {
@@ -61,7 +61,7 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         }
 
         // Validate element tree depth.
-        if (depth >= MAX_XML_ELEMENT_TREE_DEPTH)
+        if (depth >= MAX_XML_TREE_DEPTH)
         {
             throw ExceptionParseError("Maximum element tree depth exceeded.");
         }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -19,7 +19,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string MTLX_EXTENSION = "mtlx";
 
-const int MAX_MTLX_TREE_DEPTH = 256;
+const int MAX_XML_TREE_DEPTH = 256;
 
 namespace
 {
@@ -61,7 +61,7 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         }
 
         // Enforce maximum tree depth.
-        if (depth >= MAX_MTLX_TREE_DEPTH)
+        if (depth >= MAX_XML_TREE_DEPTH)
         {
             throw ExceptionParseError("Maximum tree depth exceeded.");
         }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -19,7 +19,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string MTLX_EXTENSION = "mtlx";
 
-const int MAX_XML_TREE_DEPTH = 256;
+const int MAX_MTLX_TREE_DEPTH = 256;
 
 namespace
 {
@@ -61,9 +61,9 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         }
 
         // Enforce maximum tree depth.
-        if (depth >= MAX_XML_TREE_DEPTH)
+        if (depth >= MAX_MTLX_TREE_DEPTH)
         {
-            throw ExceptionParseError("Maximum XML tree depth exceeded.");
+            throw ExceptionParseError("Maximum tree depth exceeded.");
         }
 
         // Create the new element.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -19,7 +19,7 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string MTLX_EXTENSION = "mtlx";
 
-const int MAX_ELEMENT_TREE_DEPTH = 256;
+const int MAX_XML_ELEMENT_TREE_DEPTH = 256;
 
 namespace
 {
@@ -61,7 +61,7 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         }
 
         // Validate element tree depth.
-        if (depth >= MAX_ELEMENT_TREE_DEPTH)
+        if (depth >= MAX_XML_ELEMENT_TREE_DEPTH)
         {
             throw ExceptionParseError("Maximum element tree depth exceeded.");
         }

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -60,7 +60,7 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
             continue;
         }
 
-        // Validate element tree depth.
+        // Enforce maximum tree depth.
         if (depth >= MAX_XML_TREE_DEPTH)
         {
             throw ExceptionParseError("Maximum element tree depth exceeded.");

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -63,7 +63,7 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         // Enforce maximum tree depth.
         if (depth >= MAX_XML_TREE_DEPTH)
         {
-            throw ExceptionParseError("Maximum element tree depth exceeded.");
+            throw ExceptionParseError("Maximum XML tree depth exceeded.");
         }
 
         // Create the new element.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -19,6 +19,8 @@ MATERIALX_NAMESPACE_BEGIN
 
 const string MTLX_EXTENSION = "mtlx";
 
+const int MAX_ELEMENT_TREE_DEPTH = 256;
+
 namespace
 {
 
@@ -26,9 +28,7 @@ const string XINCLUDE_TAG = "xi:include";
 const string XINCLUDE_NAMESPACE = "xmlns:xi";
 const string XINCLUDE_URL = "http://www.w3.org/2001/XInclude";
 
-const unsigned int MAX_ELEMENT_DEPTH = 256;
-
-void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptions* readOptions, unsigned int depth = 1)
+void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptions* readOptions, int depth = 1)
 {
     // Store attributes in element.
     for (const xml_attribute& xmlAttr : xmlNode.attributes())
@@ -60,10 +60,10 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
             continue;
         }
 
-        // Validate element depth.
-        if (depth >= MAX_ELEMENT_DEPTH)
+        // Validate element tree depth.
+        if (depth >= MAX_ELEMENT_TREE_DEPTH)
         {
-            throw ExceptionParseError("Maximum element depth exceeded.");
+            throw ExceptionParseError("Maximum element tree depth exceeded.");
         }
 
         // Create the new element.

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -26,7 +26,9 @@ const string XINCLUDE_TAG = "xi:include";
 const string XINCLUDE_NAMESPACE = "xmlns:xi";
 const string XINCLUDE_URL = "http://www.w3.org/2001/XInclude";
 
-void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptions* readOptions)
+const unsigned int MAX_ELEMENT_DEPTH = 256;
+
+void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptions* readOptions, unsigned int depth = 1)
 {
     // Store attributes in element.
     for (const xml_attribute& xmlAttr : xmlNode.attributes())
@@ -58,9 +60,15 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
             continue;
         }
 
+        // Validate element depth.
+        if (depth >= MAX_ELEMENT_DEPTH)
+        {
+            throw ExceptionParseError("Maximum element depth exceeded.");
+        }
+
         // Create the new element.
         ElementPtr child = elem->addChildOfCategory(category, name);
-        elementFromXml(xmlChild, child, readOptions);
+        elementFromXml(xmlChild, child, readOptions, depth + 1);
 
         // Handle the interpretation of XML comments and newlines.
         if (readOptions && category.empty())

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,6 +22,8 @@ class XmlReadOptions;
 
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
+extern MX_FORMAT_API const int MAX_ELEMENT_TREE_DEPTH;
+
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.
 using XmlReadFunction = std::function<void(DocumentPtr, const FilePath&, const FileSearchPath&, const XmlReadOptions*)>;

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,7 +22,7 @@ class XmlReadOptions;
 
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
-extern MX_FORMAT_API const int MAX_XML_ELEMENT_TREE_DEPTH;
+extern MX_FORMAT_API const int MAX_XML_TREE_DEPTH;
 
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,7 +22,7 @@ class XmlReadOptions;
 
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
-extern MX_FORMAT_API const int MAX_MTLX_TREE_DEPTH;
+extern MX_FORMAT_API const int MAX_XML_TREE_DEPTH;
 
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,7 +22,7 @@ class XmlReadOptions;
 
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
-extern MX_FORMAT_API const int MAX_ELEMENT_TREE_DEPTH;
+extern MX_FORMAT_API const int MAX_XML_ELEMENT_TREE_DEPTH;
 
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,7 +22,7 @@ class XmlReadOptions;
 
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
-extern MX_FORMAT_API const int MAX_XML_TREE_DEPTH;
+extern MX_FORMAT_API const int MAX_MTLX_TREE_DEPTH;
 
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -262,6 +262,25 @@ TEST_CASE("Comments and newlines", "[xmlio]")
     REQUIRE(origXml == newXml);
 }
 
+TEST_CASE("Element depth", "[xmlio]")
+{
+    // Create a document with invalid element depth.
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::ElementPtr elem = doc;
+    for (int i = 0; i < 1024; i++)
+    {
+        elem = elem->addChild<mx::NodeGraph>();
+    }
+
+    // Write the document to a string buffer.
+    std::string xmlString = mx::writeToXmlString(doc);
+
+    // Attempt to read the string buffer as a document, verifying that
+    // a parse error is thrown.
+    mx::DocumentPtr newDoc = mx::createDocument();
+    REQUIRE_THROWS_AS(mx::readFromXmlString(newDoc, xmlString), mx::ExceptionParseError);
+}
+
 TEST_CASE("Fuzz testing", "[xmlio]")
 {
     mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -264,7 +264,7 @@ TEST_CASE("Comments and newlines", "[xmlio]")
 
 TEST_CASE("Element tree depth", "[xmlio]")
 {
-    // Create a document that exceeds the maximum element tree depth.
+    // Create a document that exceeds the maximum tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
     for (int i = 0; i < mx::MAX_XML_TREE_DEPTH + 1; i++)

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -267,7 +267,7 @@ TEST_CASE("Element tree depth", "[xmlio]")
     // Create a document that exceeds the maximum element tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
-    for (int i = 0; i < mx::MAX_ELEMENT_TREE_DEPTH + 1; i++)
+    for (int i = 0; i < mx::MAX_XML_ELEMENT_TREE_DEPTH + 1; i++)
     {
         elem = elem->addChild<mx::NodeGraph>();
     }

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -262,12 +262,12 @@ TEST_CASE("Comments and newlines", "[xmlio]")
     REQUIRE(origXml == newXml);
 }
 
-TEST_CASE("Element tree depth", "[xmlio]")
+TEST_CASE("Maximum tree depth", "[xmlio]")
 {
     // Create a document that exceeds the maximum tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
-    for (int i = 0; i < mx::MAX_XML_TREE_DEPTH + 1; i++)
+    for (int i = 0; i < mx::MAX_MTLX_TREE_DEPTH + 1; i++)
     {
         elem = elem->addChild<mx::NodeGraph>();
     }
@@ -275,8 +275,8 @@ TEST_CASE("Element tree depth", "[xmlio]")
     // Write the document to a string buffer.
     std::string xmlString = mx::writeToXmlString(doc);
 
-    // Attempt to read the string buffer as a document, verifying that
-    // a parse error is thrown.
+    // Read the string buffer as a document, verifying that the correct
+    // exception is thrown.
     mx::DocumentPtr newDoc = mx::createDocument();
     REQUIRE_THROWS_AS(mx::readFromXmlString(newDoc, xmlString), mx::ExceptionParseError);
 }

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -267,7 +267,7 @@ TEST_CASE("Element tree depth", "[xmlio]")
     // Create a document that exceeds the maximum element tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
-    for (int i = 0; i < mx::MAX_XML_ELEMENT_TREE_DEPTH + 1; i++)
+    for (int i = 0; i < mx::MAX_XML_TREE_DEPTH + 1; i++)
     {
         elem = elem->addChild<mx::NodeGraph>();
     }

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -262,12 +262,12 @@ TEST_CASE("Comments and newlines", "[xmlio]")
     REQUIRE(origXml == newXml);
 }
 
-TEST_CASE("Element depth", "[xmlio]")
+TEST_CASE("Element tree depth", "[xmlio]")
 {
-    // Create a document with invalid element depth.
+    // Create a document that exceeds the maximum element tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
-    for (int i = 0; i < 1024; i++)
+    for (int i = 0; i < mx::MAX_ELEMENT_TREE_DEPTH + 1; i++)
     {
         elem = elem->addChild<mx::NodeGraph>();
     }

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -267,7 +267,7 @@ TEST_CASE("Maximum tree depth", "[xmlio]")
     // Create a document that exceeds the maximum tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
-    for (int i = 0; i < mx::MAX_MTLX_TREE_DEPTH + 1; i++)
+    for (int i = 0; i < mx::MAX_XML_TREE_DEPTH + 1; i++)
     {
         elem = elem->addChild<mx::NodeGraph>();
     }


### PR DESCRIPTION
This changelist adds validation for the tree depth in XML parsing, preventing an invalid document from triggering a stack overflow.

A new unit test has been added to parse a document exceeding the maximum tree depth, verifying that the correct exception is thrown.