### PR TITLE
Fix overwriting of alpha values in Viewer colorpicker

### DIFF
--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -374,7 +374,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             {
                 // Transform sRGBA color picker value to linear space for writing to material
                 mx::Color3 linearCol = mx::Color3(c.r(), c.g(), c.b()).srgbToLinear();
-                mx::Vector3 v(linearCol[0], linearCol[1], linearCol[2]);
+                mx::Vector4 v(linearCol[0], linearCol[1], linearCol[2], c.a());
 
                 material->modifyUniform(path, mx::Value::createValue(v));
             }

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -48,13 +48,37 @@ class EditorColorPicker : public ng::ColorPicker
             });
         }
 
-        // The color wheel does not handle alpha properly, so only
-        // overwrite RGB in the callback.
+        // Overwrite default callback of color wheel
+        m_color_wheel->set_callback([this](const ng::Color& c)
+        {
+            ng::Color cAlpha = ng::Color(c[0], c[1], c[2], _colorWidgets[3]->value());
+
+            m_color_wheel->set_color(cAlpha);
+
+            // Account for Alpha value when setting `m_pick_button` properties
+            m_pick_button->set_background_color(cAlpha);
+            m_pick_button->set_text_color(cAlpha.contrasting_color());
+
+            m_callback(cAlpha);
+        });
+
+        // Overwrite default callback of `m_pick_button`
+        m_pick_button->set_callback([&]() {
+            if (m_pushed) {
+                // Use `_colorWidgets` to construct new color value, which ensures that Alpha component is correctly written
+                ng::Color value(_colorWidgets[0]->value(), _colorWidgets[1]->value(), _colorWidgets[2]->value(), _colorWidgets[3]->value());
+                set_pushed(false);
+                set_color(value);
+                m_final_callback(value);
+            }
+        });
+
         m_callback = [this](const ng::Color& value)
         {
             _colorWidgets[0]->set_value(value[0]);
             _colorWidgets[1]->set_value(value[1]);
             _colorWidgets[2]->set_value(value[2]);
+            _colorWidgets[3]->set_value(value[3]);
         };
     }
 

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -66,7 +66,7 @@ class EditorColorPicker : public ng::ColorPicker
         {
             if (m_pushed)
             {
-                // Use `_colorWidgets` to construct new color value, which ensures that Alpha component is correctly written.
+                // Use _colorWidgets to construct new color value, which ensures that Alpha component is correctly written.
                 ng::Color value(_colorWidgets[0]->value(), _colorWidgets[1]->value(), _colorWidgets[2]->value(), _colorWidgets[3]->value());
                 set_pushed(false);
                 set_color(value);

--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -48,24 +48,25 @@ class EditorColorPicker : public ng::ColorPicker
             });
         }
 
-        // Overwrite default callback of color wheel
+        // Overwrite default callback of color wheel.
         m_color_wheel->set_callback([this](const ng::Color& c)
         {
             ng::Color cAlpha = ng::Color(c[0], c[1], c[2], _colorWidgets[3]->value());
-
             m_color_wheel->set_color(cAlpha);
 
-            // Account for Alpha value when setting `m_pick_button` properties
+            // Account for Alpha value when setting m_pick_button properties.
             m_pick_button->set_background_color(cAlpha);
             m_pick_button->set_text_color(cAlpha.contrasting_color());
 
             m_callback(cAlpha);
         });
 
-        // Overwrite default callback of `m_pick_button`
-        m_pick_button->set_callback([&]() {
-            if (m_pushed) {
-                // Use `_colorWidgets` to construct new color value, which ensures that Alpha component is correctly written
+        // Overwrite default callback of m_pick_button.
+        m_pick_button->set_callback([&]()
+        {
+            if (m_pushed)
+            {
+                // Use `_colorWidgets` to construct new color value, which ensures that Alpha component is correctly written.
                 ng::Color value(_colorWidgets[0]->value(), _colorWidgets[1]->value(), _colorWidgets[2]->value(), _colorWidgets[3]->value());
                 set_pushed(false);
                 set_color(value);


### PR DESCRIPTION
Currently, if an user uses the MaterialXView colorpicker for a `Color4` field, the alpha component is automatically overwritten and transformed to a value of 1, regardless of original value. Although it is shown unmodified in the UI, if written out to file, the alpha component is always "1". e.g.
```
<input name="bias" type="color4" value="0.0908109, 0.0908109, 0.0908109, 1" />
```
This is because the Nanogui `ColorWheel` class does not handle color values with 4 components, yet the Nanogui `ColorPicker` class refers to its color wheel member to set the new picked color ([code ref](https://github.com/mitsuba-renderer/nanogui/blob/6452dd6944d2ba5c0c9bc0042a1894f703ce1ace/src/colorpicker.cpp#L58-L65)).

To prevent this from happening, I modified the current `class EditorColorPicker : public ng::ColorPicker`, and created custom callbacks for `m_color_wheel` and `m_pick_button`. The logic essentially is -- since we have additional color widget members in our color picker, we instead refer to their values when setting the color value. Then, the alpha component can only be changed via the color widgets, so interacting with the color wheel does not change / overwrite the original alpha component.

The following GIF is a simple visual demonstration of the alpha being correctly preserved and previewed in the `PickButton`. I've also tested saving out to file to validate the written value.

<img src="https://github.com/user-attachments/assets/effabb0d-c3c9-405e-8ad7-65c5f15f6cc7" width="500" />