### PR TITLE
Add Python 13 to wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -391,7 +391,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-minor: ['9', '10', '11', '12']
+        python-minor: ['9', '10', '11', '12', '13']
         os: ['ubuntu-24.04', 'windows-2022', 'macos-15']
 
     steps:
@@ -415,20 +415,17 @@ jobs:
         path: sdist
 
     - name: Build Wheel
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.23.2
       with:
         package-dir: ${{ github.workspace }}/sdist/${{ needs.sdist.outputs.sdist_filename }}
       env:
         CIBW_BUILD: 'cp3${{ matrix.python-minor }}-*'
         CIBW_SKIP: '*musllinux*'
         CIBW_ARCHS: 'auto64'
-        # https://github.com/pypa/manylinux
-        # manylinux2014 is CentOS 7 based. Which means GCC 10 and glibc 2.17.
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
         CIBW_BEFORE_ALL_LINUX: yum install -y libXt-devel
         CIBW_BUILD_VERBOSITY: 1
         CIBW_ENVIRONMENT: CMAKE_BUILD_PARALLEL_LEVEL=2
-        # CIBW_BUILD_FRONTEND: build  # https://github.com/pypa/build
         MACOSX_DEPLOYMENT_TARGET: '11.0'
 
     - name: Install Wheel


### PR DESCRIPTION
This changelist adds Python 13 to the build matrix for Python wheels, along with a handful of corresponding adjustments to the `cibuildwheel` settings in GitHub CI.