### PR TITLE
Dev/tdavidovic/remove texture baker ptr

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -23,7 +23,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// A shared pointer to a TextureBaker
-using TextureBakerPtr = shared_ptr<class TextureBakerGlsl>;
+using TextureBakerGlslPtr = shared_ptr<class TextureBakerGlsl>;
 
 /// A vector of baked documents with their associated names.
 using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
@@ -33,9 +33,9 @@ using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
 class MX_RENDERGLSL_API TextureBakerGlsl : public TextureBaker<GlslRenderer, GlslShaderGenerator>
 {
   public:
-    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
+    static TextureBakerGlslPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
     {
-        return TextureBakerPtr(new TextureBakerGlsl(width, height, baseType));
+        return TextureBakerGlslPtr(new TextureBakerGlsl(width, height, baseType));
     }
 
     TextureBakerGlsl(unsigned int width, unsigned int height, Image::BaseType baseType);

--- a/source/MaterialXRenderMsl/TextureBaker.h
+++ b/source/MaterialXRenderMsl/TextureBaker.h
@@ -25,7 +25,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// A shared pointer to a TextureBakerMsl
-using TextureBakerPtr = shared_ptr<class TextureBakerMsl>;
+using TextureBakerMslPtr = shared_ptr<class TextureBakerMsl>;
 
 /// A vector of baked documents with their associated names.
 using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
@@ -37,9 +37,9 @@ using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
 class MX_RENDERMSL_API TextureBakerMsl : public TextureBaker<MslRenderer, MslShaderGenerator>
 {
   public:
-    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
+    static TextureBakerMslPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
     {
-        return TextureBakerPtr(new TextureBakerMsl(width, height, baseType));
+        return TextureBakerMslPtr(new TextureBakerMsl(width, height, baseType));
     }
 
   protected:

--- a/source/MaterialXView/RenderPipeline.h
+++ b/source/MaterialXView/RenderPipeline.h
@@ -18,14 +18,6 @@
 #include <MaterialXCore/Value.h>
 #include <MaterialXCore/Unit.h>
 
-MATERIALX_NAMESPACE_BEGIN
-#ifdef MATERIALXVIEW_METAL_BACKEND
-using TextureBakerPtr = shared_ptr<class TextureBakerMsl>;
-#else
-using TextureBakerPtr = shared_ptr<class TextureBakerGlsl>;
-#endif
-MATERIALX_NAMESPACE_END
-
 #include <memory>
 
 namespace mx = MaterialX;

--- a/source/MaterialXView/RenderPipelineGL.cpp
+++ b/source/MaterialXView/RenderPipelineGL.cpp
@@ -491,7 +491,7 @@ void GLRenderPipeline::bakeTextures()
         // Construct a texture baker.
         mx::Image::BaseType baseType = _viewer->_bakeHdr ? mx::Image::BaseType::FLOAT : mx::Image::BaseType::UINT8;
         mx::UnsignedIntPair bakingRes = _viewer->computeBakingResolution(doc);
-        mx::TextureBakerPtr baker = std::static_pointer_cast<mx::TextureBakerPtr::element_type>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
+        mx::TextureBakerGlslPtr baker = std::static_pointer_cast<mx::TextureBakerGlsl>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
         baker->setupUnitSystem(_viewer->_stdLib);
         baker->setDistanceUnit(_viewer->_genContext.getOptions().targetDistanceUnit);
         baker->setAverageImages(_viewer->_bakeAverage);

--- a/source/MaterialXView/RenderPipelineMetal.mm
+++ b/source/MaterialXView/RenderPipelineMetal.mm
@@ -664,7 +664,7 @@ void MetalRenderPipeline::bakeTextures()
         // Construct a texture baker.
         mx::Image::BaseType baseType = _viewer->_bakeHdr ? mx::Image::BaseType::FLOAT : mx::Image::BaseType::UINT8;
         mx::UnsignedIntPair bakingRes = _viewer->computeBakingResolution(doc);
-        mx::TextureBakerPtr baker = std::static_pointer_cast<mx::TextureBakerPtr::element_type>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
+        mx::TextureBakerMslPtr baker = std::static_pointer_cast<TextureBakerMsl>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
         baker->setupUnitSystem(_viewer->_stdLib);
         baker->setDistanceUnit(_viewer->_genContext.getOptions().targetDistanceUnit);
         baker->setAverageImages(_viewer->_bakeAverage);

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
@@ -13,7 +13,7 @@ namespace mx = MaterialX;
 
 void bindPyTextureBaker(py::module& mod)
 {
-    py::class_<mx::TextureBakerGlsl, mx::GlslRenderer, mx::TextureBakerPtr>(mod, "TextureBaker")
+    py::class_<mx::TextureBakerGlsl, mx::GlslRenderer, mx::TextureBakerGlslPtr>(mod, "TextureBaker")
         .def_static("create", &mx::TextureBakerGlsl::create)
         .def("setExtension", &mx::TextureBakerGlsl::setExtension)
         .def("getExtension", &mx::TextureBakerGlsl::getExtension)

--- a/source/PyMaterialX/PyMaterialXRenderMsl/PyTextureBaker.mm
+++ b/source/PyMaterialX/PyMaterialXRenderMsl/PyTextureBaker.mm
@@ -13,7 +13,7 @@ namespace mx = MaterialX;
 
 void bindPyTextureBaker(py::module& mod)
 {
-    py::class_<mx::TextureBakerMsl, mx::MslRenderer, mx::TextureBakerPtr>(mod, "TextureBaker")
+    py::class_<mx::TextureBakerMsl, mx::MslRenderer, mx::TextureBakerMslPtr>(mod, "TextureBaker")
         .def_static("create", &mx::TextureBakerMsl::create)
         .def("setExtension", &mx::TextureBakerMsl::setExtension)
         .def("getExtension", &mx::TextureBakerMsl::getExtension)


### PR DESCRIPTION
The TextureBakerPtr defined in RenderPipeline.h isn't actually used in any place where a more concrete type of TextureBaker wouldn't be known. It seems like it was intended, or originally used, as the return type from `RenderPipeline::createTextureBaker` which is now using a full type erasure by returning a void pointer.

As such, a generic type whose actual type depends on compiler switches isn't really needed, and explicit types of `TextureBakerGlslPtr` and `TextureBakerMslPtr` seem clearer.