### PR TITLE
Allow keyboard deletion of selected links in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -4280,6 +4280,27 @@ void Graph::drawGraph(ImVec2 mousePos)
                     }
                     linkGraph();
                 }
+                else if (selectedLinks.size() > 0)
+                {
+                    _frameCount = ImGui::GetFrameCount();
+                    _renderer->setMaterialCompilation(true);
+                    for (ed::LinkId id : selectedLinks)
+                    {
+                        if (int(id.Get()) > 0 && !readOnly())
+                        {
+                            deleteLink(id);
+                            _delete = true;
+                            ed::DeselectLink(id);
+                            ed::DeleteLink(id);
+                            _currUiNode = nullptr;
+                        }
+                        else if (readOnly())
+                        {
+                            _popup = true;
+                        }
+                    }
+                    linkGraph();
+                }
                 _isCut = false;
             }
 


### PR DESCRIPTION
This PR adds the ability to delete selected links using the keyboard, same as it works for nodes.
The existing functionality to Option-Click on a link is still the same, but now deletion of links should be more discoverable.

Personally I only found Option-click by looking at the code while trying to understand how I can delete links; the obvious select-and-press-delete hadn't worked, with this PR it does.