### PR TITLE
Align `Type::NONE` with default constructor for `TypeDesc`

### DIFF
--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -263,8 +263,8 @@ namespace Type
 //
 /// Define type descriptors for standard types.
 //
-    // Type::NONE matches the TypeDesc default constructor.
-    static const TypeDesc NONE;
+// Type::NONE matches the TypeDesc default constructor.
+static const TypeDesc NONE;
 TYPEDESC_DEFINE_TYPE(BOOLEAN, "boolean", TypeDesc::BASETYPE_BOOLEAN, TypeDesc::SEMANTIC_NONE, 1)
 TYPEDESC_DEFINE_TYPE(INTEGER, "integer", TypeDesc::BASETYPE_INTEGER, TypeDesc::SEMANTIC_NONE, 1)
 TYPEDESC_DEFINE_TYPE(FLOAT, "float", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_NONE, 1)

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -261,10 +261,10 @@ namespace Type
 {
 
 //
-/// Define type descriptors for standard types.
+// Define type descriptors for standard types.
 //
-// Type::NONE matches the TypeDesc default constructor.
-static const TypeDesc NONE;
+
+static const TypeDesc NONE; // Type::NONE matches the TypeDesc default constructor
 TYPEDESC_DEFINE_TYPE(BOOLEAN, "boolean", TypeDesc::BASETYPE_BOOLEAN, TypeDesc::SEMANTIC_NONE, 1)
 TYPEDESC_DEFINE_TYPE(INTEGER, "integer", TypeDesc::BASETYPE_INTEGER, TypeDesc::SEMANTIC_NONE, 1)
 TYPEDESC_DEFINE_TYPE(FLOAT, "float", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_NONE, 1)

--- a/source/MaterialXGenShader/TypeDesc.h
+++ b/source/MaterialXGenShader/TypeDesc.h
@@ -82,7 +82,7 @@ class MX_GENSHADER_API TypeDesc
 
     /// Empty constructor.
     constexpr TypeDesc() noexcept :
-        _id(0),
+        _id(constexpr_hash("none")),
         _basetype(BASETYPE_NONE),
         _semantic(SEMANTIC_NONE),
         _size(0),
@@ -263,7 +263,8 @@ namespace Type
 //
 /// Define type descriptors for standard types.
 //
-TYPEDESC_DEFINE_TYPE(NONE, "none", TypeDesc::BASETYPE_NONE, TypeDesc::SEMANTIC_NONE, 1)
+    // Type::NONE matches the TypeDesc default constructor.
+    static const TypeDesc NONE;
 TYPEDESC_DEFINE_TYPE(BOOLEAN, "boolean", TypeDesc::BASETYPE_BOOLEAN, TypeDesc::SEMANTIC_NONE, 1)
 TYPEDESC_DEFINE_TYPE(INTEGER, "integer", TypeDesc::BASETYPE_INTEGER, TypeDesc::SEMANTIC_NONE, 1)
 TYPEDESC_DEFINE_TYPE(FLOAT, "float", TypeDesc::BASETYPE_FLOAT, TypeDesc::SEMANTIC_NONE, 1)


### PR DESCRIPTION
Addresses #2285.

I don't believe there is an intentional difference between `TYPE::NONE` and `TypeDesc()`.  So we choose to align the two here. 