### PR TITLE
Standard Library Templating and Named Value implementation.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,12 +31,21 @@ jobs:
           compiler_version: "14"
           python: 3.9
 
-        - name: Linux_GCC_14_Python311
+        - name: Linux_GCC_14_Python311_expand_lib
           os: ubuntu-24.04
           compiler: gcc
           compiler_version: "14"
           python: 3.11
           test_render: ON
+          cmake_config: -DMATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS=ON -DMATERIALX_BUILD_BAKE_NAMED_VALUES=ON
+
+        - name: Linux_GCC_14_Python311_unexpanded_lib
+          os: ubuntu-24.04
+          compiler: gcc
+          compiler_version: "14"
+          python: 3.11
+          test_render: ON
+          cmake_config: -DMATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS=OFF -DMATERIALX_BUILD_BAKE_NAMED_VALUES=OFF
 
         - name: Linux_GCC_CoverageAnalysis
           os: ubuntu-24.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,8 @@ option(MATERIALX_BUILD_BENCHMARK_TESTS "Build benchmark tests." OFF)
 
 option(MATERIALX_BUILD_SHARED_LIBS "Build MaterialX libraries as shared rather than static." OFF)
 option(MATERIALX_BUILD_DATA_LIBRARY "Build generated products from the MaterialX data library." OFF)
+option(MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS "Process the data library files at build time to expand any template elements." ON)
+option(MATERIALX_BUILD_BAKE_NAMED_VALUES "Process the data library files at build time to bake out the named values." ON)
 option(MATERIALX_BUILD_MONOLITHIC "Build a single monolithic MaterialX library." OFF)
 option(MATERIALX_BUILD_USE_CCACHE "Enable the use of ccache to speed up build time, if present." ON)
 option(MATERIALX_PYTHON_LTO "Enable link-time optimizations for MaterialX Python." ON)
@@ -67,6 +69,10 @@ if (MATERIALX_BUILD_IOS)
     message(DEPRECATION "The MATERIALX_BUILD_IOS option is deprecated. Set CMAKE_SYSTEM_NAME to iOS instead.")
     set(CMAKE_SYSTEM_NAME iOS)
 endif()
+
+list(APPEND CMAKE_MODULE_PATH
+        ${PROJECT_SOURCE_DIR}/cmake/macros)
+include(Public)
 
 # Apple ecosystem cross-compilation
 # https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-visionos-or-watchos
@@ -306,129 +312,21 @@ else()
     endif()
 endif()
 
-# Shared functions
-function(assign_source_group prefix)
-    foreach(_source IN ITEMS ${ARGN})
-        if(IS_ABSOLUTE "${_source}")
-            file(RELATIVE_PATH _source_rel "${CMAKE_CURRENT_SOURCE_DIR}" "${_source}")
-        else()
-            set(_source_rel "${_source}")
-        endif()
-        get_filename_component(_source_path "${_source_rel}" PATH)
-        string(REPLACE "/" "\\" _source_path_msvc "${_source_path}")
-        source_group("${prefix}\\${_source_path_msvc}" FILES "${_source}")
-    endforeach()
-endfunction(assign_source_group)
-
-function(mx_add_library MATERIALX_MODULE_NAME)
-    set(options ADD_OBJECTIVE_C_CODE)
-    set(oneValueArgs EXPORT_DEFINE)
-    set(multiValueArgs
-        SOURCE_FILES
-        HEADER_FILES
-        INLINED_FILES
-        MTLX_MODULES)
-    cmake_parse_arguments(args
-        "${options}"
-        "${oneValueArgs}"
-        "${multiValueArgs}"
-        ${ARGN})
-
-    if (APPLE AND args_ADD_OBJECTIVE_C_CODE)
-        file(GLOB_RECURSE materialx_source_oc "${CMAKE_CURRENT_SOURCE_DIR}/*.m*")
-        set_source_files_properties(${materialx_source_oc} PROPERTIES
-            COMPILE_FLAGS "-x objective-c++")
-        set(args_SOURCE_FILES ${args_SOURCE_FILES} ${materialx_source_oc})
-    endif()
-
-    assign_source_group("Source Files" ${args_SOURCE_FILES})
-    assign_source_group("Source Files" ${args_INLINED_FILES})
-    assign_source_group("Header Files" ${args_HEADER_FILES})
-
-    if (NOT MATERIALX_BUILD_MONOLITHIC)
-        set(TARGET_NAME ${MATERIALX_MODULE_NAME})
-        add_library(${TARGET_NAME})
-
-        # Create version resource
-        if(MATERIALX_BUILD_SHARED_LIBS AND MSVC)
-            configure_file(${PROJECT_SOURCE_DIR}/cmake/modules/MaterialXVersion.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-            target_sources(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
-        endif()
-
-        target_link_libraries(${TARGET_NAME}
-            PUBLIC
-            ${args_MTLX_MODULES}
-            ${CMAKE_DL_LIBS})
-
-        target_include_directories(${TARGET_NAME}
-            PUBLIC
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
-            $<INSTALL_INTERFACE:${MATERIALX_INSTALL_INCLUDE_PATH}>
-            PRIVATE
-            ${EXTERNAL_INCLUDE_DIRS})
-
-        set_target_properties(
-            ${TARGET_NAME} PROPERTIES
-            OUTPUT_NAME ${MATERIALX_MODULE_NAME}${MATERIALX_LIBNAME_SUFFIX}
-            COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
-            LINK_FLAGS "${EXTERNAL_LINK_FLAGS}"
-            INSTALL_RPATH "${MATERIALX_SAME_DIR_RPATH}"
-            VERSION "${MATERIALX_LIBRARY_VERSION}"
-            SOVERSION "${MATERIALX_MAJOR_VERSION}")
-    else()
-        set(TARGET_NAME ${MATERIALX_MONOLITHIC_TARGET})
-        add_library(${MATERIALX_MODULE_NAME} ALIAS ${MATERIALX_MONOLITHIC_TARGET})
-
-        # Store the aliased MaterialX modules name to create CMake export aliases later.
-        set_property(GLOBAL APPEND PROPERTY MATERIALX_MODULES ${MATERIALX_MODULE_NAME})
-    endif()
-
-    set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-    set_target_properties(${TARGET_NAME} PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN 1)
-
-    target_sources(${TARGET_NAME}
-        PRIVATE
-            ${args_SOURCE_FILES}
-        PUBLIC
-            FILE_SET
-                mxHeaders
-            TYPE
-                HEADERS
-            BASE_DIRS
-                ${CMAKE_CURRENT_SOURCE_DIR}/..
-                ${CMAKE_CURRENT_BINARY_DIR}/..
-            FILES
-                ${args_HEADER_FILES}
-                ${args_INLINED_FILES})
-
-    target_include_directories(${TARGET_NAME} PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)
-
-    target_compile_definitions(${TARGET_NAME} PRIVATE "-D${args_EXPORT_DEFINE}")
-
-    if(NOT SKBUILD)
-        if(NOT MATERIALX_BUILD_MONOLITHIC)
-            install(TARGETS ${MATERIALX_MODULE_NAME}
-                    EXPORT MaterialX
-                    ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                    LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
-                    RUNTIME DESTINATION bin
-                    FILE_SET mxHeaders DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH})
-        endif()
-
-        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${MATERIALX_MODULE_NAME}.pdb"
-                DESTINATION "${MATERIALX_INSTALL_LIB_PATH}/" OPTIONAL)
-    endif()
-
-    # Pass TARGET_NAME back to call site, so the caller can modify the build target.
-    set(TARGET_NAME ${TARGET_NAME} PARENT_SCOPE)
-endfunction()
-
 # Propagate shared library setting to NanoGUI
 if(MATERIALX_BUILD_SHARED_LIBS)
     set(BUILD_SHARED_LIBS "ON")
 else()
     set(BUILD_SHARED_LIBS "OFF")
+endif()
+
+# If we're baking the named "Value:" entries - then we have to also expand any
+# template elements
+if (MATERIALX_BUILD_BAKE_NAMED_VALUES)
+    set(MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS ON)
+endif()
+
+if (MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS OR MATERIALX_BUILD_BAKE_NAMED_VALUES)
+    set(MATERIALX_BUILD_DATA_LIBRARY ON)
 endif()
 
 # Build a monolithic target - needs to be added before the other build targets that may be included.
@@ -437,9 +335,39 @@ if (MATERIALX_BUILD_MONOLITHIC)
     add_subdirectory(source)
 endif()
 
+message("XXX : MATERIALX_BUILD_BAKE_NAMED_VALUES     : ${MATERIALX_BUILD_BAKE_NAMED_VALUES}")
+message("XXX : MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS : ${MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS}")
+message("XXX : MATERIALX_BUILD_DATA_LIBRARY          : ${MATERIALX_BUILD_DATA_LIBRARY}")
+
 # Add core subdirectories
 add_subdirectory(source/MaterialXCore)
 add_subdirectory(source/MaterialXFormat)
+if (MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS OR MATERIALX_BUILD_BAKE_NAMED_VALUES)
+    if (CMAKE_CROSSCOMPILING)
+        set(_MaterialXBuildLibrary "${CMAKE_BINARY_DIR}/BUILD_TOOLS/MaterialXBuildLibrary")
+
+        add_custom_command(
+                OUTPUT ${_MaterialXBuildLibrary}
+                COMMAND ${CMAKE_COMMAND}
+                -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/BUILD_TOOLS
+                -DMATERIALX_MAJOR_VERSION=${MATERIALX_MAJOR_VERSION}
+                -DMATERIALX_MINOR_VERSION=${MATERIALX_MINOR_VERSION}
+                -DMATERIALX_BUILD_VERSION=${MATERIALX_BUILD_VERSION}
+                -DMATERIALX_NAMESPACE=${MATERIALX_NAMESPACE}
+                -DMATERIALX_BUILD_BAKE_NAMED_VALUES=ON
+                -B"BUILD_TOOLS"
+                -H"${CMAKE_SOURCE_DIR}/source/MaterialXBuildTools"
+                COMMAND ${CMAKE_COMMAND} --build BUILD_TOOLS
+                DEPENDS MaterialXCore MaterialXFormat
+        )
+        add_custom_target(MaterialXBuildLibrary ALL
+        DEPENDS ${_MaterialXBuildLibrary})
+    else()
+        set(_MaterialXBuildLibrary MaterialXBuildLibrary)
+        add_subdirectory(source/MaterialXBuildTools/buildLibrary)
+    endif()
+endif()
 
 # Add shader generation subdirectories
 add_subdirectory(source/MaterialXGenShader)

--- a/cmake/macros/Public.cmake
+++ b/cmake/macros/Public.cmake
@@ -1,0 +1,119 @@
+# Shared functions need to be extracted to allow them to be shared with the subproject
+# in source/MaterialXBuildTools
+
+function(assign_source_group prefix)
+    foreach(_source IN ITEMS ${ARGN})
+        if(IS_ABSOLUTE "${_source}")
+            file(RELATIVE_PATH _source_rel "${CMAKE_CURRENT_SOURCE_DIR}" "${_source}")
+        else()
+            set(_source_rel "${_source}")
+        endif()
+        get_filename_component(_source_path "${_source_rel}" PATH)
+        string(REPLACE "/" "\\" _source_path_msvc "${_source_path}")
+        source_group("${prefix}\\${_source_path_msvc}" FILES "${_source}")
+    endforeach()
+endfunction(assign_source_group)
+
+function(mx_add_library MATERIALX_MODULE_NAME)
+    set(options ADD_OBJECTIVE_C_CODE)
+    set(oneValueArgs EXPORT_DEFINE)
+    set(multiValueArgs
+            SOURCE_FILES
+            HEADER_FILES
+            INLINED_FILES
+            MTLX_MODULES)
+    cmake_parse_arguments(args
+            "${options}"
+            "${oneValueArgs}"
+            "${multiValueArgs}"
+            ${ARGN})
+
+    if (APPLE AND args_ADD_OBJECTIVE_C_CODE)
+        file(GLOB_RECURSE materialx_source_oc "${CMAKE_CURRENT_SOURCE_DIR}/*.m*")
+        set_source_files_properties(${materialx_source_oc} PROPERTIES
+                COMPILE_FLAGS "-x objective-c++")
+        set(args_SOURCE_FILES ${args_SOURCE_FILES} ${materialx_source_oc})
+    endif()
+
+    assign_source_group("Source Files" ${args_SOURCE_FILES})
+    assign_source_group("Source Files" ${args_INLINED_FILES})
+    assign_source_group("Header Files" ${args_HEADER_FILES})
+
+    if (NOT MATERIALX_BUILD_MONOLITHIC)
+        set(TARGET_NAME ${MATERIALX_MODULE_NAME})
+        add_library(${TARGET_NAME})
+
+        # Create version resource
+        if(MATERIALX_BUILD_SHARED_LIBS AND MSVC)
+            configure_file(${PROJECT_SOURCE_DIR}/cmake/modules/MaterialXVersion.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+            target_sources(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+        endif()
+
+        target_link_libraries(${TARGET_NAME}
+                PUBLIC
+                ${args_MTLX_MODULES}
+                ${CMAKE_DL_LIBS})
+
+        target_include_directories(${TARGET_NAME}
+                PUBLIC
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
+                $<INSTALL_INTERFACE:${MATERIALX_INSTALL_INCLUDE_PATH}>
+                PRIVATE
+                ${EXTERNAL_INCLUDE_DIRS})
+
+        set_target_properties(
+                ${TARGET_NAME} PROPERTIES
+                OUTPUT_NAME ${MATERIALX_MODULE_NAME}${MATERIALX_LIBNAME_SUFFIX}
+                COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
+                LINK_FLAGS "${EXTERNAL_LINK_FLAGS}"
+                INSTALL_RPATH "${MATERIALX_SAME_DIR_RPATH}"
+                VERSION "${MATERIALX_LIBRARY_VERSION}"
+                SOVERSION "${MATERIALX_MAJOR_VERSION}")
+    else()
+        set(TARGET_NAME ${MATERIALX_MONOLITHIC_TARGET})
+        add_library(${MATERIALX_MODULE_NAME} ALIAS ${MATERIALX_MONOLITHIC_TARGET})
+
+        # Store the aliased MaterialX modules name to create CMake export aliases later.
+        set_property(GLOBAL APPEND PROPERTY MATERIALX_MODULES ${MATERIALX_MODULE_NAME})
+    endif()
+
+    set_target_properties(${TARGET_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+    set_target_properties(${TARGET_NAME} PROPERTIES CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
+    target_sources(${TARGET_NAME}
+            PRIVATE
+            ${args_SOURCE_FILES}
+            PUBLIC
+            FILE_SET
+            mxHeaders
+            TYPE
+            HEADERS
+            BASE_DIRS
+            ${CMAKE_CURRENT_SOURCE_DIR}/..
+            ${CMAKE_CURRENT_BINARY_DIR}/..
+            FILES
+            ${args_HEADER_FILES}
+            ${args_INLINED_FILES})
+
+    target_include_directories(${TARGET_NAME} PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>)
+
+    target_compile_definitions(${TARGET_NAME} PRIVATE "-D${args_EXPORT_DEFINE}")
+
+    if(NOT SKBUILD)
+        if(NOT MATERIALX_BUILD_MONOLITHIC)
+            install(TARGETS ${MATERIALX_MODULE_NAME}
+                    EXPORT MaterialX
+                    ARCHIVE DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
+                    LIBRARY DESTINATION ${MATERIALX_INSTALL_LIB_PATH}
+                    RUNTIME DESTINATION bin
+                    FILE_SET mxHeaders DESTINATION ${MATERIALX_INSTALL_INCLUDE_PATH})
+        endif()
+
+        install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}/${MATERIALX_MODULE_NAME}.pdb"
+                DESTINATION "${MATERIALX_INSTALL_LIB_PATH}/" OPTIONAL)
+    endif()
+
+    # Pass TARGET_NAME back to call site, so the caller can modify the build target.
+    set(TARGET_NAME ${TARGET_NAME} PARENT_SCOPE)
+endfunction()

--- a/javascript/MaterialXTest/xmlIo.spec.js
+++ b/javascript/MaterialXTest/xmlIo.spec.js
@@ -10,7 +10,7 @@ describe('XmlIo', () =>
 
     // These should be relative to cwd
     const includeTestPath = 'data/includes';
-    const libraryPath = '../../libraries/stdlib';
+    const libraryPath = '../build/libraries/DataLibraryBuild/stdlib';
     const examplesPath = '../../resources/Materials/Examples';
     // TODO: Is there a better way to get these filenames than hardcoding them here?
     // The C++ tests load all files in the given directories. This would work in Node, but not in the browser.

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 if(MATERIALX_BUILD_DATA_LIBRARY)
     # Build generated products from the MaterialX data library.
     # Initially, this step is a simple copy across folders, but our intent
@@ -5,17 +6,54 @@ if(MATERIALX_BUILD_DATA_LIBRARY)
 
     set(DATA_LIBRARY_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/DataLibraryBuild)
 
-    file(GLOB_RECURSE MATERIALX_DATA_LIBRARY_SOURCE_FILES
-         RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-         LIST_DIRECTORIES false
-         *.mtlx
-         *.md
-         *.glsl
-         *.osl
-         *.h
-         *.metal)
+    file(GLOB_RECURSE MATERIALX_DATA_LIBRARY_MTLX_SOURCE_FILES
+            RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+            LIST_DIRECTORIES false
+            *.mtlx)
 
-    foreach(SOURCE_FILE IN LISTS MATERIALX_DATA_LIBRARY_SOURCE_FILES)
+    file(GLOB_RECURSE MATERIALX_DATA_LIBRARY_SHADER_SOURCE_FILES
+            RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+            LIST_DIRECTORIES false
+            *.md
+            *.glsl
+            *.osl
+            *.h
+            *.metal)
+
+    if (MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS OR MATERIALX_BUILD_BAKE_NAMED_VALUES)
+        foreach(SOURCE_FILE IN LISTS MATERIALX_DATA_LIBRARY_MTLX_SOURCE_FILES)
+            set(DEST_FILEPATH ${DATA_LIBRARY_BUILD_DIR}/${SOURCE_FILE})
+            list(APPEND MATERIALX_DATA_LIBRARY_MTLX_BUILD_FILES ${DEST_FILEPATH})
+        endforeach()
+
+        if (MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS)
+            set(EXPAND_TEMPLATE_ELEMS_ARG "--expandTemplateElems")
+        endif()
+        if (MATERIALX_BUILD_BAKE_NAMED_VALUES)
+            set(BAKE_NAMED_VALUES_ARG "--bakeNamedValues")
+        endif()
+
+        add_custom_command(
+                OUTPUT ${MATERIALX_DATA_LIBRARY_MTLX_BUILD_FILES}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${DATA_LIBRARY_BUILD_DIR}
+                COMMAND ${_MaterialXBuildLibrary} --sourceLibraryRoot ${CMAKE_CURRENT_SOURCE_DIR} --destLibraryRoot ${DATA_LIBRARY_BUILD_DIR} ${EXPAND_TEMPLATE_ELEMS_ARG} ${BAKE_NAMED_VALUES_ARG}
+                DEPENDS ${MATERIALX_DATA_LIBRARY_MTLX_SOURCE_FILES} MaterialXBuildLibrary
+        )
+
+        list(APPEND MATERIALX_DATA_LIBRARY_BUILD_FILES ${MATERIALX_DATA_LIBRARY_MTLX_BUILD_FILES})
+    else()
+        foreach(SOURCE_FILE IN LISTS MATERIALX_DATA_LIBRARY_MTLX_SOURCE_FILES)
+            set(SOURCE_FILEPATH ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE})
+            set(DEST_FILEPATH ${DATA_LIBRARY_BUILD_DIR}/${SOURCE_FILE})
+            add_custom_command(
+                    OUTPUT ${DEST_FILEPATH}
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SOURCE_FILEPATH} ${DEST_FILEPATH}
+                    DEPENDS ${SOURCE_FILEPATH})
+            list(APPEND MATERIALX_DATA_LIBRARY_BUILD_FILES ${DEST_FILEPATH})
+        endforeach()
+    endif()
+
+    foreach(SOURCE_FILE IN LISTS MATERIALX_DATA_LIBRARY_SHADER_SOURCE_FILES)
         set(SOURCE_FILEPATH ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE})
         set(DEST_FILEPATH ${DATA_LIBRARY_BUILD_DIR}/${SOURCE_FILE})
         add_custom_command(

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -12,15 +12,15 @@
   <!-- ======================================================================== -->
 
   <typedef name="boolean" />
-  <typedef name="integer" />
-  <typedef name="float" />
-  <typedef name="color3" semantic="color" />
-  <typedef name="color4" semantic="color" />
-  <typedef name="vector2" />
-  <typedef name="vector3" />
-  <typedef name="vector4" />
-  <typedef name="matrix33" />
-  <typedef name="matrix44" />
+  <typedef name="integer" zero="0" one="1"/>
+  <typedef name="float" zero="0.0" one="1.0"/>
+  <typedef name="color3" semantic="color" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
+  <typedef name="color4" semantic="color" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
+  <typedef name="vector2" zero="0.0,0.0" one="1.0,1.0"/>
+  <typedef name="vector3" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
+  <typedef name="vector4" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
+  <typedef name="matrix33" zero="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" identity="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0"/>
+  <typedef name="matrix44" zero="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" identity="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0"/>
   <typedef name="string" />
   <typedef name="filename" />
   <typedef name="geomname" />
@@ -1491,242 +1491,94 @@
     Node: <add>
     Add "in2" value/stream to the incoming float/integer/color/vector/matrix.
   -->
-  <nodedef name="ND_add_float" node="add" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_integer" node="add" nodegroup="math">
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_color3" node="add" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_color4" node="add" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_vector2" node="add" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_vector3" node="add" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_vector4" node="add" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_matrix33" node="add" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_matrix44" node="add" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_color3FA" node="add" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_color4FA" node="add" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_vector2FA" node="add" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_vector3FA" node="add" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_vector4FA" node="add" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_matrix33FA" node="add" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_add_matrix44FA" node="add" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_add" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_add_@typeName@" node="add" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_add_matrix" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_add_@typeName@" node="add" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_addFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_add_@typeName@FA" node="add" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_add_matrixFA" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_add_@typeName@FA" node="add" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in2" type="float" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <subtract>
     Subtract "in2" value/stream from the incoming float/integer/color/vector/matrix.
   -->
-  <nodedef name="ND_subtract_float" node="subtract" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_integer" node="subtract" nodegroup="math">
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
-    <output name="out" type="integer" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_color3" node="subtract" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_color4" node="subtract" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_vector2" node="subtract" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_vector3" node="subtract" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_vector4" node="subtract" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_matrix33" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_matrix44" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_color3FA" node="subtract" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_color4FA" node="subtract" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_vector2FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_vector3FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_vector4FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_matrix33FA" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_subtract_matrix44FA" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_subtract" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_subtract_@typeName@" node="subtract" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_subtract_matrix" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_subtract_@typeName@" node="subtract" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in2" type="@typeName@" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_subtractFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_subtract_@typeName@FA" node="subtract" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_subtract_matrixFA" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_subtract_@typeName@FA" node="subtract" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in2" type="float" value="Value:zero" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <multiply>
     Multiply the incoming float/color/vector by the "in2" value/stream, or multiply
     two matrices.
   -->
-  <nodedef name="ND_multiply_float" node="multiply" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_color3" node="multiply" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_color4" node="multiply" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_vector2" node="multiply" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_vector3" node="multiply" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_vector4" node="multiply" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_matrix33" node="multiply" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_matrix44" node="multiply" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_color3FA" node="multiply" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_color4FA" node="multiply" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_vector2FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_vector3FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_multiply_vector4FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_multiply" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_multiply_@typeName@" node="multiply" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_multiply_matrix" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_multiply_@typeName@" node="multiply" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in2" type="@typeName@" value="Value:identity" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_multiplyFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_multiply_@typeName@FA" node="multiply" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <divide>
@@ -1734,71 +1586,27 @@
     value by 0 results in floating-point "NaN".  Or, multiply one matrix by the
     inverse of a second matrix.
   -->
-  <nodedef name="ND_divide_float" node="divide" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="float" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_color3" node="divide" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_color4" node="divide" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_vector2" node="divide" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_vector3" node="divide" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_vector4" node="divide" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_matrix33" node="divide" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <output name="out" type="matrix33" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_matrix44" node="divide" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <output name="out" type="matrix44" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_color3FA" node="divide" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_color4FA" node="divide" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="color4" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_vector2FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector2" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_vector3FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector3" defaultinput="in1" />
-  </nodedef>
-  <nodedef name="ND_divide_vector4FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
-    <output name="out" type="vector4" defaultinput="in1" />
-  </nodedef>
+  <template name="TP_ND_divide" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_divide_@typeName@" node="divide" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="@typeName@" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_divide_matrix" varName="typeName" options="matrix33, matrix44">
+    <nodedef name="ND_divide_@typeName@" node="divide" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:identity" />
+      <input name="in2" type="@typeName@" value="Value:identity" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
+  <template name="TP_ND_divideFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodedef name="ND_divide_@typeName@FA" node="divide" nodegroup="math">
+      <input name="in1" type="@typeName@" value="Value:zero" />
+      <input name="in2" type="float" value="Value:one" />
+      <output name="out" type="@typeName@" defaultinput="in1" />
+    </nodedef>
+  </template>
 
   <!--
     Node: <modulo>

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -3434,193 +3434,45 @@
     Raise incoming half/float/color/vector values to the "in2" power.
     Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
   -->
-  <nodegraph name="NG_safepower_float" nodedef="ND_safepower_float">
-    <sign name="sign_in1" type="float">
-      <input name="in" type="float" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="float">
-      <input name="in" type="float" interfacename="in1" />
-    </absval>
-    <power name="power" type="float">
-      <input name="in1" type="float" nodename="abs_in1" />
-      <input name="in2" type="float" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="float">
-      <input name="in1" type="float" nodename="sign_in1" />
-      <input name="in2" type="float" nodename="power" />
-    </multiply>
-    <output name="out" type="float" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_color3" nodedef="ND_safepower_color3">
-    <sign name="sign_in1" type="color3">
-      <input name="in" type="color3" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="color3">
-      <input name="in" type="color3" interfacename="in1" />
-    </absval>
-    <power name="power" type="color3">
-      <input name="in1" type="color3" nodename="abs_in1" />
-      <input name="in2" type="color3" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="color3">
-      <input name="in1" type="color3" nodename="sign_in1" />
-      <input name="in2" type="color3" nodename="power" />
-    </multiply>
-    <output name="out" type="color3" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_color4" nodedef="ND_safepower_color4">
-    <sign name="sign_in1" type="color4">
-      <input name="in" type="color4" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="color4">
-      <input name="in" type="color4" interfacename="in1" />
-    </absval>
-    <power name="power" type="color4">
-      <input name="in1" type="color4" nodename="abs_in1" />
-      <input name="in2" type="color4" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="color4">
-      <input name="in1" type="color4" nodename="sign_in1" />
-      <input name="in2" type="color4" nodename="power" />
-    </multiply>
-    <output name="out" type="color4" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_vector2" nodedef="ND_safepower_vector2">
-    <sign name="sign_in1" type="vector2">
-      <input name="in" type="vector2" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="vector2">
-      <input name="in" type="vector2" interfacename="in1" />
-    </absval>
-    <power name="power" type="vector2">
-      <input name="in1" type="vector2" nodename="abs_in1" />
-      <input name="in2" type="vector2" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="vector2">
-      <input name="in1" type="vector2" nodename="sign_in1" />
-      <input name="in2" type="vector2" nodename="power" />
-    </multiply>
-    <output name="out" type="vector2" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_vector3" nodedef="ND_safepower_vector3">
-    <sign name="sign_in1" type="vector3">
-      <input name="in" type="vector3" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="vector3">
-      <input name="in" type="vector3" interfacename="in1" />
-    </absval>
-    <power name="power" type="vector3">
-      <input name="in1" type="vector3" nodename="abs_in1" />
-      <input name="in2" type="vector3" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="vector3">
-      <input name="in1" type="vector3" nodename="sign_in1" />
-      <input name="in2" type="vector3" nodename="power" />
-    </multiply>
-    <output name="out" type="vector3" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_vector4" nodedef="ND_safepower_vector4">
-    <sign name="sign_in1" type="vector4">
-      <input name="in" type="vector4" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="vector4">
-      <input name="in" type="vector4" interfacename="in1" />
-    </absval>
-    <power name="power" type="vector4">
-      <input name="in1" type="vector4" nodename="abs_in1" />
-      <input name="in2" type="vector4" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="vector4">
-      <input name="in1" type="vector4" nodename="sign_in1" />
-      <input name="in2" type="vector4" nodename="power" />
-    </multiply>
-    <output name="out" type="vector4" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_color3FA" nodedef="ND_safepower_color3FA">
-    <sign name="sign_in1" type="color3">
-      <input name="in" type="color3" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="color3">
-      <input name="in" type="color3" interfacename="in1" />
-    </absval>
-    <power name="power" type="color3">
-      <input name="in1" type="color3" nodename="abs_in1" />
-      <input name="in2" type="float" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="color3">
-      <input name="in1" type="color3" nodename="sign_in1" />
-      <input name="in2" type="color3" nodename="power" />
-    </multiply>
-    <output name="out" type="color3" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_color4FA" nodedef="ND_safepower_color4FA">
-    <sign name="sign_in1" type="color4">
-      <input name="in" type="color4" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="color4">
-      <input name="in" type="color4" interfacename="in1" />
-    </absval>
-    <power name="power" type="color4">
-      <input name="in1" type="color4" nodename="abs_in1" />
-      <input name="in2" type="float" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="color4">
-      <input name="in1" type="color4" nodename="sign_in1" />
-      <input name="in2" type="color4" nodename="power" />
-    </multiply>
-    <output name="out" type="color4" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_vector2FA" nodedef="ND_safepower_vector2FA">
-    <sign name="sign_in1" type="vector2">
-      <input name="in" type="vector2" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="vector2">
-      <input name="in" type="vector2" interfacename="in1" />
-    </absval>
-    <power name="power" type="vector2">
-      <input name="in1" type="vector2" nodename="abs_in1" />
-      <input name="in2" type="float" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="vector2">
-      <input name="in1" type="vector2" nodename="sign_in1" />
-      <input name="in2" type="vector2" nodename="power" />
-    </multiply>
-    <output name="out" type="vector2" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_vector3FA" nodedef="ND_safepower_vector3FA">
-    <sign name="sign_in1" type="vector3">
-      <input name="in" type="vector3" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="vector3">
-      <input name="in" type="vector3" interfacename="in1" />
-    </absval>
-    <power name="power" type="vector3">
-      <input name="in1" type="vector3" nodename="abs_in1" />
-      <input name="in2" type="float" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="vector3">
-      <input name="in1" type="vector3" nodename="sign_in1" />
-      <input name="in2" type="vector3" nodename="power" />
-    </multiply>
-    <output name="out" type="vector3" nodename="safepower" />
-  </nodegraph>
-  <nodegraph name="NG_safepower_vector4FA" nodedef="ND_safepower_vector4FA">
-    <sign name="sign_in1" type="vector4">
-      <input name="in" type="vector4" interfacename="in1" />
-    </sign>
-    <absval name="abs_in1" type="vector4">
-      <input name="in" type="vector4" interfacename="in1" />
-    </absval>
-    <power name="power" type="vector4">
-      <input name="in1" type="vector4" nodename="abs_in1" />
-      <input name="in2" type="float" interfacename="in2" />
-    </power>
-    <multiply name="safepower" type="vector4">
-      <input name="in1" type="vector4" nodename="sign_in1" />
-      <input name="in2" type="vector4" nodename="power" />
-    </multiply>
-    <output name="out" type="vector4" nodename="safepower" />
-  </nodegraph>
+  <template name="TP_NG_safepower" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodegraph name="NG_safepower_@typeName@" nodedef="ND_safepower_@typeName@">
+      <sign name="sign_in1" type="@typeName@">
+        <input name="in" type="@typeName@" interfacename="in1" />
+      </sign>
+      <absval name="abs_in1" type="@typeName@">
+        <input name="in" type="@typeName@" interfacename="in1" />
+      </absval>
+      <power name="power" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="abs_in1" />
+        <input name="in2" type="@typeName@" interfacename="in2" />
+      </power>
+      <multiply name="safepower" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="sign_in1" />
+        <input name="in2" type="@typeName@" nodename="power" />
+      </multiply>
+      <output name="out" type="@typeName@" nodename="safepower" />
+    </nodegraph>
+  </template>
+
+  <template name="TMPLT_NG_safepowerFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodegraph name="NG_safepower_@typeName@FA" nodedef="ND_safepower_@typeName@FA">
+      <sign name="sign_in1" type="@typeName@">
+        <input name="in" type="@typeName@" interfacename="in1" />
+      </sign>
+      <absval name="abs_in1" type="@typeName@">
+        <input name="in" type="@typeName@" interfacename="in1" />
+      </absval>
+      <power name="power" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="abs_in1" />
+        <input name="in2" type="float" interfacename="in2" />
+      </power>
+      <multiply name="safepower" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="sign_in1" />
+        <input name="in2" type="@typeName@" nodename="power" />
+      </multiply>
+      <output name="out" type="@typeName@" nodename="safepower" />
+    </nodegraph>
+  </template>
 
   <!--
     Node: <contrast>
@@ -3797,512 +3649,102 @@
     Remap a value from one range of float/color/vector values to another, optionally
     applying a gamma correction in the middle, and optionally clamping output values.
   -->
-  <nodegraph name="NG_range_float" nodedef="ND_range_float">
-    <remap name="N_remap1_float" type="float">
-      <input name="in" type="float" interfacename="in" />
-      <input name="inlow" type="float" interfacename="inlow" />
-      <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
-    </remap>
-    <divide name="N_recip_float" type="float">
-      <input name="in1" type="float" value="1.0" />
-      <input name="in2" type="float" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_float" type="float">
-      <input name="in" type="float" nodename="N_remap1_float" />
-    </absval>
-    <power name="N_pow_float" type="float">
-      <input name="in1" type="float" nodename="N_abs_float" />
-      <input name="in2" type="float" nodename="N_recip_float" />
-    </power>
-    <sign name="N_sign_float" type="float">
-      <input name="in" type="float" nodename="N_remap1_float" />
-    </sign>
-    <multiply name="N_gamma_float" type="float">
-      <input name="in1" type="float" nodename="N_pow_float" />
-      <input name="in2" type="float" nodename="N_sign_float" />
-    </multiply>
-    <remap name="N_remap2_float" type="float">
-      <input name="in" type="float" nodename="N_gamma_float" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
-      <input name="outlow" type="float" interfacename="outlow" />
-      <input name="outhigh" type="float" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_float" type="float">
-      <input name="in" type="float" nodename="N_remap2_float" />
-      <input name="low" type="float" interfacename="outlow" />
-      <input name="high" type="float" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_float" type="float">
-      <input name="in1" type="float" nodename="N_clamp_float" />
-      <input name="in2" type="float" nodename="N_remap2_float" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="float" nodename="N_switch_float" />
-  </nodegraph>
-  <nodegraph name="NG_range_color3" nodedef="ND_range_color3">
-    <remap name="N_remap1_color3" type="color3">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="inlow" type="color3" interfacename="inlow" />
-      <input name="inhigh" type="color3" interfacename="inhigh" />
-      <input name="outlow" type="color3" value="0.0, 0.0, 0.0" />
-      <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" />
-    </remap>
-    <divide name="N_recip_color3" type="color3">
-      <input name="in1" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="in2" type="color3" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_color3" type="color3">
-      <input name="in" type="color3" nodename="N_remap1_color3" />
-    </absval>
-    <power name="N_pow_color3" type="color3">
-      <input name="in1" type="color3" nodename="N_abs_color3" />
-      <input name="in2" type="color3" nodename="N_recip_color3" />
-    </power>
-    <sign name="N_sign_color3" type="color3">
-      <input name="in" type="color3" nodename="N_remap1_color3" />
-    </sign>
-    <multiply name="N_gamma_color3" type="color3">
-      <input name="in1" type="color3" nodename="N_pow_color3" />
-      <input name="in2" type="color3" nodename="N_sign_color3" />
-    </multiply>
-    <remap name="N_remap2_color3" type="color3">
-      <input name="in" type="color3" nodename="N_gamma_color3" />
-      <input name="inlow" type="color3" value="0.0, 0.0, 0.0" />
-      <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" />
-      <input name="outlow" type="color3" interfacename="outlow" />
-      <input name="outhigh" type="color3" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_color3" type="color3">
-      <input name="in" type="color3" nodename="N_remap2_color3" />
-      <input name="low" type="color3" interfacename="outlow" />
-      <input name="high" type="color3" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_color3" type="color3">
-      <input name="in1" type="color3" nodename="N_clamp_color3" />
-      <input name="in2" type="color3" nodename="N_remap2_color3" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="color3" nodename="N_switch_color3" />
-  </nodegraph>
-  <nodegraph name="NG_range_color4" nodedef="ND_range_color4">
-    <remap name="N_remap1_color4" type="color4">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="inlow" type="color4" interfacename="inlow" />
-      <input name="inhigh" type="color4" interfacename="inhigh" />
-      <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    </remap>
-    <divide name="N_recip_color4" type="color4">
-      <input name="in1" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-      <input name="in2" type="color4" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_color4" type="color4">
-      <input name="in" type="color4" nodename="N_remap1_color4" />
-    </absval>
-    <power name="N_pow_color4" type="color4">
-      <input name="in1" type="color4" nodename="N_abs_color4" />
-      <input name="in2" type="color4" nodename="N_recip_color4" />
-    </power>
-    <sign name="N_sign_color4" type="color4">
-      <input name="in" type="color4" nodename="N_remap1_color4" />
-    </sign>
-    <multiply name="N_gamma_color4" type="color4">
-      <input name="in1" type="color4" nodename="N_pow_color4" />
-      <input name="in2" type="color4" nodename="N_sign_color4" />
-    </multiply>
-    <remap name="N_remap2_color4" type="color4">
-      <input name="in" type="color4" nodename="N_gamma_color4" />
-      <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-      <input name="outlow" type="color4" interfacename="outlow" />
-      <input name="outhigh" type="color4" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_color4" type="color4">
-      <input name="in" type="color4" nodename="N_remap2_color4" />
-      <input name="low" type="color4" interfacename="outlow" />
-      <input name="high" type="color4" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_color4" type="color4">
-      <input name="in1" type="color4" nodename="N_clamp_color4" />
-      <input name="in2" type="color4" nodename="N_remap2_color4" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="color4" nodename="N_switch_color4" />
-  </nodegraph>
-  <nodegraph name="NG_range_vector2" nodedef="ND_range_vector2">
-    <remap name="N_remap1_vector2" type="vector2">
-      <input name="in" type="vector2" interfacename="in" />
-      <input name="inlow" type="vector2" interfacename="inlow" />
-      <input name="inhigh" type="vector2" interfacename="inhigh" />
-      <input name="outlow" type="vector2" value="0.0, 0.0" />
-      <input name="outhigh" type="vector2" value="1.0, 1.0" />
-    </remap>
-    <divide name="N_recip_vector2" type="vector2">
-      <input name="in1" type="vector2" value="1.0, 1.0" />
-      <input name="in2" type="vector2" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_vector2" type="vector2">
-      <input name="in" type="vector2" nodename="N_remap1_vector2" />
-    </absval>
-    <power name="N_pow_vector2" type="vector2">
-      <input name="in1" type="vector2" nodename="N_abs_vector2" />
-      <input name="in2" type="vector2" nodename="N_recip_vector2" />
-    </power>
-    <sign name="N_sign_vector2" type="vector2">
-      <input name="in" type="vector2" nodename="N_remap1_vector2" />
-    </sign>
-    <multiply name="N_gamma_vector2" type="vector2">
-      <input name="in1" type="vector2" nodename="N_pow_vector2" />
-      <input name="in2" type="vector2" nodename="N_sign_vector2" />
-    </multiply>
-    <remap name="N_remap2_vector2" type="vector2">
-      <input name="in" type="vector2" nodename="N_gamma_vector2" />
-      <input name="inlow" type="vector2" value="0.0, 0.0" />
-      <input name="inhigh" type="vector2" value="1.0, 1.0" />
-      <input name="outlow" type="vector2" interfacename="outlow" />
-      <input name="outhigh" type="vector2" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_vector2" type="vector2">
-      <input name="in" type="vector2" nodename="N_remap2_vector2" />
-      <input name="low" type="vector2" interfacename="outlow" />
-      <input name="high" type="vector2" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_vector2" type="vector2">
-      <input name="in1" type="vector2" nodename="N_clamp_vector2" />
-      <input name="in2" type="vector2" nodename="N_remap2_vector2" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="vector2" nodename="N_switch_vector2" />
-  </nodegraph>
-  <nodegraph name="NG_range_vector3" nodedef="ND_range_vector3">
-    <remap name="N_remap1_vector3" type="vector3">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="inlow" type="vector3" interfacename="inlow" />
-      <input name="inhigh" type="vector3" interfacename="inhigh" />
-      <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    </remap>
-    <divide name="N_recip_vector3" type="vector3">
-      <input name="in1" type="vector3" value="1.0, 1.0, 1.0" />
-      <input name="in2" type="vector3" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_vector3" type="vector3">
-      <input name="in" type="vector3" nodename="N_remap1_vector3" />
-    </absval>
-    <power name="N_pow_vector3" type="vector3">
-      <input name="in1" type="vector3" nodename="N_abs_vector3" />
-      <input name="in2" type="vector3" nodename="N_recip_vector3" />
-    </power>
-    <sign name="N_sign_vector3" type="vector3">
-      <input name="in" type="vector3" nodename="N_remap1_vector3" />
-    </sign>
-    <multiply name="N_gamma_vector3" type="vector3">
-      <input name="in1" type="vector3" nodename="N_pow_vector3" />
-      <input name="in2" type="vector3" nodename="N_sign_vector3" />
-    </multiply>
-    <remap name="N_remap2_vector3" type="vector3">
-      <input name="in" type="vector3" nodename="N_gamma_vector3" />
-      <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" />
-      <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" />
-      <input name="outlow" type="vector3" interfacename="outlow" />
-      <input name="outhigh" type="vector3" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_vector3" type="vector3">
-      <input name="in" type="vector3" nodename="N_remap2_vector3" />
-      <input name="low" type="vector3" interfacename="outlow" />
-      <input name="high" type="vector3" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_vector3" type="vector3">
-      <input name="in1" type="vector3" nodename="N_clamp_vector3" />
-      <input name="in2" type="vector3" nodename="N_remap2_vector3" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="vector3" nodename="N_switch_vector3" />
-  </nodegraph>
-  <nodegraph name="NG_range_vector4" nodedef="ND_range_vector4">
-    <remap name="N_remap1_vector4" type="vector4">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="inlow" type="vector4" interfacename="inlow" />
-      <input name="inhigh" type="vector4" interfacename="inhigh" />
-      <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    </remap>
-    <divide name="N_recip_vector4" type="vector4">
-      <input name="in1" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-      <input name="in2" type="vector4" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_vector4" type="vector4">
-      <input name="in" type="vector4" nodename="N_remap1_vector4" />
-    </absval>
-    <power name="N_pow_vector4" type="vector4">
-      <input name="in1" type="vector4" nodename="N_abs_vector4" />
-      <input name="in2" type="vector4" nodename="N_recip_vector4" />
-    </power>
-    <sign name="N_sign_vector4" type="vector4">
-      <input name="in" type="vector4" nodename="N_remap1_vector4" />
-    </sign>
-    <multiply name="N_gamma_vector4" type="vector4">
-      <input name="in1" type="vector4" nodename="N_pow_vector4" />
-      <input name="in2" type="vector4" nodename="N_sign_vector4" />
-    </multiply>
-    <remap name="N_remap2_vector4" type="vector4">
-      <input name="in" type="vector4" nodename="N_gamma_vector4" />
-      <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-      <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-      <input name="outlow" type="vector4" interfacename="outlow" />
-      <input name="outhigh" type="vector4" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_vector4" type="vector4">
-      <input name="in" type="vector4" nodename="N_remap2_vector4" />
-      <input name="low" type="vector4" interfacename="outlow" />
-      <input name="high" type="vector4" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_vector4" type="vector4">
-      <input name="in1" type="vector4" nodename="N_clamp_vector4" />
-      <input name="in2" type="vector4" nodename="N_remap2_vector4" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="vector4" nodename="N_switch_vector4" />
-  </nodegraph>
-  <nodegraph name="NG_range_color3FA" nodedef="ND_range_color3FA">
-    <remap name="N_remap1_color3FA" type="color3">
-      <input name="in" type="color3" interfacename="in" />
-      <input name="inlow" type="float" interfacename="inlow" />
-      <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
-    </remap>
-    <divide name="N_recip_color3FA" type="float">
-      <input name="in1" type="float" value="1.0" />
-      <input name="in2" type="float" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_color3FA" type="color3">
-      <input name="in" type="color3" nodename="N_remap1_color3FA" />
-    </absval>
-    <power name="N_pow_color3FA" type="color3">
-      <input name="in1" type="color3" nodename="N_abs_color3FA" />
-      <input name="in2" type="float" nodename="N_recip_color3FA" />
-    </power>
-    <sign name="N_sign_color3FA" type="color3">
-      <input name="in" type="color3" nodename="N_remap1_color3FA" />
-    </sign>
-    <multiply name="N_gamma_color3FA" type="color3">
-      <input name="in1" type="color3" nodename="N_pow_color3FA" />
-      <input name="in2" type="color3" nodename="N_sign_color3FA" />
-    </multiply>
-    <remap name="N_remap2_color3FA" type="color3">
-      <input name="in" type="color3" nodename="N_gamma_color3FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
-      <input name="outlow" type="float" interfacename="outlow" />
-      <input name="outhigh" type="float" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_color3FA" type="color3">
-      <input name="in" type="color3" nodename="N_remap2_color3FA" />
-      <input name="low" type="float" interfacename="outlow" />
-      <input name="high" type="float" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_color3FA" type="color3">
-      <input name="in1" type="color3" nodename="N_clamp_color3FA" />
-      <input name="in2" type="color3" nodename="N_remap2_color3FA" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="color3" nodename="N_switch_color3FA" />
-  </nodegraph>
-  <nodegraph name="NG_range_color4FA" nodedef="ND_range_color4FA">
-    <remap name="N_remap1_color4FA" type="color4">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="inlow" type="float" interfacename="inlow" />
-      <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
-    </remap>
-    <divide name="N_recip_color4FA" type="float">
-      <input name="in1" type="float" value="1.0" />
-      <input name="in2" type="float" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_color4FA" type="color4">
-      <input name="in" type="color4" nodename="N_remap1_color4FA" />
-    </absval>
-    <power name="N_pow_color4FA" type="color4">
-      <input name="in1" type="color4" nodename="N_abs_color4FA" />
-      <input name="in2" type="float" nodename="N_recip_color4FA" />
-    </power>
-    <sign name="N_sign_color4FA" type="color4">
-      <input name="in" type="color4" nodename="N_remap1_color4FA" />
-    </sign>
-    <multiply name="N_gamma_color4FA" type="color4">
-      <input name="in1" type="color4" nodename="N_pow_color4FA" />
-      <input name="in2" type="color4" nodename="N_sign_color4FA" />
-    </multiply>
-    <remap name="N_remap2_color4FA" type="color4">
-      <input name="in" type="color4" nodename="N_gamma_color4FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
-      <input name="outlow" type="float" interfacename="outlow" />
-      <input name="outhigh" type="float" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_color4FA" type="color4">
-      <input name="in" type="color4" nodename="N_remap2_color4FA" />
-      <input name="low" type="float" interfacename="outlow" />
-      <input name="high" type="float" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_color4FA" type="color4">
-      <input name="in1" type="color4" nodename="N_clamp_color4FA" />
-      <input name="in2" type="color4" nodename="N_remap2_color4FA" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="color4" nodename="N_switch_color4FA" />
-  </nodegraph>
-  <nodegraph name="NG_range_vector2FA" nodedef="ND_range_vector2FA">
-    <remap name="N_remap1_vector2FA" type="vector2">
-      <input name="in" type="vector2" interfacename="in" />
-      <input name="inlow" type="float" interfacename="inlow" />
-      <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
-    </remap>
-    <divide name="N_recip_vector2FA" type="float">
-      <input name="in1" type="float" value="1.0" />
-      <input name="in2" type="float" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_vector2FA" type="vector2">
-      <input name="in" type="vector2" nodename="N_remap1_vector2FA" />
-    </absval>
-    <power name="N_pow_vector2FA" type="vector2">
-      <input name="in1" type="vector2" nodename="N_abs_vector2FA" />
-      <input name="in2" type="float" nodename="N_recip_vector2FA" />
-    </power>
-    <sign name="N_sign_vector2FA" type="vector2">
-      <input name="in" type="vector2" nodename="N_remap1_vector2FA" />
-    </sign>
-    <multiply name="N_gamma_vector2FA" type="vector2">
-      <input name="in1" type="vector2" nodename="N_pow_vector2FA" />
-      <input name="in2" type="vector2" nodename="N_sign_vector2FA" />
-    </multiply>
-    <remap name="N_remap2_vector2FA" type="vector2">
-      <input name="in" type="vector2" nodename="N_gamma_vector2FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
-      <input name="outlow" type="float" interfacename="outlow" />
-      <input name="outhigh" type="float" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_vector2FA" type="vector2">
-      <input name="in" type="vector2" nodename="N_remap2_vector2FA" />
-      <input name="low" type="float" interfacename="outlow" />
-      <input name="high" type="float" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_vector2FA" type="vector2">
-      <input name="in1" type="vector2" nodename="N_clamp_vector2FA" />
-      <input name="in2" type="vector2" nodename="N_remap2_vector2FA" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="vector2" nodename="N_switch_vector2FA" />
-  </nodegraph>
-  <nodegraph name="NG_range_vector3FA" nodedef="ND_range_vector3FA">
-    <remap name="N_remap1_vector3FA" type="vector3">
-      <input name="in" type="vector3" interfacename="in" />
-      <input name="inlow" type="float" interfacename="inlow" />
-      <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
-    </remap>
-    <divide name="N_recip_vector3FA" type="float">
-      <input name="in1" type="float" value="1.0" />
-      <input name="in2" type="float" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_vector3FA" type="vector3">
-      <input name="in" type="vector3" nodename="N_remap1_vector3FA" />
-    </absval>
-    <power name="N_pow_vector3FA" type="vector3">
-      <input name="in1" type="vector3" nodename="N_abs_vector3FA" />
-      <input name="in2" type="float" nodename="N_recip_vector3FA" />
-    </power>
-    <sign name="N_sign_vector3FA" type="vector3">
-      <input name="in" type="vector3" nodename="N_remap1_vector3FA" />
-    </sign>
-    <multiply name="N_gamma_vector3FA" type="vector3">
-      <input name="in1" type="vector3" nodename="N_pow_vector3FA" />
-      <input name="in2" type="vector3" nodename="N_sign_vector3FA" />
-    </multiply>
-    <remap name="N_remap2_vector3FA" type="vector3">
-      <input name="in" type="vector3" nodename="N_gamma_vector3FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
-      <input name="outlow" type="float" interfacename="outlow" />
-      <input name="outhigh" type="float" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_vector3FA" type="vector3">
-      <input name="in" type="vector3" nodename="N_remap2_vector3FA" />
-      <input name="low" type="float" interfacename="outlow" />
-      <input name="high" type="float" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_vector3FA" type="vector3">
-      <input name="in1" type="vector3" nodename="N_clamp_vector3FA" />
-      <input name="in2" type="vector3" nodename="N_remap2_vector3FA" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="vector3" nodename="N_switch_vector3FA" />
-  </nodegraph>
-  <nodegraph name="NG_range_vector4FA" nodedef="ND_range_vector4FA">
-    <remap name="N_remap1_vector4FA" type="vector4">
-      <input name="in" type="vector4" interfacename="in" />
-      <input name="inlow" type="float" interfacename="inlow" />
-      <input name="inhigh" type="float" interfacename="inhigh" />
-      <input name="outlow" type="float" value="0.0" />
-      <input name="outhigh" type="float" value="1.0" />
-    </remap>
-    <divide name="N_recip_vector4FA" type="float">
-      <input name="in1" type="float" value="1.0" />
-      <input name="in2" type="float" interfacename="gamma" />
-    </divide>
-    <absval name="N_abs_vector4FA" type="vector4">
-      <input name="in" type="vector4" nodename="N_remap1_vector4FA" />
-    </absval>
-    <power name="N_pow_vector4FA" type="vector4">
-      <input name="in1" type="vector4" nodename="N_abs_vector4FA" />
-      <input name="in2" type="float" nodename="N_recip_vector4FA" />
-    </power>
-    <sign name="N_sign_vector4FA" type="vector4">
-      <input name="in" type="vector4" nodename="N_remap1_vector4FA" />
-    </sign>
-    <multiply name="N_gamma_vector4FA" type="vector4">
-      <input name="in1" type="vector4" nodename="N_pow_vector4FA" />
-      <input name="in2" type="vector4" nodename="N_sign_vector4FA" />
-    </multiply>
-    <remap name="N_remap2_vector4FA" type="vector4">
-      <input name="in" type="vector4" nodename="N_gamma_vector4FA" />
-      <input name="inlow" type="float" value="0.0" />
-      <input name="inhigh" type="float" value="1.0" />
-      <input name="outlow" type="float" interfacename="outlow" />
-      <input name="outhigh" type="float" interfacename="outhigh" />
-    </remap>
-    <clamp name="N_clamp_vector4FA" type="vector4">
-      <input name="in" type="vector4" nodename="N_remap2_vector4FA" />
-      <input name="low" type="float" interfacename="outlow" />
-      <input name="high" type="float" interfacename="outhigh" />
-    </clamp>
-    <ifequal name="N_switch_vector4FA" type="vector4">
-      <input name="in1" type="vector4" nodename="N_clamp_vector4FA" />
-      <input name="in2" type="vector4" nodename="N_remap2_vector4FA" />
-      <input name="value1" type="boolean" interfacename="doclamp" />
-      <input name="value2" type="boolean" value="true" />
-    </ifequal>
-    <output name="out" type="vector4" nodename="N_switch_vector4FA" />
-  </nodegraph>
+  <template name="TP_NG_range" varName="typeName" options="float, color3, color4, vector2, vector3, vector4">
+    <nodegraph name="NG_range_@typeName@" nodedef="ND_range_@typeName@">
+      <remap name="N_remap1" type="@typeName@">
+        <input name="in" type="@typeName@" interfacename="in" />
+        <input name="inlow" type="@typeName@" interfacename="inlow" />
+        <input name="inhigh" type="@typeName@" interfacename="inhigh" />
+        <input name="outlow" type="@typeName@" value="Value:zero" />
+        <input name="outhigh" type="@typeName@" value="Value:one" />
+      </remap>
+      <divide name="N_recip" type="@typeName@">
+        <input name="in1" type="@typeName@" value="Value:one" />
+        <input name="in2" type="@typeName@" interfacename="gamma" />
+      </divide>
+      <absval name="N_abs" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_remap1" />
+      </absval>
+      <power name="N_pow" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="N_abs" />
+        <input name="in2" type="@typeName@" nodename="N_recip" />
+      </power>
+      <sign name="N_sign" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_remap1" />
+      </sign>
+      <multiply name="N_gamma" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="N_pow" />
+        <input name="in2" type="@typeName@" nodename="N_sign" />
+      </multiply>
+      <remap name="N_remap2" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_gamma" />
+        <input name="inlow" type="@typeName@" value="Value:zero" />
+        <input name="inhigh" type="@typeName@" value="Value:one" />
+        <input name="outlow" type="@typeName@" interfacename="outlow" />
+        <input name="outhigh" type="@typeName@" interfacename="outhigh" />
+      </remap>
+      <clamp name="N_clamp" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_remap2" />
+        <input name="low" type="@typeName@" interfacename="outlow" />
+        <input name="high" type="@typeName@" interfacename="outhigh" />
+      </clamp>
+      <ifequal name="N_switch" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="N_clamp" />
+        <input name="in2" type="@typeName@" nodename="N_remap2" />
+        <input name="value1" type="boolean" interfacename="doclamp" />
+        <input name="value2" type="boolean" value="true" />
+      </ifequal>
+      <output name="out" type="@typeName@" nodename="N_switch" />
+    </nodegraph>
+  </template>
+  <template name="TP_NG_rangeFA" varName="typeName" options="color3, color4, vector2, vector3, vector4">
+    <nodegraph name="NG_range_@typeName@FA" nodedef="ND_range_@typeName@FA">
+      <remap name="N_remap1_FA" type="@typeName@">
+        <input name="in" type="@typeName@" interfacename="in" />
+        <input name="inlow" type="float" interfacename="inlow" />
+        <input name="inhigh" type="float" interfacename="inhigh" />
+        <input name="outlow" type="float" value="Value:zero" />
+        <input name="outhigh" type="float" value="Value:one" />
+      </remap>
+      <divide name="N_recip_FA" type="float">
+        <input name="in1" type="float" value="Value:one" />
+        <input name="in2" type="float" interfacename="gamma" />
+      </divide>
+      <absval name="N_abs_FA" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_remap1_FA" />
+      </absval>
+      <power name="N_pow_FA" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="N_abs_FA" />
+        <input name="in2" type="float" nodename="N_recip_FA" />
+      </power>
+      <sign name="N_sign_FA" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_remap1_FA" />
+      </sign>
+      <multiply name="N_gamma_FA" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="N_pow_FA" />
+        <input name="in2" type="@typeName@" nodename="N_sign_FA" />
+      </multiply>
+      <remap name="N_remap2_FA" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_gamma_FA" />
+        <input name="inlow" type="float" value="Value:zero" />
+        <input name="inhigh" type="float" value="Value:one" />
+        <input name="outlow" type="float" interfacename="outlow" />
+        <input name="outhigh" type="float" interfacename="outhigh" />
+      </remap>
+      <clamp name="N_clamp_FA" type="@typeName@">
+        <input name="in" type="@typeName@" nodename="N_remap2_FA" />
+        <input name="low" type="float" interfacename="outlow" />
+        <input name="high" type="float" interfacename="outhigh" />
+      </clamp>
+      <ifequal name="N_switch_FA" type="@typeName@">
+        <input name="in1" type="@typeName@" nodename="N_clamp_FA" />
+        <input name="in2" type="@typeName@" nodename="N_remap2_FA" />
+        <input name="value1" type="boolean" interfacename="doclamp" />
+        <input name="value2" type="boolean" value="true" />
+      </ifequal>
+      <output name="out" type="@typeName@" nodename="N_switch_FA" />
+    </nodegraph>
+  </template>
 
   <!--
     Node: <hsvadjust>
@@ -5192,1016 +4634,136 @@
   <!-- Switch nodes                                                             -->
   <!-- ======================================================================== -->
 
-  <nodegraph name="NG_switch_float" nodedef="ND_switch_float">
-    <ifgreater name="ifgreater_10" type="float">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in10" />
-      <input name="in2" type="float" value="0.0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="float">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in9" />
-      <input name="in2" type="float" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="float">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in8" />
-      <input name="in2" type="float" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="float">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in7" />
-      <input name="in2" type="float" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="float">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in6" />
-      <input name="in2" type="float" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="float">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in5" />
-      <input name="in2" type="float" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="float">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in4" />
-      <input name="in2" type="float" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="float">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in3" />
-      <input name="in2" type="float" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="float">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in2" />
-      <input name="in2" type="float" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="float">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="float" interfacename="in1" />
-      <input name="in2" type="float" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="float" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_color3" nodedef="ND_switch_color3">
-    <ifgreater name="ifgreater_10" type="color3">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in10" />
-      <input name="in2" type="color3" value="0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="color3">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in9" />
-      <input name="in2" type="color3" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="color3">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in8" />
-      <input name="in2" type="color3" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="color3">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in7" />
-      <input name="in2" type="color3" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="color3">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in6" />
-      <input name="in2" type="color3" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="color3">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in5" />
-      <input name="in2" type="color3" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="color3">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in4" />
-      <input name="in2" type="color3" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="color3">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in3" />
-      <input name="in2" type="color3" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="color3">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in2" />
-      <input name="in2" type="color3" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="color3">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in1" />
-      <input name="in2" type="color3" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="color3" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_color4" nodedef="ND_switch_color4">
-    <ifgreater name="ifgreater_10" type="color4">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in10" />
-      <input name="in2" type="color4" value="0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="color4">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in9" />
-      <input name="in2" type="color4" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="color4">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in8" />
-      <input name="in2" type="color4" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="color4">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in7" />
-      <input name="in2" type="color4" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="color4">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in6" />
-      <input name="in2" type="color4" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="color4">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in5" />
-      <input name="in2" type="color4" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="color4">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in4" />
-      <input name="in2" type="color4" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="color4">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in3" />
-      <input name="in2" type="color4" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="color4">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in2" />
-      <input name="in2" type="color4" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="color4">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in1" />
-      <input name="in2" type="color4" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="color4" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_vector2" nodedef="ND_switch_vector2">
-    <ifgreater name="ifgreater_10" type="vector2">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in10" />
-      <input name="in2" type="vector2" value="0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="vector2">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in9" />
-      <input name="in2" type="vector2" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="vector2">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in8" />
-      <input name="in2" type="vector2" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="vector2">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in7" />
-      <input name="in2" type="vector2" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="vector2">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in6" />
-      <input name="in2" type="vector2" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="vector2">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in5" />
-      <input name="in2" type="vector2" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="vector2">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in4" />
-      <input name="in2" type="vector2" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="vector2">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in3" />
-      <input name="in2" type="vector2" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="vector2">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in2" />
-      <input name="in2" type="vector2" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="vector2">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in1" />
-      <input name="in2" type="vector2" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="vector2" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_vector3" nodedef="ND_switch_vector3">
-    <ifgreater name="ifgreater_10" type="vector3">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in10" />
-      <input name="in2" type="vector3" value="0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="vector3">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in9" />
-      <input name="in2" type="vector3" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="vector3">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in8" />
-      <input name="in2" type="vector3" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="vector3">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in7" />
-      <input name="in2" type="vector3" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="vector3">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in6" />
-      <input name="in2" type="vector3" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="vector3">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in5" />
-      <input name="in2" type="vector3" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="vector3">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in4" />
-      <input name="in2" type="vector3" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="vector3">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in3" />
-      <input name="in2" type="vector3" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="vector3">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in2" />
-      <input name="in2" type="vector3" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="vector3">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in1" />
-      <input name="in2" type="vector3" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="vector3" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_vector4" nodedef="ND_switch_vector4">
-    <ifgreater name="ifgreater_10" type="vector4">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in10" />
-      <input name="in2" type="vector4" value="0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="vector4">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in9" />
-      <input name="in2" type="vector4" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="vector4">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in8" />
-      <input name="in2" type="vector4" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="vector4">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in7" />
-      <input name="in2" type="vector4" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="vector4">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in6" />
-      <input name="in2" type="vector4" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="vector4">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in5" />
-      <input name="in2" type="vector4" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="vector4">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in4" />
-      <input name="in2" type="vector4" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="vector4">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in3" />
-      <input name="in2" type="vector4" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="vector4">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in2" />
-      <input name="in2" type="vector4" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="vector4">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in1" />
-      <input name="in2" type="vector4" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="vector4" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_matrix33" nodedef="ND_switch_matrix33">
-    <ifgreater name="ifgreater_10" type="matrix33">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in10" />
-      <input name="in2" type="matrix33" value="0,0,0,0,0,0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="matrix33">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in9" />
-      <input name="in2" type="matrix33" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="matrix33">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in8" />
-      <input name="in2" type="matrix33" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="matrix33">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in7" />
-      <input name="in2" type="matrix33" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="matrix33">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in6" />
-      <input name="in2" type="matrix33" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="matrix33">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in5" />
-      <input name="in2" type="matrix33" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="matrix33">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in4" />
-      <input name="in2" type="matrix33" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="matrix33">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in3" />
-      <input name="in2" type="matrix33" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="matrix33">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in2" />
-      <input name="in2" type="matrix33" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="matrix33">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in1" />
-      <input name="in2" type="matrix33" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="matrix33" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_matrix44" nodedef="ND_switch_matrix44">
-    <ifgreater name="ifgreater_10" type="matrix44">
-      <input name="value1" type="float" value="10.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in10" />
-      <input name="in2" type="matrix44" value="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="matrix44">
-      <input name="value1" type="float" value="9.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in9" />
-      <input name="in2" type="matrix44" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="matrix44">
-      <input name="value1" type="float" value="8.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in8" />
-      <input name="in2" type="matrix44" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="matrix44">
-      <input name="value1" type="float" value="7.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in7" />
-      <input name="in2" type="matrix44" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="matrix44">
-      <input name="value1" type="float" value="6.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in6" />
-      <input name="in2" type="matrix44" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="matrix44">
-      <input name="value1" type="float" value="5.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in5" />
-      <input name="in2" type="matrix44" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="matrix44">
-      <input name="value1" type="float" value="4.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in4" />
-      <input name="in2" type="matrix44" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="matrix44">
-      <input name="value1" type="float" value="3.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in3" />
-      <input name="in2" type="matrix44" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="matrix44">
-      <input name="value1" type="float" value="2.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in2" />
-      <input name="in2" type="matrix44" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="matrix44">
-      <input name="value1" type="float" value="1.0" />
-      <input name="value2" type="float" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in1" />
-      <input name="in2" type="matrix44" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="matrix44" nodename="ifgreater_1" />
-  </nodegraph>
-
-  <nodegraph name="NG_switch_floatI" nodedef="ND_switch_floatI">
-    <ifgreater name="ifgreater_10" type="float">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in10" />
-      <input name="in2" type="float" value="0.0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="float">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in9" />
-      <input name="in2" type="float" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="float">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in8" />
-      <input name="in2" type="float" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="float">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in7" />
-      <input name="in2" type="float" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="float">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in6" />
-      <input name="in2" type="float" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="float">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in5" />
-      <input name="in2" type="float" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="float">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in4" />
-      <input name="in2" type="float" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="float">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in3" />
-      <input name="in2" type="float" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="float">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in2" />
-      <input name="in2" type="float" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="float">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="float" interfacename="in1" />
-      <input name="in2" type="float" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="float" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_color3I" nodedef="ND_switch_color3I">
-    <ifgreater name="ifgreater_10" type="color3">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in10" />
-      <input name="in2" type="color3" value="0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="color3">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in9" />
-      <input name="in2" type="color3" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="color3">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in8" />
-      <input name="in2" type="color3" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="color3">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in7" />
-      <input name="in2" type="color3" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="color3">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in6" />
-      <input name="in2" type="color3" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="color3">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in5" />
-      <input name="in2" type="color3" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="color3">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in4" />
-      <input name="in2" type="color3" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="color3">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in3" />
-      <input name="in2" type="color3" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="color3">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in2" />
-      <input name="in2" type="color3" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="color3">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color3" interfacename="in1" />
-      <input name="in2" type="color3" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="color3" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_color4I" nodedef="ND_switch_color4I">
-    <ifgreater name="ifgreater_10" type="color4">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in10" />
-      <input name="in2" type="color4" value="0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="color4">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in9" />
-      <input name="in2" type="color4" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="color4">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in8" />
-      <input name="in2" type="color4" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="color4">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in7" />
-      <input name="in2" type="color4" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="color4">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in6" />
-      <input name="in2" type="color4" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="color4">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in5" />
-      <input name="in2" type="color4" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="color4">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in4" />
-      <input name="in2" type="color4" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="color4">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in3" />
-      <input name="in2" type="color4" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="color4">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in2" />
-      <input name="in2" type="color4" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="color4">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="color4" interfacename="in1" />
-      <input name="in2" type="color4" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="color4" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_vector2I" nodedef="ND_switch_vector2I">
-    <ifgreater name="ifgreater_10" type="vector2">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in10" />
-      <input name="in2" type="vector2" value="0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="vector2">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in9" />
-      <input name="in2" type="vector2" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="vector2">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in8" />
-      <input name="in2" type="vector2" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="vector2">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in7" />
-      <input name="in2" type="vector2" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="vector2">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in6" />
-      <input name="in2" type="vector2" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="vector2">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in5" />
-      <input name="in2" type="vector2" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="vector2">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in4" />
-      <input name="in2" type="vector2" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="vector2">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in3" />
-      <input name="in2" type="vector2" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="vector2">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in2" />
-      <input name="in2" type="vector2" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="vector2">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector2" interfacename="in1" />
-      <input name="in2" type="vector2" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="vector2" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_vector3I" nodedef="ND_switch_vector3I">
-    <ifgreater name="ifgreater_10" type="vector3">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in10" />
-      <input name="in2" type="vector3" value="0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="vector3">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in9" />
-      <input name="in2" type="vector3" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="vector3">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in8" />
-      <input name="in2" type="vector3" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="vector3">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in7" />
-      <input name="in2" type="vector3" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="vector3">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in6" />
-      <input name="in2" type="vector3" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="vector3">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in5" />
-      <input name="in2" type="vector3" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="vector3">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in4" />
-      <input name="in2" type="vector3" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="vector3">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in3" />
-      <input name="in2" type="vector3" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="vector3">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in2" />
-      <input name="in2" type="vector3" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="vector3">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector3" interfacename="in1" />
-      <input name="in2" type="vector3" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="vector3" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_vector4I" nodedef="ND_switch_vector4I">
-    <ifgreater name="ifgreater_10" type="vector4">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in10" />
-      <input name="in2" type="vector4" value="0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="vector4">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in9" />
-      <input name="in2" type="vector4" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="vector4">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in8" />
-      <input name="in2" type="vector4" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="vector4">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in7" />
-      <input name="in2" type="vector4" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="vector4">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in6" />
-      <input name="in2" type="vector4" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="vector4">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in5" />
-      <input name="in2" type="vector4" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="vector4">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in4" />
-      <input name="in2" type="vector4" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="vector4">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in3" />
-      <input name="in2" type="vector4" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="vector4">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in2" />
-      <input name="in2" type="vector4" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="vector4">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="vector4" interfacename="in1" />
-      <input name="in2" type="vector4" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="vector4" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_matrix33I" nodedef="ND_switch_matrix33I">
-    <ifgreater name="ifgreater_10" type="matrix33">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in10" />
-      <input name="in2" type="matrix33" value="0,0,0,0,0,0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="matrix33">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in9" />
-      <input name="in2" type="matrix33" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="matrix33">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in8" />
-      <input name="in2" type="matrix33" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="matrix33">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in7" />
-      <input name="in2" type="matrix33" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="matrix33">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in6" />
-      <input name="in2" type="matrix33" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="matrix33">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in5" />
-      <input name="in2" type="matrix33" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="matrix33">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in4" />
-      <input name="in2" type="matrix33" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="matrix33">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in3" />
-      <input name="in2" type="matrix33" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="matrix33">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in2" />
-      <input name="in2" type="matrix33" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="matrix33">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix33" interfacename="in1" />
-      <input name="in2" type="matrix33" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="matrix33" nodename="ifgreater_1" />
-  </nodegraph>
-  <nodegraph name="NG_switch_matrix44I" nodedef="ND_switch_matrix44I">
-    <ifgreater name="ifgreater_10" type="matrix44">
-      <input name="value1" type="integer" value="10" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in10" />
-      <input name="in2" type="matrix44" value="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" />
-    </ifgreater>
-    <ifgreater name="ifgreater_9" type="matrix44">
-      <input name="value1" type="integer" value="9" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in9" />
-      <input name="in2" type="matrix44" nodename="ifgreater_10" />
-    </ifgreater>
-    <ifgreater name="ifgreater_8" type="matrix44">
-      <input name="value1" type="integer" value="8" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in8" />
-      <input name="in2" type="matrix44" nodename="ifgreater_9" />
-    </ifgreater>
-    <ifgreater name="ifgreater_7" type="matrix44">
-      <input name="value1" type="integer" value="7" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in7" />
-      <input name="in2" type="matrix44" nodename="ifgreater_8" />
-    </ifgreater>
-    <ifgreater name="ifgreater_6" type="matrix44">
-      <input name="value1" type="integer" value="6" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in6" />
-      <input name="in2" type="matrix44" nodename="ifgreater_7" />
-    </ifgreater>
-    <ifgreater name="ifgreater_5" type="matrix44">
-      <input name="value1" type="integer" value="5" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in5" />
-      <input name="in2" type="matrix44" nodename="ifgreater_6" />
-    </ifgreater>
-    <ifgreater name="ifgreater_4" type="matrix44">
-      <input name="value1" type="integer" value="4" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in4" />
-      <input name="in2" type="matrix44" nodename="ifgreater_5" />
-    </ifgreater>
-    <ifgreater name="ifgreater_3" type="matrix44">
-      <input name="value1" type="integer" value="3" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in3" />
-      <input name="in2" type="matrix44" nodename="ifgreater_4" />
-    </ifgreater>
-    <ifgreater name="ifgreater_2" type="matrix44">
-      <input name="value1" type="integer" value="2" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in2" />
-      <input name="in2" type="matrix44" nodename="ifgreater_3" />
-    </ifgreater>
-    <ifgreater name="ifgreater_1" type="matrix44">
-      <input name="value1" type="integer" value="1" />
-      <input name="value2" type="integer" interfacename="which" />
-      <input name="in1" type="matrix44" interfacename="in1" />
-      <input name="in2" type="matrix44" nodename="ifgreater_2" />
-    </ifgreater>
-    <output name="out" type="matrix44" nodename="ifgreater_1" />
-  </nodegraph>
-
+  <template name="TP_NG_switch" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
+    <nodegraph name="NG_switch_@typeName@" nodedef="ND_switch_@typeName@">
+      <ifgreater name="ifgreater_10" type="@typeName@">
+        <input name="value1" type="float" value="10.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in10" />
+        <input name="in2" type="@typeName@" value="Value:zero" />
+      </ifgreater>
+      <ifgreater name="ifgreater_9" type="@typeName@">
+        <input name="value1" type="float" value="9.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in9" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_10" />
+      </ifgreater>
+      <ifgreater name="ifgreater_8" type="@typeName@">
+        <input name="value1" type="float" value="8.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in8" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_9" />
+      </ifgreater>
+      <ifgreater name="ifgreater_7" type="@typeName@">
+        <input name="value1" type="float" value="7.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in7" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_8" />
+      </ifgreater>
+      <ifgreater name="ifgreater_6" type="@typeName@">
+        <input name="value1" type="float" value="6.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in6" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_7" />
+      </ifgreater>
+      <ifgreater name="ifgreater_5" type="@typeName@">
+        <input name="value1" type="float" value="5.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in5" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_6" />
+      </ifgreater>
+      <ifgreater name="ifgreater_4" type="@typeName@">
+        <input name="value1" type="float" value="4.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in4" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_5" />
+      </ifgreater>
+      <ifgreater name="ifgreater_3" type="@typeName@">
+        <input name="value1" type="float" value="3.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in3" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_4" />
+      </ifgreater>
+      <ifgreater name="ifgreater_2" type="@typeName@">
+        <input name="value1" type="float" value="2.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in2" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_3" />
+      </ifgreater>
+      <ifgreater name="ifgreater_1" type="@typeName@">
+        <input name="value1" type="float" value="1.0" />
+        <input name="value2" type="float" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in1" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_2" />
+      </ifgreater>
+      <output name="out" type="@typeName@" nodename="ifgreater_1" />
+    </nodegraph>
+  </template>
+  <template name="TP_NG_switchI" varName="typeName" options="float, color3, color4, vector2, vector3, vector4, matrix33, matrix44">
+    <nodegraph name="NG_switch_@typeName@I" nodedef="ND_switch_@typeName@I">
+      <ifgreater name="ifgreater_10" type="@typeName@">
+        <input name="value1" type="integer" value="10" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in10" />
+        <input name="in2" type="@typeName@" value="Value:zero" />
+      </ifgreater>
+      <ifgreater name="ifgreater_9" type="@typeName@">
+        <input name="value1" type="integer" value="9" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in9" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_10" />
+      </ifgreater>
+      <ifgreater name="ifgreater_8" type="@typeName@">
+        <input name="value1" type="integer" value="8" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in8" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_9" />
+      </ifgreater>
+      <ifgreater name="ifgreater_7" type="@typeName@">
+        <input name="value1" type="integer" value="7" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in7" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_8" />
+      </ifgreater>
+      <ifgreater name="ifgreater_6" type="@typeName@">
+        <input name="value1" type="integer" value="6" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in6" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_7" />
+      </ifgreater>
+      <ifgreater name="ifgreater_5" type="@typeName@">
+        <input name="value1" type="integer" value="5" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in5" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_6" />
+      </ifgreater>
+      <ifgreater name="ifgreater_4" type="@typeName@">
+        <input name="value1" type="integer" value="4" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in4" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_5" />
+      </ifgreater>
+      <ifgreater name="ifgreater_3" type="@typeName@">
+        <input name="value1" type="integer" value="3" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in3" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_4" />
+      </ifgreater>
+      <ifgreater name="ifgreater_2" type="@typeName@">
+        <input name="value1" type="integer" value="2" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in2" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_3" />
+      </ifgreater>
+      <ifgreater name="ifgreater_1" type="@typeName@">
+        <input name="value1" type="integer" value="1" />
+        <input name="value2" type="integer" interfacename="which" />
+        <input name="in1" type="@typeName@" interfacename="in1" />
+        <input name="in2" type="@typeName@" nodename="ifgreater_2" />
+      </ifgreater>
+      <output name="out" type="@typeName@" nodename="ifgreater_1" />
+    </nodegraph>
+  </template>
 
   <!-- ======================================================================== -->
   <!-- Logical operator nodes                                                   -->

--- a/python/MaterialXTest/main.py
+++ b/python/MaterialXTest/main.py
@@ -25,8 +25,9 @@ _testValues = (1,
                [1.0, 2.0, 3.0],
                ['one', 'two', 'three'])
 
+_defaultSearchPath = mx.getDefaultDataSearchPath().asString()
 _fileDir = os.path.dirname(os.path.abspath(__file__))
-_libraryDir = os.path.join(_fileDir, '../../libraries/stdlib/')
+_libraryDir = os.path.join(_defaultSearchPath, 'libraries/stdlib/')
 _exampleDir = os.path.join(_fileDir, '../../resources/Materials/Examples/')
 _searchPath = _libraryDir + mx.PATH_LIST_SEPARATOR + _exampleDir
 

--- a/source/JsMaterialX/CMakeLists.txt
+++ b/source/JsMaterialX/CMakeLists.txt
@@ -85,7 +85,7 @@ else()
 endif()
 
 
-set(JS_LINK_FLAGS_GENSHADER "${JS_LINK_FLAGS_CORE} --preload-file ${PROJECT_SOURCE_DIR}/libraries@libraries ")
+set(JS_LINK_FLAGS_GENSHADER "${JS_LINK_FLAGS_CORE} --preload-file ${PROJECT_BINARY_DIR}/libraries/DataLibraryBuild@libraries ")
 
 add_executable(JsMaterialXCore MaterialXLib.cpp
     ${CORE_DEPS}
@@ -129,6 +129,8 @@ set_target_properties(JsMaterialXGenShader
     LINK_FLAGS "${JS_LINK_FLAGS_GENSHADER}"
     INSTALL_RPATH "${MATERIALX_UP_TWO_RPATH}"
     SOVERSION "${MATERIALX_MAJOR_VERSION}")
+
+add_dependencies(JsMaterialXGenShader MaterialXBuildData)
 
 target_link_libraries(JsMaterialXCore
     PUBLIC MaterialXCore

--- a/source/MaterialXBuildTools/CMakeLists.txt
+++ b/source/MaterialXBuildTools/CMakeLists.txt
@@ -1,0 +1,19 @@
+# This subproject is necessary to support building the build tools on the host machine
+# where they may be used when cross compiling for another target
+
+cmake_minimum_required(VERSION 3.26)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+set(CMAKE_MACOSX_RPATH ON)
+
+project(MaterialXBuildTools)
+
+list(APPEND CMAKE_MODULE_PATH
+        ${PROJECT_SOURCE_DIR}/../../cmake/macros)
+
+include(Public)
+
+add_subdirectory(../MaterialXCore MaterialXCore)
+add_subdirectory(../MaterialXFormat MaterialXFormat)
+
+add_subdirectory(buildLibrary)

--- a/source/MaterialXBuildTools/buildLibrary/CMakeLists.txt
+++ b/source/MaterialXBuildTools/buildLibrary/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(TARGET_NAME MaterialXBuildLibrary)
+
+file(GLOB materialx_source       "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB materialx_headers      "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
+
+add_executable(${TARGET_NAME} ${materialx_source} ${materialx_headers})
+
+target_link_libraries(${TARGET_NAME} PRIVATE
+        MaterialXFormat
+        MaterialXCore)

--- a/source/MaterialXBuildTools/buildLibrary/Main.cpp
+++ b/source/MaterialXBuildTools/buildLibrary/Main.cpp
@@ -1,0 +1,201 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXFormat/Util.h>
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/XmlIo.h>
+#include <MaterialXCore/Exception.h>
+#include <MaterialXCore/Util.h>
+
+namespace mx = MaterialX;
+
+#include <iostream>
+
+const std::string cmdLineOptions =
+    " Options: \n"
+    "    --sourceLibraryRoot [FILEPATH]     Directory containing the source data library files.\n"
+    "    --destLibraryRoot [FILEPATH]       Directory to write the modified data library files.\n"
+    "    --help                             Display the complete list of command-line options\n";
+
+template <class T> void parseToken(std::string token, std::string type, T& res)
+{
+    if (token.empty())
+    {
+        return;
+    }
+
+    mx::ValuePtr value = mx::Value::createValueFromStrings(token, type);
+    if (!value)
+    {
+        std::cout << "Unable to parse token " << token << " as type " << type << std::endl;
+        return;
+    }
+
+    res = value->asA<T>();
+}
+
+mx::FilePathVec getMaterialXFiles(const mx::FilePath& libraryRoot)
+{
+    mx::FilePathVec result;
+
+    auto subDirs = libraryRoot.getSubDirectories();
+    for (const auto& subDir : subDirs)
+    {
+        for (const auto& file : subDir.getFilesInDirectory("mtlx"))
+        {
+            auto absFile = subDir / file;
+            std::string absFileStr = absFile.asString();
+            std::string relFileStr = absFileStr.substr(libraryRoot.asString().size()+1);
+            result.emplace_back(mx::FilePath(relFileStr));
+        }
+    }
+    return result;
+}
+
+void replaceNamedValues(mx::DocumentPtr doc, mx::ConstDocumentPtr stdlib)
+{
+    const std::string typeValuePrefix = "Value:";
+
+    // replace named value "Value:" strings with concrete values
+    for (auto elem : doc->traverseTree())
+    {
+        auto port = elem->asA<mx::PortElement>();
+        if (!port)
+        {
+            continue;
+        }
+
+        if (!port->hasValueString())
+        {
+            continue;
+        }
+
+        auto valueStr = port->getValueString();
+        if (mx::stringStartsWith(valueStr, typeValuePrefix))
+        {
+
+            auto typeDef = stdlib->getTypeDef(port->getType());
+            if (!typeDef)
+            {
+                throw mx::Exception("Unable to find typeDef '"+port->getType()+"'");
+            }
+
+            auto valueNameStr = valueStr.substr(typeValuePrefix.size());
+            if (!typeDef->hasAttribute(valueNameStr))
+            {
+                throw mx::Exception("Unable to find named value '"+valueNameStr+"' for type '"+typeDef->getName()+"'");
+            }
+
+            port->setValueString(typeDef->getAttribute(valueNameStr));
+        }
+    }
+}
+
+int main(int argc, char* const argv[])
+{
+    std::vector<std::string> tokens;
+    for (int i = 1; i < argc; i++)
+    {
+        tokens.emplace_back(argv[i]);
+    }
+
+    std::string sourceLibraryRootStr = "";
+    std::string destLibraryRootStr = "";
+    bool bakeNamedValues = false;
+    bool expandTemplateElems = false;
+
+    for (size_t i = 0; i < tokens.size(); i++)
+    {
+        const std::string& token = tokens[i];
+        const std::string& nextToken = i + 1 < tokens.size() ? tokens[i + 1] : mx::EMPTY_STRING;
+
+        if (token == "--sourceLibraryRoot")
+        {
+            sourceLibraryRootStr = nextToken;
+        }
+        else if (token == "--destLibraryRoot")
+        {
+            destLibraryRootStr = nextToken;
+        }
+        else if (token == "--bakeNamedValues")
+        {
+            bakeNamedValues = true;
+            continue;
+        }
+        else if (token == "--expandTemplateElems")
+        {
+            expandTemplateElems = true;
+            continue;
+        }
+        else if (token == "--help")
+        {
+            std::cout << " MaterialXBuildLibrary version " << mx::getVersionString() << std::endl;
+            std::cout << cmdLineOptions << std::endl;
+            return 0;
+        }
+        else
+        {
+            std::cout << "Unrecognized command-line option: " << token << std::endl;
+            std::cout << "Launch the viewer with '--help' for a complete list of supported options." << std::endl;
+            continue;
+        }
+
+        if (nextToken.empty())
+        {
+            std::cout << "Expected another token following command-line option: " << token << std::endl;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    mx::FilePath sourceLibraryRoot = mx::FilePath(sourceLibraryRootStr);
+    mx::FilePath destLibrarayRoot = mx::FilePath(destLibraryRootStr);
+
+    if (!sourceLibraryRoot.isDirectory())
+    {
+        std::cerr << "Source Library Root is not a directory" << std::endl;
+        return 1;
+    }
+
+    if (!destLibrarayRoot.isDirectory())
+    {
+        std::cerr << "Destination Library Root is not a directory" << std::endl;
+        return 1;
+    }
+
+    mx::DocumentPtr stdlib = mx::createDocument();
+    mx::loadLibraries({}, mx::FileSearchPath(sourceLibraryRootStr), stdlib);
+
+    mx::FilePathVec mtlxFiles = getMaterialXFiles(sourceLibraryRoot);
+
+    mx::XmlReadOptions readOptions;
+    readOptions.readComments = true;
+    readOptions.readNewlines = true;
+    readOptions.expandTemplateElems = expandTemplateElems;
+
+    mx::XmlWriteOptions writeOptions;
+    writeOptions.createDirectories = true;
+
+    for (const auto& mtlxFile : mtlxFiles)
+    {
+        mx::DocumentPtr doc = mx::createDocument();
+
+        mx::FilePath sourceFile = sourceLibraryRoot / mtlxFile;
+        mx::FilePath destFile = destLibrarayRoot / mtlxFile;
+
+        mx::readFromXmlFile(doc, sourceFile, mx::FileSearchPath(), &readOptions);
+
+        if (bakeNamedValues)
+        {
+            replaceNamedValues(doc, stdlib);
+        }
+
+        mx::writeToXmlFile(doc, destFile, &writeOptions);
+    }
+
+    return 0;
+}

--- a/source/MaterialXCore/CMakeLists.txt
+++ b/source/MaterialXCore/CMakeLists.txt
@@ -15,3 +15,9 @@ mx_add_library(MaterialXCore
 target_include_directories(${TARGET_NAME}
         PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>)
+
+# This define controls if the named "Value:" are dynamically evaluated at runtime
+target_compile_definitions(${TARGET_NAME}
+        PRIVATE
+        MATERIALX_BUILD_BAKE_NAMED_VALUES=$<BOOL:${MATERIALX_BUILD_BAKE_NAMED_VALUES}>
+)

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -644,6 +644,36 @@ TypeDefPtr TypedElement::getTypeDef() const
 //
 // ValueElement methods
 //
+/// Get the value string of a element.
+const string ValueElement::getValueString() const
+{
+#if MATERIALX_BUILD_BAKE_NAMED_VALUES
+    return getAttribute(VALUE_ATTRIBUTE);
+#else
+    const string typeValuePrefix = "Value:";
+
+    auto valueStr = getAttribute(VALUE_ATTRIBUTE);
+    if (!stringStartsWith(valueStr, typeValuePrefix))
+    {
+        return valueStr;
+    }
+
+    auto typeDef = getTypeDef();
+    if (!typeDef)
+    {
+        throw Exception("Unable to find typeDef '"+getType()+"'");
+    }
+
+    auto valueNameStr = valueStr.substr(typeValuePrefix.size());
+    if (!typeDef->hasAttribute(valueNameStr))
+    {
+        throw Exception("Unable to find named value '"+valueNameStr+"' for type '"+typeDef->getName()+"'");
+    }
+
+    return typeDef->getAttribute(valueNameStr);
+#endif
+}
+
 
 string ValueElement::getResolvedValueString(StringResolverPtr resolver) const
 {

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -954,10 +954,7 @@ class MX_CORE_API ValueElement : public TypedElement
     }
 
     /// Get the value string of a element.
-    const string& getValueString() const
-    {
-        return getAttribute(VALUE_ATTRIBUTE);
-    }
+    const string getValueString() const;
 
     /// Return the resolved value string of an element, applying any string
     /// substitutions that are defined at the element's scope.

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -39,15 +39,15 @@ class MX_FORMAT_API XmlReadOptions
 
     /// If true, then XML comments will be read into documents as comment elements.
     /// Defaults to false.
-    bool readComments;
+    bool readComments = false;
 
     /// If true, then XML newlines will be read into documents as newline elements.
     /// Defaults to false.
-    bool readNewlines;
+    bool readNewlines = false;
 
     /// If true, then documents from earlier versions of MaterialX will be upgraded
     /// to the current version.  Defaults to true.
-    bool upgradeVersion;
+    bool upgradeVersion = true;
 
     /// If provided, this function will be invoked when an XInclude reference
     /// needs to be read into a document.  Defaults to readFromXmlFile.
@@ -56,6 +56,9 @@ class MX_FORMAT_API XmlReadOptions
     /// The vector of parent XIncludes at the scope of the current document.
     /// Defaults to an empty vector.
     StringVec parentXIncludes;
+
+    /// Expand any <template> tags present in the document
+    bool expandTemplateElems = true;
 };
 
 /// @class XmlWriteOptions
@@ -68,11 +71,15 @@ class MX_FORMAT_API XmlWriteOptions
 
     /// If true, elements with source file markings will be written as
     /// XIncludes rather than explicit data.  Defaults to true.
-    bool writeXIncludeEnable;
+    bool writeXIncludeEnable = true;
 
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
+
+    /// If true, any necessary directories will be created to write the
+    /// file.
+    bool createDirectories = false;
 };
 
 /// @class ExceptionParseError


### PR DESCRIPTION
This PR proposes a concrete implementation inspired by proposals presented in #2148 and #2149.  We will recap these briefly.

## Problem Statement
The standard data library is repetitive due to the type strictness of MaterialX.  A lot of node definitions need to be concretely instantiated for each type they support. For instance `<add>` ends up with 16 different node definitions, spanning about 80 lines of XML. Due to the repetitive nature of these lines of XML, it can be hard to identify typos, and encourages copy/pasting which can be error prone. 

## Proposed Solution
Instead of authoring each node definition explicitly, this PR introduces the concept of a `<template>` for specifying repetitive elements.  We also introduce a new syntax to abstract the specification of common values that have a different expression for different types, but are semantically the same, ie. `zero` and `one`. 

```
<template name="TP_ND_add" varName="typeName" options="float, integer, color3, color4, vector2, vector3, vector4">
  <nodedef name="ND_add_@typeName@" node="add" nodegroup="math">
    <input name="in1" type="@typeName@" value="Value:zero" />
    <input name="in2" type="@typeName@" value="Value:zero" />
    <output name="out" type="@typeName@" defaultinput="in1" />
  </nodedef>
</template>
```

Here we wrap a variation of the node definition for `<add>` inside a container `<template>` element. The `<template>` element has the following three attributes:
* `name` - unique identifier 
* `varName` - the name of a variable to be identified and replace within the contents of the template
* `options` - a list of strings that will used to instantiate copies of the template.

The length of the `options` list determines how many copies of the template are instantiated. Each copy will substitute a value from the `options` list for each attribute that contains the value of the `varName` attribute wrapped in `@` characters. 

In the example above `@typeName@` is replaced with each of the elements in the `options` list. 

```
<nodedef name="ND_add_float" node="add" nodegroup="math">
  <input name="in1" type="float" value="Value:zero" />
  <input name="in2" type="float" value="Value:zero" />
  <output name="out" type="float" defaultinput="in1" />
</nodedef>
<nodedef name="ND_add_integer" node="add" nodegroup="math">
  <input name="in1" type="integer" value="Value:zero" />
  <input name="in2" type="integer" value="Value:zero" />
  <output name="out" type="integer" defaultinput="in1" />
</nodedef>
<nodedef name="ND_add_color3" node="add" nodegroup="math">
  <input name="in1" type="color3" value="Value:zero" />
  <input name="in2" type="color3" value="Value:zero" />
  <output name="out" type="color3" defaultinput="in1" />
</nodedef>
<nodedef name="ND_add_color4" node="add" nodegroup="math">
  <input name="in1" type="color4" value="Value:zero" />
  <input name="in2" type="color4" value="Value:zero" />
  <output name="out" type="color4" defaultinput="in1" />
</nodedef>
<nodedef name="ND_add_vector2" node="add" nodegroup="math">
  <input name="in1" type="vector2" value="Value:zero" />
  <input name="in2" type="vector2" value="Value:zero" />
  <output name="out" type="vector2" defaultinput="in1" />
</nodedef>
<nodedef name="ND_add_vector3" node="add" nodegroup="math">
  <input name="in1" type="vector3" value="Value:zero" />
  <input name="in2" type="vector3" value="Value:zero" />
  <output name="out" type="vector3" defaultinput="in1" />
</nodedef>
<nodedef name="ND_add_vector4" node="add" nodegroup="math">
  <input name="in1" type="vector4" value="Value:zero" />
  <input name="in2" type="vector4" value="Value:zero" />
  <output name="out" type="vector4" defaultinput="in1" />
</nodedef>
```

The second expansion that happens is the resolution of the named values.  In the expanded template above we still have inputs that have `value` attributes that are not currently legal values, we see `Value:zero` and `Value:one`.

The expansion of these named values relies upon additional attributes specified in the type definitions.

```
  <typedef name="integer" zero="0" one="1"/>
  <typedef name="float" zero="0.0" one="1.0"/>
  <typedef name="color3" semantic="color" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
  <typedef name="color4" semantic="color" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
  <typedef name="vector2" zero="0.0,0.0" one="1.0,1.0"/>
  <typedef name="vector3" zero="0.0,0.0,0.0" one="1.0,1.0,1.0"/>
  <typedef name="vector4" zero="0.0,0.0,0.0,0.0" one="1.0,1.0,1.0,1.0"/>
```

Again the named value expansion is just another text replacement, we located any `value` attributes that starts with the string `Value:`, we then interrogate the type of that value, and look up the concrete value value in the corresponding type definition.

## Build vs Runtime evaluation
In order to maintain compatibility with the existing specification, the build has been updated to perform these template expansions and string replacements during the build.  This ensures that the generated data library remains compatible with the current specification.  These build time expansions are performed by C++ based tools built during the project, and using the MaterialX library itself.

The MaterialX C++ library has also been updated to provide implementation to evaluate these new concepts at runtime.  Concretely, the template expansion can be performed during file read if the read option `XmlReadOptions.expandTemplateElems` is enabled.  If this is used during the runtime, the list of node definitions returned by `Document::GetNodeDefs()` would remain unchanged, and the complete list would be returned. 

The runtime evaluation of the named value replacement takes place in `ValueElement::GetValueString()`, where we optionally apply the same string replacement logic, based on the type and the type definition.

## CMake changes

CMake arguments have been added to control these build vs runtime choices.
* `MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS` - if enabled, then the templates will be expanded during the build, and the standard data library generated by the build will contain the concrete instances of the template.
* `MATERIALX_BUILD_BAKE_NAMED_VALUES` - if enabled, the named values will be baked out to their concrete type based values. Note, if this option is enabled, then `MATERIALX_BUILD_EXPAND_TEMPLATE_ELEMS` is forced to be true, as any named values inside a template may not be able to resolve to a specific type.

In order to support the cross compilation used to generate MaterialX library for uses on other platforms, such as iOS, we have to ensure that the tools used to generate the data library are built for the build machines architecture.  The easiest way to support this cross compilation approach in CMake is to create a small subproject that allows the tools to be built with a separate toolchain. (source references [here](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Cross%20Compiling%20With%20CMake.html) and [here](https://stackoverflow.com/questions/36173840/how-to-instruct-cmake-to-use-the-build-architecture-compiler))

