### PR TITLE
Ensure determinism of ShaderGen with color and unit transforms

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1116,11 +1116,11 @@ void ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManage
             {
                 if (asInput)
                 {
-                    _inputColorTransformMap.emplace(static_cast<ShaderInput*>(shaderPort), transform);
+                    _inputColorTransformMap.emplace_back(static_cast<ShaderInput*>(shaderPort), transform);
                 }
                 else
                 {
-                    _outputColorTransformMap.emplace(static_cast<ShaderOutput*>(shaderPort), transform);
+                    _outputColorTransformMap.emplace_back(static_cast<ShaderOutput*>(shaderPort), transform);
                 }
             }
             else
@@ -1180,11 +1180,11 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
             shaderPort->setUnit(sourceUnitSpace);
             if (asInput)
             {
-                _inputUnitTransformMap.emplace(static_cast<ShaderInput*>(shaderPort), transform);
+                _inputUnitTransformMap.emplace_back(static_cast<ShaderInput*>(shaderPort), transform);
             }
             else
             {
-                _outputUnitTransformMap.emplace(static_cast<ShaderOutput*>(shaderPort), transform);
+                _outputUnitTransformMap.emplace_back(static_cast<ShaderOutput*>(shaderPort), transform);
             }
         }
     }

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -189,14 +189,14 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     IdentifierMap _identifiers;
 
     // Temporary storage for inputs that require color transformations
-    std::unordered_map<ShaderInput*, ColorSpaceTransform> _inputColorTransformMap;
+    std::vector<std::pair<ShaderInput*, ColorSpaceTransform>> _inputColorTransformMap;
     // Temporary storage for inputs that require unit transformations
-    std::unordered_map<ShaderInput*, UnitTransform> _inputUnitTransformMap;
+    std::vector<std::pair<ShaderInput*, UnitTransform>> _inputUnitTransformMap;
 
     // Temporary storage for outputs that require color transformations
-    std::unordered_map<ShaderOutput*, ColorSpaceTransform> _outputColorTransformMap;
+    std::vector<std::pair<ShaderOutput*, ColorSpaceTransform>> _outputColorTransformMap;
     // Temporary storage for outputs that require unit transformations
-    std::unordered_map<ShaderOutput*, UnitTransform> _outputUnitTransformMap;
+    std::vector<std::pair<ShaderOutput*, UnitTransform>> _outputUnitTransformMap;
 };
 
 /// @class ShaderGraphEdge


### PR DESCRIPTION
While working on some shader code generation caching systems, I noticed that I was getting non-deterministic code generation if colorspace transformation was enabled.  Upon further investigation the cause appears to be the use of `std::unordered_map` with a pointer as the key.  

```
 std::unordered_map<ShaderInput*, ColorSpaceTransform> _inputColorTransformMap;
```

I'm not super familiar with the history of the code here to know if there's a good reason this is a map, but it appears safe to change this to a vector of pairs, to ensure we process the colorspace transformations in a consistent order.

The same logic appears to apply to the unit transformations, so I changed the storage there too.