### PR TITLE
Fix token handling in functional nodegraphs

### DIFF
--- a/resources/Materials/TestSuite/stdlib/texture/token_graph.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/token_graph.mtlx
@@ -1,34 +1,51 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
   <!-- use tokens which are defined by the parent nodegraph -->
-  <nodegraph name="Tokenized_Image_2k_png">
-    <token name="Image_Resolution" type="string" value="2k" uiname="Image Resolution" />
+  <nodegraph name="Parent_Token_Graph">
+    <token name="Image_Name" type="string" value="cloth" uiname="Image Name" />
     <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
-    <input name="Image_Filename" type="filename" uniform="true" value="resources/Images/cloth.[Image_Extension]" />
+    <input name="Image_Filename" type="filename" uniform="true" value="resources/Images/[Image_Name].[Image_Extension]" />
     <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
       <input name="file" type="filename" uniform="true" interfacename="Image_Filename" />
     </tiledimage>
-    <output name="out_png" type="color3" nodename="tiledimage" />
+    <output name="out" type="color3" nodename="tiledimage" />
   </nodegraph>
 
   <!-- use tokens which are sibling of the input -->
-  <nodegraph name="Tokenized_Image_4k_jpg">
+  <nodegraph name="Sibling_Token">
     <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
-      <token name="Image_Resolution" type="string" value="4k" uiname="Image Resolution" />
+      <token name="Image_Name" type="string" value="wood_color" uiname="Image Resolution" />
       <token name="Image_Extension" type="string" value="jpg" uiname="Image Extension" />
-      <input name="file" type="filename" uniform="true" value="resources/images/cloth.[Image_Extension]" />
+      <input name="file" type="filename" uniform="true" value="resources/images/[Image_Name].[Image_Extension]" />
     </tiledimage>
-    <output name="out_4k_jpg" type="color3" nodename="tiledimage" />
+    <output name="out" type="color3" nodename="tiledimage" />
   </nodegraph>
 
   <!-- top level tokens are not support. bmp will be the found token -->
-  <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
+  <token name="Image_Extension" type="string" value="jpg" uiname="Image Extension" />
   <nodegraph name="Tokenized_Image_top_level">
     <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
-      <token name="Image_Extension" type="string" value="bmp" uiname="Image Extension" />
-      <input name="file" type="filename" uniform="true" value="resources/Images/cloth.[Image_Extension]" />
+      <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
+      <input name="file" type="filename" uniform="true" value="resources/Images/brass_color.[Image_Extension]" />
     </tiledimage>
-    <output name="out_bmp" type="color3" nodename="tiledimage" />
+    <output name="out" type="color3" nodename="tiledimage" />
   </nodegraph>
 
+  <!-- use tokens which are defined by nodedef -->
+  <nodedef name="ND_token" node="token_image" >
+    <token name="Image_Name" type="string" value="grid" uiname="Image Name" />
+    <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
+    <output name="out" type="color3"></output>
+  </nodedef>
+  <nodegraph name="NG_token" nodedef="ND_token">
+    <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
+      <input name="file" type="filename" uniform="true" value="resources/Images/[Image_Name].[Image_Extension]" />
+    </tiledimage>
+    <output name="out" type="color3" nodename="tiledimage" />
+  </nodegraph>
+  <nodegraph name="token_nodedef_graph">
+    <token_image name="token_image1" type="color3">
+    </token_image>
+    <output name="out" type="color3" nodename="token_image1"></output>
+  </nodegraph>
 </materialx>

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -873,6 +873,28 @@ void StringResolver::addTokenSubstitutions(ConstElementPtr element)
                     setFilenameSubstitution(key, value);
                 }
             }
+
+            // This is a functional nodegraph. Get the corresponding nodedef and
+            // check for tokens on it.
+            ConstNodeGraphPtr nodegraph = parent->asA<NodeGraph>();
+            if (nodegraph)
+            {
+                NodeDefPtr nodedef = nodegraph->getNodeDef();
+                if (nodedef)
+                {
+                    tokens = nodedef->getActiveTokens();
+                    for (auto token : tokens)
+                    {
+                        string key = DELIMITER_PREFIX + token->getName() + DELIMITER_POSTFIX;
+                        string value = token->getResolvedValueString();
+                        if (!_filenameMap.count(key))
+                        {
+                            setFilenameSubstitution(key, value);
+                        }
+                    }
+                }
+            }
+
         }
         parent = parent->getParent();
     }


### PR DESCRIPTION
## Issue

Tokens on `nodedef`s are not checked when resolving inputs on nodes in a functional nodegraph. 
Update: #2361 

## Change

Patch token search to check `nodedef` tokens when applying token resolution

## Test

Modified existing token test and added in `nodedef` case.
Example below is evaluation of an instance of a definition using tokens to resolve the input file name to an unlit shader. The token is the image name.
```xml
<nodedef name="ND_token" node="token_image" >
    <token name="Image_Name" type="string" value="grid" uiname="Image Name" />
    <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
    <output name="out" type="color3"></output>
  </nodedef>
  <nodegraph name="NG_token" nodedef="ND_token">
    <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
      <input name="file" type="filename" uniform="true" value="resources/Images/[Image_Name].[Image_Extension]" />
    </tiledimage>
    <output name="out" type="color3" nodename="tiledimage" />
  </nodegraph>
  <nodegraph name="token_nodedef_graph">
    <token_image name="token_image1" type="color3">
    </token_image>
    <output name="out" type="color3" nodename="token_image1"></output>
  </nodegraph>
```
![image](https://github.com/user-attachments/assets/e8661f0f-771b-489a-9b5e-2a99577515d0)
