### PR TITLE
Remove unnecessary includes in TextureBaker implementations

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.cpp
+++ b/source/MaterialXRenderGlsl/TextureBaker.cpp
@@ -5,14 +5,6 @@
 
 #include <MaterialXRenderGlsl/TextureBaker.h>
 
-#include <MaterialXRender/OiioImageLoader.h>
-#include <MaterialXRender/StbImageLoader.h>
-#include <MaterialXRender/Util.h>
-
-#include <MaterialXGenShader/DefaultColorManagementSystem.h>
-
-#include <MaterialXFormat/XmlIo.h>
-
 MATERIALX_NAMESPACE_BEGIN
 TextureBakerGlsl::TextureBakerGlsl(unsigned int width, unsigned int height, Image::BaseType baseType) :
     TextureBaker<GlslRenderer, GlslShaderGenerator>(width, height, baseType, true)

--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -9,15 +9,11 @@
 /// @file
 /// Texture baking functionality
 
-#include <iostream>
-
-#include <MaterialXCore/Unit.h>
 #include <MaterialXRender/TextureBaker.h>
 
 #include <MaterialXRenderGlsl/Export.h>
 
 #include <MaterialXRenderGlsl/GlslRenderer.h>
-#include <MaterialXRenderGlsl/GLTextureHandler.h>
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXRenderMsl/TextureBaker.h
+++ b/source/MaterialXRenderMsl/TextureBaker.h
@@ -9,17 +9,11 @@
 /// @file
 /// Texture baking functionality
 
-#include <iostream>
-
-#include <MaterialXCore/Unit.h>
-
 #include <MaterialXRender/TextureBaker.h>
 
 #include <MaterialXRenderMsl/Export.h>
 
 #include <MaterialXRenderMsl/MslRenderer.h>
-#include <MaterialXRenderMsl/MetalTextureHandler.h>
-
 #include <MaterialXGenMsl/MslShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXRenderMsl/TextureBaker.mm
+++ b/source/MaterialXRenderMsl/TextureBaker.mm
@@ -5,14 +5,6 @@
 
 #include <MaterialXRenderMsl/TextureBaker.h>
 
-#include <MaterialXRender/OiioImageLoader.h>
-#include <MaterialXRender/StbImageLoader.h>
-#include <MaterialXRender/Util.h>
-
-#include <MaterialXGenShader/DefaultColorManagementSystem.h>
-
-#include <MaterialXFormat/XmlIo.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 TextureBakerMsl::TextureBakerMsl(unsigned int width, unsigned int height, Image::BaseType baseType) :


### PR DESCRIPTION
GLSL and Msl TextureBaker implementations are including files that are not necessary.