### PR TITLE
Add support for `closest` filtering in GLSL

### DIFF
--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -61,7 +61,7 @@ bool GLTextureHandler::bindImage(ImagePtr image, const ImageSamplingProperties& 
 
     // Set up texture properties
     GLint minFilterType = mapFilterTypeToGL(samplingProperties.filterType, samplingProperties.enableMipmaps);
-    GLint magFilterType = GL_LINEAR; // Magnification filters are more restrictive than minification
+    GLint magFilterType = mapFilterTypeToGL(samplingProperties.filterType);
     GLint uaddressMode = mapAddressModeToGL(samplingProperties.uaddressMode);
     GLint vaddressMode = mapAddressModeToGL(samplingProperties.vaddressMode);
     Color4 borderColor(samplingProperties.defaultColor);

--- a/source/MaterialXRenderGlsl/GLTextureHandler.h
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.h
@@ -50,7 +50,7 @@ class MX_RENDERGLSL_API GLTextureHandler : public ImageHandler
     static int mapAddressModeToGL(ImageSamplingProperties::AddressMode addressModeEnum);
 
     /// Utility to map a filter type enumeration to an OpenGL filter type
-    static int mapFilterTypeToGL(ImageSamplingProperties::FilterType filterTypeEnum, bool enableMipmaps);
+    static int mapFilterTypeToGL(ImageSamplingProperties::FilterType filterTypeEnum, bool enableMipmaps = false);
 
     /// Utility to map generic texture properties to OpenGL texture formats.
     static void mapTextureFormatToGL(Image::BaseType baseType, unsigned int channelCount, bool srgb,


### PR DESCRIPTION
This changelist adds support for the `closest` filter type in GLSL rendering, allowing it to correctly affect the magnification filtering of textures.