### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         - name: MacOS_Xcode_15_Python311
           os: macos-15
           compiler: xcode
-          compiler_version: "15.4"
+          compiler_version: "16.1"
           python: 3.11
           test_shaders: ON
 
@@ -97,11 +97,11 @@ jobs:
           python: None
           cmake_config: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=`xcrun --sdk iphoneos --show-sdk-path` -DCMAKE_OSX_ARCHITECTURES=arm64
 
-        - name: Windows_VS2019_Win32_Python39
-          os: windows-2019
+        - name: Windows_VS2022_Win32_Python39
+          os: windows-2022
           architecture: x86
           python: 3.9
-          cmake_config: -G "Visual Studio 16 2019" -A "Win32"
+          cmake_config: -G "Visual Studio 17 2022" -A "Win32"
 
         - name: Windows_VS2022_x64_Python311
           os: windows-2025


### PR DESCRIPTION
This changelist makes two updates to accommodate changes in GitHub Actions virtual environments:

- Update from the unsupported `windows-2019` to `windows-2022`.
- Update from the unsupported Xcode 15.4 to Xcode 16.1 in `macos-15`.