### PR TITLE
Fix race in format settings for multithreaded codegen

### DIFF
--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -14,11 +14,11 @@
 MATERIALX_NAMESPACE_BEGIN
 
 Value::CreatorMap Value::_creatorMap;
-Value::FloatFormat Value::_floatFormat = Value::FloatFormatDefault;
-int Value::_floatPrecision = 6;
 
 namespace
 {
+thread_local Value::FloatFormat _floatFormat = Value::FloatFormatDefault;
+thread_local int _floatPrecision = 6;
 
 template <class T> using enable_if_mx_vector_t =
     typename std::enable_if<std::is_base_of<VectorBase, T>::value, T>::type;
@@ -268,6 +268,26 @@ template <class T> ValuePtr TypedValue<T>::createFromString(const string& value)
 //
 // Value methods
 //
+
+void Value::setFloatFormat(FloatFormat format)
+{
+    _floatFormat = format;
+}
+
+void Value::setFloatPrecision(int precision)
+{
+    _floatPrecision = precision;
+}
+
+Value::FloatFormat Value::getFloatFormat()
+{
+    return _floatFormat;
+}
+
+int Value::getFloatPrecision()
+{
+    return _floatPrecision;
+}
 
 ValuePtr Value::createValueFromStrings(const string& value, const string& type, ConstTypeDefPtr typeDef)
 {

--- a/source/MaterialXCore/Value.cpp
+++ b/source/MaterialXCore/Value.cpp
@@ -17,6 +17,7 @@ Value::CreatorMap Value::_creatorMap;
 
 namespace
 {
+
 thread_local Value::FloatFormat _floatFormat = Value::FloatFormatDefault;
 thread_local int _floatPrecision = 6;
 

--- a/source/MaterialXCore/Value.h
+++ b/source/MaterialXCore/Value.h
@@ -99,28 +99,16 @@ class MX_CORE_API Value
     /// Set float formatting for converting values to strings.
     /// Formats to use are FloatFormatFixed, FloatFormatScientific
     /// or FloatFormatDefault to set default format.
-    static void setFloatFormat(FloatFormat format)
-    {
-        _floatFormat = format;
-    }
+    static void setFloatFormat(FloatFormat format);
 
     /// Set float precision for converting values to strings.
-    static void setFloatPrecision(int precision)
-    {
-        _floatPrecision = precision;
-    }
+    static void setFloatPrecision(int precision);
 
     /// Return the current float format.
-    static FloatFormat getFloatFormat()
-    {
-        return _floatFormat;
-    }
+    static FloatFormat getFloatFormat();
 
     /// Return the current float precision.
-    static int getFloatPrecision()
-    {
-        return _floatPrecision;
-    }
+    static int getFloatPrecision();
 
     // Returns true if value data matches.
     virtual bool isEqual(ConstValuePtr other) const = 0;
@@ -133,8 +121,6 @@ class MX_CORE_API Value
 
   private:
     static CreatorMap _creatorMap;
-    static FloatFormat _floatFormat;
-    static int _floatPrecision;
 };
 
 /// The class template for typed subclasses of Value


### PR DESCRIPTION
When testing [parallel MaterialX codegen in Storm](https://github.com/PixarAnimationStudios/OpenUSD/pull/3567), and comparing the generated code between test runs using a [persistent MaterialX cache](https://github.com/PixarAnimationStudios/OpenUSD/pull/3661), I noticed that the results were varying around `float` literal formatting. It turned out to be due to a data race on `static` variables controlling the formatting settings.

This is similar to #2378 but limited to multithreaded codegen.

Waiting on the CLA approval before I promote this draft to a full PR.