### PR TITLE
Add snapshot capability to MaterialX Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -4094,10 +4094,11 @@ mx::ImagePtr Graph::getFrameImage() const
 
     // 2. Calculate the ACTUAL right pane dimensions (not just the stored variables)
     ImVec2 rightPanePos = windowPos;
-    rightPanePos.x += _leftPaneWidth + _leftPanelIndent + _leftPanelIndent;  // leftPane + splitter width
+    rightPanePos.x += _leftPaneWidth + _leftPanelIndent + 4;// +_leftPanelIndent;  // leftPane + splitter width
+    rightPanePos.y += _leftPanelIndent;
 
     ImVec2 rightPaneSize;
-    rightPaneSize.x = windowSize.x - (_leftPaneWidth + _leftPanelIndent + (2.0f *_leftPanelIndent));  // dynamic width
+    rightPaneSize.x = windowSize.x - (_leftPaneWidth + _leftPanelIndent + (_leftPanelIndent));  // dynamic width
     
     //rightPaneSize.y = windowSize.y - (windowPos.y - ImGui::GetCursorStartPos().y + 30.0f);  // content height
     //rightPaneSize.y = windowSize.y - (windowPos.y + 30.0f);  // content height
@@ -4110,7 +4111,7 @@ mx::ImagePtr Graph::getFrameImage() const
     //ImVec2 displaySize = ImGui::GetIO().DisplaySize;
     ImVec2 capturePos = rightPanePos;
     //capturePos.y = displaySize.y - rightPanePos.y - rightPaneSize.y;  // Flip Y for OpenGL
-    capturePos.y = displaySize.y - rightPanePos.y - rightPaneSize.y;  // Flip Y for OpenGL
+    capturePos.y = displaySize.y + 4 - rightPanePos.y - rightPaneSize.y;  // Flip Y for OpenGL
     std::cout << "Capture Position: " << capturePos.x << ", " << capturePos.y << std::endl;
 
     int w = static_cast<int>(rightPaneSize.x);
@@ -4122,7 +4123,7 @@ mx::ImagePtr Graph::getFrameImage() const
     glFlush();
     glReadPixels(
         (int)capturePos.x,
-        (int)0/*(capturePos.y*/,
+        (int)0,//capturePos.y,
         (int)rightPaneSize.x,
         (int)rightPaneSize.y,
         GL_RGB,
@@ -4196,7 +4197,6 @@ void Graph::drawGraph(ImVec2 mousePos)
     if (ImGui::IsKeyDown(ImGuiKey_LeftCtrl) && ImGui::IsKeyPressed(ImGuiKey_B))
     {
         mx::ImagePtr frameImage = getFrameImage();
-        static bool showFrameSavedPopup = false;
         std::string filename = "graph_capture.png";
         if (frameImage && _renderer->getImageHandler()->saveImage(filename, frameImage, true))
         {

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -4115,7 +4115,7 @@ mx::ImagePtr Graph::getFrameImage() const
     std::cout << "Capture Position: " << capturePos.x << ", " << capturePos.y << std::endl;
 
     int w = static_cast<int>(rightPaneSize.x);
-    int h = static_cast<int>(rightPaneSize.y);
+    int h = static_cast<int>(rightPaneSize.y) - 15;
     mx::ImagePtr frameImage = mx::Image::create((unsigned int)(w),
         (unsigned int)(h), 3);
     frameImage->createResourceBuffer();
@@ -4123,9 +4123,9 @@ mx::ImagePtr Graph::getFrameImage() const
     glFlush();
     glReadPixels(
         (int)capturePos.x,
-        (int)0,//capturePos.y,
+        (int)capturePos.y - 11,
         (int)rightPaneSize.x,
-        (int)rightPaneSize.y,
+        (int)rightPaneSize.y - 15,
         GL_RGB,
         GL_UNSIGNED_BYTE,
         frameImage->getResourceBuffer()

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -236,7 +236,10 @@ class Graph
 
     void showHelp() const;
 
-    mx::ImagePtr getFrameImage() const;
+    // Methods to capture snapshot to file
+    mx::ImagePtr performSnapshot(bool captureWindow = false) const;
+    void showSnapshotDialog();
+    void saveSnapshotToFile();
 
   private:
     mx::StringVec _geomFilter;
@@ -297,6 +300,7 @@ class Graph
     FileDialog _fileDialogSave;
     FileDialog _fileDialogImage;
     FileDialog _fileDialogGeom;
+    FileDialog _fileDialogSnapshot;
     std::string _fileDialogImageInputName;
 
     bool _isNodeGraph;
@@ -329,10 +333,13 @@ class Graph
     // Options
     bool _saveNodePositions;
 
+    // Panel information
     float _leftPaneWidth = 375.0f;
-    float _leftPanelIndent = 15.0f;
+    float _nodeEditorIndent = 15.0f;
     float _rightPaneWidth = 750.0f;
 
+    // Image capture
+    mx::ImagePtr _capturedImage;
 };
 
 #endif

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -236,6 +236,8 @@ class Graph
 
     void showHelp() const;
 
+    mx::ImagePtr getFrameImage() const;
+
   private:
     mx::StringVec _geomFilter;
     mx::StringVec _mtlxFilter;
@@ -326,6 +328,11 @@ class Graph
 
     // Options
     bool _saveNodePositions;
+
+    float _leftPaneWidth = 375.0f;
+    float _leftPanelIndent = 15.0f;
+    float _rightPaneWidth = 750.0f;
+
 };
 
 #endif


### PR DESCRIPTION
## Changes

Fixes issue #2429

Add in "snapshot" capability for node editor panel.

## Interface Changes

### New Keys
- `CTRL-I` : capture the editor panel
- `CTRL-SHIFT-I` :  capture the entire window 

### Help Dialog Update
<img  src="https://github.com/user-attachments/assets/91829930-8bbf-45c3-a3ab-f54180bab6e4" width=50%>

Each option will bring up file dialog to allow user to input file name to save. Defaults to PNG extension.

## Examples:
| Example | Snapshot |
| :--: | :--: |
| Top Level  |  ![capture2](https://github.com/user-attachments/assets/2ee4c006-c15d-4463-9810-cf2b7a008987) | 
| Inside Graph |  ![capture3](https://github.com/user-attachments/assets/aae31630-40e3-4043-b7fd-bb38e18f5462) |
| Entire Window | ![capture4](https://github.com/user-attachments/assets/745d5880-e627-4b9f-9434-06c161b7836b) 
