### PR TITLE
Add deprecated `fps` input to `time` node

### DIFF
--- a/documents/Specification/MaterialX.StandardNodes.md
+++ b/documents/Specification/MaterialX.StandardNodes.md
@@ -515,6 +515,7 @@ Standard Application nodes:
 <a id="node-time"> </a>
 
 * **`time`**: the current time in seconds, as defined by the host environment.  This node must be of type float.  Applications may use whatever method is appropriate to communicate the current time to the &lt;time> node's implementation, whether via an internal state variable, a custom input, dividing the current frame number by a local "frames per second" value, or other method; real-time applications may return some variation of wall-clock time.
+    * `fps` (float): an unused input, to be removed in a future specification version.
 
 <br>
 

--- a/libraries/stdlib/genosl/mx_time_float.osl
+++ b/libraries/stdlib/genosl/mx_time_float.osl
@@ -1,4 +1,4 @@
-void mx_time_float(output float result)
+void mx_time_float(float fps, output float result)
 {
     // Use the standard default value if the attribute is not present.
     result = 0.0;

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1490,6 +1490,7 @@
     The current time in seconds as defined by the host environment.
   -->
   <nodedef name="ND_time_float" node="time" nodegroup="application">
+    <input name="fps" type="float" value="24.0" /> <!-- An unused input, to be removed in a future specification version -->
     <output name="out" type="float" default="0.0" />
   </nodedef>
 

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -1584,6 +1584,7 @@ export float mx_frame_float(
 }
 
 export float mx_time_float(
+	uniform float mxp_fps = float(24.0) [[ anno::unused() ]]
 )
 	[[
 		anno::description("Node Group: application")


### PR DESCRIPTION
This changelist adds a deprecated `fps` input to the specification and implementations of the `time` node, providing continuity of node signatures for applications using earlier versions of the MaterialX data libraries.

In a future minor version upgrade, we can then formally remove this input, providing version upgrade logic to handle earlier assets.

In a quick survey of `time` node implementations, the `fps` input appears to be ignored, making this proposed approach a reasonable match with industry expectations:

Houdini: https://www.sidefx.com/docs/houdini/nodes/vop/mtlxtime.html
RealityKit: https://developer.apple.com/documentation/shadergraph/application/time-(float)
Three.js: https://github.com/mrdoob/three.js/pull/29149