### PR TITLE
Optimization to mx_ggx_smith_G2

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -78,7 +78,7 @@ float mx_ggx_smith_G2(float NdotL, float NdotV, float alpha)
     float alpha2 = mx_square(alpha);
     float lambdaL = sqrt(alpha2 + (1.0 - alpha2) * mx_square(NdotL));
     float lambdaV = sqrt(alpha2 + (1.0 - alpha2) * mx_square(NdotV));
-    return 2.0 / (lambdaL / NdotL + lambdaV / NdotV);
+    return 2.0 * NdotL * NdotV / (lambdaL * NdotV + lambdaV * NdotL);
 }
 
 // Rational quadratic fit to Monte Carlo data for GGX directional albedo.


### PR DESCRIPTION
This changelist implements an optimization to the `mx_ggx_smith_G2` function in GLSL, replacing two divides with four multiplies.

Validation of this proposed optimization was conducted by rendering the `standard_surface_default.mtlx` example in the MaterialX Viewer on an NVIDIA RTX A6000 at 4K resolution, with the directional albedo mode set to Monte Carlo, and this change reduces the total frame time from 72ms to 70ms.