### PR TITLE
Handle object-space `normalmap` in version upgrade

### DIFF
--- a/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
@@ -35,4 +35,32 @@
     <input name="surfaceshader" type="surfaceshader" nodename="N_surface_2" />
   </surfacematerial>
 
+  <normal name="N_objectnormal" type="vector3">
+    <input name="space" type="string" value="object" />
+  </normal>
+  <multiply name="N_multiply" type="vector3">
+    <input name="in1" type="vector3" nodename="N_objectnormal" />
+    <input name="in2" type="float" value="0.5" />
+  </multiply>
+  <add name="N_add" type="vector3">
+    <input name="in1" type="vector3" nodename="N_multiply" />
+    <input name="in2" type="float" value="0.5" />
+  </add>
+  <normalmap name="N_normalmap_3" type="vector3">
+    <input name="in" type="vector3" nodename="N_add" />
+    <input name="space" type="string" value="object" />
+  </normalmap>
+  <transformnormal name="N_transformnormal" type="vector3">
+    <input name="in" type="vector3" nodename="N_normalmap_3" />
+    <input name="fromspace" type="string" value="object" />
+    <input name="tospace" type="string" value="world" />
+  </transformnormal>
+  <standard_surface name="N_surface_3" type="surfaceshader">
+    <input name="metalness" type="float" value="1" />
+    <input name="normal" type="vector3" nodename="N_transformnormal" />
+  </standard_surface>
+  <surfacematerial name="N_material_3" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="N_surface_3" />
+  </surfacematerial>
+
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
@@ -46,7 +46,7 @@
     <input name="in1" type="vector3" nodename="N_multiply" />
     <input name="in2" type="float" value="0.5" />
   </add>
-  <normalmap name="N_normalmap_3" type="vector3">
+  <normalmap name="N_normalmap_3" type="vector3" nodedef="ND_normalmap">
     <input name="in" type="vector3" nodename="N_add" />
     <input name="space" type="string" value="object" />
   </normalmap>

--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1316,6 +1316,13 @@ void Document::upgradeVersion()
             }
             else if (nodeCategory == "normalmap")
             {
+                // Handle a rename of the float-typed nodedef.
+                if (node->getNodeDefString() == "ND_normalmap")
+                {
+                    node->setNodeDefString("ND_normalmap_float");
+                }
+
+                // Handle each supported space.
                 InputPtr space = node->getInput("space");
                 if (space && space->getValueString() == "object")
                 {
@@ -1339,12 +1346,6 @@ void Document::upgradeVersion()
                 {
                     // Clear tangent-space input.
                     node->removeInput("space");
-
-                    // Handle a rename of the float-typed nodedef.
-                    if (node->getNodeDefString() == "ND_normalmap")
-                    {
-                        node->setNodeDefString("ND_normalmap_float");
-                    }
 
                     // If the normal or tangent inputs are set and the bitangent input is not, 
                     // the bitangent should be set to normalize(cross(N, T))

--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1316,13 +1316,6 @@ void Document::upgradeVersion()
             }
             else if (nodeCategory == "normalmap")
             {
-                // Handle a rename of the float-typed nodedef.
-                if (node->getNodeDefString() == "ND_normalmap")
-                {
-                    node->setNodeDefString("ND_normalmap_float");
-                }
-
-                // Handle each supported space.
                 InputPtr space = node->getInput("space");
                 if (space && space->getValueString() == "object")
                 {
@@ -1341,6 +1334,12 @@ void Document::upgradeVersion()
                         node->removeChild(input->getName());
                     }
                     node->addInput("in", "vector3")->setConnectedNode(subtract);
+
+                    // Update nodedef name if present.
+                    if (node->hasNodeDefString())
+                    {
+                        node->setNodeDefString("ND_normalize_vector3");
+                    }
                 }
                 else
                 {
@@ -1363,6 +1362,12 @@ void Document::upgradeVersion()
                         normalizeNode->addInput("in", "vector3")->setConnectedNode(crossNode);
 
                         node->addInput("bitangent", "vector3")->setConnectedNode(normalizeNode);
+                    }
+
+                    // Update nodedef name if present.
+                    if (node->getNodeDefString() == "ND_normalmap")
+                    {
+                        node->setNodeDefString("ND_normalmap_float");
                     }
                 }
             }


### PR DESCRIPTION
This changelist adds handling for object-space `normalmap` nodes in the version upgrade pathway from 1.38 to 1.39.