### PR TITLE
Restore original NanoGUI workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,12 +172,17 @@ jobs:
       if: matrix.python != 'None'
       run: pip install setuptools
 
+    - name: Install CMake
+      uses: lukka/get-cmake@28983e0d3955dba2bb0a6810caae0c6cf268ec0c # v4.0.0
+      with:
+        cmakeVersion: 3.26
+
     - name: Run Clang Format
       if: matrix.clang_format == 'ON'
       run: find source \( -name *.h -o -name *.cpp -o -name *.mm -o -name *.inl \) ! -path "*/External/*" ! -path "*/NanoGUI/*" | xargs clang-format -i --verbose
 
     - name: CMake Generate
-      run: cmake -S . -B build -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_BUILD_VIEWER=ON -DMATERIALX_BUILD_GRAPH_EDITOR=ON -DMATERIALX_BUILD_TESTS=ON -DMATERIALX_TEST_RENDER=OFF -DMATERIALX_WARNINGS_AS_ERRORS=ON "-DCMAKE_POLICY_VERSION_MINIMUM=3.5" ${{matrix.cmake_config}}
+      run: cmake -S . -B build -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_BUILD_VIEWER=ON -DMATERIALX_BUILD_GRAPH_EDITOR=ON -DMATERIALX_BUILD_TESTS=ON -DMATERIALX_TEST_RENDER=OFF -DMATERIALX_WARNINGS_AS_ERRORS=ON ${{matrix.cmake_config}}
 
     - name: CMake Build
       run: cmake --build build --target install --config Release --parallel 2


### PR DESCRIPTION
This changelist restores our original NanoGUI workaround for GitHub CI, which seems to be more robust in our Windows builds.