### PR TITLE
MaterialXView: Treat checkbox-driven uniforms as bool rather than float

### DIFF
--- a/source/MaterialXView/Editor.cpp
+++ b/source/MaterialXView/Editor.cpp
@@ -303,7 +303,7 @@ void PropertyEditor::addItemToForm(const mx::UIPropertyItem& item, const std::st
             mx::MaterialPtr material = viewer->getSelectedMaterial();
             if (material)
             {
-                material->modifyUniform(path, mx::Value::createValue((float) v));
+                material->modifyUniform(path, mx::Value::createValue((bool) v));
             }
         });
     }


### PR DESCRIPTION
This PR seeks to address #2437, wherein toggling a checkbox off and on in the Property Editor causes the corresponding uniform to stop updating, remaining in the "off" state indefinitely thereafter. The proposed fix is to pass the value of the checkbox to shaders as a bool rather than a float.

Tested in MaterialXView on macOS 15.5 (OpenGL and Metal rendering paths).