### PR TITLE
Add genvulkan target definition

### DIFF
--- a/libraries/targets/genvulkan.mtlx
+++ b/libraries/targets/genvulkan.mtlx
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+
+  <!--
+  Copyright Contributors to the MaterialX Project
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+  <!-- ======================================================================== -->
+  <!-- Target definition for Vulkan target. Derives from base GLSL target         -->
+  <!-- ======================================================================== -->
+  <targetdef name="genvulkan" inherit="genglsl" />
+
+</materialx>


### PR DESCRIPTION
This PR adds the genvulkan target definition, to be used as a unique identifier for the VkShaderGenerator. 

I ran through the MaterialX unit tests and generated a `genglsl_glsl_vulkan_generate_test` output from the executable. I did not see anything out of place - please let me know if I need to add something for complete test coverage. 