### PR TITLE
Workaround for setup.py removal in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,17 +25,17 @@ jobs:
           python: 3.9
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON -DMATERIALX_BUILD_MONOLITHIC=ON
 
-        - name: Linux_GCC_14_Python312
+        - name: Linux_GCC_14_Python39
           os: ubuntu-24.04
           compiler: gcc
           compiler_version: "14"
-          python: 3.12
+          python: 3.9
 
-        - name: Linux_GCC_14_Python313
+        - name: Linux_GCC_14_Python311
           os: ubuntu-24.04
           compiler: gcc
           compiler_version: "14"
-          python: 3.13
+          python: 3.11
           test_render: ON
 
         - name: Linux_GCC_CoverageAnalysis
@@ -53,32 +53,32 @@ jobs:
           python: 3.9
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_Clang_18_Python313
+        - name: Linux_Clang_18_Python311
           os: ubuntu-24.04
           compiler: clang
           compiler_version: "18"
-          python: 3.13
+          python: 3.11
           clang_format: ON
 
-        - name: MacOS_Xcode_15_Python311
+        - name: MacOS_Xcode_15_Python39
           os: macos-14
           compiler: xcode
           compiler_version: "15.4"
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
-          python: 3.11
+          python: 3.9
 
-        - name: MacOS_Xcode_15_Python312
+        - name: MacOS_Xcode_15_Python311
           os: macos-15
           compiler: xcode
           compiler_version: "15.4"
-          python: 3.12
+          python: 3.11
           test_shaders: ON
 
-        - name: MacOS_Xcode_16_Python313
+        - name: MacOS_Xcode_16_Python311
           os: macos-15
           compiler: xcode
           compiler_version: "16.1"
-          python: 3.13
+          python: 3.11
           static_analysis: ON
           cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
@@ -103,10 +103,10 @@ jobs:
           python: 3.9
           cmake_config: -G "Visual Studio 16 2019" -A "Win32"
 
-        - name: Windows_VS2022_x64_Python313
+        - name: Windows_VS2022_x64_Python311
           os: windows-2025
           architecture: x64
-          python: 3.13
+          python: 3.11
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           test_shaders: ON
 


### PR DESCRIPTION
This changelist is a workaround for the recent removal of setup.py support in GitHub CI.  Moving forward, we should upgrade our Python packaging to the more modern practices described in https://packaging.python.org/en/latest/guides/modernize-setup-py-project/.