### PR TITLE
Add setName with updateReferences

### DIFF
--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -20,6 +20,26 @@ const string Backdrop::HEIGHT_ATTRIBUTE = "height";
 // Node methods
 //
 
+void Node::setName(const std::string& name, bool updateReferences)
+{
+    if (!updateReferences)
+    {
+        Element::setName(name);
+        return;
+    }
+    if (name.empty() || getName() == name)
+    {
+        return;
+    }
+    std::string validName = getParent()->createValidChildName(name);
+    vector<PortElementPtr> downStreamPorts = getDownstreamPorts();
+    for (PortElementPtr& port : downStreamPorts)
+    {
+        port->setNodeName(validName);
+    }
+    setName(validName);
+}
+
 void Node::setConnectedNode(const string& inputName, ConstNodePtr node)
 {
     InputPtr input = getInput(inputName);
@@ -559,6 +579,26 @@ string GraphElement::asStringDot() const
 //
 // NodeGraph methods
 //
+
+void NodeGraph::setName(const std::string& name, bool updateReferences)
+{
+    if (!updateReferences)
+    {
+        Element::setName(name);
+        return;
+    }
+    if (name.empty() || getName() == name)
+    {
+        return;
+    }
+    std::string validName = getParent()->createValidChildName(name);
+    vector<PortElementPtr> downStreamPorts = getDownstreamPorts();
+    for (PortElementPtr& port : downStreamPorts)
+    {
+        port->setNodeGraphString(validName);
+    }
+    setName(validName);
+}
 
 vector<OutputPtr> NodeGraph::getMaterialOutputs() const
 {

--- a/source/MaterialXCore/Node.h
+++ b/source/MaterialXCore/Node.h
@@ -58,6 +58,16 @@ class MX_CORE_API Node : public InterfaceElement
     }
     virtual ~Node() { }
 
+    /// @name Name
+    /// @{
+
+    /// Set the element's name string.  The name of a MaterialX element must be
+    /// unique among all elements at the same scope. Optionally updates downstream ports.
+    /// @throws Exception if an element at the same scope already possesses the
+    ///    given name.
+    void setName(const std::string& name, bool updateReferences = false);
+
+    /// @}
     /// @name Connections
     /// @{
 
@@ -327,6 +337,13 @@ class MX_CORE_API NodeGraph : public GraphElement
     }
     virtual ~NodeGraph() { }
 
+    /// Set the element's name string.  The name of a MaterialX element must be
+    /// unique among all elements at the same scope. Optionally updates downstream ports.
+    /// @throws Exception if an element at the same scope already possesses the
+    ///    given name.
+    void setName(const std::string& name, bool updateReferences = false);
+
+    /// @}
     /// @name Material References
     /// @{
 

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -774,6 +774,123 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
 
         doc->removeChild(graph->getName());
     }
-    
+
     REQUIRE(doc->validate());
+}
+
+TEST_CASE("renameElement with connections", "[node, nodegraph]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+
+    const std::string type = "float";
+    const std::string new_name = "new_name";
+    SECTION("node")
+    {
+        // Upstream -> Downstream
+        SECTION("Node within NodeGraph -> NodeGraph output")
+        {
+            mx::NodeGraphPtr parentGraph = doc->addNodeGraph();
+
+            mx::NodePtr upstreamNode = parentGraph->addNode("constant", "upstreamNode", type);
+            upstreamNode->addOutput("output", type);
+
+            mx::PortElementPtr downstreamOutput = parentGraph->addOutput("out", type);
+            downstreamOutput->setNodeName(upstreamNode->getName());
+
+            upstreamNode->setName(new_name, true);
+            REQUIRE(upstreamNode->getName() == new_name);
+            REQUIRE(downstreamOutput->getNodeName() == new_name);
+        }
+        SECTION("Free node")
+        {
+            SECTION("Free Node -> Free Node")
+            {
+                mx::NodePtr upstreamNode = doc->addNode("constant", "upstreamNode", type);
+                upstreamNode->addOutput("output", type);
+
+                mx::NodePtr downStreamNode = doc->addNode("downStreamNode");
+                mx::InputPtr downstreamInput = downStreamNode->addInput("in", type);
+                downstreamInput->setNodeName(upstreamNode->getName());
+                SECTION("Update references")
+                {
+                    upstreamNode->setName(new_name, true);
+                    REQUIRE(upstreamNode->getName() == new_name);
+                    REQUIRE(downstreamInput->getNodeName() == new_name);
+                }
+                SECTION("Do not update references")
+                {
+                    upstreamNode->setName(new_name, false);
+                    REQUIRE(upstreamNode->getName() == new_name);
+                    REQUIRE(downstreamInput->getNodeName() != new_name);
+                }
+            }
+            SECTION("Free Node -> NodeGraph input")
+            {
+                mx::NodePtr upstreamNode = doc->addNode("constant", "upstreamNode", type);
+                upstreamNode->addOutput("output", type);
+
+                mx::NodeGraphPtr downstreamGraph = doc->addNodeGraph();
+                mx::InputPtr downstreamInput = downstreamGraph->addInput("input", type);
+                downstreamInput->setNodeName(upstreamNode->getName());
+
+                upstreamNode->setName(new_name, true);
+                REQUIRE(upstreamNode->getName() == new_name);
+                REQUIRE(downstreamInput->getNodeName() == new_name);
+            }
+        }
+        SECTION("Node -> NodeDef output")
+        {
+            mx::NodeGraphPtr compoundNodeGraph = doc->addNodeGraph();
+            mx::OutputPtr compoundNodeGraphOutput = compoundNodeGraph->addOutput("output", type);
+
+            mx::NodePtr compoundNodeGraphNode = compoundNodeGraph->addNode("constant", "upstreamNode", type);
+            compoundNodeGraphNode->addOutput("output", type);
+            compoundNodeGraphOutput->setNodeName(compoundNodeGraphNode->getName());
+
+            std::string newNodeDefName = doc->createValidChildName("ND_" + compoundNodeGraph->getName());
+            std::string newGraphName = doc->createValidChildName("NG_" + compoundNodeGraph->getName());
+            mx::NodeDefPtr nodeDef = doc->addNodeDefFromGraph(compoundNodeGraph, newNodeDefName, "NODENAME", newGraphName);
+            mx::NodeGraphPtr functionalNodeGraph = nodeDef->getImplementation()->asA<mx::NodeGraph>();
+
+            mx::NodePtr upstreamNode = functionalNodeGraph->getChild(compoundNodeGraphNode->getName())->asA<mx::Node>();
+            REQUIRE(upstreamNode);
+
+            mx::OutputPtr downstreamOutput = functionalNodeGraph->getOutput(compoundNodeGraphOutput->getName());
+            REQUIRE(downstreamOutput);
+
+            upstreamNode->setName(new_name, true);
+            REQUIRE(upstreamNode->getName() == new_name);
+            REQUIRE(downstreamOutput->getNodeName() == new_name);
+        }
+    }
+    SECTION("nodegraph")
+    {
+        mx::NodeGraphPtr upstreamGraph = doc->addNodeGraph();
+        mx::NodePtr upstreamGraphNode = upstreamGraph->addNode("constant", "upstreamNode", type);
+        mx::OutputPtr upstreamGraphOutput = upstreamGraph->addOutput("output", type);
+        upstreamGraphOutput->setNodeName(upstreamGraphNode->getName());
+
+        SECTION("Node Graph -> Node")
+        {
+            mx::NodePtr downstreamNode = doc->addNode("constant", "downstreamNode", type);
+            mx::InputPtr downstreamInput = downstreamNode->addInput("input", type);
+            downstreamInput->setNodeGraphString(upstreamGraph->getName());
+            downstreamInput->setOutputString(upstreamGraphOutput->getName());
+
+            upstreamGraph->setName(new_name, true);
+            REQUIRE(upstreamGraph->getName() == new_name);
+            REQUIRE(downstreamInput->getNodeGraphString() == new_name);
+        }
+        SECTION("Node Graph -> Node Graph")
+        {
+            mx::NodeGraphPtr downstreamGraph = doc->addNodeGraph();
+            mx::InputPtr downstreamInput = downstreamGraph->addInput("input", type);
+            downstreamInput->setNodeGraphString(upstreamGraph->getName());
+            downstreamInput->setOutputString(upstreamGraphOutput->getName());
+
+            upstreamGraph->setName(new_name, true);
+            REQUIRE(upstreamGraph->getName() == new_name);
+            REQUIRE(downstreamInput->getNodeGraphString() == new_name);
+        }
+    }
 }


### PR DESCRIPTION
This solves (or partially solves): https://github.com/AcademySoftwareFoundation/MaterialX/issues/1847

This commit adds the `setName` method on `Node` and `NodeGraph`.
- When `updateReferences == false`, behave exactly like the original `setName()`.  
- When `updateReferences == true`, also walk downstream ports or inputs and updates corresponding node or nodegraph name.

 **API added**
  ```cpp
  void Node::setName(const std::string& newName, bool updateReferences);
  void NodeGraph::setName(const std::string& newName, bool updateReferences);