### PR TITLE
Handle UI display color space in MaterialX Viewer

### DIFF
--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -11,8 +11,6 @@
 #include <nanogui/slider.h>
 #include <nanogui/vscrollpanel.h>
 
-#include <iostream>
-
 namespace
 {
 
@@ -334,10 +332,6 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             mx::Color3 displayCol = v.linearToSrgb();
 
             ng::Color c(displayCol[0], displayCol[1], displayCol[2], 1.0);
-            ng::Color linCol(v[0], v[1], v[2], 1.0);
-
-            std::cout << "[" << label << " Color3 READ] linear: " << linCol << std::endl;
-            std::cout << "display: " << c << std::endl;
 
             new ng::Label(twoColumns, label);
             auto colorVar = new EditorColorPicker(twoColumns, c);
@@ -351,11 +345,6 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                     // Transform sRGBA color picker value to linear space for writing to material
                     mx::Color3 linearCol = mx::Color3(c.r(), c.g(), c.b()).srgbToLinear();
                     mx::Vector3 v(linearCol[0], linearCol[1], linearCol[2]);
-
-                    ng::Color linCol(linearCol[0], linearCol[1], linearCol[2], c.a());
-
-                    std::cout << "[" << path << " Color3 WRITE] display: " << c << std::endl;
-                    std::cout << "linear: " << linCol << std::endl;
 
                     material->modifyUniform(path, mx::Value::createValue(v));
                 }
@@ -374,10 +363,6 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         mx::Color3 displayCol = mx::Color3(v[0], v[1], v[2]).linearToSrgb();
 
         ng::Color c(displayCol[0], displayCol[1], displayCol[2], v[3]);
-        ng::Color linCol(v[0], v[1], v[2], v[3]);
-
-        std::cout << "[" << label << " Color4 READ] linear: " << linCol << std::endl;
-        std::cout << "display: " << c << std::endl;
 
         auto colorVar = new EditorColorPicker(twoColumns, c);
         colorVar->set_fixed_size({ 100, 20 });
@@ -391,10 +376,6 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                 mx::Color3 linearCol = mx::Color3(c.r(), c.g(), c.b()).srgbToLinear();
                 mx::Vector3 v(linearCol[0], linearCol[1], linearCol[2]);
 
-                ng::Color linCol(linearCol[0], linearCol[1], linearCol[2], c.a());
-
-                std::cout << "[" << path << " Color4 WRITE] display: " << c << std::endl;
-                std::cout << "linear: " << linCol << std::endl;
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -329,14 +329,14 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         }
         else
         {
-            // Transform stored linear space color value to sRGB for nanogui color picker
+            // Transform stored linear space color3 value to sRGBA for nanogui color picker
             mx::Color3 v = value->asA<mx::Color3>();
             mx::Color3 displayCol = v.linearToSrgb();
 
             ng::Color c(displayCol[0], displayCol[1], displayCol[2], 1.0);
             ng::Color linCol(v[0], v[1], v[2], 1.0);
 
-            std::cout << "[" << label << " READ] linear: " << linCol << std::endl;
+            std::cout << "[" << label << " Color3 READ] linear: " << linCol << std::endl;
             std::cout << "display: " << c << std::endl;
 
             new ng::Label(twoColumns, label);
@@ -348,13 +348,13 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                 mx::MaterialPtr material = viewer->getSelectedMaterial();
                 if (material)
                 {
-                    // Transform sRGB color picker value to linear space for writing to material
+                    // Transform sRGBA color picker value to linear space for writing to material
                     mx::Color3 linearCol = mx::Color3(c.r(), c.g(), c.b()).srgbToLinear();
                     mx::Vector3 v(linearCol[0], linearCol[1], linearCol[2]);
 
-                    ng::Color linCol(linearCol[0], linearCol[1], linearCol[2], 1.0);
+                    ng::Color linCol(linearCol[0], linearCol[1], linearCol[2], c.a());
 
-                    std::cout << "[" << path << " WRITE] display: " << c << std::endl;
+                    std::cout << "[" << path << " Color3 WRITE] display: " << c << std::endl;
                     std::cout << "linear: " << linCol << std::endl;
 
                     material->modifyUniform(path, mx::Value::createValue(v));
@@ -371,7 +371,14 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
 
         new ng::Label(twoColumns, label);
         mx::Color4 v = value->asA<mx::Color4>();
-        ng::Color c(v[0], v[1], v[2], v[3]);
+        mx::Color3 displayCol = mx::Color3(v[0], v[1], v[2]).linearToSrgb();
+
+        ng::Color c(displayCol[0], displayCol[1], displayCol[2], v[3]);
+        ng::Color linCol(v[0], v[1], v[2], v[3]);
+
+        std::cout << "[" << label << " Color4 READ] linear: " << linCol << std::endl;
+        std::cout << "display: " << c << std::endl;
+
         auto colorVar = new EditorColorPicker(twoColumns, c);
         colorVar->set_fixed_size({ 100, 20 });
         colorVar->set_font_size(15);
@@ -380,7 +387,14 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             mx::MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                mx::Vector4 v(c.r(), c.g(), c.b(), c.w());
+                // Transform sRGBA color picker value to linear space for writing to material
+                mx::Color3 linearCol = mx::Color3(c.r(), c.g(), c.b()).srgbToLinear();
+                mx::Vector3 v(linearCol[0], linearCol[1], linearCol[2]);
+
+                ng::Color linCol(linearCol[0], linearCol[1], linearCol[2], c.a());
+
+                std::cout << "[" << path << " Color4 WRITE] display: " << c << std::endl;
+                std::cout << "linear: " << linCol << std::endl;
                 material->modifyUniform(path, mx::Value::createValue(v));
             }
         });

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -11,6 +11,8 @@
 #include <nanogui/slider.h>
 #include <nanogui/vscrollpanel.h>
 
+#include <iostream>
+
 namespace
 {
 
@@ -327,8 +329,15 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
         }
         else
         {
+            // Transform stored linear space color value to sRGB for nanogui color picker
             mx::Color3 v = value->asA<mx::Color3>();
-            ng::Color c(v[0], v[1], v[2], 1.0);
+            mx::Color3 displayCol = v.linearToSrgb();
+
+            ng::Color c(displayCol[0], displayCol[1], displayCol[2], 1.0);
+            ng::Color linCol(v[0], v[1], v[2], 1.0);
+
+            std::cout << "[" << label << " READ] linear: " << linCol << std::endl;
+            std::cout << "display: " << c << std::endl;
 
             new ng::Label(twoColumns, label);
             auto colorVar = new EditorColorPicker(twoColumns, c);
@@ -339,7 +348,15 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
                 mx::MaterialPtr material = viewer->getSelectedMaterial();
                 if (material)
                 {
-                    mx::Vector3 v(c.r(), c.g(), c.b());
+                    // Transform sRGB color picker value to linear space for writing to material
+                    mx::Color3 linearCol = mx::Color3(c.r(), c.g(), c.b()).srgbToLinear();
+                    mx::Vector3 v(linearCol[0], linearCol[1], linearCol[2]);
+
+                    ng::Color linCol(linearCol[0], linearCol[1], linearCol[2], 1.0);
+
+                    std::cout << "[" << path << " WRITE] display: " << c << std::endl;
+                    std::cout << "linear: " << linCol << std::endl;
+
                     material->modifyUniform(path, mx::Value::createValue(v));
                 }
             });


### PR DESCRIPTION
_ASWF Dev Days May 2025
**Original Issue:** #1209_ 

This PR fixes discrepancies between the rendered preview material in MaterialXView and the NanoGUI color picker. In both the `Color3` and `Color4` cases, it completes the following conversions:

1. Uses `Color3::linearToSrgb()` to convert the stored value in "lin_rec709" color space to sRGB space for use in the color picker.
2. After user selects a color in the GUI and presses the "Pick" button, converts the selected RGB values to linear space using the `Color3::srgbToLinear()` conversion function. The converted linear color value is what is ultimately written to the material.

In the `Color4` case, the alpha channel is left untouched, both during reading and writing.

Note: Similar changes may have to be implemented for MaterialXGraphEditor. However, while attempting to implement those changes, I observed that ImGUI performs automatic gamma correction on its color picker widgets (color space in ImGUI seems to be being discussed in-depth in this [issue](https://github.com/ocornut/imgui/issues/578)). All-in-all, after discussion with @ld-kerley, it seems to be unclear what desired behavior in the ImGUI / MaterialXGraphEditor case is, so it is not handled yet in this PR.