### PR TITLE
Add TSC stakeholder

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -72,6 +72,7 @@ The current Stakeholders of the MaterialX TSC are:
 - Bernard Kwok - Khronos Group
 - André Mazzone - ILM
 - Magnus Pettersson - IKEA
+- Dimitar Toshev - Chaos
 
 ### TSC Nomination and Succession
 


### PR DESCRIPTION
This changelist adds Dimitar Toshev as the Chaos stakeholder on the MaterialX TSC, as confirmed by vote at a recent TSC meeting.