### PR TITLE
Remove legacy `MATERIALX_OIIO_DIR`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,6 @@ set(MATERIALX_PYTHON_EXECUTABLE "" CACHE FILEPATH
 set(MATERIALX_PYTHON_PYBIND11_DIR "" CACHE PATH
     "Path to a folder containing the PyBind11 source to be used in building MaterialX Python.")
 
-set(MATERIALX_OIIO_DIR "" CACHE PATH "Path to the root folder of the OpenImageIO installation.")
-
 # Settings to define installation layout
 set(MATERIALX_INSTALL_INCLUDE_PATH "include" CACHE STRING "Install header include path (e.g. 'inc', 'include').")
 set(MATERIALX_INSTALL_LIB_PATH "lib" CACHE STRING "Install lib path (e.g. 'libs', 'lib').")
@@ -186,7 +184,6 @@ mark_as_advanced(MATERIALX_DYNAMIC_ANALYSIS)
 mark_as_advanced(MATERIALX_PYTHON_VERSION)
 mark_as_advanced(MATERIALX_PYTHON_EXECUTABLE)
 mark_as_advanced(MATERIALX_PYTHON_PYBIND11_DIR)
-mark_as_advanced(MATERIALX_OIIO_DIR)
 mark_as_advanced(MATERIALX_OSL_BINARY_OSLC)
 mark_as_advanced(MATERIALX_OSL_BINARY_TESTRENDER)
 mark_as_advanced(MATERIALX_OSL_INCLUDE_PATH)

--- a/documents/DeveloperGuide/MainPage.md
+++ b/documents/DeveloperGuide/MainPage.md
@@ -29,7 +29,6 @@ The MaterialX C++ libraries are automatically included when building MaterialX t
 To enable OpenImageIO and OpenColorIO support in MaterialX builds, the following additional options may be used:
 
 - `MATERIALX_BUILD_OIIO`: Requests that MaterialXRender be built with OpenImageIO in addition to stb_image, extending the set of supported image formats.  The minimum supported version of OpenImageIO is 2.2.
-- `MATERIALX_OIIO_DIR`: Path to the root folder of an OpenImageIO installation.  If MATERIALX_BUILD_OIIO has been enabled, then this option may be used to select which installation is used.
 - `MATERIALX_BUILD_OCIO`: Requests that MaterialXGenShader be built with support for custom OpenColorIO color spaces and transforms.  The minimum supported version of OpenColorIO is 2.4.
 
 See the [MaterialX Unit Tests](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/source/MaterialXTest) page for documentation on shader generation and render testing in GLSL, OSL, and MDL.

--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -26,7 +26,6 @@ if(UNIX)
 endif()
 
 if(MATERIALX_BUILD_OIIO)
-    set(OPENIMAGEIO_ROOT_DIR ${MATERIALX_OIIO_DIR})
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/External/OpenImageIO")
     find_package(OpenImageIO CONFIG REQUIRED)
     target_link_libraries(${TARGET_NAME} PRIVATE OpenImageIO::OpenImageIO OpenImageIO::OpenImageIO_Util)


### PR DESCRIPTION
This changelist removes the legacy `MATERIALX_OIIO_DIR` option, which connected to a CMake pathway that is no longer present in OpenImageIO 2.2+.