### PR TITLE
Raise minimum Python version to 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: Linux_GCC_10_Python37
+        - name: Linux_GCC_10_Python39
           os: ubuntu-22.04
           compiler: gcc
           compiler_version: "10"
-          python: 3.7
+          python: 3.9
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON -DMATERIALX_BUILD_MONOLITHIC=ON
 
         - name: Linux_GCC_14_Python312
@@ -46,11 +46,11 @@ jobs:
           coverage_analysis: ON
           cmake_config: -DMATERIALX_COVERAGE_ANALYSIS=ON -DMATERIALX_BUILD_RENDER=OFF -DMATERIALX_BUILD_PYTHON=OFF
 
-        - name: Linux_Clang_13_Python37
+        - name: Linux_Clang_13_Python39
           os: ubuntu-22.04
           compiler: clang
           compiler_version: "13"
-          python: 3.7
+          python: 3.9
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
         - name: Linux_Clang_18_Python313
@@ -97,18 +97,11 @@ jobs:
           python: None
           cmake_config: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=`xcrun --sdk iphoneos --show-sdk-path` -DCMAKE_OSX_ARCHITECTURES=arm64
 
-        - name: Windows_VS2019_Win32_Python37
+        - name: Windows_VS2019_Win32_Python39
           os: windows-2019
           architecture: x86
-          python: 3.7
-          cmake_config: -G "Visual Studio 16 2019" -A "Win32" -DMATERIALX_BUILD_SHARED_LIBS=ON
-
-        - name: Windows_VS2022_x64_Python312
-          os: windows-2022
-          architecture: x64
-          python: 3.12
-          cmake_config: -G "Visual Studio 17 2022" -A "x64"
-          upload_shaders: ON
+          python: 3.9
+          cmake_config: -G "Visual Studio 16 2019" -A "Win32"
 
         - name: Windows_VS2022_x64_Python313
           os: windows-2025
@@ -116,6 +109,13 @@ jobs:
           python: 3.13
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           test_shaders: ON
+
+        - name: Windows_VS2022_x64_SharedLibs
+          os: windows-2025
+          architecture: x64
+          python: None
+          cmake_config: -G "Visual Studio 17 2022" -A "x64" -DMATERIALX_BUILD_SHARED_LIBS=ON
+          upload_shaders: ON
 
     steps:
     - name: Sync Repository
@@ -282,7 +282,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: matrix.upload_shaders == 'ON'
       with:
-        name: Reference_Shaders_${{ matrix.name }}
+        name: MaterialX_ReferenceShaders
         path: build/bin/reference/
 
     - name: Upload Renders
@@ -356,7 +356,7 @@ jobs:
 
   sdist:
     name: Python SDist
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'AcademySoftwareFoundation/MaterialX'
     outputs:
       sdist_filename: ${{ steps.generate.outputs.filename }}
@@ -391,8 +391,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-minor: ['7', '8', '9', '10', '11', '12']
-        os: ['ubuntu-22.04', 'windows-2022', 'macos-14-large']
+        python-minor: ['9', '10', '11', '12']
+        os: ['ubuntu-24.04', 'windows-2022', 'macos-15']
 
     steps:
     - name: Sync Repository
@@ -429,7 +429,7 @@ jobs:
         CIBW_BUILD_VERBOSITY: 1
         CIBW_ENVIRONMENT: CMAKE_BUILD_PARALLEL_LEVEL=2
         # CIBW_BUILD_FRONTEND: build  # https://github.com/pypa/build
-        MACOSX_DEPLOYMENT_TARGET: '10.15'
+        MACOSX_DEPLOYMENT_TARGET: '11.0'
 
     - name: Install Wheel
       run: python -m pip install MaterialX --find-links wheelhouse --no-index

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 project(MaterialX VERSION ${MATERIALX_LIBRARY_VERSION})
 
-option(MATERIALX_BUILD_PYTHON "Build the MaterialX Python package from C++ bindings. Requires Python 3.6 or greater." OFF)
+option(MATERIALX_BUILD_PYTHON "Build the MaterialX Python package from C++ bindings. Requires Python 3.9 or greater." OFF)
 option(MATERIALX_BUILD_VIEWER "Build the MaterialX Viewer." OFF)
 option(MATERIALX_BUILD_GRAPH_EDITOR "Build the MaterialX Graph Editor." OFF)
 option(MATERIALX_BUILD_DOCS "Create HTML documentation using Doxygen. Requires that Doxygen be installed." OFF)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The MaterialX codebase requires a compiler with support for C++17, and can be bu
 - GCC 8 or newer
 - Clang 5 or newer
 
-The Python bindings for MaterialX are based on [PyBind11](https://github.com/pybind/pybind11), and support Python versions 3.6 and greater.
+The Python bindings for MaterialX are based on [PyBind11](https://github.com/pybind/pybind11), and support Python versions 3.9 and greater.
 
 ## MaterialX Viewer
 

--- a/documents/DeveloperGuide/MainPage.md
+++ b/documents/DeveloperGuide/MainPage.md
@@ -18,7 +18,7 @@ The MaterialX codebase requires a compiler with support for C++17, and can be bu
 - GCC 8 or newer
 - Clang 5 or newer
 
-The Python bindings for MaterialX are based on [PyBind11](https://github.com/pybind/pybind11), and support Python versions 3.6 and greater.
+The Python bindings for MaterialX are based on [PyBind11](https://github.com/pybind/pybind11), and support Python versions 3.9 and greater.
 
 ## Building MaterialX
 

--- a/source/PyMaterialX/CMakeLists.txt
+++ b/source/PyMaterialX/CMakeLists.txt
@@ -35,12 +35,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES Clang)
     endif()
 endif()
 
-# Add proper postfix for Python 2.7 on Windows when using a Debug interpreter:
-set(MATERIALX_PYTHON_DEBUG_POSTFIX "")
-if(MSVC AND PYTHON_IS_DEBUG AND (PYBIND11_PYTHON_VERSION VERSION_LESS 3.0))
-    set(MATERIALX_PYTHON_DEBUG_POSTFIX "_d")
-endif()
-
 add_subdirectory(PyMaterialXCore)
 add_subdirectory(PyMaterialXFormat)
 if (MATERIALX_BUILD_GEN_GLSL OR MATERIALX_BUILD_GEN_OSL OR MATERIALX_BUILD_GEN_MDL OR MATERIALX_BUILD_GEN_MSL)


### PR DESCRIPTION
This changelist raises the minimum Python version in MaterialX to 3.9, allowing the integration of new releases of PyBind11 and NanoBind in the future.

Previously, the minimum Python version in MaterialX was 3.6, and recent releases of PyBind11 and NanoBind no longer support Python versions before 3.8.