### PR TITLE
Fix Cloverleaf offset

### DIFF
--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -2173,6 +2173,10 @@
       <input name="in1" type="vector2" interfacename="texcoord" />
       <input name="in2" type="vector2" interfacename="texcoord" />
     </add>
+    <add name="center_double" type="vector2">
+      <input name="in1" type="vector2" interfacename="center" />
+      <input name="in2" type="vector2" interfacename="center" />
+    </add>
     <add name="sample_add" type="vector2">
       <input name="in1" type="vector2" nodename="sample_double" />
       <input name="in2" type="float" interfacename="radius" />
@@ -2208,22 +2212,22 @@
     </combine2>
     <circle name="circle1" type="float">
       <input name="texcoord" type="vector2" nodename="coord1" />
-      <input name="center" type="vector2" interfacename="center" />
+      <input name="center" type="vector2" nodename="center_double" />
       <input name="radius" type="float" interfacename="radius" />
     </circle>
     <circle name="circle2" type="float">
       <input name="texcoord" type="vector2" nodename="coord2" />
-      <input name="center" type="vector2" interfacename="center" />
+      <input name="center" type="vector2" nodename="center_double" />
       <input name="radius" type="float" interfacename="radius" />
     </circle>
     <circle name="circle3" type="float">
       <input name="texcoord" type="vector2" nodename="coord3" />
-      <input name="center" type="vector2" interfacename="center" />
+      <input name="center" type="vector2" nodename="center_double" />
       <input name="radius" type="float" interfacename="radius" />
     </circle>
     <circle name="circle4" type="float">
       <input name="texcoord" type="vector2" nodename="coord4" />
-      <input name="center" type="vector2" interfacename="center" />
+      <input name="center" type="vector2" nodename="center_double" />
       <input name="radius" type="float" interfacename="radius" />
     </circle>
     <max name="max1" type="float">


### PR DESCRIPTION
Cloverleaf Center was not doubled as other dimensions within the node, resulting in a different offset than other similar shape nodes (circle, hexagon).

The Tiledcloverleafs node, which uses Cloverleaf, is not affected by the fix as the scale and offsets of the tiled pattern is achieved through UVs and Center is always 0,0.

This fixes the following issue:
https://github.com/AcademySoftwareFoundation/MaterialX/issues/1841

@bernardkwok Please let me know if it works on your previous tests