### PR TITLE
Align screen colors between Editor and Viewer

### DIFF
--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -780,7 +780,8 @@ void RenderView::renderFrame()
 
     _renderFrame->bind();
 
-    glClearColor(.70f, .70f, .75f, 1.0f);
+    mx::Color3 screenColor(mx::DEFAULT_SCREEN_COLOR_SRGB);
+    glClearColor(screenColor[0], screenColor[1], screenColor[2], 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
     glEnable(GL_FRAMEBUFFER_SRGB);
 


### PR DESCRIPTION
Following up on recent work from @mialana, this changelist updates the viewport screen color in the MaterialX Graph Editor to match that of the MaterialX Viewer.

Now that the UI elements in the Graph Editor have their intended dark color scheme, the darker screen color from the Viewer makes a good choice for the Graph Editor as well.