### PR TITLE
Improvements to OIIO support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,6 +165,8 @@ jobs:
       if: matrix.build_oiio == 'ON' && runner.os == 'Windows'
       run: |
         C:/vcpkg/vcpkg install openimageio --triplet=x64-windows-release
+        Add-Content $env:GITHUB_PATH "C:/vcpkg/installed/x64-windows-release/bin"
+        Add-Content $env:GITHUB_PATH "C:/vcpkg/installed/x64-windows-release/share/openimageio"
 
     - name: Install Python ${{ matrix.python }}
       if: matrix.python != 'None'

--- a/documents/DeveloperGuide/MainPage.md
+++ b/documents/DeveloperGuide/MainPage.md
@@ -28,7 +28,7 @@ The MaterialX C++ libraries are automatically included when building MaterialX t
 
 To enable OpenImageIO and OpenColorIO support in MaterialX builds, the following additional options may be used:
 
-- `MATERIALX_BUILD_OIIO`: Requests that MaterialXRender be built with OpenImageIO in addition to stb_image, extending the set of supported image formats.
+- `MATERIALX_BUILD_OIIO`: Requests that MaterialXRender be built with OpenImageIO in addition to stb_image, extending the set of supported image formats.  The minimum supported version of OpenImageIO is 2.2.
 - `MATERIALX_OIIO_DIR`: Path to the root folder of an OpenImageIO installation.  If MATERIALX_BUILD_OIIO has been enabled, then this option may be used to select which installation is used.
 - `MATERIALX_BUILD_OCIO`: Requests that MaterialXGenShader be built with support for custom OpenColorIO color spaces and transforms.  The minimum supported version of OpenColorIO is 2.4.
 

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -6,17 +6,10 @@
 #include <MaterialXRender/OiioImageLoader.h>
 
 #if defined(_MSC_VER)
-    #pragma warning(push)
-    #pragma warning(disable : 4100)
-    #pragma warning(disable : 4244)
-    #pragma warning(disable : 4800)
+    #define FMT_UNICODE 0
 #endif
 
 #include <OpenImageIO/imageio.h>
-
-#if defined(_WIN32)
-    #pragma warning(pop)
-#endif
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -71,11 +64,6 @@ bool OiioImageLoader::saveImage(const FilePath& filePath,
                 written = imageOutput->write_image(format, image->getResourceBuffer());
             }
             imageOutput->close();
-
-            // Handle deallocation in OpenImageIO 1.x
-            #if OIIO_VERSION < 10903
-            OIIO::ImageOutput::destroy(imageOutput);
-            #endif
         }
     }
     return written;
@@ -123,11 +111,6 @@ ImagePtr OiioImageLoader::loadImage(const FilePath& filePath)
         image = nullptr;
     }
     imageInput->close();
-
-    // Handle deallocation in OpenImageIO 1.x
-    #if OIIO_VERSION < 10903
-    OIIO::ImageInput::destroy(imageInput);
-    #endif
 
     return image;
 }


### PR DESCRIPTION
- Declare OpenImageIO 2.2 as the minimum supported version in MaterialX, aligning with our minimum OSL version of 1.12.6.  This follows from a discussion with Larry Gritz and others in the MaterialX channel of the ASWF Slack.
- Remove legacy workarounds for OpenImageIO 1.x.
- Improve our optional build step for OpenImageIO in GitHub CI.  For now, this build step takes slightly too long to include in our regular workflows, but it's available for developers to enable manually.