### PR TITLE
Fix typo in swizzle upgrade logic

### DIFF
--- a/source/MaterialXCore/Version.cpp
+++ b/source/MaterialXCore/Version.cpp
@@ -1234,7 +1234,7 @@ void Document::upgradeVersion()
                         node->setCategory("extract");
                         if (node->hasNodeDefString())
                         {
-                            node->setNodeDefString("ND_extract_" + node->getType());
+                            node->setNodeDefString("ND_extract_" + sourceType);
                         }
                         if (!channelString.empty() && CHANNEL_INDEX_MAP.count(channelString[0]))
                         {


### PR DESCRIPTION
This changelist fixes a typo in the latest updates to swizzle upgrade logic.  Thanks to Jerry Gamache for catching this issue in USD/MaterialX testing and proposing the fix.