### PR TITLE
Validate that node output matches node definitions

### DIFF
--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -117,6 +117,7 @@ bool NodeDef::validate(string* message) const
 {
     bool res = true;
     validateRequire(!hasType(), res, message, "Nodedef should not have a type but an explicit output");
+    validateRequire(getOutputCount() != 0, res, message, "Nodedef must have at lesst one output");
     return InterfaceElement::validate(message) && res;
 }
 

--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -117,7 +117,6 @@ bool NodeDef::validate(string* message) const
 {
     bool res = true;
     validateRequire(!hasType(), res, message, "Nodedef should not have a type but an explicit output");
-    validateRequire(getOutputCount() != 0, res, message, "Nodedef must have at lesst one output");
     return InterfaceElement::validate(message) && res;
 }
 

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -200,14 +200,15 @@ bool Node::validate(string* message) const
         bool exactMatch = hasExactInputMatch(nodeDef, &matchMessage);
         validateRequire(exactMatch, res, message, "Node interface error: " + matchMessage);
 
-        vector<OutputPtr> nodeDefOutputs = nodeDef->getOutputs();
-        if(nodeDefOutputs.size() == 1)
+        const vector<OutputPtr>& activeOutputs = nodeDef->getActiveOutputs();
+        const size_t numActiveOutputs = activeOutputs.size();
+        if (numActiveOutputs > 1)
         {
-            validateRequire(getType() == nodeDefOutputs[0]->getType(), res, message, "The attribute type must match the type of the output of the node definition");
+            validateRequire(getType() == MULTI_OUTPUT_TYPE_STRING, res, message, "Node type is not 'multioutput' for node with multiple outputs");
         }
-        else if(nodeDefOutputs.size() > 1)
+        else if (numActiveOutputs == 1)
         {
-            validateRequire(getType() == "multioutput", res, message, "The attribute type must be multioutput to match the implementation");
+            validateRequire(getType() == activeOutputs[0]->getType(), res, message, "Node type does not match output port type");
         }
     }
     else

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -199,6 +199,16 @@ bool Node::validate(string* message) const
         string matchMessage;
         bool exactMatch = hasExactInputMatch(nodeDef, &matchMessage);
         validateRequire(exactMatch, res, message, "Node interface error: " + matchMessage);
+
+        vector<OutputPtr> nodeDefOutputs = nodeDef->getOutputs();
+        if(nodeDefOutputs.size() == 1)
+        {
+            validateRequire(getType() == nodeDefOutputs[0]->getType(), res, message, "The attribute type must match the type of the output of the node definition");
+        }
+        else if(nodeDefOutputs.size() > 1)
+        {
+            validateRequire(getType() == "multioutput", res, message, "The attribute type must be multioutput to match the implementation");
+        }
     }
     else
     {

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -822,6 +822,28 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
 
         doc->removeChild(graph->getName());
     }
-    
+
     REQUIRE(doc->validate());
+}
+
+TEST_CASE("NodDef validation no outputs", "[nodedef]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+
+    std::string name = mx::EMPTY_STRING;
+    std::string type = mx::EMPTY_STRING;
+    // If the 'type' given to addNodeDef is not empty then an output will be created implicitly
+    mx::NodeDefPtr nodeDef = doc->addNodeDef(name, type);
+
+    // Make sure no outputs were created
+    REQUIRE(nodeDef->getOutputCount() == 0);
+
+    // It will now fail the validation
+    REQUIRE_FALSE(nodeDef->validate());
+
+    // Add any output
+    nodeDef->addOutput();
+
+    // It will now pass the validation
+    REQUIRE(nodeDef->validate());
 }

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -83,6 +83,54 @@ TEST_CASE("Interface Input Validation", "[node]")
     }
 }
 
+TEST_CASE("Node Type Multioutput Validation", "[Node]")
+{
+    // Create a document
+    mx::DocumentPtr doc = mx::createDocument();
+
+    // Create a graph and add two outputs, types of the outputs are not important
+    mx::NodeGraphPtr graph = doc->addNodeGraph("NG_custom_node");
+    graph->addOutput("output1", "float");
+    graph->addOutput("output2", "float");
+
+    // Create a nodeDef based on the graph and make sure it has two outputs
+    mx::NodeDefPtr nodeDef = doc->addNodeDefFromGraph(graph, "nodeDefName", "Category", "ND_custom_node");
+    REQUIRE(nodeDef->getOutputCount() == 2);
+
+    // Create a node based on the nodeDef and make sure it is of type multioutput and has no errors
+    mx::NodePtr node = doc->addNodeInstance(nodeDef);
+    REQUIRE(node->getType() == "multioutput");
+    REQUIRE(node->validate());
+
+    // Change the type of the node so that it does not match the nodeDef
+    node->setType("float");
+    // Make sure the validation fails as the node no longer has multioutput as type
+    REQUIRE(!node->validate());
+}
+
+TEST_CASE("Node Type Validation", "[Node]")
+{
+    // Create a document
+    mx::DocumentPtr doc = mx::createDocument();
+
+    // Create a graph and add a single output
+    mx::NodeGraphPtr graph = doc->addNodeGraph("NG_custom_node");
+    graph->addOutput("output1", "float");
+
+    // Create a nodeDef based on the graph and make sure it has a single output
+    mx::NodeDefPtr nodeDef = doc->addNodeDefFromGraph(graph, "nodeDefName", "Category", "ND_custom_node");
+    REQUIRE(nodeDef->getOutputCount() == 1);
+
+    // Create a node based on the nodeDef and make sure it has no errors
+    mx::NodePtr node = doc->addNodeInstance(nodeDef);
+    REQUIRE(node->validate());
+
+    // Change the type of the node so that it does not match the nodeDef
+    node->setType("int");
+    // Make sure the validation fails as the node has a different type than the single output of the nodedef
+    REQUIRE(!node->validate());
+}
+
 TEST_CASE("Node", "[node]")
 {
     // Create a document.

--- a/source/MaterialXTest/MaterialXCore/Node.cpp
+++ b/source/MaterialXTest/MaterialXCore/Node.cpp
@@ -825,25 +825,3 @@ TEST_CASE("Node Definition Creation", "[nodedef]")
 
     REQUIRE(doc->validate());
 }
-
-TEST_CASE("NodDef validation no outputs", "[nodedef]")
-{
-    mx::DocumentPtr doc = mx::createDocument();
-
-    std::string name = mx::EMPTY_STRING;
-    std::string type = mx::EMPTY_STRING;
-    // If the 'type' given to addNodeDef is not empty then an output will be created implicitly
-    mx::NodeDefPtr nodeDef = doc->addNodeDef(name, type);
-
-    // Make sure no outputs were created
-    REQUIRE(nodeDef->getOutputCount() == 0);
-
-    // It will now fail the validation
-    REQUIRE_FALSE(nodeDef->validate());
-
-    // Add any output
-    nodeDef->addOutput();
-
-    // It will now pass the validation
-    REQUIRE(nodeDef->validate());
-}


### PR DESCRIPTION
Enforce that a node’s type aligns with its NodeDef outputs:
- **Single-output** NodeDefs require the node’s type to match that output’s type.  
- **Multi-output** NodeDefs require the node’s type to be `"multioutput"`.

Changes
- In `Node::validate()`, inspect `nodeDef->getOutputs()`:  
  - **1 output** → `node.getType() == output.getType()`  
  - **>1 output** → `node.getType() == "multioutput"`  

No existing API has been altered; this strictly adds validation logic.
