### PR TITLE
Fix GLSL implementation of BSDF addition

### DIFF
--- a/libraries/pbrlib/genglsl/mx_add_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_add_bsdf.glsl
@@ -2,6 +2,8 @@
 
 void mx_add_bsdf(ClosureData closureData, BSDF in1, BSDF in2, out BSDF result)
 {
+    // To provide a throughput computation for hardware shading languages,
+    // we reinterpret BSDF addition as in1 + in2 = mix(in1, in2, 0.5) * 2.
     result.response = in1.response + in2.response;
-    result.throughput = in1.throughput + in2.throughput;
+    result.throughput = mix(in1.throughput, in2.throughput, 0.5);
 }


### PR DESCRIPTION
This changelist fixes the computation of throughput in the GLSL implementation of BSDF addition, with a comment describing the motivation for the provided math.