### PR TITLE
Static analyis fixes

### DIFF
--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -16,7 +16,7 @@ const string& TypeDesc::getName() const
     return _data ? _data->getName() : NONE_TYPE_NAME;
 }
 
-const StructMemberDescVecPtr TypeDesc::getStructMembers() const
+StructMemberDescVecPtr TypeDesc::getStructMembers() const
 {
     return _data ? _data->getStructMembers() : StructMemberDescVecPtr();
 }

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -71,7 +71,7 @@ class MX_GENSHADER_API TypeDesc
         DataBlock(const string& name, const StructMemberDescVecPtr members = nullptr) noexcept : _name(name), _members(members) {}
 
         const string& getName() const { return _name; }
-        const StructMemberDescVecPtr getStructMembers() const { return _members; }
+        StructMemberDescVecPtr getStructMembers() const { return _members; }
 
       private:
         const string _name;
@@ -145,7 +145,7 @@ class MX_GENSHADER_API TypeDesc
 
     /// Return a pointer to the struct member description.
     /// Will return nullptr if this is not a struct type.
-    const StructMemberDescVecPtr getStructMembers() const;
+    StructMemberDescVecPtr getStructMembers() const;
 
     /// Equality operator
     bool operator==(TypeDesc rhs) const

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2072,8 +2072,7 @@ void Graph::buildGroupNode(UiNodePtr node)
     ed::BeginNode(node->getId());
     ImGui::PushID(node->getId());
 
-    std::string original = node->getMessage();
-    std::string temp = original;
+    std::string temp = node->getMessage();
     ImVec2 messageSize = ImGui::CalcTextSize(temp.c_str());
     ImGui::PushItemWidth(messageSize.x + 15);
     ImGui::InputText("##edit", &temp);


### PR DESCRIPTION
This changelist addresses two static analysis warnings flagged by PVS-Studio:

- Remove an unneeded const modifier from the return argument of `TypeDesc::getStructMembers`.
- Remove an unused intermediate value in `Graph::buildGroupNode`.