### PR TITLE
Optimizations to `heighttonormal`

### DIFF
--- a/libraries/stdlib/genglsl/mx_heighttonormal_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_heighttonormal_vector3.glsl
@@ -1,32 +1,28 @@
 void mx_heighttonormal_vector3(float height, float scale, vec2 texcoord, out vec3 result)
 {
-    // Compute the gradient of the heightfield with respect to the screen.
-    vec2 dHdS = vec2(dFdx(height), dFdy(height)) * scale;
+    // Scale factor for parity with traditional Sobel filtering.
+    const float SOBEL_SCALE_FACTOR = 1.0 / 16.0;
 
-    // Compute the gradient of the texture coordinates with respect to the screen.
+    // Compute screen-space gradients of the heightfield and texture coordinates.
+    vec2 dHdS = vec2(dFdx(height), dFdy(height)) * scale * SOBEL_SCALE_FACTOR;
     vec2 dUdS = vec2(dFdx(texcoord.x), dFdy(texcoord.x));
     vec2 dVdS = vec2(dFdx(texcoord.y), dFdy(texcoord.y));
 
-    // Use the chain rule to compute the gradient of the heightfield with
-    // respect to the texture coordinates.
-    vec2 dHdT;
-    float det = dUdS.x * dVdS.y - dUdS.y * dVdS.x;
-    if (abs(det) > M_FLOAT_EPS)
+    // Construct a screen-space tangent frame.
+    vec3 tangent = vec3(dUdS.x, dVdS.x, dHdS.x);
+    vec3 bitangent = vec3(dUdS.y, dVdS.y, dHdS.y);
+    vec3 n = cross(tangent, bitangent);
+
+    // Handle invalid and mirrored texture coordinates.
+    if (dot(n, n) < M_FLOAT_EPS * M_FLOAT_EPS)
     {
-        mat2 invJacobian = mat2(-dVdS.y, dUdS.y, dVdS.x, -dUdS.x) / det;
-        dHdT = invJacobian * dHdS;
+        n = vec3(0, 0, 1);
     }
-    else
+    else if (n.z < 0.0)
     {
-        dHdT = vec2(0.0);
+        n *= -1.0;
     }
 
-    // Scale the results for parity with traditional Sobel filtering.
-    // https://nrsyed.com/2018/02/18/edge-detection-in-images-how-to-derive-the-sobel-operator/
-    const float SOBEL_SCALE_FACTOR = 1.0 / 16.0;
-    dHdT *= SOBEL_SCALE_FACTOR;
-
-    // Convert the gradient to a normal and encode for storage.
-    vec3 n = normalize(vec3(dHdT.x, dHdT.y, 1.0));
-    result = n * 0.5 + 0.5;
+    // Normalize and encode the results.
+    result = normalize(n) * 0.5 + 0.5;
 }

--- a/libraries/stdlib/genosl/mx_heighttonormal_vector3.osl
+++ b/libraries/stdlib/genosl/mx_heighttonormal_vector3.osl
@@ -1,33 +1,28 @@
 void mx_heighttonormal_vector3(float height, float scale, vector2 texcoord, output vector result)
 {
-    // Compute the gradient of the heightfield with respect to the screen.
-    vector2 dHdS = vector2(Dx(height), Dy(height)) * scale;
+    // Scale factor for parity with traditional Sobel filtering.
+    float SOBEL_SCALE_FACTOR = 1.0 / 16.0;
 
-    // Compute the gradient of the texture coordinates with respect to the screen.
+    // Compute screen-space gradients of the heightfield and texture coordinates.
+    vector2 dHdS = vector2(Dx(height), Dy(height)) * scale * SOBEL_SCALE_FACTOR;
     vector2 dUdS = vector2(Dx(texcoord.x), Dy(texcoord.x));
     vector2 dVdS = vector2(Dx(texcoord.y), Dy(texcoord.y));
 
-    // Use the chain rule to compute the gradient of the heightfield with
-    // respect to the texture coordinates.
-    vector2 dHdT;
-    float det = dUdS.x * dVdS.y - dUdS.y * dVdS.x;
-    if (abs(det) > M_FLOAT_EPS)
+    // Construct a screen-space tangent frame.
+    vector tangent = vector(dUdS.x, dVdS.x, dHdS.x);
+    vector bitangent = vector(dUdS.y, dVdS.y, dHdS.y);
+    vector n = cross(tangent, bitangent);
+
+    // Handle invalid and mirrored texture coordinates.
+    if (dot(n, n) < M_FLOAT_EPS * M_FLOAT_EPS)
     {
-        vector4 invJacobian = vector4(-dVdS.y, dVdS.x, dUdS.y, -dUdS.x) / det;
-        dHdT.x = dot(vector2(invJacobian.x, invJacobian.y), dHdS);
-        dHdT.y = dot(vector2(invJacobian.z, invJacobian.w), dHdS);
+        n = vector(0, 0, 1);
     }
-    else
+    else if (n[2] < 0.0)
     {
-        dHdT = vector2(0.0, 0.0);
+        n *= -1.0;
     }
 
-    // Scale the results for parity with traditional Sobel filtering.
-    // https://nrsyed.com/2018/02/18/edge-detection-in-images-how-to-derive-the-sobel-operator/
-    float SOBEL_SCALE_FACTOR = 1.0 / 16.0;
-    dHdT *= SOBEL_SCALE_FACTOR;
-
-    // Convert the gradient to a normal and encode for storage.
-    vector n = normalize(vector(dHdT.x, dHdT.y, 1.0));
-    result = n * 0.5 + 0.5;
+    // Normalize and encode the results.
+    result = normalize(n) * 0.5 + 0.5;
 }


### PR DESCRIPTION
This changelist implements optimizations to our gradient-based implementation of `heighttonormal` in GLSL and OSL, using a cross product in place of the inverse Jacobian.  The new version requires no division instructions at runtime, and generates virtually identical results.

Credit for this idea is due to @kwokcb, who originally suggested it in a [comment](https://github.com/AcademySoftwareFoundation/MaterialX/pull/2424#pullrequestreview-2893382794), and it was additionally inspired by recent discussions with Stephen Hill and Ron Radeztsky at the Lucasfilm ADG.