### PR TITLE
Keep original object and material names in Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -889,7 +889,7 @@ export class Material
                         assigned += viewer.getScene().updateMaterial(matassign);
                         matassign.setGeometry(temp);
                         assignedSolo = true;
-                        break
+                        break;
                     }
                 }
                 else
@@ -982,7 +982,8 @@ export class Material
             blendEquation: THREE.AddEquation,
             blendSrc: THREE.OneMinusSrcAlphaFactor,
             blendDst: THREE.SrcAlphaFactor,
-            side: THREE.DoubleSide
+            side: THREE.DoubleSide,
+            name: elem.getName(),
         });
 
         if (logDetailedTime)


### PR DESCRIPTION
Previously, object names were taken directly from the three.js scene. However, three.js enforces specific constraints for object names (e.g. spaces, braces and so on are replaced with `_`).

This renaming breaks DAG matching for geom expressions, as the compared name might not be right. three.js keeps the original name around though, so this PR makes sure the original name is used for path matching instead of the in-scene name.

The PR also sets the material name properly from the `materialassign` instead of keeping it empty.