### PR TITLE
Static analysis optimizations

### DIFF
--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -42,7 +42,8 @@ void HeightToNormalNodeMdl::computeSampleOffsetStrings(const string& sampleSizeN
     {
         for (int col = -1; col <= 1; col++)
         {
-            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString + "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+            offsetStrings.emplace_back(" + " + sampleSizeName + " * " + offsetTypeString +
+                                       "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
         }
     }
 }

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -493,7 +493,7 @@ void OslShaderGenerator::emitMetadata(const ShaderPort* port, ShaderStage& stage
                     const string& delim = (widgetMetadata || j < metadata->size() - 1) ? Syntax::COMMA : EMPTY_STRING;
                     const string& dataType = _syntax->getTypeName(data.type);
                     const string dataValue = _syntax->getValue(data.type, *data.value, true);
-                    metadataLines.push_back(dataType + " " + data.name + " = " + dataValue + delim);
+                    metadataLines.emplace_back(dataType + " " + data.name + " = " + dataValue + delim);
                 }
             }
         }
@@ -501,7 +501,7 @@ void OslShaderGenerator::emitMetadata(const ShaderPort* port, ShaderStage& stage
         {
             const string& dataType = _syntax->getTypeName(widgetMetadata->type);
             const string dataValue = _syntax->getValue(widgetMetadata->type, *widgetMetadata->value, true);
-            metadataLines.push_back(dataType + " " + widgetMetadata->name + " = " + dataValue);
+            metadataLines.emplace_back(dataType + " " + widgetMetadata->name + " = " + dataValue);
         }
         if (metadataLines.size())
         {

--- a/source/MaterialXGenShader/Nodes/BlurNode.cpp
+++ b/source/MaterialXGenShader/Nodes/BlurNode.cpp
@@ -41,7 +41,8 @@ void BlurNode::computeSampleOffsetStrings(const string& sampleSizeName, const st
     {
         for (int col = -w; col <= w; col++)
         {
-            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString + "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+            offsetStrings.emplace_back(" + " + sampleSizeName + " * " + offsetTypeString +
+                                       "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
         }
     }
 }

--- a/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenShader/Nodes/ConvolutionNode.cpp
@@ -186,7 +186,7 @@ void ConvolutionNode::emitInputSamplesUV(const ShaderNode& node,
                         context.removeOutputSuffix(upstreamOutput);
 
                         // Keep track of the output name with the suffix
-                        sampleStrings.push_back(upstreamOutput->getVariable() + outputSuffix);
+                        sampleStrings.emplace_back(upstreamOutput->getVariable() + outputSuffix);
                     }
                 }
                 else

--- a/source/MaterialXGenShader/Nodes/HwHeightToNormalNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwHeightToNormalNode.cpp
@@ -46,7 +46,8 @@ void HwHeightToNormalNode::computeSampleOffsetStrings(const string& sampleSizeNa
     {
         for (int col = -1; col <= 1; col++)
         {
-            offsetStrings.push_back(" + " + sampleSizeName + " * " + offsetTypeString + "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
+            offsetStrings.emplace_back(" + " + sampleSizeName + " * " + offsetTypeString +
+                                       "(" + std::to_string(float(col)) + "," + std::to_string(float(row)) + ")");
         }
     }
 }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -176,7 +176,7 @@ Graph::Graph(const std::string& materialFilename,
     _renderer->initialize();
     for (const std::string& ext : _renderer->getImageHandler()->supportedExtensions())
     {
-        _imageFilter.push_back("." + ext);
+        _imageFilter.emplace_back("." + ext);
     }
     _renderer->updateMaterials(nullptr);
     for (const std::string& incl : _renderer->getXincludeFiles())


### PR DESCRIPTION
This changelist addresses a handful of recommendations from PVS-Studio, replacing `std::vector::push_back` with `std::vector::emplace_back` to minimize string copies.