### PR TITLE
Fix MSVC warnings

### DIFF
--- a/source/MaterialXRender/ShaderRenderer.h
+++ b/source/MaterialXRender/ShaderRenderer.h
@@ -124,7 +124,7 @@ class MX_RENDER_API ShaderRenderer
     /// @{
 
     /// Capture the current rendered output as an image.
-    virtual ImagePtr captureImage(ImagePtr image = nullptr)
+    virtual ImagePtr captureImage(ImagePtr = nullptr)
     {
         return nullptr;
     }

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -202,7 +202,7 @@ class ShaderGeneratorTester
     void validate(const mx::GenOptions& generateOptions, const std::string& optionsFilePath);
 
     // Allow the tester to alter the document, e.g., by flattening file names.
-    virtual void preprocessDocument(mx::DocumentPtr doc) {};
+    virtual void preprocessDocument(mx::DocumentPtr) {};
 
     // Compile generated source code. Default implementation does nothing.
     virtual void compileSource(const std::vector<mx::FilePath>& /*sourceCodePaths*/) {};

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -52,7 +52,7 @@ void ShaderRenderTester::getGenerationOptions(const GenShaderUtil::TestSuiteOpti
 void ShaderRenderTester::printRunLog(const RenderProfileTimes &profileTimes,
                                      const GenShaderUtil::TestSuiteOptions& options,
                                      std::ostream& stream,
-                                     mx::DocumentPtr dependLib)
+                                     mx::DocumentPtr)
 {
     profileTimes.print(stream);
 


### PR DESCRIPTION
This changelist fixes a handful of warnings when building MaterialXRender and MaterialXTest with the latest release of Microsoft Visual C++.

These new warnings relate to function arguments that are never used within the body of the function.