### PR TITLE
Update deploy action in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,7 +337,7 @@ jobs:
 
     - name: Deploy Web Viewer
       if: github.event_name != 'pull_request'
-      uses: JamesIves/github-pages-deploy-action@v4.6.4
+      uses: JamesIves/github-pages-deploy-action@v4.7.3
       with:
         branch: gh-pages
         folder: javascript/MaterialXView/dist


### PR DESCRIPTION
This changelist updates the web deploy action in GitHub CI to to v4.7.3, the latest version.