### PR TITLE
Fix color space issues with sRGB framebuffer in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -104,10 +104,12 @@ std::string getUserNodeDefName(const std::string& val)
     return result;
 }
 
-static void EnableSRGBCallback(const ImDrawList*, const ImDrawCmd*)   {
+static void EnableSRGBCallback(const ImDrawList*, const ImDrawCmd*)
+{
     glEnable(GL_FRAMEBUFFER_SRGB);
 }
-static void DisableSRGBCallback(const ImDrawList*, const ImDrawCmd*)  {
+static void DisableSRGBCallback(const ImDrawList*, const ImDrawCmd*)
+{
     glDisable(GL_FRAMEBUFFER_SRGB);
 }
 
@@ -979,7 +981,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         {
             mx::Color3 prev, temp;
 
-            // read material value in converted display space
+            // Read material value in converted display space
             prev = temp = val->asA<mx::Color3>().linearToSrgb();
 
             // Use ImGuiColorEditFlags_Uint8 flag for built-in Uint8 input fields
@@ -992,7 +994,7 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             // Set input value and update materials if different from previous value
             if (prev != temp)
             {
-                // convert back to linear color space for writing to material and node input
+                // Convert back to linear color space for writing to material and node input
                 mx::Color3 linearCol = temp.srgbToLinear();
 
                 addNodeInput(_currUiNode, input);
@@ -1008,12 +1010,12 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         mx::ValuePtr val = input->getValue();
         if (val && val->isA<mx::Color4>())
         {
-            // read material value and convert RGB components to display space
+            // Read material value and convert RGB components to display space
             mx::Color4 linearCol = val->asA<mx::Color4>();
             mx::Color3 displayCol3 = mx::Color3(linearCol[0], linearCol[1], linearCol[2]).linearToSrgb();
 
             mx::Color4 prev, temp;
-            // create 4D vector with converted RGB and non-converted, stored Alpha value
+            // Create 4D vector with converted RGB and non-converted, stored Alpha value
             prev = temp = mx::Color4(displayCol3[0], displayCol3[1], displayCol3[2], linearCol[3]);
 
             // Use ImGuiColorEditFlags_Uint8 flag for built-in Uint8 input fields
@@ -1026,9 +1028,9 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             // Set input value and update materials if different from previous value
             if (temp != prev)
             {
-                // convert back to linear color space for writing to material and node input
+                // Convert back to linear color space for writing to material and node input
                 mx::Color3 linearCol3 = mx::Color3(temp[0], temp[1], temp[2]).srgbToLinear();
-                mx::Color4 linearCol = mx::Color4(linearCol3[0], linearCol3[1], linearCol3[2], temp[3]); // use new Alpha val
+                mx::Color4 linearCol = mx::Color4(linearCol3[0], linearCol3[1], linearCol3[2], temp[3]); // Use new Alpha val
 
                 addNodeInput(_currUiNode, input);
                 input->setValue(linearCol, input->getType());

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -978,21 +978,22 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
         if (val && val->isA<mx::Color3>())
         {
             mx::Color3 prev, temp;
-            prev = temp = val->asA<mx::Color3>();
-            float min = minVal ? minVal->asA<mx::Color3>()[0] : 0.f;
-            float max = maxVal ? maxVal->asA<mx::Color3>()[0] : 100.f;
-            float speed = (max - min) / 1000.0f;
-            ImGui::PushItemWidth(-100);
-            ImGui::DragFloat3("##hidelabel", &temp[0], speed, min, max);
-            ImGui::PopItemWidth();
-            ImGui::SameLine();
-            ImGui::ColorEdit3("##color", &temp[0], ImGuiColorEditFlags_NoInputs);
+
+            // read material value in converted display space
+            prev = temp = val->asA<mx::Color3>().linearToSrgb();
+
+            // Use ImGuiColorEditFlags_Float flag for built-in Float3 input fields
+            ImGui::ColorEdit3("##color", &temp[0], ImGuiColorEditFlags_Float);
 
             // Set input value and update materials if different from previous value
             if (prev != temp)
             {
+                mx::Color3 linearCol = temp.srgbToLinear();
+                mx::ValuePtr linearVal = mx::Value::createValue<mx::Color3>(linearCol);
+
                 addNodeInput(_currUiNode, input);
-                input->setValue(temp, input->getType());
+                input->setValue(linearCol, input->getType());
+
                 updateMaterials(input, input->getValue());
             }
         }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -982,8 +982,12 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             // read material value in converted display space
             prev = temp = val->asA<mx::Color3>().linearToSrgb();
 
-            // Use ImGuiColorEditFlags_Float flag for built-in Float3 input fields
-            ImGui::ColorEdit3("##color", &temp[0], ImGuiColorEditFlags_Float);
+            // Use ImGuiColorEditFlags_Uint8 flag for built-in Uint8 input fields
+            ImGui::ColorEdit3("##color", &temp[0], ImGuiColorEditFlags_Uint8);
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+            {
+                ImGui::SetTooltip("Color is selected and rendered to Viewer in sRGB display space, \nbut written to .mtlx file in linear format.");
+            }
 
             // Set input value and update materials if different from previous value
             if (prev != temp)
@@ -1012,8 +1016,12 @@ void Graph::setConstant(UiNodePtr node, mx::InputPtr& input, const mx::UIPropert
             // create 4D vector with converted RGB and non-converted, stored Alpha value
             prev = temp = mx::Color4(displayCol3[0], displayCol3[1], displayCol3[2], linearCol[3]);
 
-            // Use ImGuiColorEditFlags_Float flag for built-in Float3 input fields
-            ImGui::ColorEdit4("##color", &temp[0], ImGuiColorEditFlags_Float);
+            // Use ImGuiColorEditFlags_Uint8 flag for built-in Uint8 input fields
+            ImGui::ColorEdit4("##color", &temp[0], ImGuiColorEditFlags_Uint8);
+            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+            {
+                ImGui::SetTooltip("Color is selected and rendered to Viewer in sRGB display space, \nbut written to .mtlx file in linear format.");
+            }
 
             // Set input value and update materials if different from previous value
             if (temp != prev)

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -104,6 +104,13 @@ std::string getUserNodeDefName(const std::string& val)
     return result;
 }
 
+static void EnableSRGBCallback(const ImDrawList*, const ImDrawCmd*)   {
+    glEnable(GL_FRAMEBUFFER_SRGB);
+}
+static void DisableSRGBCallback(const ImDrawList*, const ImDrawCmd*)  {
+    glDisable(GL_FRAMEBUFFER_SRGB);
+}
+
 } // anonymous namespace
 
 //
@@ -3319,13 +3326,19 @@ void Graph::graphButtons()
 
     if (_renderer)
     {
-        glEnable(GL_FRAMEBUFFER_SRGB);
+        // Enable sRGB conversion for framebuffer ONLY when drawing material preview
+        ImGui::GetWindowDrawList()->AddCallback(EnableSRGBCallback,  nullptr);
+
         _renderer->getViewCamera()->setViewportSize(mx::Vector2(screenSize[0], screenSize[1]));
         GLuint64 my_image_texture = _renderer->_textureID;
         mx::Vector2 vec = _renderer->getViewCamera()->getViewportSize();
-        // current image has correct color space but causes problems for gui
+
         ImGui::Image((ImTextureID) my_image_texture, screenSize, ImVec2(0, 1), ImVec2(1, 0));
+
+        // Disable sRGB conversion for all other imgui ui components.
+        ImGui::GetWindowDrawList()->AddCallback(DisableSRGBCallback,  nullptr);
     }
+
     ImGui::Separator();
 
     // Property editor for current nodes

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -850,7 +850,9 @@ void RenderView::renderFrame()
     {
         glDisable(GL_CULL_FACE);
     }
+    // restore framebuffer and disable sRGB conversion in preparation for ImGUI drawing
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glDisable(GL_FRAMEBUFFER_SRGB);
 
     // Store viewport texture for render.
     _textureID = _renderFrame->getColorTexture();

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -850,7 +850,7 @@ void RenderView::renderFrame()
     {
         glDisable(GL_CULL_FACE);
     }
-    // restore framebuffer and disable sRGB conversion in preparation for ImGUI drawing
+    // Restore framebuffer and disable sRGB conversion in preparation for ImGUI drawing
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDisable(GL_FRAMEBUFFER_SRGB);
 


### PR DESCRIPTION
_Related [issue](https://github.com/AcademySoftwareFoundation/MaterialX/issues/1209) and [Dev Days PR for Viewer](https://github.com/AcademySoftwareFoundation/MaterialX/pull/2394)_

This PR addresses color space discrepancies / logic in MaterialX Graph Editor.

---
#### Summary of Problem: 
Before, the graph editor used an sRGB framebuffer (i.e. `glEnable(GL_FRAMEBUFFER_SRGB)`) for the entire GUI, meaning both the rendered material (with its color values given in linear space) _and_ the ImGUI components had an automatic "to-sRGB" transformation applied to them.

Although this is desired for the material preview, which is a rendered, PBR result and needs to be color corrected to display space, it has adverse results on ImGUI components that handle color. This is because currently, ImGUI is not completely compatible with sRGB-enabled framebuffers (ref: [578](https://github.com/ocornut/imgui/issues/578), [1724](https://github.com/ocornut/imgui/issues/1724), [2943](https://github.com/ocornut/imgui/pull/2943) [4890](https://github.com/ocornut/imgui/issues/4890), [6583](https://github.com/ocornut/imgui/issues/6583)). To exemplify a problem that arises, alpha-blending is calculated incorrectly when using an sRGB framebuffer.

Compare a "correct" color picker rendered w/o sRGB-enabled framebuffer with a color picker rendered w/ sRGB-enabled framebuffer, which is how it was done before this PR. I gave it the same color value, but in linear space:

<img width="300" alt="Screenshot 2025-05-21 at 16 55 20" src="https://github.com/user-attachments/assets/6bf6d9a3-a098-4216-9d95-42dec68f8db8" />
<img width="300" alt="Screenshot 2025-05-21 at 16 57 52" src="https://github.com/user-attachments/assets/85471b95-b84e-474f-aacf-e9ba6f263605" />

There is clearly a non-negligible difference in both the color ramp and the overall canvas (which is the result of a completely different blending equation being applied, as commented on [here](https://github.com/ocornut/imgui/issues/578#issuecomment-1585432977)). This calculation error results in the color picker UI component being in a nonlinear display space and should be avoided.

---
#### Resolution Implemented:

1. To avoid these calculation errors in ImGUI, the sRGB framebuffer should be disabled for the UI. However, the rendered material view needs to still have a sRGB transformation applied to it. To solve this, I used the `ImGui::GetWindowDrawList()->AddCallback()` function to to inject a call to`glEnable(GL_FRAMEBUFFER_SRGB)` into ImGUI's iterative draw list right before the materialview texture is drawn, and disable it immediately after.

This effectively maintains the original material render result, but solves the color problems in the UI.

2. Then, regarding the original [issue](https://github.com/AcademySoftwareFoundation/MaterialX/issues/1209), `Color3::linearToSrgb()` and `Color3::srgbToLinear()` are used to transform between color spaces. The result is below. 

_**Before:** User previews rendered material and color picker swatch in display space, but the actual color value numbers are actually in the linear range. These values will not match up in other applications, such as Adobe products, which is misleading._
<img width="600" alt="Screenshot 2025-05-21 at 13 29 01" src="https://github.com/user-attachments/assets/3c1740b8-a905-4393-b66c-3dbe885df034" />

_**After:** User always interacts with color in display space (pick + view), but behind-the-scenes, the color is written / stored in linear space._
<img width="600" alt="Screenshot 2025-05-21 at 16 26 17" src="https://github.com/user-attachments/assets/57d4853e-8095-4730-83f4-13778f9a58f6" />

_Rendered material result is successfully maintained:_

<img width="300" alt="Screenshot 2025-05-21 at 17 19 02" src="https://github.com/user-attachments/assets/97a62cb9-2ed0-46e1-9832-5f9f3584228f" />
<img width="300" alt="Screenshot 2025-05-21 at 17 18 24" src="https://github.com/user-attachments/assets/34ad2187-2ffb-4101-8ddd-646c8daa693c" />

3. Lastly, a simple tooltip is added to the color picker component, clarifying the difference between front-facing UI values and stored values.
<img width="800" alt="Screenshot 2025-05-21 at 17 44 40" src="https://github.com/user-attachments/assets/04731a33-e786-48b1-b1c6-ee6ca98a048c" />

---
Please let me know if I can clarify on any of the points I mentioned above. I tried to balance digital color principles / correctness with overall UI experience in these changes. Thanks!