### PR TITLE
Fix assignment of geomprops in Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -192,9 +192,20 @@ export class Scene
                 // Use default MaterialX naming convention.
                 var startStreamTime = performance.now();
                 child.geometry.attributes.i_position = child.geometry.attributes.position;
-                child.geometry.attributes.i_normal = child.geometry.attributes.normal;
-                child.geometry.attributes.i_tangent = child.geometry.attributes.tangent;
-                child.geometry.attributes.i_texcoord_0 = child.geometry.attributes.uv;
+                if (child.geometry.attributes.normal)
+                    child.geometry.attributes.i_normal = child.geometry.attributes.normal;
+                if (child.geometry.attributes.tangent)
+                    child.geometry.attributes.i_tangent = child.geometry.attributes.tangent;
+                if (child.geometry.attributes.color)
+                    child.geometry.attributes.i_color_0 = child.geometry.attributes.color;
+                if (child.geometry.attributes.color_1)
+                    child.geometry.attributes.i_color_1 = child.geometry.attributes.color_1;
+                if (child.geometry.attributes.uv)
+                    child.geometry.attributes.i_texcoord_0 = child.geometry.attributes.uv;
+                if (child.geometry.attributes.uv1)
+                    child.geometry.attributes.i_texcoord_1 = child.geometry.attributes.uv1;
+                if (child.geometry.attributes.uv2)
+                    child.geometry.attributes.i_texcoord_2 = child.geometry.attributes.uv2;
                 streamTime += performance.now() - startStreamTime;
             }
         });


### PR DESCRIPTION
The web viewer did assign vertex attributes no matter if they existed, leading to exceptions when a loaded file e.g. didn't have UV coordinates.
I also added more properties – UV0, UV1, UV2, Color, Color1 – so that they can be leveraged in loaded materials.

Here's a sample file:
[MeshAttributes.zip](https://github.com/user-attachments/files/21022477/MeshAttributes.zip)

To test it,
1. Unpack the zip
2. Drop the GLB file on the WebViewer
3. Drop the mtlx file on the WebViewer
4. In the top right, switch between the variants in the material to see different geomprops

![image](https://github.com/user-attachments/assets/1d4899f6-c8aa-4a04-bb06-910caf0c7b8a)
