### PR TITLE
Fix failing hextile unit testing

### DIFF
--- a/libraries/README.md
+++ b/libraries/README.md
@@ -75,4 +75,4 @@ This folder contains the standard data libraries for MaterialX, providing declar
     - point, directional, spot
 - Shader generation does not currently support:
     - `displacementshader` and `volumeshader` nodes for hardware shading targets (GLSL, MSL).
-    - `hextiledimage` and `hextilednormalmap` for MSL, OSL, and MDL.
+    - `hextiledimage` and `hextilednormalmap` for OSL and MDL.

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
@@ -85,7 +85,7 @@ TEST_CASE("GenShader: MSL Implementation Check", "[genmsl]")
     mx::StringSet generatorSkipNodeTypes;
     mx::StringSet generatorSkipNodeDefs;
     // To skip specific node definitions for this code generation target add them as below
-    // generatorSkipNodeDefs.insert("ND_hextiledimage_color3");
+    // generatorSkipNodeDefs.insert("ND_example_color3");
     GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs);
 }
 

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
@@ -84,9 +84,8 @@ TEST_CASE("GenShader: MSL Implementation Check", "[genmsl]")
 
     mx::StringSet generatorSkipNodeTypes;
     mx::StringSet generatorSkipNodeDefs;
-    generatorSkipNodeDefs.insert("ND_hextiledimage_color3");
-    generatorSkipNodeDefs.insert("ND_hextiledimage_color4");
-    generatorSkipNodeDefs.insert("ND_hextilednormalmap_vector3");
+    // To skip specific node definitions for this code generation target add them as below
+    // generatorSkipNodeDefs.insert("ND_hextiledimage_color3");
     GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs);
 }
 

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
@@ -84,7 +84,7 @@ TEST_CASE("GenShader: MSL Implementation Check", "[genmsl]")
 
     mx::StringSet generatorSkipNodeTypes;
     mx::StringSet generatorSkipNodeDefs;
-    // To skip specific node definitions for this code generation target add them as below
+    // To skip specific node definitions for this code generation target, add them as below:
     // generatorSkipNodeDefs.insert("ND_example_color3");
     GenShaderUtil::checkImplementations(context, generatorSkipNodeTypes, generatorSkipNodeDefs);
 }

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
@@ -43,8 +43,8 @@ class MslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 
     void addSkipFiles() override
     {
-        // to skip specific files for this render target - add them to the list as below.
-        // _skipFiles.insert("standard_surface_onyx_hextiled.mtlx");
+        // To skip specific files for this render target, add them as below:
+        // _skipFiles.insert("example.mtlx");
     }
 
     void setupDependentLibraries() override

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
@@ -43,8 +43,8 @@ class MslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
 
     void addSkipFiles() override
     {
-        _skipFiles.insert("standard_surface_onyx_hextiled.mtlx");
-        _skipFiles.insert("hextiled.mtlx");
+        // to skip specific files for this render target - add them to the list as below.
+        // _skipFiles.insert("standard_surface_onyx_hextiled.mtlx");
     }
 
     void setupDependentLibraries() override

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -146,6 +146,8 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
 
     createRenderer(log);
 
+    addSkipFiles();
+
     mx::ColorManagementSystemPtr colorManagementSystem;
 #ifdef MATERIALX_BUILD_OCIO
     try
@@ -218,6 +220,12 @@ bool ShaderRenderTester::validate(const mx::FilePath optionsFilePath)
             // Check if a file override set is used and ignore all files
             // not part of the override set
             if (testfileOverride.size() && testfileOverride.count(file) == 0)
+            {
+                ioTimer.endTimer();
+                continue;
+            }
+
+            if (_skipFiles.count(file) > 0)
             {
                 ioTimer.endTimer();
                 continue;

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -163,7 +163,7 @@ class ShaderRenderTester
     // If these streams don't exist add them for testing purposes
     void addAdditionalTestStreams(mx::MeshPtr mesh);
 
-    // add any paths to explicitly skip here
+    // Add any paths to explicitly skip here
     virtual void addSkipFiles() {}
 
     // Generator to use

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -163,6 +163,9 @@ class ShaderRenderTester
     // If these streams don't exist add them for testing purposes
     void addAdditionalTestStreams(mx::MeshPtr mesh);
 
+    // add any paths to explicitly skip here
+    virtual void addSkipFiles() {}
+
     // Generator to use
     mx::ShaderGeneratorPtr _shaderGenerator;
     // Whether to resolve image file name references before code generation
@@ -172,6 +175,9 @@ class ShaderRenderTester
     // Color management information
     mx::ColorManagementSystemPtr _colorManagementSystem;
     mx::FilePath _colorManagementConfigFile;
+
+    // Filter controls for tests.
+    mx::StringSet _skipFiles;
 };
 
 } // namespace RenderUtil

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -102,6 +102,12 @@ class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
                      const std::string& outputPath = ".",
                      mx::ImageVec* imageVec = nullptr) override;
 
+    void addSkipFiles() override
+    {
+        _skipFiles.insert("standard_surface_onyx_hextiled.mtlx");
+        _skipFiles.insert("hextiled.mtlx");
+    }
+
     bool saveImage(const mx::FilePath& filePath, mx::ConstImagePtr image, bool /*verticalFlip*/) const override
     {
         return _renderer->getImageHandler()->saveImage(filePath, image, false);


### PR DESCRIPTION
The recent addition of an example hextile unit test is currently failing the OSL render tests.  The do not run in CI because of the time it takes to build OSL - so this failure was not caught during the merge checks.

This PR adds a filtering mechanism to the render tests, similar to the shader generation tests, to allow for specific files to be excluded for render testing.  The hextile tests are then excluded from OSL render testing, as that node has not yet been implemented.

Also removing the hextile exclusion for shader generation for MSL.
