### PR TITLE
Fixed incorrect number of faces and vertices in createQuadMesh

### DIFF
--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -160,8 +160,9 @@ MeshPtr GeometryHandler::createQuadMesh(const Vector2& uvMin, const Vector2& uvM
     }
     MeshPartitionPtr quadIndices = MeshPartition::create();
     quadIndices->getIndices().assign({ 0, 1, 3, 1, 2, 3 });
-    quadIndices->setFaceCount(6);
+    quadIndices->setFaceCount(2);
     MeshPtr quadMesh = Mesh::create("ScreenSpaceQuad");
+    quadMesh->setVertexCount(4);
     quadMesh->addStream(quadPositions);
     quadMesh->addStream(quadTexCoords);
     quadMesh->addPartition(quadIndices);


### PR DESCRIPTION
createQuadMesh claimed the created mesh had 6 faces, and 0 vertices, while it has 2 faces and 4 vertices.