### PR TITLE
Fix invalid connections in `flattenSubgraphs`

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -322,6 +322,12 @@ void GraphElement::flattenSubgraphs(const string& target, NodePredicate filter)
                         if (sourceInput)
                         {
                             destInput->copyContentFrom(sourceInput);
+                            NodePtr connectedNode = destInput->getConnectedNode();
+                            // Update downstream port map with the new instance
+                            if (connectedNode && downstreamPortMap.count(connectedNode) > 0)
+                            {
+                                downstreamPortMap[connectedNode] = connectedNode->getDownstreamPorts();
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
As described in this issue: https://github.com/AcademySoftwareFoundation/MaterialX/issues/2117

Sometimes when flattening a document, we can produce documents which connects nodes with other nodes not existing in the document anymore (they have been replaced during flattensubgraph).

The issue happens if a node downstream is flatten before the upstream node. The new instance will be connected to the upstream node when created, but when flattening the upstream node, it's downstream connections will be updated using the downstreamPortMap, which don't refers to the new created instances.

This PR makes sure the downstreamPortMap is in sync.