### PR TITLE
Optimization to `MslProgram::updateAttributeList`

### DIFF
--- a/source/MaterialXRenderMsl/MslPipelineStateObject.h
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.h
@@ -293,9 +293,10 @@ class MX_RENDERMSL_API MslProgram
     // List of program input uniforms
     InputMap _uniformList;
     std::unordered_map<std::string, std::string> _globalUniformNameList;
+
     // List of program input attributes
-    bool _attributeListComplete{false};
     InputMap _attributeList;
+    bool _attributeListComplete = false;
 
     std::unordered_map<std::string, ImagePtr> _explicitBoundImages;
 

--- a/source/MaterialXRenderMsl/MslPipelineStateObject.h
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.h
@@ -294,6 +294,7 @@ class MX_RENDERMSL_API MslProgram
     InputMap _uniformList;
     std::unordered_map<std::string, std::string> _globalUniformNameList;
     // List of program input attributes
+    bool _attributeListComplete{false};
     InputMap _attributeList;
 
     std::unordered_map<std::string, ImagePtr> _explicitBoundImages;

--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -298,6 +298,8 @@ id<MTLRenderPipelineState> MslProgram::build(id<MTLDevice> device, MetalFramebuf
         throw ExceptionRenderError(errorType, errors);
     }
 
+    _attributeListComplete = false;
+
     // If we encountered any errors while trying to create return list
     // of all errors. That is we collect all errors per stage plus any
     // errors during linking and throw one exception for them all so that
@@ -1515,6 +1517,11 @@ const MslProgram::InputMap& MslProgram::updateAttributesList()
         throw ExceptionRenderError(errorType, errors);
     }
 
+    if (_attributeListComplete)
+    {
+        return _attributeList;
+    }
+
     if (_shader)
     {
         const ShaderStage& vs = _shader->getStage(Stage::VERTEX);
@@ -1555,6 +1562,8 @@ const MslProgram::InputMap& MslProgram::updateAttributesList()
                 }
             }
         }
+
+        _attributeListComplete = true;
 
         // Throw an error if any type mismatches were found
         if (uniformTypeMismatchFound)


### PR DESCRIPTION
This PR addresses #2309

introduce guard to avoid repeatedly setting the value and type string for the `_attributeList`.