### PR TITLE
Improve remapEnumeration() for GLSL and MSL (and align MDL source)

### DIFF
--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -373,27 +373,29 @@ bool GlslSyntax::remapEnumeration(const string& value, TypeDesc type, const stri
         return false;
     }
 
+    // Early out if no valid value provided
+    if (value.empty())
+    {
+        return false;
+    }
+
     // For GLSL we always convert to integer,
     // with the integer value being an index into the enumeration.
     result.first = Type::INTEGER;
     result.second = nullptr;
 
-    // Try remapping to an enum value.
-    if (!value.empty())
+    StringVec valueElemEnumsVec = splitString(enumNames, ",");
+    for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
     {
-        StringVec valueElemEnumsVec = splitString(enumNames, ",");
-        for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
-        {
-            valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
-        }
-        auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
-        if (pos == valueElemEnumsVec.end())
-        {
-            throw ExceptionShaderGenError("Given value '" + value + "' is not a valid enum value for input.");
-        }
-        const int index = static_cast<int>(std::distance(valueElemEnumsVec.begin(), pos));
-        result.second = Value::createValue<int>(index);
+        valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
     }
+    auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
+    if (pos == valueElemEnumsVec.end())
+    {
+        throw ExceptionShaderGenError("Given value '" + value + "' is not a valid enum value for input.");
+    }
+    const int index = static_cast<int>(std::distance(valueElemEnumsVec.begin(), pos));
+    result.second = Value::createValue<int>(index);
 
     return true;
 }

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -539,32 +539,32 @@ bool MdlSyntax::remapEnumeration(const string& value, TypeDesc type, const strin
         return false;
     }
 
-    // Try remapping to an enum value.
-    if (!value.empty())
+    // Early out if no valid value provided
+    if (value.empty())
     {
-        result.first = getEnumeratedType(value);
-        if (result.first == Type::NONE || (result.first.getSemantic() != TypeDesc::Semantic::SEMANTIC_ENUM))
-        {
-            return false;
-        }
-
-        StringVec valueElemEnumsVec = splitString(enumNames, ",");
-        for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
-        {
-            valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
-        }
-        auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
-        if (pos == valueElemEnumsVec.end())
-        {
-            throw ExceptionShaderGenError("Given value '" + value + "' is not a valid enum value.");
-        }
-        const int index = static_cast<int>(std::distance(valueElemEnumsVec.begin(), pos));
-        result.second = Value::createValue<string>(valueElemEnumsVec[index]);
-
-        return true;
+        return false;
     }
 
-    return false;
+    result.first = getEnumeratedType(value);
+    if (result.first == Type::NONE || (result.first.getSemantic() != TypeDesc::Semantic::SEMANTIC_ENUM))
+    {
+        return false;
+    }
+
+    StringVec valueElemEnumsVec = splitString(enumNames, ",");
+    for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
+    {
+        valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
+    }
+    auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
+    if (pos == valueElemEnumsVec.end())
+    {
+        throw ExceptionShaderGenError("Given value '" + value + "' is not a valid enum value.");
+    }
+    const int index = static_cast<int>(std::distance(valueElemEnumsVec.begin(), pos));
+    result.second = Value::createValue<string>(valueElemEnumsVec[index]);
+
+    return true;
 }
 
 void MdlSyntax::makeValidName(string& name) const

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -360,27 +360,29 @@ bool MslSyntax::remapEnumeration(const string& value, TypeDesc type, const strin
         return false;
     }
 
+    // Early out if no valid value provided
+    if (value.empty())
+    {
+        return false;
+    }
+
     // For MSL we always convert to integer,
     // with the integer value being an index into the enumeration.
     result.first = Type::INTEGER;
     result.second = nullptr;
 
-    // Try remapping to an enum value.
-    if (!value.empty())
+    StringVec valueElemEnumsVec = splitString(enumNames, ",");
+    for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
     {
-        StringVec valueElemEnumsVec = splitString(enumNames, ",");
-        for (size_t i = 0; i < valueElemEnumsVec.size(); i++)
-        {
-            valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
-        }
-        auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
-        if (pos == valueElemEnumsVec.end())
-        {
-            throw ExceptionShaderGenError("Given value '" + value + "' is not a valid enum value for input.");
-        }
-        const int index = static_cast<int>(std::distance(valueElemEnumsVec.begin(), pos));
-        result.second = Value::createValue<int>(index);
+        valueElemEnumsVec[i] = trimSpaces(valueElemEnumsVec[i]);
     }
+    auto pos = std::find(valueElemEnumsVec.begin(), valueElemEnumsVec.end(), value);
+    if (pos == valueElemEnumsVec.end())
+    {
+        throw ExceptionShaderGenError("Given value '" + value + "' is not a valid enum value for input.");
+    }
+    const int index = static_cast<int>(std::distance(valueElemEnumsVec.begin(), pos));
+    result.second = Value::createValue<int>(index);
 
     return true;
 }


### PR DESCRIPTION
Related to #2423 

After the PR above was merged Bernard Kwok rightly pointed out that `remapEnumeration()` itself should also have guard against empty input values.
