### PR TITLE
Restore limit on XML tree depth

### DIFF
--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -23,6 +23,7 @@ class XmlReadOptions;
 extern MX_FORMAT_API const string MTLX_EXTENSION;
 
 extern MX_FORMAT_API const int MAX_XINCLUDE_DEPTH;
+extern MX_FORMAT_API const int MAX_XML_TREE_DEPTH;
 
 /// A standard function that reads from an XML file into a Document, with
 /// optional search path and read options.

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -262,12 +262,12 @@ TEST_CASE("Comments and newlines", "[xmlio]")
     REQUIRE(origXml == newXml);
 }
 
-TEST_CASE("Element tree depth", "[xmlio]")
+TEST_CASE("Maximum tree depth", "[xmlio]")
 {
-    // Create a document with an unusually high element tree depth.
+    // Create a document that exceeds the maximum tree depth.
     mx::DocumentPtr doc = mx::createDocument();
     mx::ElementPtr elem = doc;
-    for (int i = 0; i < 1024; i++)
+    for (int i = 0; i < mx::MAX_XML_TREE_DEPTH + 1; i++)
     {
         elem = elem->addChild<mx::NodeGraph>();
     }
@@ -275,9 +275,10 @@ TEST_CASE("Element tree depth", "[xmlio]")
     // Write the document to a string buffer.
     std::string xmlString = mx::writeToXmlString(doc);
 
-    // Read the string buffer as a document.
+    // Read the string buffer as a document, verifying that the correct
+    // exception is thrown.
     mx::DocumentPtr newDoc = mx::createDocument();
-    mx::readFromXmlString(newDoc, xmlString);
+    REQUIRE_THROWS_AS(mx::readFromXmlString(newDoc, xmlString), mx::ExceptionParseError);
 }
 
 TEST_CASE("Fuzz testing", "[xmlio]")


### PR DESCRIPTION
This changelist restores the earlier limit on the tree depth during XML parsing, as this limit is still valuable in protecting applications from stack overflow conditions, independent of the XML parsing process itself.