### PR TITLE
Release all images in `MetalTextureHandler::releaseRenderResources`

### DIFF
--- a/source/MaterialXRenderMsl/MetalTextureHandler.h
+++ b/source/MaterialXRenderMsl/MetalTextureHandler.h
@@ -89,7 +89,7 @@ class MX_RENDERMSL_API MetalTextureHandler : public ImageHandler
     std::vector<unsigned int> _boundTextureLocations;
 
     std::unordered_map<unsigned int, id<MTLTexture>> _metalTextureMap;
-    std::unordered_map<unsigned int, std::pair<ImagePtr, ImageSamplingProperties>> _imageBindingInfo;
+    std::unordered_map<unsigned int, ImageSamplingProperties> _imageBindingInfo;
     std::unordered_map<ImageSamplingProperties, id<MTLSamplerState>, ImageSamplingKeyHasher> _imageSamplerStateMap;
 
     id<MTLDevice> _device = nil;

--- a/source/MaterialXRenderMsl/MetalTextureHandler.mm
+++ b/source/MaterialXRenderMsl/MetalTextureHandler.mm
@@ -281,7 +281,16 @@ bool MetalTextureHandler::createRenderResources(ImagePtr image, bool generateMip
 void MetalTextureHandler::releaseRenderResources(ImagePtr image)
 {
     if (!image)
+    {
+        for (auto iter : _imageCache)
+        {
+            if (iter.second)
+            {
+                releaseRenderResources(iter.second);
+            }
+        }
         return;
+    }
 
     if (image->getResourceId() == MslProgram::UNDEFINED_METAL_RESOURCE_ID)
     {

--- a/source/MaterialXRenderMsl/MetalTextureHandler.mm
+++ b/source/MaterialXRenderMsl/MetalTextureHandler.mm
@@ -29,7 +29,7 @@ bool MetalTextureHandler::bindImage(ImagePtr image, const ImageSamplingPropertie
             return false;
         }
     }
-    _imageBindingInfo[image->getResourceId()] = std::make_pair(image, samplingProperties);
+    _imageBindingInfo[image->getResourceId()] = samplingProperties;
     return true;
 }
 
@@ -72,7 +72,7 @@ bool MetalTextureHandler::bindImage(id<MTLRenderCommandEncoder> renderCmdEncoder
     _boundTextureLocations[textureUnit] = image->getResourceId();
 
     [renderCmdEncoder setFragmentTexture:_metalTextureMap[image->getResourceId()] atIndex:textureUnit];
-    [renderCmdEncoder setFragmentSamplerState:getSamplerState(_imageBindingInfo[image->getResourceId()].second) atIndex:textureUnit];
+    [renderCmdEncoder setFragmentSamplerState:getSamplerState(_imageBindingInfo[image->getResourceId()]) atIndex:textureUnit];
 
     return true;
 }
@@ -90,15 +90,10 @@ id<MTLTexture> MetalTextureHandler::getAssociatedMetalTexture(ImagePtr image)
 
 id<MTLTexture> MetalTextureHandler::getMTLTextureForImage(unsigned int index) const
 {
-    auto imageInfo = _imageBindingInfo.find(index);
-    if (imageInfo != _imageBindingInfo.end())
+    auto metalTexture = _metalTextureMap.find(index);
+    if (metalTexture != _metalTextureMap.end())
     {
-        if (!imageInfo->second.first)
-            return nil;
-
-        auto metalTexture = _metalTextureMap.find(imageInfo->second.first->getResourceId());
-        if (metalTexture != _metalTextureMap.end())
-            return metalTexture->second;
+        return metalTexture->second;
     }
 
     return nil;
@@ -109,7 +104,7 @@ id<MTLSamplerState> MetalTextureHandler::getMTLSamplerStateForImage(unsigned int
     auto imageInfo = _imageBindingInfo.find(index);
     if (imageInfo != _imageBindingInfo.end())
     {
-        return getSamplerState(imageInfo->second.second);
+        return getSamplerState(imageInfo->second);
     }
     return nil;
 }


### PR DESCRIPTION
This PR addresses #2303.

This brings the MetalTextureHandler inline with the GLTextureHandler for releasing all the images when `nullptr` is passed.

Without this - both CPU and Metal texture memory is being leaked if the image caches are flushed.  

Recursively releasing the resources fixes the Metal texture memory leak, but that just highlighted the CPU side memory leak.  This is due to the MetalTextureHandler also retaining an `ImagePtr` in `_imageBindingInfo`.  Removing the `ImagePtr` from this storage fixes the memory leak, and it doesn't seem to be necessary to store the image, the only thing the image is used for is to access the resource ID - which is the same as the key to the `unordered_map`. 