### PR TITLE
Add optional OIIO install to GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,11 @@ jobs:
       run: |
         Add-Content $env:GITHUB_PATH "$PWD/build/installed/bin"
 
+    - name: Install OpenImageIO
+      if: matrix.build_oiio == 'ON' && runner.os == 'Windows'
+      run: |
+        C:/vcpkg/vcpkg install openimageio --triplet=x64-windows-release
+
     - name: Install Python ${{ matrix.python }}
       if: matrix.python != 'None'
       uses: actions/setup-python@v5


### PR DESCRIPTION
This changelist adds an optional OpenImageIO installation step to our GitHub CI, in preparation for future validation of MaterialX builds with OIIO support.