### PR TITLE
Added oslFileTextureColorspace GenOptions

### DIFF
--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -15,6 +15,6 @@ void mx_image_color3(textureresource file, string layer, color default_value, ve
     out = texture(file.filename, st.x, st.y,
                   "subimage", layer, "interp", filtertype,
                   "missingcolor", missingColor,
-                  "swrap", uaddressmode, "twrap", vaddressmode,
-                  "colorspace", file.colorspace);
+                  "swrap", uaddressmode, "twrap", vaddressmode
+                  $oslFileTextureColorspace);
 }

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -17,8 +17,8 @@ void mx_image_color4(textureresource file, string layer, color4 default_value, v
     color rgb = texture(file.filename, st.x, st.y, "alpha", alpha,
                         "subimage", layer, "interp", filtertype,
                         "missingcolor", missingColor, "missingalpha", missingAlpha,
-                        "swrap", uaddressmode, "twrap", vaddressmode,
-                        "colorspace", file.colorspace);
+                        "swrap", uaddressmode, "twrap", vaddressmode
+                        $oslFileTextureColorspace);
 
     out = color4(rgb, alpha);
 }

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -72,6 +72,18 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
         _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv.osl";
     }
 
+    // Pass the colorspace optional argument to OSL's texture() function.
+    // Some renderers will error out if this is set as they don't support
+    // the optional argument.
+    if (context.getOptions().oslFileTextureColorspace)
+    {
+        _tokenSubstitutions[ShaderGenerator::T_OSL_FILE_TEXTURE_COLORSPACE] = ", \"colorspace\", file.colorspace";
+    }
+    else
+    {
+        _tokenSubstitutions[ShaderGenerator::T_OSL_FILE_TEXTURE_COLORSPACE] = "";
+    }
+
     // Emit function definitions for all nodes
     emitFunctionDefinitions(graph, context, stage);
 

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -93,7 +93,8 @@ class MX_GENSHADER_API GenOptions
         hwNormalizeUdimTexCoords(false),
         hwWriteAlbedoTable(false),
         hwWriteEnvPrefilter(false),
-        hwImplicitBitangents(true)
+        hwImplicitBitangents(true),
+        oslFileTextureColorspace(true)
     {
     }
     virtual ~GenOptions() { }
@@ -191,6 +192,10 @@ class MX_GENSHADER_API GenOptions
     /// Calculate fallback bitangents from existing normals and tangents
     /// inside the bitangent node.
     bool hwImplicitBitangents;
+
+    /// OSL-specific override to enable/disable the optional argument
+    /// to OSL's texture() function.
+    bool oslFileTextureColorspace;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -24,6 +24,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 const string ShaderGenerator::T_FILE_TRANSFORM_UV = "$fileTransformUv";
+const string ShaderGenerator::T_OSL_FILE_TEXTURE_COLORSPACE = "$oslFileTextureColorspace";
 
 //
 // ShaderGenerator methods

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -233,6 +233,7 @@ class MX_GENSHADER_API ShaderGenerator
 
   protected:
     static const string T_FILE_TRANSFORM_UV;
+    static const string T_OSL_FILE_TEXTURE_COLORSPACE;
 
     TypeSystemPtr _typeSystem;
     SyntaxPtr _syntax;


### PR DESCRIPTION
Added oslFileTextureColorspace GenOptions to omit the colorspace optional argument to the texture function.

I commented in https://github.com/AcademySoftwareFoundation/MaterialX/issues/2127#issuecomment-2705692762 about it, but I thought I'd figure it out myself.

I couldn't think of another way to approach it but this seems to allow generating the nodes without the optional argument to `texture()` which causes errors in some renderers.

eg. `ERROR : RenderMan : S20006 OSL: Unknown texture optional argument: "colorspace", <string> (shaders\\__mtlx\\__ND_image_color3.osl:35)`

Kind regards
-Alex