### PR TITLE
Improve height to normal implementation for OSL

### DIFF
--- a/libraries/stdlib/genosl/mx_heighttonormal_vector3.osl
+++ b/libraries/stdlib/genosl/mx_heighttonormal_vector3.osl
@@ -1,8 +1,46 @@
 void mx_heighttonormal_vector3(float in, float scale, output vector result)
 {
-    float dx = -Dx(in);
-    float dy = Dy(in);
-    float dz = max(scale, 1.0E-05) * sqrt(max(1.0 - dx*dx - dy*dy, 1.0E-05));
-    vector dir = normalize(vector(dx, dy, dz));
-    result = dir * vector(0.5) + vector(0.5);
+    // these should probably be inputs to the node (note propose n -> N if moved to node input)
+    normal n = N;
+    vector T = dPdu;
+    vector B = dPdv;
+
+    // calculate normal in world space.
+    normal NN = normalize(n);
+    result = normalize(calculatenormal(P + in * scale * NN));
+
+    // create orthonormal basis
+    vector TT = normalize(dPdu);
+    vector BB = normalize(dPdv);
+    TT = normalize(TT - dot(TT, NN) * NN);
+    BB = normalize(B - dot(BB, NN) * NN - dot(BB, TT) * TT);
+
+    // convert normal to tangent space
+    result = vector(dot(TT, result), dot(BB, result), dot(NN, result));
+
+    // remap to 0-1 space
+    result = (result * 0.5) + 0.5;
 }
+
+/*
+This version of the function could be used if we add the additional inputs to the node.
+
+void mx_heighttonormal_vector3(float in, float scale, vector N, vector T, vector B, output vector result)
+{
+    // calculate normal in world space.
+    normal NN = normalize(N);
+    result = normalize(calculatenormal(P + in * scale * NN));
+
+    // create orthonormal basis
+    vector TT = normalize(dPdu);
+    vector BB = normalize(dPdv);
+    TT = normalize(TT - dot(TT, NN) * NN);
+    BB = normalize(B - dot(BB, NN) * NN - dot(BB, TT) * TT);
+
+    // convert normal to tangent space
+    result = vector(dot(TT, result), dot(BB, result), dot(NN, result));
+
+    // remap to 0-1 space
+    result = (result * 0.5) + 0.5;
+}
+*/


### PR DESCRIPTION
This PR updates the `heighttonormal` implementation for OSL.  Instead of using a screen space metric for the derivatives, that can vary as you zoom on an asset, we revert to using the `calculatenormal()` function that is part of the OSL language spec.  This was used previously, but the result was not then correctly transformed to tangent space - which is required by the spec for this node.  This PR transforms the normal returned by `calculatenormal()`, which is in world space, in to tangent space. 

The implementation provided here uses `dPdu` and `dPdv` as the tangent and bitangent directions.  An orthonormal basis is then created to convert the normal to tangent space.

I think we should consider adding a `normal`, `tangent` and `bitangent` input to the `heighttonormal` node. ie.
```
  <nodedef name="ND_heighttonormal_vector3" node="heighttonormal" nodegroup="convolution2d">
    <input name="in" type="float" value="0.0" />
    <input name="scale" type="float" value="1.0" />
    <input name="normal" type="vector3" defaultgeomprop="Nworld" />
    <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" />
    <output name="out" type="vector3" default="0.5, 0.5, 1.0" />
  </nodedef>
```

I propose these additional inputs, to align with the `normalmap` node inputs. 

If this PR is accepted, then I think we should also follow up with an optimized version of `bump` for OSL that shortcuts the transform to and from tangent space. 