### PR TITLE
Validate XInclude depth in XML parsing

### DIFF
--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -22,6 +22,7 @@ class XmlReadOptions;
 
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
+extern MX_FORMAT_API const int MAX_XINCLUDE_DEPTH;
 extern MX_FORMAT_API const int MAX_XML_TREE_DEPTH;
 
 /// A standard function that reads from an XML file into a Document, with


### PR DESCRIPTION
This changelist adds validation for XInclude depth in XML parsing, preventing an XInclude sequence from triggering a stack overflow.