### PR TITLE
Improvements to `swizzle` upgrade logic

### DIFF
--- a/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
@@ -63,4 +63,15 @@
     <input name="surfaceshader" type="surfaceshader" nodename="N_surface_3" />
   </surfacematerial>
 
+  <swizzle name="N_swizzle" type="color3" nodedef="ND_swizzle_color3_color3">
+    <input name="in" type="color3" value="0.8, 0.7, 0.6" />
+    <input name="channels" type="string" value="bgr" />
+  </swizzle>
+  <standard_surface name="N_surface_4" type="surfaceshader">
+    <input name="base_color" type="color3" nodename="N_swizzle" />
+  </standard_surface>
+  <surfacematerial name="N_material_4" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="N_surface_4" />
+  </surfacematerial>
+
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
+++ b/resources/Materials/TestSuite/stdlib/upgrade/syntax_1_38.mtlx
@@ -63,12 +63,20 @@
     <input name="surfaceshader" type="surfaceshader" nodename="N_surface_3" />
   </surfacematerial>
 
-  <swizzle name="N_swizzle" type="color3" nodedef="ND_swizzle_color3_color3">
-    <input name="in" type="color3" value="0.8, 0.7, 0.6" />
+  <swizzle name="N_swizzle_1" type="color3" nodedef="ND_swizzle_color3_color3">
+    <input name="in" type="color3" value="0.4, 0.5, 0.6" />
+    <input name="channels" type="string" value="bgr" />
+  </swizzle>
+  <swizzle name="N_swizzle_2" type="color4" nodedef="ND_swizzle_color3_color4">
+    <input name="in" type="color3" nodename="N_swizzle_1" />
+    <input name="channels" type="string" value="rgb1" />
+  </swizzle>
+  <swizzle name="N_swizzle_3" type="color3">
+    <input name="in" type="color4" nodename="N_swizzle_2" nodedef="ND_swizzle_color4_color3"/>
     <input name="channels" type="string" value="bgr" />
   </swizzle>
   <standard_surface name="N_surface_4" type="surfaceshader">
-    <input name="base_color" type="color3" nodename="N_swizzle" />
+    <input name="base_color" type="color3" nodename="N_swizzle_3" />
   </standard_surface>
   <surfacematerial name="N_material_4" type="material">
     <input name="surfaceshader" type="surfaceshader" nodename="N_surface_4" />

--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1191,6 +1191,7 @@ void Document::upgradeVersion()
                     {
                         // Replace swizzle with constant.
                         node->setCategory("constant");
+                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
                         string valueString = inInput->getValueString();
                         StringVec origValueTokens = splitString(valueString, ARRAY_VALID_SEPARATORS);
                         StringVec newValueTokens;
@@ -1228,6 +1229,7 @@ void Document::upgradeVersion()
                     {
                         // Replace swizzle with extract.
                         node->setCategory("extract");
+                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
                         if (!channelString.empty() && CHANNEL_INDEX_MAP.count(channelString[0]))
                         {
                             node->setInputValue("index", (int) CHANNEL_INDEX_MAP.at(channelString[0]));
@@ -1238,11 +1240,13 @@ void Document::upgradeVersion()
                     {
                         // Replace swizzle with convert.
                         node->setCategory("convert");
+                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
                     }
                     else if (sourceChannelCount == 1)
                     {
                         // Replace swizzle with combine.
                         node->setCategory("combine" + std::to_string(destChannelCount));
+                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
                         for (size_t i = 0; i < destChannelCount; i++)
                         {
                             InputPtr combineInInput = node->addInput(std::string("in") + std::to_string(i + 1), "float");
@@ -1269,6 +1273,7 @@ void Document::upgradeVersion()
                             graph->setChildIndex(separateNode->getName(), childIndex);
                         }
                         node->setCategory("combine" + std::to_string(destChannelCount));
+                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
                         for (size_t i = 0; i < destChannelCount; i++)
                         {
                             InputPtr combineInInput = node->addInput(std::string("in") + std::to_string(i + 1), "float");

--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1191,7 +1191,10 @@ void Document::upgradeVersion()
                     {
                         // Replace swizzle with constant.
                         node->setCategory("constant");
-                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+                        if (node->hasNodeDefString())
+                        {
+                            node->setNodeDefString("ND_constant_" + node->getType());
+                        }
                         string valueString = inInput->getValueString();
                         StringVec origValueTokens = splitString(valueString, ARRAY_VALID_SEPARATORS);
                         StringVec newValueTokens;
@@ -1229,7 +1232,10 @@ void Document::upgradeVersion()
                     {
                         // Replace swizzle with extract.
                         node->setCategory("extract");
-                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+                        if (node->hasNodeDefString())
+                        {
+                            node->setNodeDefString("ND_extract_" + node->getType());
+                        }
                         if (!channelString.empty() && CHANNEL_INDEX_MAP.count(channelString[0]))
                         {
                             node->setInputValue("index", (int) CHANNEL_INDEX_MAP.at(channelString[0]));
@@ -1240,13 +1246,19 @@ void Document::upgradeVersion()
                     {
                         // Replace swizzle with convert.
                         node->setCategory("convert");
-                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+                        if (node->hasNodeDefString())
+                        {
+                            node->setNodeDefString("ND_convert_" + sourceType + "_" + destType);
+                        }
                     }
                     else if (sourceChannelCount == 1)
                     {
                         // Replace swizzle with combine.
                         node->setCategory("combine" + std::to_string(destChannelCount));
-                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+                        if (node->hasNodeDefString())
+                        {
+                            node->setNodeDefString("ND_combine" + std::to_string(destChannelCount) + "_" + node->getType());
+                        }
                         for (size_t i = 0; i < destChannelCount; i++)
                         {
                             InputPtr combineInInput = node->addInput(std::string("in") + std::to_string(i + 1), "float");
@@ -1273,7 +1285,10 @@ void Document::upgradeVersion()
                             graph->setChildIndex(separateNode->getName(), childIndex);
                         }
                         node->setCategory("combine" + std::to_string(destChannelCount));
-                        node->removeAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+                        if (node->hasNodeDefString())
+                        {
+                            node->setNodeDefString("ND_combine" + std::to_string(destChannelCount) + "_" + node->getType());
+                        }
                         for (size_t i = 0; i < destChannelCount; i++)
                         {
                             InputPtr combineInInput = node->addInput(std::string("in") + std::to_string(i + 1), "float");


### PR DESCRIPTION
This changelist improves the upgrade logic for the `swizzle` node in v1.38 documents, extending support to nodes with explicit `nodedef` attributes, while maintaining support for nodes without them.

New examples of this usage have been added to the `TestSuite/stdlib/upgrade` folder for validation in unit testing.