### PR TITLE
Fix Graph Editor crash with multioutput nodes

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2652,7 +2652,16 @@ void Graph::addLink(ed::PinId startPinId, ed::PinId endPinId)
                             }
                             else
                             {
-                                pin->_input->setConnectedNode(uiUpNode->getNode());
+                                mx::NodePtr upstreamNode = uiUpNode->getNode();
+                                if (upstreamNode)
+                                {
+                                    mx::OutputPtr output = upstreamNode->getOutput(outputPin->_name);
+                                    if (!output)
+                                    {
+                                        output = upstreamNode->addOutput(outputPin->_name, pin->_input->getType());
+                                    }
+                                    pin->_input->setConnectedOutput(output);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
When connecting multiple output nodes to surface shaders, `Graph::addLink` was not specifying the output being connected. As a consequence, the shader would end up using the first output on the upstream node which could cause shader compilation errors and exceptions if the input and output types did not match.

This change ensures that the output is specified on the input pin.