### PR TITLE
Translation for specular anisotropy, rotation from Standard surface to gltf_pbr

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -5,6 +5,8 @@
     <input name="base" type="float" value="1" />
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
     <input name="metalness" type="float" value="0" />
+    <input name="specular_anisotropy" type="float" value="0.0" />
+    <input name="specular_rotation" type="float" value="0.0" />
     <input name="specular_roughness" type="float" value="0.2" />
     <input name="transmission" type="float" value="0" />
     <input name="transmission_color" type="color3" value="1, 1, 1" />
@@ -21,6 +23,8 @@
     <output name="base_color_out" type="color3" />
     <output name="metallic_out" type="float" />
     <output name="roughness_out" type="float" />
+    <output name="anisotropy_strength_out" type="float" />
+    <output name="anisotropy_rotation_out" type="float" />
     <output name="transmission_out" type="float" />
     <output name="thickness_out" type="float" />
     <output name="attenuation_color_out" type="color3" />
@@ -41,6 +45,10 @@
     <convert name="constantOneThirdVector" type="vector3">
       <input name="in" type="float" nodename="constantOneThird" />
     </convert>
+    <constant name="negativeTwoPI" type="float">
+      <input name="value" type="float" value="-6.283" />
+    </constant>
+
 
     <!-- Coat attenuation -->
     <convert name="coatColorVector" type="vector3">
@@ -75,7 +83,7 @@
       <input name="in2" type="vector3" nodename="constantOneThirdVector" />
     </dotproduct>
 
-    <!-- Metallic roughness -->
+    <!-- Metallic  -->
     <ifequal name="baseColor" type="color3">
       <input name="value1" type="float" nodename="hasCoatColor" />
       <input name="value2" type="float" value="0" />
@@ -97,9 +105,43 @@
     <dot name="metallic" type="float">
       <input name="in" type="float" interfacename="metalness" />
     </dot>
-    <dot name="roughness" type="float">
-      <input name="in" type="float" interfacename="specular_roughness" />
-    </dot>
+
+    <!-- Roughness Anisotropy -->
+    <roughness_anisotropy name="roughness_anisotropy" type="vector2" nodedef="ND_roughness_anisotropy">
+      <input name="roughness" type="float" interfacename="specular_roughness" />
+      <input name="anisotropy" type="float" interfacename="specular_anisotropy" />
+    </roughness_anisotropy>
+    <separate2 name="separate_roughness" type="multioutput">
+      <input name="in" type="vector2" nodename="roughness_anisotropy" />
+    </separate2>
+    <sqrt name="roughness" type="float">
+      <input name="in" type="float" nodename="separate_roughness" output="outy" />
+    </sqrt>
+    <subtract name="numerator" type="float">
+      <input name="in1" type="float" nodename="separate_roughness" output="outx" />
+      <input name="in2" type="float" nodename="separate_roughness" output="outy" />
+    </subtract>
+    <subtract name="denumerator" type="float">
+      <input name="in1" type="float" value="1" />
+      <input name="in2" type="float" nodename="separate_roughness" output="outy" />
+    </subtract>
+    <divide name="anisotropy_sq" type="float">
+      <input name="in1" type="float" nodename="numerator" />
+      <input name="in2" type="float" nodename="denumerator" />
+    </divide>
+    <sqrt name="anisotropy" type="float">
+      <input name="in" type="float" nodename="anisotropy_sq" />
+    </sqrt>
+    <multiply name="anisotropy_rotation" type="float">
+      <input name="in1" type="float" interfacename="specular_rotation" />
+      <input name="in2" type="float" nodename="negativeTwoPI" />
+    </multiply>
+    <ifgreatereq name="anisotropy_strength" type="float">
+      <input name="value1" type="float" value="0.0" />
+      <input name="value2" type="float" nodename="denumerator" />
+      <input name="in1" type="float" value="0.0" />
+      <input name="in2" type="float" nodename="anisotropy" />
+    </ifgreatereq>
 
     <!-- Transmission -->
     <dot name="transmission" type="float">
@@ -153,6 +195,8 @@
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
+    <output name="anisotropy_strength_out" type="float" nodename="anisotropy_strength" />
+    <output name="anisotropy_rotation_out" type="float" nodename="anisotropy_rotation" />
     <output name="transmission_out" type="float" nodename="transmission" />
     <output name="thickness_out" type="float" nodename="thickness" />
     <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />


### PR DESCRIPTION
## Changes
Adds translations for specular_anisotropy and specular_rotation from `standardSurface` to `gltf_pbr`

## Renders

Material from [AMD GPU Open MaterialX Library](https://matlib.gpuopen.com/main/materials/all)- [Aluminum Brushed](https://matlib.gpuopen.com/main/materials/all?category=Metal&material=c12edfda-a5bd-4469-8147-4a6540a0a213)

|![](https://github.com/user-attachments/assets/d140610b-2f21-4f56-86fa-72a424d05e4e)<br>Standard Surface - OSL Render|![](https://github.com/user-attachments/assets/c2e8308c-4860-489b-b09d-9e35ce25731a)<br>gltf_pbr - OSL Render|
|:-:|:-:|

|![std surf - brushed aluminum - glsl](https://github.com/user-attachments/assets/7f14e295-29b1-4f01-abc7-f203f4347dad)<br>Standard Surface - GLSL MaterialXGraphEditor|![gltf_pbr - brushed aluminum - glsl](https://github.com/user-attachments/assets/58d494ed-c09e-409b-9ad7-a215817a1960)<br>gltf_pbr - GLSL MaterialXGraphEditor|
|:-:|:-:|

## Before / After PR
|![BEFORE-PR gltf_pbr - brushed aluminum - osl](https://github.com/user-attachments/assets/2a2fea24-85a5-49a3-bd19-a37a001c6f5a)<br>Before PR - gltf_pbr - OSL Render|![](https://github.com/user-attachments/assets/c2e8308c-4860-489b-b09d-9e35ce25731a)<br>After PR - gltf_pbr - OSL Render|
|:-:|:-:|

## Description

I have created a transfer function going from standard surface input for specular_roughness, specular_anisotropy, specular_rotation to glTFs roughness, anisotropy_strength, anisotropy_rotation

Visual implementation of the added parts in the translation graph. Highlighted inputs are interfaced inputs.
![image](https://github.com/user-attachments/assets/adb8e91f-8d5d-43b9-b8bf-adddc3b0d8be)


### Anisotropy Strength & roughness

Roughness anisotropy defined in Standard Surface
```python
def mx_roughness_anisotropy(roughness: float, anisotropy: float) -> tuple[float, float]:
    roughness_sqr = clamp(roughness*roughness, sys.float_info.epsilon, 1.0 )
    if anisotropy > 0.0:
        aspect = math.sqrt(1.0 - clamp(anisotropy, 0.0, 0.98))
        rx = min(roughness_sqr, aspect, 1.0)
        ry = roughness_sqr * aspect
        return (rx, ry)

    return roughness_sqr,roughness_sqr
```

Roughness anisotropy defined in gltf_pbr
```python
def gltf_roughness_anisotropy(roughness: float, anisotropy: float) -> tuple[float, float]:
    alphaRoughness = clamp(roughness*roughness, sys.float_info.epsilon, 1.0 )
    at = mix(alphaRoughness, 1.0, anisotropy * anisotropy)
    ab = alphaRoughness

    return at,ab
```

Transfer function used in this PR
```python
def transform_mx_to_gltf_inputs(roughness_mx: float, anisotropy_mx: float) -> tuple[float, float]:
    separate_roughness_x, separate_roughness_y = mx_roughness_anisotropy(roughness_mx, anisotropy_mx)

    roughness_gltf = math.sqrt(separate_roughness_y)

    numerator = separate_roughness_x - separate_roughness_y
    denominator = 1.0 - separate_roughness_y

    if denominator <= 0:
        anisotropy_gltf = 0.0
    else:
        anisotropy_gltf_sq = numerator / denominator
        anisotropy_gltf = math.sqrt(anisotropy_gltf_sq)

    return roughness_gltf, anisotropy_gltf
```

Plots of the results
|![mx_roughness_anisotropy](https://github.com/user-attachments/assets/96d97c1e-7cb7-4b80-bb7a-2a7d54fe2c56)<br>_mx_roughness_anisotropy_|![gltf_roughness_anisotropy](https://github.com/user-attachments/assets/0fa45a98-bb5b-4aa1-ba1d-6b061ef276fb)<br>_gltf_roughness_anisotropy_|![translated_standard_surface_to_gltf_anisotropy_roughness](https://github.com/user-attachments/assets/2a099f14-4d2d-43da-b58a-bebfd36b01af)<br>_transform_mx_to_gltf_inputs_ -> _gltf_roughness_anisotropy_|
|:-:|:-:|:-:|

### Anisotropy Rotation
Standard surface have it's rotation maped between [0-1] where 1 is a complete rotation, in the MaterialX implementation it's currently in clockwise direction. Note that it may change: #2083 

glTF uses radiance, i.e a complete rotation is 2*PI, glTF rotation is defined as counter-clockwise.

**Transfare function** is implemented as a **multiplication with negative 2*PI**


## Sources
* [glTF Anisotropy spec](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md#extending-materials)
* [Standard surface documentation - Specular Reflection](https://autodesk.github.io/standard-surface/#closures/specularreflection)



