### PR TITLE
Fix GLSL implementation of layer node

### DIFF
--- a/libraries/pbrlib/genglsl/mx_layer_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_layer_bsdf.glsl
@@ -3,5 +3,5 @@
 void mx_layer_bsdf(ClosureData closureData, BSDF top, BSDF base, out BSDF result)
 {
     result.response = top.response + base.response * top.throughput;
-    result.throughput = top.throughput + base.throughput;
+    result.throughput = top.throughput * base.throughput;
 }

--- a/resources/Materials/TestSuite/pbrlib/bsdf/layer_bsdf.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/bsdf/layer_bsdf.mtlx
@@ -11,16 +11,16 @@
       <input name="tint" type="color3" value="1,0,0" />
     </dielectric_bsdf>
     <layer name="layer_bsdf_1" type="BSDF">
-      <input name="top" type="BSDF" nodename="sheen_brdf_1" />
-      <input name="base" type="BSDF" nodename="diffuse_brdf_1" />
+      <input name="top" type="BSDF" nodename="dielectric_brdf_2" />
+      <input name="base" type="BSDF" nodename="dielectric_brdf_1" />
     </layer>
     <layer name="layer_bsdf_2" type="BSDF">
-      <input name="top" type="BSDF" nodename="dielectric_brdf_1" />
-      <input name="base" type="BSDF" nodename="layer_bsdf_1" />
+      <input name="top" type="BSDF" nodename="layer_bsdf_1" />
+      <input name="base" type="BSDF" nodename="sheen_brdf_1" />
     </layer>
     <layer name="layer_bsdf_3" type="BSDF">
-      <input name="top" type="BSDF" nodename="dielectric_brdf_2" />
-      <input name="base" type="BSDF" nodename="layer_bsdf_2" />
+      <input name="top" type="BSDF" nodename="layer_bsdf_2" />
+      <input name="base" type="BSDF" nodename="diffuse_brdf_1" />
     </layer>
     <surface name="surface1" type="surfaceshader">
       <input name="bsdf" type="BSDF" nodename="layer_bsdf_3" />


### PR DESCRIPTION
This changelist fixes a typo in the GLSL implementation of the `layer` node, where the throughput term was computed via addition rather than multiplication.

For more straightforward validation, the `layer_bsdf.mtlx` example has been updated so that the throughput computation in `layer` influences its rendered result.