### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -32,7 +32,7 @@ class Document::Cache
         valid(false)
     {
     }
-    ~Cache() { }
+    ~Cache() = default;
 
     void refresh()
     {

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -933,7 +933,7 @@ template <class T> class ElementRegistry
     {
         Element::_creatorMap[T::CATEGORY] = Element::createElement<T>;
     }
-    ~ElementRegistry() { }
+    ~ElementRegistry() = default;
 };
 
 //

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -1366,7 +1366,7 @@ class MX_CORE_API ElementEquivalenceOptions
         floatPrecision = Value::getFloatPrecision();
         attributeExclusionList = {};
     };
-    ~ElementEquivalenceOptions() { }
+    ~ElementEquivalenceOptions() = default;
 
     /// Perform value comparisons as opposed to literal string comparisons.
     /// Default is true.

--- a/source/MaterialXCore/Geom.h
+++ b/source/MaterialXCore/Geom.h
@@ -64,7 +64,7 @@ class MX_CORE_API GeomPath
         _empty(true)
     {
     }
-    ~GeomPath() { }
+    ~GeomPath() = default;
 
     bool operator==(const GeomPath& rhs) const
     {

--- a/source/MaterialXCore/Traversal.h
+++ b/source/MaterialXCore/Traversal.h
@@ -35,7 +35,7 @@ class MX_CORE_API Edge
         _elemUp(elemUp)
     {
     }
-    ~Edge() { }
+    ~Edge() = default;
 
     bool operator==(const Edge& rhs) const
     {
@@ -94,7 +94,7 @@ class MX_CORE_API TreeIterator
         _holdCount(0)
     {
     }
-    ~TreeIterator() { }
+    ~TreeIterator() = default;
 
   private:
     using StackFrame = std::pair<ElementPtr, size_t>;
@@ -198,7 +198,7 @@ class MX_CORE_API GraphIterator
     {
         _pathElems.insert(elem);
     }
-    ~GraphIterator() { }
+    ~GraphIterator() = default;
 
   private:
     using ElementSet = std::set<ElementPtr>;
@@ -341,7 +341,7 @@ class MX_CORE_API InheritanceIterator
     {
         _pathElems.insert(elem);
     }
-    ~InheritanceIterator() { }
+    ~InheritanceIterator() = default;
 
   private:
     using ConstElementSet = std::set<ConstElementPtr>;

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -421,7 +421,7 @@ template <class T> class ValueRegistry
             Value::_creatorMap[TypedValue<T>::TYPE] = TypedValue<T>::createFromString;
         }
     }
-    ~ValueRegistry() { }
+    ~ValueRegistry() = default;
 };
 
 //

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -49,7 +49,7 @@ class MX_FORMAT_API FilePath
         _type(TypeRelative)
     {
     }
-    ~FilePath() { }
+    ~FilePath() = default;
 
     bool operator==(const FilePath& rhs) const
     {

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -35,7 +35,7 @@ class MX_FORMAT_API XmlReadOptions
 {
   public:
     XmlReadOptions();
-    ~XmlReadOptions() { }
+    ~XmlReadOptions() = default;
 
     /// If true, then XML comments will be read into documents as comment elements.
     /// Defaults to false.
@@ -64,7 +64,7 @@ class MX_FORMAT_API XmlWriteOptions
 {
   public:
     XmlWriteOptions();
-    ~XmlWriteOptions() { }
+    ~XmlWriteOptions() = default;
 
     /// If true, elements with source file markings will be written as
     /// XIncludes rather than explicit data.  Defaults to true.

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.h
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.h
@@ -29,7 +29,7 @@ class MX_GENSHADER_API SourceCodeNode : public ShaderNodeImpl
     /// Resolve the source file and read the source code during the initialization of the node.
     virtual void resolveSourceCode(const InterfaceElement& element, GenContext& context);
 
-    bool _inlined;
+    bool _inlined = false;
     string _functionName;
     string _functionSource;
     FilePath _sourceFilename;

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -235,7 +235,7 @@ class MX_GENSHADER_API ShaderGraphEdgeIterator
 {
   public:
     ShaderGraphEdgeIterator(ShaderOutput* output);
-    ~ShaderGraphEdgeIterator() { }
+    ~ShaderGraphEdgeIterator() = default;
 
     bool operator==(const ShaderGraphEdgeIterator& rhs) const
     {

--- a/source/MaterialXGenShader/ShaderTranslator.h
+++ b/source/MaterialXGenShader/ShaderTranslator.h
@@ -34,7 +34,7 @@ class MX_GENSHADER_API ShaderTranslator
     void translateAllMaterials(DocumentPtr doc, const string& destShader);
 
   protected:
-    ShaderTranslator() { }
+    ShaderTranslator() = default;
 
     // Connect translation node inputs from the original shader
     void connectTranslationInputs(NodePtr shader, NodeDefPtr translationNodeDef);

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -61,6 +61,7 @@ class Graph
           const mx::FilePathVec& libraryFolders,
           int viewWidth,
           int viewHeight);
+    ~Graph() = default;
 
     mx::DocumentPtr loadDocument(const mx::FilePath& filename);
     void drawGraph(ImVec2 mousePos);
@@ -74,8 +75,6 @@ class Graph
     {
         _fontScale = val;
     }
-
-    ~Graph(){};
 
   private:
     mx::ElementPredicate getElementPredicate() const;

--- a/source/MaterialXGraphEditor/RenderView.h
+++ b/source/MaterialXGraphEditor/RenderView.h
@@ -35,7 +35,7 @@ class RenderView
                const mx::FileSearchPath& searchPath,
                int viewWidth,
                int viewHeight);
-    ~RenderView() { }
+    ~RenderView() = default;
 
     // Initialize the viewer for rendering.
     void initialize();

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -150,7 +150,7 @@ class UiNode
   public:
     UiNode();
     UiNode(const std::string& name, int id);
-    ~UiNode(){};
+    ~UiNode() = default;
 
     std::string getName()
     {

--- a/source/MaterialXRender/Camera.h
+++ b/source/MaterialXRender/Camera.h
@@ -29,7 +29,7 @@ class MX_RENDER_API Camera
         _arcballSpeed(2.0f)
     {
     }
-    ~Camera() { }
+    ~Camera() = default;
 
     /// Create a new camera.
     static CameraPtr create() { return std::make_shared<Camera>(); }

--- a/source/MaterialXRender/Mesh.h
+++ b/source/MaterialXRender/Mesh.h
@@ -51,7 +51,7 @@ class MX_RENDER_API MeshStream
         _stride(DEFAULT_STRIDE)
     {
     }
-    ~MeshStream() { }
+    ~MeshStream() = default;
 
     /// Create a new mesh stream
     static MeshStreamPtr create(const string& name, const string& type, unsigned int index = 0)
@@ -155,7 +155,7 @@ class MX_RENDER_API MeshPartition
         _faceCount(0)
     {
     }
-    ~MeshPartition() { }
+    ~MeshPartition() = default;
 
     /// Create a new mesh partition
     static MeshPartitionPtr create()
@@ -241,7 +241,7 @@ class MX_RENDER_API Mesh
 {
   public:
     Mesh(const string& name);
-    ~Mesh() { }
+    ~Mesh() = default;
 
     /// Create a new mesh
     static MeshPtr create(const string& name)


### PR DESCRIPTION
This changelist addresses two static analysis warnings flagged by PVS-Studio:

- Favor defaulted destructors over explicit empty destructors for performance.
- Add a missing initializer for the _inlined member of SourceCodeNode.