### PR TITLE
Move uniform updates to object scope in Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/index.js
+++ b/javascript/MaterialXView/source/index.js
@@ -53,7 +53,6 @@ function init()
         viewer.getEditor().initialize();
         viewer.getMaterial().loadMaterials(viewer, materialFilename);
         viewer.getEditor().updateProperties(0.9);
-        viewer.getScene().setUpdateTransforms();
     });
 
     // Handle geometry selection changes
@@ -79,10 +78,6 @@ function init()
 
     // Set up controls
     orbitControls = new OrbitControls(scene.getCamera(), renderer.domElement);
-    orbitControls.addEventListener('change', () =>
-    {
-        viewer.getScene().setUpdateTransforms();
-    })
 
     // Add hotkey 'f' to capture the current frame and save an image file.
     // See check inside the render loop when a capture can be performed.
@@ -145,7 +140,6 @@ function init()
         viewer.getEditor().initialize();
         viewer.getMaterial().loadMaterials(viewer, materialFilename);
         viewer.getEditor().updateProperties(0.9);
-        viewer.getScene().setUpdateTransforms();
     });
 
     setSceneLoadingCallback(file =>
@@ -163,7 +157,6 @@ function init()
 function onWindowResize()
 {
     viewer.getScene().updateCamera();
-    viewer.getScene().setUpdateTransforms();
     renderer.setSize(window.innerWidth, window.innerHeight);
 }
 
@@ -177,12 +170,10 @@ function animate()
         turntableStep = (turntableStep + 1) % 360;
         var turntableAngle = turntableStep * (360.0 / turntableSteps) / 180.0 * Math.PI;
         scene._scene.rotation.y = turntableAngle;
-        scene.setUpdateTransforms();
     }
 
-    scene.updateUniforms();
+    scene.updateTimeUniforms();
     renderer.render(scene.getScene(), scene.getCamera());
-    scene.updateTransforms();
 
     if (captureRequested)
     {

--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -106,6 +106,15 @@ export class Scene
         }
         scene.add(model);
 
+        // Set up onBeforeRender callbacks so that we can update uniforms per object right before rendering.
+        model.traverse((child) =>
+        {
+            child.onBeforeRender = (_renderer, _scene, camera, _geometry, material, _group) =>
+            {
+                this.updateObjectUniforms(child, material, camera);
+            };
+        })
+
         console.log("- Scene load time: ", performance.now() - geomLoadTime, "ms");
 
         // Always reset controls based on camera for each load. 
@@ -116,7 +125,6 @@ export class Scene
 
         viewer.getMaterial().clearSoloMaterialUI();
         viewer.getMaterial().updateMaterialAssignments(viewer, "");
-        this.setUpdateTransforms();
     }
 
     //
@@ -222,55 +230,30 @@ export class Scene
         orbitControls.update();
     }
 
-    setUpdateTransforms(val=true)
+    updateObjectUniforms(child, material, camera)
     {
-        this.#_updateTransforms = val;
-    }
+        if (!child || !material || !camera) return;
+        const uniforms = material.uniforms;
+        if (!uniforms) return;
 
-    getUpdateTransforms()
-    {
-        return this.#_updateTransforms;
-    }
+        uniforms.u_worldMatrix.value = child.matrixWorld;
+        uniforms.u_viewProjectionMatrix.value = this.#_viewProjMat.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
 
-    updateTransforms()
-    {
-        // Only update on demand versus continuously.
-        // Call setUpdateTransforms() to trigger an update here.
-        // Required for: scene geometry, camera change and viewport resize. 
-        if (!this.#_updateTransforms)
-        {
-            return;
-        }
-        this.setUpdateTransforms(false);
+        if (uniforms.u_viewPosition)
+            uniforms.u_viewPosition.value = camera.getWorldPosition(this.#_worldViewPos);
 
-        const scene = this.getScene();
-        const camera = this.getCamera();
-        scene.traverse((child) =>
-        {
-            if (child.isMesh)
-            {
-                const uniforms = child.material.uniforms;
-                if (uniforms)
-                {
-                    uniforms.u_worldMatrix.value = child.matrixWorld;
-                    uniforms.u_viewProjectionMatrix.value = this.#_viewProjMat.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+        if (uniforms.u_worldInverseTransposeMatrix)
+            uniforms.u_worldInverseTransposeMatrix.value =
+                new THREE.Matrix4().setFromMatrix3(this.#_normalMat.getNormalMatrix(child.matrixWorld));
 
-                    if (uniforms.u_viewPosition)
-                        uniforms.u_viewPosition.value = camera.getWorldPosition(this.#_worldViewPos);
-
-                    if (uniforms.u_worldInverseTransposeMatrix)
-                        uniforms.u_worldInverseTransposeMatrix.value =
-                            new THREE.Matrix4().setFromMatrix3(this.#_normalMat.getNormalMatrix(child.matrixWorld));
-                }
-            }
-        });
+        material.uniformsNeedUpdate = true;
     }
 
     /**
      * Update uniforms for all scene objects. This is called once per frame
      * and updates time and frame count uniforms.
      */
-    updateUniforms() {
+    updateTimeUniforms() {
         this._frame++;
 
         const scene = this.getScene();
@@ -285,13 +268,9 @@ export class Scene
                 if (uniforms)
                 {
                     if (uniforms.u_time)
-                    {
                         uniforms.u_time.value = time;
-                    }
                     if (uniforms.u_frame)
-                    {
                         uniforms.u_frame.value = frame;
-                    }
                 }
             }
         });
@@ -461,7 +440,6 @@ export class Scene
     #_normalMat = new THREE.Matrix3();
     #_viewProjMat = new THREE.Matrix4();
     #_worldViewPos = new THREE.Vector3();
-    #_updateTransforms = true;
 
     // Root node of imported scene
     #_rootNode = null;
@@ -856,9 +834,6 @@ export class Material
         // Update scene shader assignments
         this.updateMaterialAssignments(viewer, "");
 
-        // Mark transform update
-        viewer.getScene().setUpdateTransforms();
-
         console.log("Total material time: ", (performance.now() - startTime), "ms");
     }
 
@@ -1050,7 +1025,6 @@ export class Material
             }
         }
         viewer.getMaterial().updateMaterialAssignments(viewer, this._soloMaterial);
-        viewer.getScene().setUpdateTransforms();
     }
 
     //


### PR DESCRIPTION
The current handling of uniforms was per-material, which means that when a material is used on multiple objects, they all share uniforms – thus, they were all rendered with the uniforms of the last user of that material.

Any multi-object files were affected. It just happened to work for the default shader ball because there all objects have the same pivot.

As a side effect of this, the previous on-demand updating of uniforms (using `#_updateTransforms`) isn't possible anymore, so I removed the related code.

| File | Before PR | Now
| - | - | - |
| Primitives.glb<br>[Primitives.glb.zip](https://github.com/user-attachments/files/20656983/Primitives.glb.zip) | <img width="928" alt="image" src="https://github.com/user-attachments/assets/159c6967-f9c2-444f-80da-9ded8629e23d" /> | <img width="734" alt="image" src="https://github.com/user-attachments/assets/e7839a98-354b-4385-a130-fdd7eec13132" /> | 
| ComplexScene.glb<br>[ComplexScene.glb.zip](https://github.com/user-attachments/files/20656988/ComplexScene.glb.zip) | <img width="208" alt="image" src="https://github.com/user-attachments/assets/1aecc270-269a-469f-b7cf-0cb75a5fa87d" /> | <img width="374" alt="image" src="https://github.com/user-attachments/assets/988a0ff1-0a54-4508-9751-ea4ec8742459" /> |