### PR TITLE
Improve Add Node Workflow in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3677,7 +3677,7 @@ void Graph::showHelp() const
 
 void Graph::addNodePopup(bool cursor)
 {
-    bool open_AddPopup = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow) && ImGui::IsKeyReleased(ImGuiKey_Tab) ||
+    bool open_AddPopup = (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow) && ImGui::IsKeyReleased(ImGuiKey_Tab)) ||
         (_pinFilterType != mx::EMPTY_STRING && ImGui::IsMouseReleased(0));
     static char input[32]{ "" };
     if (open_AddPopup)
@@ -3720,7 +3720,8 @@ void Graph::addNodePopup(bool cursor)
                 // Allow spaces to be used to search for node names
                 std::replace(subs.begin(), subs.end(), ' ', '_');
 
-                if ((subs.size() == 0 || str.find(subs) != std::string::npos) && (_menuFilterType == mx::EMPTY_STRING || node.getType() == _menuFilterType))
+                if ((subs.size() == 0 || str.find(subs) != std::string::npos) &&
+                    (_menuFilterType == mx::EMPTY_STRING || node.getType() == _menuFilterType))
                 {
                     if (ImGui::MenuItem(getUserNodeDefName(nodeName).c_str()) || (ImGui::IsItemFocused() && ImGui::IsKeyPressedMap(ImGuiKey_Enter)))
                     {

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2007,7 +2007,7 @@ void Graph::addNode(const std::string& category, const std::string& name, const 
         newNode->_showAllInputs = true;
         node->setType(type);
         ++_graphTotalSize;
-        _pinIdToLinkToForAddedNode = ed::PinId();
+        _pinIdToLinkTo = ed::PinId();
         for (mx::InputPtr input : defInputs)
         {
             UiPinPtr inPin = std::make_shared<UiPin>(_graphTotalSize, &*input->getName().begin(), input->getType(), newNode, ax::NodeEditor::PinKind::Input, input, nullptr);
@@ -2015,9 +2015,9 @@ void Graph::addNode(const std::string& category, const std::string& name, const 
             _currPins.push_back(inPin);
             ++_graphTotalSize;
 
-            if (_pinIdToLinkFromForAddedNode != ed::PinId() && _pinIdToLinkToForAddedNode == ed::PinId() && _menuFilterType == input->getType())
+            if (_pinIdToLinkFrom != ed::PinId() && _pinIdToLinkTo == ed::PinId() && _menuFilterType == input->getType())
             {
-                _pinIdToLinkToForAddedNode = inPin->_pinId;
+                _pinIdToLinkTo = inPin->_pinId;
             }
         }
         std::vector<mx::OutputPtr> defOutputs = matchingNodeDefs[num]->getActiveOutputs();
@@ -2520,15 +2520,13 @@ void Graph::setDefaults(mx::InputPtr input)
 bool Graph::checkCanAddLink(ed::PinId startPinId, ed::PinId endPinId)
 {
     // Prefer to assume left to right - start is an output, end is an input; swap if inaccurate
-    if (UiPinPtr inputPin = getPin(endPinId); inputPin && inputPin->_kind != ed::PinKind::Input)
+    if (UiPinPtr endPin = getPin(endPinId); endPin && endPin->_kind != ed::PinKind::Input)
     {
         auto tmp = startPinId;
         startPinId = endPinId;
         endPinId = tmp;
     }
 
-    int end_attr = int(endPinId.Get());
-    int start_attr = int(startPinId.Get());
     ed::PinId outputPinId = startPinId;
     ed::PinId inputPinId = endPinId;
     UiPinPtr outputPin = getPin(outputPinId);
@@ -2595,7 +2593,7 @@ bool Graph::checkCanAddLink(ed::PinId startPinId, ed::PinId endPinId)
 void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
 {
     // Prefer to assume left to right - start is an output, end is an input; swap if inaccurate
-    if (UiPinPtr inputPin = getPin(endPinId); inputPin && inputPin->_kind != ed::PinKind::Input)
+    if (UiPinPtr endPin = getPin(endPinId); endPin && endPin->_kind != ed::PinKind::Input)
     {
         auto tmp = startPinId;
         startPinId = endPinId;
@@ -4119,12 +4117,12 @@ void Graph::drawGraph(ImVec2 mousePos)
             _copiedNodes.clear();
             _addNewNode = false;
 
-            if (_pinIdToLinkFromForAddedNode != ed::PinId() && _pinIdToLinkToForAddedNode != ed::PinId())
+            if (_pinIdToLinkFrom != ed::PinId() && _pinIdToLinkTo != ed::PinId())
             {
                 // we have a link to draw for the newly created node.
-                if (checkCanAddLink(_pinIdToLinkFromForAddedNode, _pinIdToLinkToForAddedNode))
+                if (checkCanAddLink(_pinIdToLinkFrom, _pinIdToLinkTo))
                 {
-                    addLink(_pinIdToLinkFromForAddedNode, _pinIdToLinkToForAddedNode);
+                    addLink(_pinIdToLinkFrom, _pinIdToLinkTo);
                 }
             }
         }
@@ -4258,7 +4256,7 @@ void Graph::drawGraph(ImVec2 mousePos)
                 if (getPin(filterPinId)->_type != "null")
                 {
                     _pinFilterType = getPin(filterPinId)->_type;
-                    _pinIdToLinkFromForAddedNode = filterPinId;
+                    _pinIdToLinkFrom = filterPinId;
                 }
 
                 showLabel("Release Mouse to Add a New Node", ImColor(50, 50, 50, 255));

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3704,8 +3704,17 @@ void Graph::addNodePopup(bool cursor)
         // Filter nodedefs and add to menu if matches filter
         for (auto node : _nodesToAdd)
         {
+            // Filter out nodes that do not match the _menuFilterType
+            if (_menuFilterType != mx::EMPTY_STRING)
+            {
+                if (node.getType() != _menuFilterType)
+                {
+                    continue;
+                }
+            }
+
             // Filter out list of nodes
-            if (subs.size() > 0 || _menuFilterType != mx::EMPTY_STRING)
+            if (subs.size() > 0)
             {
                 ImGui::SetNextWindowSizeConstraints(ImVec2(250.0f, 300.0f), ImVec2(-1.0f, 500.0f));
                 std::string str(node.getName());
@@ -3720,8 +3729,7 @@ void Graph::addNodePopup(bool cursor)
                 // Allow spaces to be used to search for node names
                 std::replace(subs.begin(), subs.end(), ' ', '_');
 
-                if ((subs.size() == 0 || str.find(subs) != std::string::npos) &&
-                    (_menuFilterType == mx::EMPTY_STRING || node.getType() == _menuFilterType))
+                if (subs.size() == 0 || str.find(subs) != std::string::npos)
                 {
                     if (ImGui::MenuItem(getUserNodeDefName(nodeName).c_str()) || (ImGui::IsItemFocused() && ImGui::IsKeyPressedMap(ImGuiKey_Enter)))
                     {

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2694,23 +2694,19 @@ void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
                                     pin->_input->setConnectedOutput(outputs);
                                 }
                             }
-                            else
-                            {
-                                mx::NodePtr upstreamNode = uiUpNode->getNode();
-                                if (upstreamNode)
-                                {
-                                    mx::OutputPtr output = upstreamNode->getOutput(outputPin->_name);
-                                    if (!output)
-                                    {
-                                        output = upstreamNode->addOutput(outputPin->_name, pin->_input->getType());
-                                    }
-                                    pin->_input->setConnectedOutput(output);
-                                }
-                            }
                         }
                         else
                         {
-                            pin->_input->setConnectedNode(uiUpNode->getNode());
+                            mx::NodePtr upstreamNode = uiUpNode->getNode();
+                            if (upstreamNode)
+                            {
+                                mx::OutputPtr output = upstreamNode->getOutput(outputPin->_name);
+                                if (!output)
+                                {
+                                    output = upstreamNode->addOutput(outputPin->_name, pin->_input->getType());
+                                }
+                                pin->_input->setConnectedOutput(output);
+                            }
                         }
                     }
                 }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3677,12 +3677,14 @@ void Graph::showHelp() const
 
 void Graph::addNodePopup(bool cursor)
 {
-    bool open_AddPopup = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow) && ImGui::IsKeyReleased(ImGuiKey_Tab);
+    bool open_AddPopup = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow) && ImGui::IsKeyReleased(ImGuiKey_Tab) ||
+        (_pinFilterType != mx::EMPTY_STRING && ImGui::IsMouseReleased(0));
     static char input[32]{ "" };
     if (open_AddPopup)
     {
         cursor = true;
         ImGui::OpenPopup("add node");
+        _menuFilterType = _pinFilterType;
     }
     if (ImGui::BeginPopup("add node"))
     {
@@ -3703,7 +3705,7 @@ void Graph::addNodePopup(bool cursor)
         for (auto node : _nodesToAdd)
         {
             // Filter out list of nodes
-            if (subs.size() > 0)
+            if (subs.size() > 0 || _menuFilterType != mx::EMPTY_STRING)
             {
                 ImGui::SetNextWindowSizeConstraints(ImVec2(250.0f, 300.0f), ImVec2(-1.0f, 500.0f));
                 std::string str(node.getName());
@@ -3718,7 +3720,7 @@ void Graph::addNodePopup(bool cursor)
                 // Allow spaces to be used to search for node names
                 std::replace(subs.begin(), subs.end(), ' ', '_');
 
-                if (str.find(subs) != std::string::npos)
+                if ((subs.size() == 0 || str.find(subs) != std::string::npos) && (_menuFilterType == mx::EMPTY_STRING || node.getType() == _menuFilterType))
                 {
                     if (ImGui::MenuItem(getUserNodeDefName(nodeName).c_str()) || (ImGui::IsItemFocused() && ImGui::IsKeyPressedMap(ImGuiKey_Enter)))
                     {
@@ -4198,6 +4200,8 @@ void Graph::drawGraph(ImVec2 mousePos)
                 {
                     _pinFilterType = getPin(filterPinId)->_type;
                 }
+
+                showLabel("Release Mouse to Add a New Node", ImColor(50, 50, 50, 255));
             }
         }
         else

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -20,26 +20,29 @@ namespace mx = MaterialX;
 class MenuItem
 {
   public:
-    MenuItem(const std::string& name, const std::string& type, const std::string& category, const std::string& group) :
-        name(name), type(type), category(category), group(group) { }
+    MenuItem(const std::string& name, const std::string& type, const std::string& category, const std::string& group, const std::set<std::string>& inputTypes) :
+        name(name), type(type), category(category), group(group), inputTypes(inputTypes) { }
 
     // getters
     std::string getName() const { return name; }
     std::string getType() const { return type; }
     std::string getCategory() const { return category; }
     std::string getGroup() const { return group; }
+    const std::set<std::string>& getInputTypes() const { return inputTypes; }
 
     // setters
     void setName(const std::string& newName) { this->name = newName; }
     void setType(const std::string& newType) { this->type = newType; }
     void setCategory(const std::string& newCategory) { this->category = newCategory; }
     void setGroup(const std::string& newGroup) { this->group = newGroup; }
+    void setInputTypes(const std::set<std::string>& newInputTypes) { this->inputTypes = newInputTypes; }
 
   private:
     std::string name;
     std::string type;
     std::string category;
     std::string group;
+    std::set<std::string> inputTypes;
 };
 
 // A link connects two pins and includes a unique id and the ids of the two pins it connects

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -107,6 +107,9 @@ class Graph
     // Check if link exists in the current link vector
     bool linkExists(Link newLink);
 
+    // Check if link can be added. Show a diagnostic message as the label.
+    bool checkCanAddLink(ed::PinId startPinId, ed::PinId endPinId);
+
     // Add link to nodegraph and set up connections between UiNodes and
     // MaterialX Nodes to update shader
     // startPinId - where the link was initiated
@@ -311,6 +314,9 @@ class Graph
     std::string _pinFilterType;
     // used for filtering pins when adding a node from a link
     std::string _menuFilterType;
+    // used for auto connecting pins if a node is added by drawing a link from a pin
+    ed::PinId _pinIdToLinkFromForAddedNode;
+    ed::PinId _pinIdToLinkToForAddedNode;
 
     // DPI scaling for fonts
     float _fontScale;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -315,8 +315,8 @@ class Graph
     // used for filtering pins when adding a node from a link
     std::string _menuFilterType;
     // used for auto connecting pins if a node is added by drawing a link from a pin
-    ed::PinId _pinIdToLinkFromForAddedNode;
-    ed::PinId _pinIdToLinkToForAddedNode;
+    ed::PinId _pinIdToLinkFrom;
+    ed::PinId _pinIdToLinkTo;
 
     // DPI scaling for fonts
     float _fontScale;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -306,6 +306,8 @@ class Graph
     int _frameCount;
     // used for filtering pins when connecting links
     std::string _pinFilterType;
+    // used for filtering pins when adding a node from a link
+    std::string _menuFilterType;
 
     // DPI scaling for fonts
     float _fontScale;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -20,8 +20,8 @@ namespace mx = MaterialX;
 class MenuItem
 {
   public:
-    MenuItem(const std::string& name, const std::string& type, const std::string& category, const std::string& group, const std::set<std::string>& inputTypes) :
-        name(name), type(type), category(category), group(group), inputTypes(inputTypes) { }
+    MenuItem(const std::string& name, const std::string& type, const std::string& category, const std::string& group, const std::set<std::string>& inputTypes, const std::set<std::string>& outputTypes) :
+        name(name), type(type), category(category), group(group), inputTypes(inputTypes), outputTypes(outputTypes) { }
 
     // getters
     std::string getName() const { return name; }
@@ -29,6 +29,7 @@ class MenuItem
     std::string getCategory() const { return category; }
     std::string getGroup() const { return group; }
     const std::set<std::string>& getInputTypes() const { return inputTypes; }
+    const std::set<std::string>& getOutputTypes() const { return outputTypes; }
 
     // setters
     void setName(const std::string& newName) { this->name = newName; }
@@ -36,6 +37,7 @@ class MenuItem
     void setCategory(const std::string& newCategory) { this->category = newCategory; }
     void setGroup(const std::string& newGroup) { this->group = newGroup; }
     void setInputTypes(const std::set<std::string>& newInputTypes) { this->inputTypes = newInputTypes; }
+    void setOutputTypes(const std::set<std::string>& newOutputTypes) { this->outputTypes = newOutputTypes; }
 
   private:
     std::string name;
@@ -43,6 +45,7 @@ class MenuItem
     std::string category;
     std::string group;
     std::set<std::string> inputTypes;
+    std::set<std::string> outputTypes;
 };
 
 // A link connects two pins and includes a unique id and the ids of the two pins it connects


### PR DESCRIPTION
For #1542 

Continuing on from @beersandrew 's early work on adding the ability to add a node by drawing a link from a pin.

For reference, this is @beersandrew 's original PR: https://github.com/AcademySoftwareFoundation/MaterialX/pull/2157

What I have added/modified so far:
* Improvement on @beersandrew 's filtering logic for simpler if statements and also for categorized filtered candidate nodes in the tree menu
* Filter out nodes having no inputs of matching type rather than filtering by node types only as per @beersandrew 's original plan
* Added the logic to automatically link the newly created node back to the original pin, from which the link was drawn from

Also done the reverse direction too.

* Distinguish if the currently drawn link is forward or backward
* Candidate nodes are filtered based on output types if backward
* Connect the original input pin back to the output pin of the newly created node

Ready for review now.

https://github.com/user-attachments/assets/f7c7fd5e-34d0-4aa9-ad14-acf5f4aaa36f
