### PR TITLE
Allow `backspace` for deletion in Graph Editor on MacBook

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -4252,7 +4252,7 @@ void Graph::drawGraph(ImVec2 mousePos)
         // or if the shortcut for cut is used
         if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow))
         {
-            if (ImGui::IsKeyReleased(ImGuiKey_Delete) || _isCut)
+            if (ImGui::IsKeyReleased(ImGuiKey_Delete) || ImGui::IsKeyReleased(ImGuiKey_Backspace) || _isCut)
             {
                 if (selectedNodes.size() > 0)
                 {


### PR DESCRIPTION
Seems the key bindings in the current graph editor are rather low-level (they are not taking OS differences into account).
This PR allows deleting things on MacBooks that don't have a delete key (everything uses backspace there).