### PR TITLE
Fix division by singular matrices in test suite

### DIFF
--- a/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
@@ -701,7 +701,7 @@
   </nodegraph>
   <nodegraph name="divide_matrix33">
     <divide name="divide1" type="matrix33">
-      <input name="in1" type="matrix33" value="1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0" />
+      <input name="in1" type="matrix33" value="1.5, 1.5, 0.0,  0.0, 1.5, 1.5,  0.0, 0.0, 1.0" />
       <input name="in2" type="matrix33" value="1.0, 1.0, 1.0,  1.0, 1.0, 1.0,  1.0, 1.0, 1.0" />
     </divide>
     <transformmatrix name="transformmatrix1" type="vector3">
@@ -712,8 +712,8 @@
   </nodegraph>
   <nodegraph name="divide_matrix44">
     <divide name="divide1" type="matrix44">
-      <input name="in1" type="matrix44" value="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
-      <input name="in2" type="matrix44" value="1.0, 1.0, 1.0, 1.0,  1.0, 1.0, 1.0, 1.0,  1.0, 1.0, 1.0, 1.0,  1.0, 1.0, 1.0, 1.0" />
+      <input name="in1" type="matrix44" value="1.5, 1.5, 0.0, 0.0,  0.0, 1.5, 1.5, 0.0,  0.0, 0.0, 1.5, 1.5,  0.0, 0.0, 0.0, 1.0" />
+      <input name="in2" type="matrix44" value="1.0, 1.0, 0.0, 0.0,  0.0, 1.0, 1.0, 0.0,  0.0, 0.0, 1.0, 1.0,  0.0, 0.0, 0.0, 1.0" />
     </divide>
     <transformmatrix name="transformmatrix1" type="vector4">
       <input name="in" type="vector4" value="0.5, 0.5, 0.5, 1.0" />


### PR DESCRIPTION
The matrix division unit test uses a singular matrix as a divisor.
This change instead does matrix divison that will result is matrix with 1.5, 1.5, 1.5, 1.0 on the diagonal.

This in isolation will make the GLSL test produce NaNs, because of the issue #2089 , so merging PR #2298 first is highly recommended.