### PR TITLE
Turned at() calls to operator[] where bounds checks were not necessary.

### DIFF
--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -112,7 +112,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
     {
         for (size_t j = 0; j < metadata->size(); ++j)
         {
-            const ShaderMetadata& data = metadata->at(j);
+            const ShaderMetadata& data = (*metadata)[j];
             const string& delim = (j == metadata->size() - 1) ? EMPTY_STRING : Syntax::COMMA;
             const string& dataType = _syntax->getTypeName(data.type);
             const string dataValue = _syntax->getValue(data.type, *data.value, true);
@@ -487,7 +487,7 @@ void OslShaderGenerator::emitMetadata(const ShaderPort* port, ShaderStage& stage
         {
             for (size_t j = 0; j < metadata->size(); ++j)
             {
-                const ShaderMetadata& data = metadata->at(j);
+                const ShaderMetadata& data = (*metadata)[j];
                 if (METADATA_TYPE_BLACKLIST.count(data.type) == 0)
                 {
                     const string& delim = (widgetMetadata || j < metadata->size() - 1) ? Syntax::COMMA : EMPTY_STRING;

--- a/source/MaterialXGenShader/TypeDesc.cpp
+++ b/source/MaterialXGenShader/TypeDesc.cpp
@@ -44,7 +44,7 @@ ValuePtr TypeDesc::createValueFromStrings(const string& value) const
     AggregateValuePtr result = AggregateValue::createAggregateValue(getName());
     for (size_t i = 0; i < structMembers->size(); ++i)
     {
-        result->appendValue(structMembers->at(i).getType().createValueFromStrings(subValues[i]));
+        result->appendValue((*structMembers)[i].getType().createValueFromStrings(subValues[i]));
     }
 
     return result;

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -1014,7 +1014,7 @@ const GlslProgram::InputMap& GlslProgram::updateUniformsList()
 
                                 for (size_t i = 0, n = variableStructMembers->size(); i < n; ++i)
                                 {
-                                    const auto& structMember = variableStructMembers->at(i);
+                                    const auto& structMember = (*variableStructMembers)[i];
                                     auto memberVariableName = variableName + "." + structMember.getName();
                                     auto memberVariableValue = aggregateValue->getMemberValue(i);
 

--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -1099,7 +1099,7 @@ const MslProgram::InputMap& MslProgram::updateUniformsList()
                             const auto& members = variableTypeDesc.getStructMembers();
                             for (size_t i = 0, n = members->size(); i < n; ++i)
                             {
-                                const auto& structMember = members->at(i);
+                                const auto& structMember = (*members)[i];
                                 auto memberVariableName = variableName + "." + structMember.getName();
                                 auto memberVariableValue = aggregateValue->getMemberValue(i);
 


### PR DESCRIPTION
In several places, where the variable was a pointer to `std::vector`, the code used `->at(x)` to fetch elements, most probably for the syntax convenience. However, `at()` is always bounds checked, unlike `operator[]` which is bounds checked only in debug mode. This makes `at()` slightly less efficient where performance matters, and if the bounds checking is not desired, using `(*vectorPtr)[x]` pattern makes the code slightly faster.