### PR TITLE
Update width and height consistently in MslRenderer::setSize

### DIFF
--- a/source/MaterialXRenderMsl/MslRenderer.mm
+++ b/source/MaterialXRenderMsl/MslRenderer.mm
@@ -139,14 +139,14 @@ void MslRenderer::createFrameBuffer(bool encodeSrgb)
 
 void MslRenderer::setSize(unsigned int width, unsigned int height)
 {
+    _width = width;
+    _height = height;
     if (_framebuffer)
     {
         _framebuffer->resize(width, height);
     }
     else
     {
-        _width = width;
-        _height = height;
         createFrameBuffer(true);
     }
 }


### PR DESCRIPTION
In the `MslRenderer::setSize`, if the `_framebuffer` already existed, the `_width` and `_height` haven't been updated.