### PR TITLE
ShaderGen : Fix interface input value for 

### DIFF
--- a/resources/Materials/TestSuite/stdlib/texture/token_graph_material.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/token_graph_material.mtlx
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <nodegraph name="Parent_Token_Graph">
+    <token name="Image_Name" type="string" value="cloth" uiname="Image Name" />
+    <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
+    <input name="Image_Filename" type="filename" uniform="true" value="resources/Images/[Image_Name].[Image_Extension]" />
+    <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
+      <input name="file" type="filename" uniform="true" interfacename="Image_Filename" />
+    </tiledimage>
+    <output name="out" type="color3" nodename="tiledimage" />
+  </nodegraph>
+  <nodegraph name="Sibling_Token">
+    <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
+      <token name="Image_Name" type="string" value="wood_color" uiname="Image Resolution" />
+      <token name="Image_Extension" type="string" value="jpg" uiname="Image Extension" />
+      <input name="file" type="filename" uniform="true" value="resources/images/[Image_Name].[Image_Extension]" />
+    </tiledimage>
+    <output name="out" type="color3" nodename="tiledimage" />
+  </nodegraph>
+  <token name="Brass_Image_Extension" type="string" value="jpg" uiname="Image Extension" />
+  <nodegraph name="Tokenized_Image_top_level">
+    <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
+      <token name="Brass_Image_Extension" type="string" value="png" uiname="Image Extension" />
+      <input name="file" type="filename" uniform="true" value="resources/Images/brass_color.[Brass_Image_Extension]" />
+    </tiledimage>
+    <output name="out" type="color3" nodename="tiledimage" />
+  </nodegraph>
+  <nodedef name="ND_token" node="token_image">
+    <token name="Image_Name" type="string" value="grid" uiname="Image Name" />
+    <token name="Image_Extension" type="string" value="png" uiname="Image Extension" />
+    <output name="out" type="color3" />
+  </nodedef>
+  <nodegraph name="NG_token" nodedef="ND_token">
+    <tiledimage name="tiledimage" type="color3" nodedef="ND_tiledimage_color3">
+      <input name="file" type="filename" uniform="true" value="resources/Images/[Image_Name].[Image_Extension]" />
+    </tiledimage>
+    <output name="out" type="color3" nodename="tiledimage" />
+  </nodegraph>
+  <nodegraph name="token_nodedef_graph">
+    <token_image name="token_image1" type="color3" />
+    <output name="out" type="color3" nodename="token_image1" />
+  </nodegraph>
+  <surface_unlit name="Parent_Token_Shader" type="surfaceshader">
+    <input name="emission_color" type="color3" output="out" nodegraph="Parent_Token_Graph" />
+  </surface_unlit>
+  <surface_unlit name="Token_Nodedef_Shader" type="surfaceshader">
+    <input name="emission_color" type="color3" output="out" nodegraph="token_nodedef_graph" />
+  </surface_unlit>
+  <surface_unlit name="TopLevel_Token_Shader" type="surfaceshader">
+    <input name="emission_color" type="color3" output="out" nodegraph="Tokenized_Image_top_level" />
+  </surface_unlit>
+  <surface_unlit name="Token_Silbing_Shader" type="surfaceshader">
+    <input name="emission_color" type="color3" output="out" nodegraph="Sibling_Token" />
+  </surface_unlit>
+  <surfacematerial name="Token_Silbing_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Token_Silbing_Shader" />
+  </surfacematerial>
+  <surfacematerial name="Token_Nodedef_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Token_Nodedef_Shader" />
+  </surfacematerial>
+  <surfacematerial name="TopLevel_Token_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="TopLevel_Token_Shader" />
+  </surfacematerial>
+  <surfacematerial name="Parent_Token_Material" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Parent_Token_Shader" />
+  </surfacematerial>
+</materialx>

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -576,6 +576,14 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
             if (nodeInput)
             {
                 ValuePtr value = nodeInput->getResolvedValue();
+                if (!value)
+                {
+                    InputPtr interfaceInput = nodeInput->getInterfaceInput();
+                    if (interfaceInput)
+                    {
+                        value= interfaceInput->getResolvedValue();
+                    }
+                }
                 if (value)
                 {
                     const string& valueString = value->getValueString();

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -349,7 +349,7 @@ void ShaderNode::initialize(const Node& node, const NodeDef& nodeDef, GenContext
                 InputPtr interfaceInput = nodeInput->getInterfaceInput();
                 if (interfaceInput)
                 {
-                    portValue = interfaceInput->getValue();
+                    portValue = interfaceInput->getResolvedValue();
                 }
             }
             const string& valueString = portValue ? portValue->getValueString() : EMPTY_STRING;


### PR DESCRIPTION
## Issue

When a node is created in shader generation the incorrect values may be stored due to:
1. A node definition's input interface resolved values are not used.
2. A node instance's input interface  resolved  values are not used.

## Notes

There were past fixes for proper meta-data passing such as colorspace / units and geometry stream bindings on interface inputs. This addresses the missing evaluation of resolved values.

## Fix

1. On node creation query the resolved value on nodedef interface inputs instead of unresolved values
2. On node creation check for interface input values and stored resolved ones if found.

Note that the logic for token resolution has not changed, it was just not being called for properly.

## Test

Add a new variant for token resolution by adding downstream materials to the previous token test.
The previous test resolves properly for some cases if the interface inputs are at the nodegraph level of an unconnected output.

In order, parent, nodedef, top and sibling level token override tests.

![image](https://github.com/user-attachments/assets/66356467-0310-40ba-b170-6f2d2083b07a)
![image](https://github.com/user-attachments/assets/640aaeab-9873-41d6-879f-b26eab1c69bb)
![image](https://github.com/user-attachments/assets/001ea152-d330-4eca-8e62-b844d0d59be2)
![image](https://github.com/user-attachments/assets/697d7ac5-7256-414b-b36b-695c359fa479)

