### PR TITLE
MDL: apply subsurface_bsdf weight in MDL implementation and add tests

### DIFF
--- a/resources/Materials/TestSuite/pbrlib/bsdf/subsurface_bsdf.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/subsurface_bsdf.mtlx
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodegraph name="subsurface_1_common">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="anisotropy" type="float" value="0.0" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <!-- SSS radius of 1 cm assuming the scene units are in meters -->
+  <nodegraph name="subsurface_2_radius_0_01">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="0.01, 0.01, 0.01" />
+      <input name="anisotropy" type="float" value="0.0" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <!-- SSS radius of 2.5 cm assuming the scene units are in meters -->
+  <nodegraph name="subsurface_2_radius_0_025">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="0.025, 0.025, 0.025" />
+      <input name="anisotropy" type="float" value="0.0" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <!-- SSS radius of 5 m (thin gas) assuming the scene units are in meters -->
+  <nodegraph name="subsurface_2_radius_5_0">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="5.0, 5.0, 5.0" />
+      <input name="anisotropy" type="float" value="0.0" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <nodegraph name="subsurface_3_weighted">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="0.25" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="anisotropy" type="float" value="0.0" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <nodegraph name="subsurface_4_forward">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="anisotropy" type="float" value="0.9" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+  <nodegraph name="subsurface_4_backward">
+    <subsurface_bsdf name="subsurface_bsdf1" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="color" type="color3" value="0.816, 0.140, 0.124" />
+      <input name="radius" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="anisotropy" type="float" value="-0.9" />
+    </subsurface_bsdf>
+    <surface name="surface1" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="subsurface_bsdf1" />
+      <input name="opacity" type="float" value="1.0" />
+    </surface>
+    <output name="out" type="surfaceshader" nodename="surface1" />
+  </nodegraph>
+
+</materialx>

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
@@ -340,7 +340,7 @@ export material mx_generalized_schlick_bsdf(
 );
 
 export material mx_subsurface_bsdf(
-    float  mxp_weight    = 1.0 [[ anno::unused() ]],
+    float  mxp_weight    = 1.0,
     color  mxp_color     = color(0.18),
     color  mxp_radius    = color(1.0),
     float  mxp_anisotropy = 0.0,
@@ -351,22 +351,20 @@ export material mx_subsurface_bsdf(
 = let {
     // https://blog.selfshadow.com/publications/s2017-shading-course/imageworks/s2017_pbs_imageworks_slides_v2.pdf
     // Phase function eccentricity 'g' has been omitted here since we pass that directly 
-    // to anisotropic_vdf(directional_bias: g).    
+    // to anisotropic_vdf(directional_bias: g).
+    color C = math::saturate(mxp_weight) * mxp_color;
     color albedo = color(4.09712) +
-           (4.20863f * mxp_color) -
+           (4.20863f * C) -
            math::sqrt(
                9.59217f +
-               41.6808f * mxp_color +
-               17.7126f * mxp_color * mxp_color);
+               41.6808f * C +
+               17.7126f * C * C);
 
     color albedo_sq = albedo * albedo;
-
     color white = color(1.0, 1.0, 1.0);
+    color alpha = (white - albedo_sq) / (white - mxp_anisotropy * albedo_sq);
 
-    color alpha = 
-        (white - albedo_sq) / (white - mxp_anisotropy * albedo_sq);
-
-    color radius_inv = white / mxp_radius;
+    color radius_inv = white / math::max(color(0.001), mxp_radius);
 
     color sigma_s = alpha * radius_inv;
     color sigma_a = radius_inv - sigma_s;


### PR DESCRIPTION
This PR is mostly about the added tests materials.
Attached is a comparison between GLSL, OSL, and MDL.

- MDL should be correct as far as I can tell. SSS is implemented using a random walk in the path tracer (which will be added to #2254) 
- For the GLSL implementation the radius seems to not have a big impact which might be okay due to the real-time approximation. But we are wondering about  the `max(mfp, 0.1)` [here ](https://github.com/AcademySoftwareFoundation/MaterialX/blob/0e6b5bfb46c7d3c4ad804e4394c8333d740e6d01/libraries/pbrlib/genglsl/lib/mx_microfacet_diffuse.glsl#L175). This means at least 10cm radius if the scene is modelled in meters, right?
- OSL matches GLSL but I haven't checked the source.

![Screenshot_7-3-2025_153024_](https://github.com/user-attachments/assets/d74237e7-f840-431c-a3dd-cd67da2cf010)
