### PR TITLE
Fix MDL code gen after removing ClosureSourceCodeNode

### DIFF
--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -43,14 +43,6 @@ void SourceCodeNodeMdl::initialize(const InterfaceElement& element, GenContext& 
         throw ExceptionShaderGenError("Can't find nodedef for implementation element " + element.getName());
     }
 
-    // store the output type for special handling during function call emission
-    vector<OutputPtr> outputs = nodeDef->getActiveOutputs();
-    if (outputs.empty())
-    {
-        throw ExceptionShaderGenError("NodeDef '" + nodeDef->getName() + "' has no outputs defined");
-    }
-    _outputType = syntax.getType(outputs[0]->getType());
-
     _returnStruct = EMPTY_STRING;
     if (nodeDef->getOutputCount() > 1)
     {
@@ -86,7 +78,7 @@ void SourceCodeNodeMdl::emitFunctionCall(const ShaderNode& node, GenContext& con
         const ShaderGenerator& shadergen = context.getShaderGenerator();
         const MdlShaderGenerator& shadergenMdl = static_cast<const MdlShaderGenerator&>(shadergen);
 
-        if (_outputType.isClosure())
+        if (nodeOutputIsClosure(node))
         {
             // Emit calls for any closure dependencies upstream from this node.
             shadergen.emitDependentFunctionCalls(node, context, stage, ShaderNode::Classification::CLOSURE);

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.h
@@ -27,7 +27,6 @@ class MX_GENMDL_API SourceCodeNodeMdl : public SourceCodeNode
   protected:
     void resolveSourceCode(const InterfaceElement& element, GenContext& context) override;
     string _returnStruct;
-    TypeDesc _outputType;
 };
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
In #2400 the ClosureSourceCodeNode has been removed and replaced by the regular SourceCodeNode.
For that to work, the SourceCodeNode needs to emit dependent function calls to generate code for the inputs.