### PR TITLE
Fix bug in multiply_bsdf for GLSL

### DIFF
--- a/libraries/pbrlib/genglsl/mx_multiply_bsdf_color3.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_bsdf_color3.glsl
@@ -4,5 +4,5 @@ void mx_multiply_bsdf_color3(ClosureData closureData, BSDF in1, vec3 in2, out BS
 {
     vec3 tint = clamp(in2, 0.0, 1.0);
     result.response = in1.response * tint;
-    result.throughput = in1.throughput * tint;
+    result.throughput = in1.throughput;
 }

--- a/libraries/pbrlib/genglsl/mx_multiply_bsdf_float.glsl
+++ b/libraries/pbrlib/genglsl/mx_multiply_bsdf_float.glsl
@@ -4,5 +4,5 @@ void mx_multiply_bsdf_float(ClosureData closureData, BSDF in1, float in2, out BS
 {
     float weight = clamp(in2, 0.0, 1.0);
     result.response = in1.response * weight;
-    result.throughput = in1.throughput * weight;
+    result.throughput = in1.throughput;
 }


### PR DESCRIPTION
This change list fixes a bug in the GLSL implementation of node multiply_bsdf, as logged in #2324.