### PR TITLE
Remove redundant clearInputLists in MslProgram::setStages

### DIFF
--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -66,9 +66,6 @@ void MslProgram::setStages(ShaderPtr shader)
         const ShaderStage& stage = shader->getStage(i);
         addStage(stage.getName(), stage.getSourceCode());
     }
-
-    // A stage change invalidates any cached parsed inputs
-    clearInputLists();
 }
 
 void MslProgram::addStage(const string& stage, const string& sourceCode)


### PR DESCRIPTION
`clearInputLists();` called explicitly in `MslProgram::setStages` is already part of `clearStages();` called at the start of the method.