### PR TITLE
Fixed a typo in GLSL rotation matrix used in hextiling

### DIFF
--- a/libraries/stdlib/genglsl/lib/mx_geometry.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_geometry.glsl
@@ -34,7 +34,7 @@ mat3 mx_axis_rotation_matrix(vec3 a, float r)
     float c = cos(r);
     float omc = 1.0 - c;
     return mat3(
-        a.x*a.x*omc + c,     a.x*a.y*omc - a.x*s, a.x*a.z*omc + a.y*s,
+        a.x*a.x*omc + c,     a.x*a.y*omc - a.z*s, a.x*a.z*omc + a.y*s,
         a.y*a.x*omc + a.z*s, a.y*a.y*omc + c,     a.y*a.z*omc - a.x*s,
         a.z*a.x*omc - a.y*s, a.z*a.y*omc + a.x*s, a.z*a.z*omc + c
     );


### PR DESCRIPTION
There is a typo in the GLSL rotation matrix used in hextiling. The 1st row, 2nd column should be `-a.z` instead of `-a.x`.
See `mx_rotate_vector3.glsl` for the other axis rotation matrix implementation (or [`Rotation matrix from axis and angle` ](https://en.wikipedia.org/wiki/Rotation_matrix#Rotation_matrix_from_axis_and_angle) on wikipedia)