### PR TITLE
Add missing calls in unit tests

### DIFF
--- a/source/MaterialXTest/MaterialXCore/Look.cpp
+++ b/source/MaterialXTest/MaterialXCore/Look.cpp
@@ -76,6 +76,7 @@ TEST_CASE("Look", "[look]")
     mx::LookPtr look2 = doc->addLook();
     look2->setInheritsFrom(look);
     REQUIRE(look2->getActiveMaterialAssigns().size() == 2);
+    REQUIRE(look2->getActivePropertyAssigns().size() == 1);
     REQUIRE(look2->getActivePropertySetAssigns().size() == 1);
     REQUIRE(look2->getActiveVisibilities().size() == 1);
 
@@ -88,6 +89,7 @@ TEST_CASE("Look", "[look]")
     // Disconnect the inherited look.
     look2->setInheritsFrom(nullptr);
     REQUIRE(look2->getActiveMaterialAssigns().empty());
+    REQUIRE(look2->getActivePropertyAssigns().empty());
     REQUIRE(look2->getActivePropertySetAssigns().empty());
     REQUIRE(look2->getActiveVisibilities().empty());
 }


### PR DESCRIPTION
This changelist adds two missing calls to getActivePropertyAssigns in the unit tests for Look elements, improving statement coverage for this area of the codebase.