### PR TITLE
Update values in example materials

### DIFF
--- a/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/math_operators.mtlx
@@ -702,7 +702,7 @@
   <nodegraph name="divide_matrix33">
     <divide name="divide1" type="matrix33">
       <input name="in1" type="matrix33" value="1.5, 1.5, 0.0,  0.0, 1.5, 1.5,  0.0, 0.0, 1.0" />
-      <input name="in2" type="matrix33" value="1.0, 1.0, 1.0,  1.0, 1.0, 1.0,  1.0, 1.0, 1.0" />
+      <input name="in2" type="matrix33" value="1.0, 1.0, 0.0,  0.0, 1.0, 1.0,  0.0, 0.0, 1.0" />
     </divide>
     <transformmatrix name="transformmatrix1" type="vector3">
       <input name="in" type="vector3" value="0.5, 0.5, 0.5" />

--- a/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
@@ -71,7 +71,7 @@
     <output name="out" type="vector2" nodename="rotate1" />
     <rotate2d name="rotate1" type="vector2">
       <input name="in" type="vector2" nodename="combine1" />
-      <input name="amount" type="float" value="1.5708" unittype="angle" unit="radian" />
+      <input name="amount" type="float" value="2.356" unittype="angle" unit="radian" />
     </rotate2d>
     <separate3 name="separate" type="multioutput">
       <input name="in" type="vector3" nodename="position1" />
@@ -87,7 +87,7 @@
     </position>
     <rotate3d name="rotate1" type="vector3">
       <input name="in" type="vector3" nodename="position1" />
-      <input name="amount" type="float" value="180.0000" unittype="angle" unit="degree" />
+      <input name="amount" type="float" value="135.0000" unittype="angle" unit="degree" />
       <input name="axis" type="vector3" value="0.0, 1.0000, 1.0000" />
     </rotate3d>
     <output name="out" type="vector3" nodename="rotate1" />


### PR DESCRIPTION
Fixes:
* In the division matrix33 test, the divisor was still a singular matrix, now it is aligned with matrix44.
* In rotate3d, the rotation was 180 degrees which, if used as an actual test, would miss transposed rotation matrices. The rotation is now 135 degrees to clearly separate the left and right rotation.
* In rotate2d, the rotation was 90 degrees, and it was updated to 135 degrees (3/4 PI) to also avoid missing possible bugs in rotation matrix.

This set of changes makes running tests on all of `resources/Materials` more useful.