### PR TITLE
Remove ShaderNodeImpl::getTarget() function

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -787,9 +787,4 @@ ShaderNodeImplPtr GlslShaderGenerator::getImplementation(const NodeDef& nodedef,
     return impl;
 }
 
-const string& GlslImplementation::getTarget() const
-{
-    return GlslShaderGenerator::TARGET;
-}
-
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -97,16 +97,6 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     vector<ShaderNodePtr> _lightSamplingNodes;
 };
 
-/// Base class for common GLSL node implementations
-class MX_GENGLSL_API GlslImplementation : public HwImplementation
-{
-  public:
-    const string& getTarget() const override;
-
-  protected:
-    GlslImplementation() { }
-};
-
 MATERIALX_NAMESPACE_END
 
 #endif

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -20,11 +20,6 @@ ShaderNodeImplPtr LightCompoundNodeGlsl::create()
     return std::make_shared<LightCompoundNodeGlsl>();
 }
 
-const string& LightCompoundNodeGlsl::getTarget() const
-{
-    return GlslShaderGenerator::TARGET;
-}
-
 void LightCompoundNodeGlsl::initialize(const InterfaceElement& element, GenContext& context)
 {
     CompoundNode::initialize(element, context);

--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.h
@@ -24,8 +24,6 @@ class MX_GENGLSL_API LightCompoundNodeGlsl : public CompoundNode
 
     static ShaderNodeImplPtr create();
 
-    const string& getTarget() const override;
-
     void initialize(const InterfaceElement& element, GenContext& context) override;
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightNodeGlsl.h
@@ -11,7 +11,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Light node implementation for GLSL
-class MX_GENGLSL_API LightNodeGlsl : public GlslImplementation
+class MX_GENGLSL_API LightNodeGlsl : public HwImplementation
 {
   public:
     LightNodeGlsl();

--- a/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightSamplerNodeGlsl.h
@@ -11,7 +11,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Utility node for sampling lights for GLSL.
-class MX_GENGLSL_API LightSamplerNodeGlsl : public GlslImplementation
+class MX_GENGLSL_API LightSamplerNodeGlsl : public HwImplementation
 {
   public:
     LightSamplerNodeGlsl();

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.cpp
@@ -19,11 +19,6 @@ ShaderNodeImplPtr LightShaderNodeGlsl::create()
     return std::make_shared<LightShaderNodeGlsl>();
 }
 
-const string& LightShaderNodeGlsl::getTarget() const
-{
-    return GlslShaderGenerator::TARGET;
-}
-
 void LightShaderNodeGlsl::initialize(const InterfaceElement& element, GenContext& context)
 {
     SourceCodeNode::initialize(element, context);

--- a/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/LightShaderNodeGlsl.h
@@ -20,8 +20,6 @@ class MX_GENGLSL_API LightShaderNodeGlsl : public SourceCodeNode
 
     static ShaderNodeImplPtr create();
 
-    const string& getTarget() const override;
-
     void initialize(const InterfaceElement& element, GenContext& context) override;
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/NumLightsNodeGlsl.h
@@ -11,7 +11,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Utility node for getting number of active lights for GLSL.
-class MX_GENGLSL_API NumLightsNodeGlsl : public GlslImplementation
+class MX_GENGLSL_API NumLightsNodeGlsl : public HwImplementation
 {
   public:
     NumLightsNodeGlsl();

--- a/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h
+++ b/source/MaterialXGenGlsl/Nodes/SurfaceNodeGlsl.h
@@ -12,7 +12,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Surface node implementation for GLSL
-class MX_GENGLSL_API SurfaceNodeGlsl : public GlslImplementation
+class MX_GENGLSL_API SurfaceNodeGlsl : public HwImplementation
 {
   public:
     SurfaceNodeGlsl();

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.cpp
@@ -104,9 +104,4 @@ void HeightToNormalNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext&
     }
 }
 
-const string& HeightToNormalNodeMdl::getTarget() const
-{
-    return MdlShaderGenerator::TARGET;
-}
-
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/HeightToNormalNodeMdl.h
@@ -20,8 +20,6 @@ class MX_GENMDL_API HeightToNormalNodeMdl : public ConvolutionNode
 
     void emitFunctionCall(const ShaderNode& node, GenContext& context, ShaderStage& stage) const override;
 
-    const string& getTarget() const override;
-
   protected:
     /// Return if given type is an acceptable input
     bool acceptsInputType(TypeDesc type) const override;

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -1302,9 +1302,4 @@ ShaderNodeImplPtr MslShaderGenerator::getImplementation(const NodeDef& nodedef, 
     return impl;
 }
 
-const string& MslImplementation::getTarget() const
-{
-    return MslShaderGenerator::TARGET;
-}
-
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMsl/MslShaderGenerator.h
+++ b/source/MaterialXGenMsl/MslShaderGenerator.h
@@ -124,16 +124,6 @@ class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
     vector<ShaderNodePtr> _lightSamplingNodes;
 };
 
-/// Base class for common MSL node implementations
-class MX_GENMSL_API MslImplementation : public HwImplementation
-{
-  public:
-    const string& getTarget() const override;
-
-  protected:
-    MslImplementation() { }
-};
-
 MATERIALX_NAMESPACE_END
 
 #endif

--- a/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.cpp
@@ -20,11 +20,6 @@ ShaderNodeImplPtr LightCompoundNodeMsl::create()
     return std::make_shared<LightCompoundNodeMsl>();
 }
 
-const string& LightCompoundNodeMsl::getTarget() const
-{
-    return MslShaderGenerator::TARGET;
-}
-
 void LightCompoundNodeMsl::initialize(const InterfaceElement& element, GenContext& context)
 {
     CompoundNode::initialize(element, context);

--- a/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightCompoundNodeMsl.h
@@ -24,8 +24,6 @@ class MX_GENMSL_API LightCompoundNodeMsl : public CompoundNode
 
     static ShaderNodeImplPtr create();
 
-    const string& getTarget() const override;
-
     void initialize(const InterfaceElement& element, GenContext& context) override;
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/LightNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightNodeMsl.h
@@ -11,7 +11,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Light node implementation for MSL
-class MX_GENMSL_API LightNodeMsl : public MslImplementation
+class MX_GENMSL_API LightNodeMsl : public HwImplementation
 {
   public:
     LightNodeMsl();

--- a/source/MaterialXGenMsl/Nodes/LightSamplerNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightSamplerNodeMsl.h
@@ -11,7 +11,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Utility node for sampling lights for MSL.
-class MX_GENMSL_API LightSamplerNodeMsl : public MslImplementation
+class MX_GENMSL_API LightSamplerNodeMsl : public HwImplementation
 {
   public:
     LightSamplerNodeMsl();

--- a/source/MaterialXGenMsl/Nodes/LightShaderNodeMsl.cpp
+++ b/source/MaterialXGenMsl/Nodes/LightShaderNodeMsl.cpp
@@ -19,11 +19,6 @@ ShaderNodeImplPtr LightShaderNodeMsl::create()
     return std::make_shared<LightShaderNodeMsl>();
 }
 
-const string& LightShaderNodeMsl::getTarget() const
-{
-    return MslShaderGenerator::TARGET;
-}
-
 void LightShaderNodeMsl::initialize(const InterfaceElement& element, GenContext& context)
 {
     SourceCodeNode::initialize(element, context);

--- a/source/MaterialXGenMsl/Nodes/LightShaderNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/LightShaderNodeMsl.h
@@ -20,8 +20,6 @@ class MX_GENMSL_API LightShaderNodeMsl : public SourceCodeNode
 
     static ShaderNodeImplPtr create();
 
-    const string& getTarget() const override;
-
     void initialize(const InterfaceElement& element, GenContext& context) override;
 
     void createVariables(const ShaderNode& node, GenContext& context, Shader& shader) const override;

--- a/source/MaterialXGenMsl/Nodes/NumLightsNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/NumLightsNodeMsl.h
@@ -11,7 +11,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Utility node for getting number of active lights for MSL.
-class MX_GENMSL_API NumLightsNodeMsl : public MslImplementation
+class MX_GENMSL_API NumLightsNodeMsl : public HwImplementation
 {
   public:
     NumLightsNodeMsl();

--- a/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.h
+++ b/source/MaterialXGenMsl/Nodes/SurfaceNodeMsl.h
@@ -12,7 +12,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// Surface node implementation for MSL
-class MX_GENMSL_API SurfaceNodeMsl : public MslImplementation
+class MX_GENMSL_API SurfaceNodeMsl : public HwImplementation
 {
   public:
     SurfaceNodeMsl();

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -33,12 +33,6 @@ class MX_GENSHADER_API ShaderNodeImpl
   public:
     virtual ~ShaderNodeImpl() { }
 
-    /// Return an identifier for the target used by this implementation.
-    /// By default an empty string is returned, representing all targets.
-    /// Only override this method if your derived node implementation class
-    /// is for a specific target.
-    virtual const string& getTarget() const { return EMPTY_STRING; }
-
     /// Initialize with the given implementation element.
     /// Initialization must set the name and hash for the implementation,
     /// as well as any other data needed to emit code for the node.


### PR DESCRIPTION
This PR removes `ShaderNodeImpl::getTarget()` and all its downstream overloaded functions.

It appears that this function isn't used anywhere, and removing it allows us to simplify the class hierarchy, and possibly opens the door to more consolidation between the GLSL/MSL C++ implementation nodes. 

If removing this function is going to cause problems downstream anywhere, it would be great if someone could give some context - and we should probably add some tests to capture that behavior.