### PR TITLE
Refine matrix multiplication tests to enable validation

### DIFF
--- a/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
@@ -679,8 +679,8 @@
   </nodegraph>
   <nodegraph name="multiply_matrix33">
     <multiply name="multiply1" type="matrix33">
-      <input name="in1" type="matrix33" value="1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0" />
-      <input name="in2" type="matrix33" value="1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0" />
+      <input name="in1" type="matrix33" value="0.0, 1.5, 0.0,  0.5, 0.0, 0.0,  0.0, 0.0, 1.0" />
+      <input name="in2" type="matrix33" value="0.0, 1.0, 0.0,  1.0, 0.0, 0.0,  0.0, 0.0, 1.0" />
     </multiply>
     <transformmatrix name="transformmatrix1" type="vector3">
       <input name="in" type="vector3" value="0.5, 0.5, 0.5" />
@@ -690,8 +690,8 @@
   </nodegraph>
   <nodegraph name="multiply_matrix44">
     <multiply name="multiply1" type="matrix44">
-      <input name="in1" type="matrix44" value="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
-      <input name="in2" type="matrix44" value="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
+      <input name="in1" type="matrix44" value="0.0, 1.5, 0.0, 0.0,  0.5, 0.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
+      <input name="in2" type="matrix44" value="0.0, 1.0, 0.0, 0.0,  1.0, 0.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
     </multiply>
     <transformmatrix name="transformmatrix1" type="vector4">
       <input name="in" type="vector4" value="0.5, 0.5, 0.5, 1.0" />


### PR DESCRIPTION
The `math_operators.mtlx` test for matrix multiplication was multiplying just identity matrices. If actually ran to produce an image, it would not show an error in matrices having swapped arguments.

In this PR I've changed the values so the result is `0.75, 0.25, 0.5, 1` when multiplies correctly, and `0.25, 0.75, 0.5, 1` when swapped.

I ran the tests with this `<input name="renderTestPaths" type="string" value="resources/Materials/TestSuite/stdlib/math" />`, before after the fix introduced in #2298.

Original values, before fix:
![image](https://github.com/user-attachments/assets/5e8d5f54-7726-42fc-a0f0-3d1235d39649)
Original values, after fix:
![image](https://github.com/user-attachments/assets/10415903-823a-4005-91c1-0d196c1fa1bb)

Updated values, before fix:
![image](https://github.com/user-attachments/assets/fc958781-1721-4f6a-8beb-058a30023dad)
Updated values, after fix:
![image](https://github.com/user-attachments/assets/18d46655-5e6c-40a6-be6b-8d0a22cd6fbe)

The test now can be used to actually verify the calculated value (and shows that the fix in #2298 does indeed bring GLSL matrix multiplication in line with OSL)
