### PR TITLE
Fix enumeration interfacename bug

### DIFF
--- a/resources/Materials/TestSuite/stdlib/definition/definition_with_enum_interface.mtlx
+++ b/resources/Materials/TestSuite/stdlib/definition/definition_with_enum_interface.mtlx
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+
+  <!-- create a custom node that exposes an enumeration input via "interfacename" -->
+  <nodedef name="ND_positionwrapper" node="positionwrapper">
+    <input name="wrap_space" type="string" value="object" enum="model, object, world" uniform="true"/>
+    <output name="out" type="vector3"/>
+  </nodedef>
+  <nodegraph name="NG_positionwrapper" nodedef="ND_positionwrapper">
+    <position name="myPos" type="vector3">
+      <input name="space" type="string" interfacename="wrap_space"/>
+    </position>
+    <output name="out" type="vector3" nodename="myPos"/>
+  </nodegraph>
+
+  <positionwrapper name="myPosWrapper" type="vector3">
+    <input name="wrap_space" type="string" value="object"/>
+  </positionwrapper>
+
+  <extract name="extract" type="float">
+    <input name="in" type="vector3" nodename="myPosWrapper"/>
+    <input name="index" type="integer" value="1"/>
+  </extract>
+  <surface_unlit name="Srf" type="surfaceshader">
+    <input name="emission" type="float" nodename="extract" />
+  </surface_unlit>
+  <surfacematerial name="Mtl" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="Srf" />
+  </surfacematerial>
+</materialx>

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -353,16 +353,21 @@ void ShaderNode::initialize(const Node& node, const NodeDef& nodeDef, GenContext
                 }
             }
             const string& valueString = portValue ? portValue->getValueString() : EMPTY_STRING;
-            std::pair<TypeDesc, ValuePtr> enumResult;
-            const string& enumNames = nodeDefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
-            const TypeDesc type = context.getTypeDesc(nodeDefInput->getType());
-            if (context.getShaderGenerator().getSyntax().remapEnumeration(valueString, type, enumNames, enumResult))
+            if (!valueString.empty())
             {
-                input->setValue(enumResult.second);
-            }
-            else if (!valueString.empty())
-            {
-                input->setValue(portValue);
+                // We explicitly check the valueString is not empty before checking the enumeration,
+                // because otherwise the enumeration value would always return nullptr
+                std::pair<TypeDesc, ValuePtr> enumResult;
+                const string& enumNames = nodeDefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+                const TypeDesc type = context.getTypeDesc(nodeDefInput->getType());
+                if (context.getShaderGenerator().getSyntax().remapEnumeration(valueString, type, enumNames, enumResult))
+                {
+                    input->setValue(enumResult.second);
+                }
+                else
+                {
+                    input->setValue(portValue);
+                }
             }
         }
     }


### PR DESCRIPTION
Related to #2422.

When creating the `Input`, during construction of the graph for code generation, currently if an enumeration is exposed via `interfacename`, then the `value` member ends up getting set to `nullptr`, which means later the code generation cannot determine the correct type.

This PR guards the setting of the value, to avoid setting this to `nullptr`. 