### PR TITLE
Added `defaultgeomprop` to OSL metadata if specified for the input

### DIFF
--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -479,8 +479,9 @@ void OslShaderGenerator::emitMetadata(const ShaderPort* port, ShaderStage& stage
     auto widgetMetadataIt = UI_WIDGET_METADATA.find(port->getType());
     const ShaderMetadata* widgetMetadata = widgetMetadataIt != UI_WIDGET_METADATA.end() ? &widgetMetadataIt->second : nullptr;
     const ShaderMetadataVecPtr& metadata = port->getMetadata();
+    const string& geomprop = port->getGeomProp();
 
-    if (widgetMetadata || (metadata && metadata->size()))
+    if (widgetMetadata || (metadata && metadata->size()) || !geomprop.empty())
     {
         StringVec metadataLines;
         if (metadata)
@@ -499,9 +500,15 @@ void OslShaderGenerator::emitMetadata(const ShaderPort* port, ShaderStage& stage
         }
         if (widgetMetadata)
         {
+            const string& delim = geomprop.empty() ? EMPTY_STRING : Syntax::COMMA;
             const string& dataType = _syntax->getTypeName(widgetMetadata->type);
             const string dataValue = _syntax->getValue(widgetMetadata->type, *widgetMetadata->value, true);
-            metadataLines.push_back(dataType + " " + widgetMetadata->name + " = " + dataValue);
+            metadataLines.push_back(dataType + " " + widgetMetadata->name + " = " + dataValue + delim);
+        }
+        if (!geomprop.empty())
+        {
+            const string& dataType = _syntax->getTypeName(Type::STRING);
+            metadataLines.push_back(dataType + " defaultgeomprop = \"" + geomprop + "\"");
         }
         if (metadataLines.size())
         {


### PR DESCRIPTION
Hi, this adds the `defaultgeomprop` as metadata for GenOSL, referencing https://github.com/AcademySoftwareFoundation/MaterialX/issues/2281

I chose not to add `doc` (or `help`) metadata for this one, but that could be added also.

Cheers