### PR TITLE
Add Graph Editor info to Developer Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ MaterialX is an open standard for representing rich material and look-developmen
 - Download the latest version of the [CMake](https://cmake.org/) build system.
 - Point CMake to the root of the MaterialX library and generate C++ projects for your platform and compiler.
 - Select the `MATERIALX_BUILD_PYTHON` option to build Python bindings.
-- Select the `MATERIALX_BUILD_VIEWER` option to build the MaterialX viewer.
+- Select the `MATERIALX_BUILD_VIEWER` option to build the [MaterialX viewer](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/Viewer.md).
+- Select the `MATERIALX_BUILD_GRAPH_EDITOR` option to build the [MaterialX graph editor](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/GraphEditor.md). 
 
 ## Supported Platforms
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ MaterialX is an open standard for representing rich material and look-developmen
 - Download the latest version of the [CMake](https://cmake.org/) build system.
 - Point CMake to the root of the MaterialX library and generate C++ projects for your platform and compiler.
 - Select the `MATERIALX_BUILD_PYTHON` option to build Python bindings.
-- Select the `MATERIALX_BUILD_VIEWER` option to build the [MaterialX viewer](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/Viewer.md).
-- Select the `MATERIALX_BUILD_GRAPH_EDITOR` option to build the [MaterialX graph editor](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/GraphEditor.md). 
+- Select the `MATERIALX_BUILD_VIEWER` option to build the [MaterialX Viewer](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/Viewer.md).
+- Select the `MATERIALX_BUILD_GRAPH_EDITOR` option to build the [MaterialX Graph Editor](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/DeveloperGuide/GraphEditor.md). 
 
 ## Supported Platforms
 


### PR DESCRIPTION
Explicitly mention how to build the Graph Editor; it's included with the compiled binary, and I think it's fair to assume newcomers will not know to look for it but would appreciate knowing of its existence upfront.