### PR TITLE
Re-add OSL normalmap tangent frame orthogonalization

### DIFF
--- a/libraries/stdlib/genosl/mx_normalmap.osl
+++ b/libraries/stdlib/genosl/mx_normalmap.osl
@@ -13,7 +13,7 @@ void mx_normalmap_vector2(vector value, vector2 normal_scale, vector N, vector T
         //
         vector v = value * 2.0 - 1.0;
         vector Tn = normalize(T - dot(T, N) * N);
-        vector Bn = normalize(cross(N, Tn));
+        vector Bn = normalize(B - dot(B, N) * N - dot(B, Tn) * Tn);
         result = normalize(Tn * v[0] * normal_scale.x + Bn * v[1] * normal_scale.y + N * v[2]);
     }
 }


### PR DESCRIPTION
This PR reverts the removal of OSL tangent frame orthogonalization (caused by PR #1911) and adds an explanatory comment.