### PR TITLE
Improvements to GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,18 +25,17 @@ jobs:
           python: 3.7
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON -DMATERIALX_BUILD_MONOLITHIC=ON
 
-        - name: Linux_GCC_13_Python311
-          os: ubuntu-24.04
-          compiler: gcc
-          compiler_version: "13"
-          python: 3.11
-          build_javascript: ON
-
         - name: Linux_GCC_14_Python312
           os: ubuntu-24.04
           compiler: gcc
           compiler_version: "14"
           python: 3.12
+
+        - name: Linux_GCC_14_Python313
+          os: ubuntu-24.04
+          compiler: gcc
+          compiler_version: "14"
+          python: 3.13
 
         - name: Linux_GCC_CoverageAnalysis
           os: ubuntu-24.04
@@ -53,11 +52,11 @@ jobs:
           python: 3.7
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_Clang_18_Python312
+        - name: Linux_Clang_18_Python313
           os: ubuntu-24.04
           compiler: clang
           compiler_version: "18"
-          python: 3.12
+          python: 3.13
           test_render: ON
           clang_format: ON
 
@@ -176,22 +175,6 @@ jobs:
     - name: Install Python Dependencies
       if: matrix.python != 'None'
       run: pip install setuptools
-
-    - name: Install Emscripten
-      if: matrix.build_javascript == 'ON'
-      run: |
-        git clone https://github.com/emscripten-core/emsdk --recursive
-        cd emsdk
-        ./emsdk install 2.0.20
-        ./emsdk activate 2.0.20
-        source ./emsdk_env.sh
-        echo "EMSDK=$EMSDK" >> $GITHUB_ENV
-
-    - name: Install Node
-      if: matrix.build_javascript == 'ON'
-      uses: actions/setup-node@v4
-      with:
-         node-version: '16'
 
     - name: Run Clang Format
       if: matrix.clang_format == 'ON'
@@ -313,16 +296,35 @@ jobs:
         name: MaterialX_Coverage
         path: build/coverage
 
+  javascript:
+    name: JavaScript
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Sync Repository
+      uses: actions/checkout@v4
+
+    - name: Install Emscripten
+      run: |
+        git clone https://github.com/emscripten-core/emsdk --recursive
+        cd emsdk
+        ./emsdk install 2.0.20
+        ./emsdk activate 2.0.20
+        source ./emsdk_env.sh
+        echo "EMSDK=$EMSDK" >> $GITHUB_ENV
+
+    - name: Install Node
+      uses: actions/setup-node@v4
+      with:
+         node-version: '16'
+
     - name: JavaScript CMake Generate
-      if: matrix.build_javascript == 'ON'
       run: cmake -S . -B javascript/build -DMATERIALX_BUILD_JS=ON -DMATERIALX_EMSDK_PATH=${{ env.EMSDK }}
 
     - name: JavaScript CMake Build
-      if: matrix.build_javascript == 'ON'
       run: cmake --build javascript/build --target install --config Release --parallel 2
     
     - name: JavaScript Unit Tests
-      if: matrix.build_javascript == 'ON'
       run: |
         npm install
         npm run test
@@ -330,14 +332,13 @@ jobs:
       working-directory: javascript/MaterialXTest
 
     - name: Build Web Viewer
-      if: matrix.build_javascript == 'ON'
       run: |
         npm install
         npm run build
       working-directory: javascript/MaterialXView
 
     - name: Deploy Web Viewer
-      if: matrix.build_javascript == 'ON' && github.event_name != 'pull_request'
+      if: github.event_name != 'pull_request'
       uses: JamesIves/github-pages-deploy-action@v4.6.4
       with:
         branch: gh-pages
@@ -345,11 +346,10 @@ jobs:
         single-commit: true
 
     - name: Upload JavaScript Package
-      if: matrix.build_javascript == 'ON'
       uses: actions/upload-artifact@v4
       with:
         name: MaterialX_JavaScript
-        path: javascript/build/installed/JavaScript/MaterialX        
+        path: javascript/build/installed/JavaScript/MaterialX
 
   sdist:
     name: Python SDist


### PR DESCRIPTION
- Move JavaScript builds into their own CI job, improving parallelism between the builds in our main workflow.
- Add Python 3.13 builds for GCC and Clang on Linux.