### PR TITLE
Use shader code token replacement instead of #ifdef HW_SEPARATE_SAMPLERS 

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -35,11 +35,7 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
         vec3 Lw = tangentToWorld * L;
         float pdf = mx_ggx_NDF(H, alpha) * G1V / (4.0 * NdotV);
         float lod = mx_latlong_compute_lod(Lw, pdf, float($envRadianceMips - 1), envRadianceSamples);
-#ifdef HW_SEPARATE_SAMPLERS 
-        vec3 sampleColor = mx_latlong_map_lookup(Lw, $envMatrix, lod, $envRadiance_texture, $envRadiance_sampler);
-#else
         vec3 sampleColor = mx_latlong_map_lookup(Lw, $envMatrix, lod, $envRadiance);
-#endif
 
         // Compute the Fresnel term.
         vec3 F = mx_compute_fresnel(VdotH, fd);
@@ -68,10 +64,6 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
 
 vec3 mx_environment_irradiance(vec3 N)
 {
-#ifdef HW_SEPARATE_SAMPLERS
-    vec3 Li = mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance_texture, $envIrradiance_sampler);
-#else
     vec3 Li = mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance);
-#endif
     return Li * $envLightIntensity;
 }

--- a/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_prefilter.glsl
@@ -19,20 +19,12 @@ vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distributio
     float G = mx_ggx_smith_G2(NdotV, NdotV, avgAlpha);
     vec3 FG = fd.refraction ? vec3(1.0) - (F * G) : F * G;
 
-#ifdef HW_SEPARATE_SAMPLERS
-    vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_alpha_to_lod(avgAlpha), $envRadiance_texture, $envRadiance_sampler);
-#else
     vec3 Li = mx_latlong_map_lookup(L, $envMatrix, mx_latlong_alpha_to_lod(avgAlpha), $envRadiance);
-#endif
     return Li * FG * $envLightIntensity;
 }
 
 vec3 mx_environment_irradiance(vec3 N)
 {
-#ifdef HW_SEPARATE_SAMPLERS
-    vec3 Li = mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance_texture, $envIrradiance_sampler);
-#else
     vec3 Li = mx_latlong_map_lookup(N, $envMatrix, 0.0, $envIrradiance);
-#endif
     return Li * $envLightIntensity;
 }

--- a/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
@@ -27,11 +27,7 @@ vec3 mx_generate_prefilter_env()
     float NdotV = 1.0;
 
     // Compute derived properties.
-#ifdef HW_SEPARATE_SAMPLERS
-    vec2 uv = gl_FragCoord.xy * pow(2.0, $envPrefilterMip) / vec2(textureSize(sampler2D($envRadiance_texture, $envRadiance_sampler), 0));
-#else
-    vec2 uv = gl_FragCoord.xy * pow(2.0, $envPrefilterMip) / vec2(textureSize($envRadiance, 0));
-#endif
+    vec2 uv = gl_FragCoord.xy * pow(2.0, $envPrefilterMip) / vec2(textureSize($envRadianceSampler2D, 0));
     vec3 worldN = mx_latlong_map_projection_inverse(uv);
     mat3 tangentToWorld = mx_orthonormal_basis(worldN);
     float alpha = mx_latlong_lod_to_alpha(float($envPrefilterMip));
@@ -59,11 +55,7 @@ vec3 mx_generate_prefilter_env()
         vec3 Lw = tangentToWorld * L;
         float pdf = mx_ggx_NDF(H, vec2(alpha)) * G1V / (4.0 * NdotV);
         float lod = mx_latlong_compute_lod(Lw, pdf, float($envRadianceMips - 1), envRadianceSamples);
-#ifdef HW_SEPARATE_SAMPLERS
-        vec3 sampleColor = mx_latlong_map_lookup(Lw, $envMatrix, lod, $envRadiance_texture, $envRadiance_sampler);
-#else
         vec3 sampleColor = mx_latlong_map_lookup(Lw, $envMatrix, lod, $envRadiance);
-#endif
 
         // Add the radiance contribution of this sample.
         radiance += G * sampleColor;

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -491,21 +491,12 @@ vec2 mx_latlong_projection(vec3 dir)
     return vec2(longitude, latitude);
 }
 
-#ifdef HW_SEPARATE_SAMPLERS
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, texture2D env_texture, sampler env_sampler)
+vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, $texSamplerSignature)
 {
     vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
     vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(sampler2D(env_texture, env_sampler), uv, lod).rgb;
+    return textureLod($texSamplerSampler2D, uv, lod).rgb;
 }
-#else
-vec3 mx_latlong_map_lookup(vec3 dir, mat4 transform, float lod, sampler2D envSampler)
-{
-    vec3 envDir = normalize((transform * vec4(dir,0.0)).xyz);
-    vec2 uv = mx_latlong_projection(envDir);
-    return textureLod(envSampler, uv, lod).rgb;
-}
-#endif
 
 // Return the mip level with the appropriate coverage for a filtered importance sample.
 // https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html

--- a/libraries/stdlib/genglsl/mx_hextiledimage.glsl
+++ b/libraries/stdlib/genglsl/mx_hextiledimage.glsl
@@ -5,12 +5,7 @@
 // Techniques (JCGT), vol. 11, no. 2, 77-94, 2022
 // http://jcgt.org/published/0011/03/05/
 void mx_hextiledimage_color3(
-#ifdef HW_SEPARATE_SAMPLERS
-    texture2D tex_texture,
-    sampler   tex_sampler,
-#else
-    sampler2D tex_sampler,
-#endif
+    $texSamplerSignature,
     vec3 default_value,
     vec2 tex_coord,
     vec2 tiling,
@@ -30,15 +25,9 @@ void mx_hextiledimage_color3(
 
     HextileData tile_data = mx_hextile_coord(coord, rotation, rotation_range, scale, scale_range, offset, offset_range);
 
-#ifdef HW_SEPARATE_SAMPLERS
-    vec3 c1 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord1, tile_data.ddx1, tile_data.ddy1).rgb;
-    vec3 c2 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord2, tile_data.ddx2, tile_data.ddy2).rgb;
-    vec3 c3 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord3, tile_data.ddx3, tile_data.ddy3).rgb;
-#else
-    vec3 c1 = textureGrad(tex_sampler, tile_data.coord1, tile_data.ddx1, tile_data.ddy1).rgb;
-    vec3 c2 = textureGrad(tex_sampler, tile_data.coord2, tile_data.ddx2, tile_data.ddy2).rgb;
-    vec3 c3 = textureGrad(tex_sampler, tile_data.coord3, tile_data.ddx3, tile_data.ddy3).rgb;
-#endif
+    vec3 c1 = textureGrad($texSamplerSampler2D, tile_data.coord1, tile_data.ddx1, tile_data.ddy1).rgb;
+    vec3 c2 = textureGrad($texSamplerSampler2D, tile_data.coord2, tile_data.ddx2, tile_data.ddy2).rgb;
+    vec3 c3 = textureGrad($texSamplerSampler2D, tile_data.coord3, tile_data.ddx3, tile_data.ddy3).rgb;
 
     // luminance as weights
     vec3 cw = vec3(dot(c1, lumacoeffs), dot(c2, lumacoeffs), dot(c3, lumacoeffs));
@@ -62,12 +51,7 @@ void mx_hextiledimage_color3(
 }
 
 void mx_hextiledimage_color4(
-#ifdef HW_SEPARATE_SAMPLERS
-    texture2D tex_texture,
-    sampler   tex_sampler,
-#else
-    sampler2D tex_sampler,
-#endif
+    $texSamplerSignature,
     vec4 default_value,
     vec2 tex_coord,
     vec2 tiling,
@@ -87,15 +71,9 @@ void mx_hextiledimage_color4(
 
     HextileData tile_data = mx_hextile_coord(coord, rotation, rotation_range, scale, scale_range, offset, offset_range);
 
-#ifdef HW_SEPARATE_SAMPLERS
-    vec4 c1 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord1, tile_data.ddx1, tile_data.ddy1);
-    vec4 c2 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord2, tile_data.ddx2, tile_data.ddy2);
-    vec4 c3 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord3, tile_data.ddx3, tile_data.ddy3);
-#else
-    vec4 c1 = textureGrad(tex_sampler, tile_data.coord1, tile_data.ddx1, tile_data.ddy1);
-    vec4 c2 = textureGrad(tex_sampler, tile_data.coord2, tile_data.ddx2, tile_data.ddy2);
-    vec4 c3 = textureGrad(tex_sampler, tile_data.coord3, tile_data.ddx3, tile_data.ddy3);
-#endif
+    vec4 c1 = textureGrad($texSamplerSampler2D, tile_data.coord1, tile_data.ddx1, tile_data.ddy1);
+    vec4 c2 = textureGrad($texSamplerSampler2D, tile_data.coord2, tile_data.ddx2, tile_data.ddy2);
+    vec4 c3 = textureGrad($texSamplerSampler2D, tile_data.coord3, tile_data.ddx3, tile_data.ddy3);
 
     // luminance as weights
     vec3 cw = vec3(dot(c1.rgb, lumacoeffs), dot(c2.rgb, lumacoeffs), dot(c3.rgb, lumacoeffs));

--- a/libraries/stdlib/genglsl/mx_hextilednormalmap.glsl
+++ b/libraries/stdlib/genglsl/mx_hextilednormalmap.glsl
@@ -6,12 +6,7 @@
 // Techniques (JCGT), vol. 11, no. 2, 77-94, 2022
 // http://jcgt.org/published/0011/03/05/
 void mx_hextilednormalmap_vector3(
-#ifdef HW_SEPARATE_SAMPLERS
-    texture2D tex_texture,
-    sampler   tex_sampler,
-#else
-    sampler2D tex_sampler,
-#endif
+    $texSamplerSignature,
     vec3 default_value,
     vec2 tex_coord,
     vec2 tiling,
@@ -34,15 +29,9 @@ void mx_hextilednormalmap_vector3(
 
     HextileData tile_data = mx_hextile_coord(coord, rotation, rotation_range, scale, scale_range, offset, offset_range);
 
-#ifdef HW_SEPARATE_SAMPLERS
-    vec3 nm1 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord1, tile_data.ddx1, tile_data.ddy1).xyz;
-    vec3 nm2 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord2, tile_data.ddx2, tile_data.ddy2).xyz;
-    vec3 nm3 = textureGrad(sampler2D(tex_texture, tex_sampler), tile_data.coord3, tile_data.ddx3, tile_data.ddy3).xyz;
-#else
-    vec3 nm1 = textureGrad(tex_sampler, tile_data.coord1, tile_data.ddx1, tile_data.ddy1).xyz;
-    vec3 nm2 = textureGrad(tex_sampler, tile_data.coord2, tile_data.ddx2, tile_data.ddy2).xyz;
-    vec3 nm3 = textureGrad(tex_sampler, tile_data.coord3, tile_data.ddx3, tile_data.ddy3).xyz;
-#endif
+    vec3 nm1 = textureGrad($texSamplerSampler2D, tile_data.coord1, tile_data.ddx1, tile_data.ddy1).xyz;
+    vec3 nm2 = textureGrad($texSamplerSampler2D, tile_data.coord2, tile_data.ddx2, tile_data.ddy2).xyz;
+    vec3 nm3 = textureGrad($texSamplerSampler2D, tile_data.coord3, tile_data.ddx3, tile_data.ddy3).xyz;
     
     nm1.y = flip_g ? 1.0 - nm1.y : nm1.y;
     nm2.y = flip_g ? 1.0 - nm2.y : nm2.y;

--- a/libraries/stdlib/genglsl/mx_image_color3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color3.glsl
@@ -1,15 +1,7 @@
 #include "lib/$fileTransformUv"
 
-#ifdef HW_SEPARATE_SAMPLERS
-void mx_image_color3(texture2D tex_texture, sampler tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
+void mx_image_color3($texSamplerSignature, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {
     vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(sampler2D(tex_texture, tex_sampler), uv).rgb;
+    result = texture($texSamplerSampler2D, uv).rgb;
 }
-#else
-void mx_image_color3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
-{
-    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(tex_sampler, uv).rgb;
-}
-#endif

--- a/libraries/stdlib/genglsl/mx_image_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_color4.glsl
@@ -1,15 +1,7 @@
 #include "lib/$fileTransformUv"
 
-#ifdef HW_SEPARATE_SAMPLERS
-void mx_image_color4(texture2D tex_texture, sampler tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
+void mx_image_color4($texSamplerSignature, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {
     vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(sampler2D(tex_texture, tex_sampler), uv);
+    result = texture($texSamplerSampler2D, uv);
 }
-#else
-void mx_image_color4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
-{
-    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(tex_sampler, uv);
-}
-#endif

--- a/libraries/stdlib/genglsl/mx_image_float.glsl
+++ b/libraries/stdlib/genglsl/mx_image_float.glsl
@@ -1,15 +1,7 @@
 #include "lib/$fileTransformUv"
 
-#ifdef HW_SEPARATE_SAMPLERS
-void mx_image_float(texture2D tex_texture, sampler tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
+void mx_image_float($texSamplerSignature, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
 {
     vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(sampler2D(tex_texture, tex_sampler), uv).r;
+    result = texture($texSamplerSampler2D, uv).r;
 }
-#else
-void mx_image_float(sampler2D tex_sampler, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
-{
-    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(tex_sampler, uv).r;
-}
-#endif

--- a/libraries/stdlib/genglsl/mx_image_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector2.glsl
@@ -1,15 +1,7 @@
 #include "lib/$fileTransformUv"
 
-#ifdef HW_SEPARATE_SAMPLERS
-void mx_image_vector2(texture2D tex_texture, sampler tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
+void mx_image_vector2($texSamplerSignature, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
 {
     vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(sampler2D(tex_texture, tex_sampler), uv).rg;
+    result = texture($texSamplerSampler2D, uv).rg;
 }
-#else
-void mx_image_vector2(sampler2D tex_sampler, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
-{
-    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(tex_sampler, uv).rg;
-}
-#endif

--- a/libraries/stdlib/genglsl/mx_image_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector3.glsl
@@ -1,15 +1,7 @@
 #include "lib/$fileTransformUv"
 
-#ifdef HW_SEPARATE_SAMPLERS
-void mx_image_vector3(texture2D tex_texture, sampler tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
+void mx_image_vector3($texSamplerSignature, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
 {
     vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(sampler2D(tex_texture, tex_sampler), uv).rgb;
+    result = texture($texSamplerSampler2D, uv).rgb;
 }
-#else
-void mx_image_vector3(sampler2D tex_sampler, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
-{
-    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(tex_sampler, uv).rgb;
-}
-#endif

--- a/libraries/stdlib/genglsl/mx_image_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_image_vector4.glsl
@@ -1,15 +1,7 @@
 #include "lib/$fileTransformUv"
 
-#ifdef HW_SEPARATE_SAMPLERS
-void mx_image_vector4(texture2D tex_texture, sampler tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
+void mx_image_vector4($texSamplerSignature, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
 {
     vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(sampler2D(tex_texture, tex_sampler), uv);
+    result = texture($texSamplerSampler2D, uv);
 }
-#else
-void mx_image_vector4(sampler2D tex_sampler, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
-{
-    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
-    result = texture(tex_sampler, uv);
-}
-#endif

--- a/source/MaterialXGenGlsl/WgslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/WgslShaderGenerator.cpp
@@ -21,10 +21,13 @@ WgslShaderGenerator::WgslShaderGenerator(TypeSystemPtr typeSystem) :
     _resourceBindingCtx = std::make_shared<MaterialX::WgslResourceBindingContext>(0);
 
     // For functions described in ::emitSpecularEnvironment()
-    _tokenSubstitutions[HW::T_ENV_RADIANCE_TEXTURE] = HW::ENV_RADIANCE_TEXTURE;
-    _tokenSubstitutions[HW::T_ENV_RADIANCE_SAMPLER] = HW::ENV_RADIANCE_SAMPLER;
-    _tokenSubstitutions[HW::T_ENV_IRRADIANCE_TEXTURE] = HW::ENV_IRRADIANCE_TEXTURE;
-    _tokenSubstitutions[HW::T_ENV_IRRADIANCE_SAMPLER] = HW::ENV_IRRADIANCE_SAMPLER;
+    // override map value from HwShaderGenerator
+    _tokenSubstitutions[HW::T_ENV_RADIANCE]             = HW::ENV_RADIANCE_SPLIT; 
+    _tokenSubstitutions[HW::T_ENV_RADIANCE_SAMPLER2D]   = HW::ENV_RADIANCE_SAMPLER2D_SPLIT;
+    _tokenSubstitutions[HW::T_ENV_IRRADIANCE]           = HW::ENV_IRRADIANCE_SPLIT;
+    _tokenSubstitutions[HW::T_ENV_IRRADIANCE_SAMPLER2D] = HW::ENV_IRRADIANCE_SAMPLER2D_SPLIT;
+    _tokenSubstitutions[HW::T_TEX_SAMPLER_SAMPLER2D]    = HW::TEX_SAMPLER_SAMPLER2D_SPLIT;
+    _tokenSubstitutions[HW::T_TEX_SAMPLER_SIGNATURE]    = HW::TEX_SAMPLER_SIGNATURE_SPLIT;
 }
 
 void WgslShaderGenerator::emitDirectives(GenContext& context, ShaderStage& stage) const

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -74,14 +74,14 @@ const string T_ALPHA_THRESHOLD                = "$alphaThreshold";
 const string T_NUM_ACTIVE_LIGHT_SOURCES       = "$numActiveLightSources";
 const string T_ENV_MATRIX                     = "$envMatrix";
 const string T_ENV_RADIANCE                   = "$envRadiance";
-const string T_ENV_RADIANCE_TEXTURE           = "$envRadiance_texture";
-const string T_ENV_RADIANCE_SAMPLER           = "$envRadiance_sampler";
+const string T_ENV_RADIANCE_SAMPLER2D         = "$envRadianceSampler2D";
 const string T_ENV_RADIANCE_MIPS              = "$envRadianceMips";
 const string T_ENV_RADIANCE_SAMPLES           = "$envRadianceSamples";
-
 const string T_ENV_IRRADIANCE                 = "$envIrradiance";
-const string T_ENV_IRRADIANCE_TEXTURE         = "$envIrradiance_texture";
-const string T_ENV_IRRADIANCE_SAMPLER         = "$envIrradiance_sampler";
+const string T_ENV_IRRADIANCE_SAMPLER2D       = "$envIrradianceSampler2D";
+const string T_TEX_SAMPLER_SAMPLER2D          = "$texSamplerSampler2D";
+const string T_TEX_SAMPLER_SIGNATURE          = "$texSamplerSignature";
+
 const string T_ENV_LIGHT_INTENSITY            = "$envLightIntensity";
 const string T_ENV_PREFILTER_MIP              = "$envPrefilterMip";
 const string T_REFRACTION_TWO_SIDED           = "$refractionTwoSided";
@@ -135,13 +135,22 @@ const string ALPHA_THRESHOLD                  = "u_alphaThreshold";
 const string NUM_ACTIVE_LIGHT_SOURCES         = "u_numActiveLightSources";
 const string ENV_MATRIX                       = "u_envMatrix";
 const string ENV_RADIANCE                     = "u_envRadiance";
-const string ENV_RADIANCE_TEXTURE             = "u_envRadiance_texture";
-const string ENV_RADIANCE_SAMPLER             = "u_envRadiance_sampler";
+const string ENV_RADIANCE_SPLIT               = "u_envRadiance_texture, u_envRadiance_sampler";
+const string ENV_RADIANCE_SAMPLER2D           = "u_envRadiance";
+const string ENV_RADIANCE_SAMPLER2D_SPLIT     = "sampler2D(u_envRadiance_texture, u_envRadiance_sampler)";
+
 const string ENV_RADIANCE_MIPS                = "u_envRadianceMips";
 const string ENV_RADIANCE_SAMPLES             = "u_envRadianceSamples";
 const string ENV_IRRADIANCE                   = "u_envIrradiance";
-const string ENV_IRRADIANCE_TEXTURE           = "u_envIrradiance_texture";
-const string ENV_IRRADIANCE_SAMPLER           = "u_envIrradiance_sampler";
+const string ENV_IRRADIANCE_SPLIT             = "u_envIrradiance_texture, u_envIrradiance_sampler";
+const string ENV_IRRADIANCE_SAMPLER2D         = "u_envIrradiance";
+const string ENV_IRRADIANCE_SAMPLER2D_SPLIT   = "sampler2D(u_envIradiance_texture, u_envIrradiance_sampler)";
+
+const string TEX_SAMPLER_SAMPLER2D            = "tex_sampler";
+const string TEX_SAMPLER_SAMPLER2D_SPLIT      = "sampler2D(tex_texture, tex_sampler)";
+const string TEX_SAMPLER_SIGNATURE            = "sampler2D tex_sampler";
+const string TEX_SAMPLER_SIGNATURE_SPLIT      = "texture2D tex_texture, sampler tex_sampler";
+
 const string ENV_LIGHT_INTENSITY              = "u_envLightIntensity";
 const string ENV_PREFILTER_MIP                = "u_envPrefilterMip";
 const string REFRACTION_TWO_SIDED             = "u_refractionTwoSided";
@@ -233,9 +242,11 @@ HwShaderGenerator::HwShaderGenerator(TypeSystemPtr typeSystem, SyntaxPtr syntax)
     _tokenSubstitutions[HW::T_NUM_ACTIVE_LIGHT_SOURCES] = HW::NUM_ACTIVE_LIGHT_SOURCES;
     _tokenSubstitutions[HW::T_ENV_MATRIX] = HW::ENV_MATRIX;
     _tokenSubstitutions[HW::T_ENV_RADIANCE] = HW::ENV_RADIANCE;
+    _tokenSubstitutions[HW::T_ENV_RADIANCE_SAMPLER2D] = HW::ENV_RADIANCE_SAMPLER2D;
     _tokenSubstitutions[HW::T_ENV_RADIANCE_MIPS] = HW::ENV_RADIANCE_MIPS;
     _tokenSubstitutions[HW::T_ENV_RADIANCE_SAMPLES] = HW::ENV_RADIANCE_SAMPLES;
     _tokenSubstitutions[HW::T_ENV_IRRADIANCE] = HW::ENV_IRRADIANCE;
+    _tokenSubstitutions[HW::T_ENV_IRRADIANCE_SAMPLER2D] = HW::ENV_IRRADIANCE_SAMPLER2D;
     _tokenSubstitutions[HW::T_ENV_LIGHT_INTENSITY] = HW::ENV_LIGHT_INTENSITY;
     _tokenSubstitutions[HW::T_REFRACTION_TWO_SIDED] = HW::REFRACTION_TWO_SIDED;
     _tokenSubstitutions[HW::T_ALBEDO_TABLE] = HW::ALBEDO_TABLE;
@@ -247,6 +258,8 @@ HwShaderGenerator::HwShaderGenerator(TypeSystemPtr typeSystem, SyntaxPtr syntax)
     _tokenSubstitutions[HW::T_VERTEX_DATA_INSTANCE] = HW::VERTEX_DATA_INSTANCE;
     _tokenSubstitutions[HW::T_LIGHT_DATA_INSTANCE] = HW::LIGHT_DATA_INSTANCE;
     _tokenSubstitutions[HW::T_ENV_PREFILTER_MIP] = HW::ENV_PREFILTER_MIP;
+    _tokenSubstitutions[HW::T_TEX_SAMPLER_SAMPLER2D] = HW::TEX_SAMPLER_SAMPLER2D;
+    _tokenSubstitutions[HW::T_TEX_SAMPLER_SIGNATURE] = HW::TEX_SAMPLER_SIGNATURE;
 }
 
 ShaderPtr HwShaderGenerator::createShader(const string& name, ElementPtr element, GenContext& context) const

--- a/source/MaterialXGenShader/HwShaderGenerator.cpp
+++ b/source/MaterialXGenShader/HwShaderGenerator.cpp
@@ -138,7 +138,6 @@ const string ENV_RADIANCE                     = "u_envRadiance";
 const string ENV_RADIANCE_SPLIT               = "u_envRadiance_texture, u_envRadiance_sampler";
 const string ENV_RADIANCE_SAMPLER2D           = "u_envRadiance";
 const string ENV_RADIANCE_SAMPLER2D_SPLIT     = "sampler2D(u_envRadiance_texture, u_envRadiance_sampler)";
-
 const string ENV_RADIANCE_MIPS                = "u_envRadianceMips";
 const string ENV_RADIANCE_SAMPLES             = "u_envRadianceSamples";
 const string ENV_IRRADIANCE                   = "u_envIrradiance";

--- a/source/MaterialXGenShader/HwShaderGenerator.h
+++ b/source/MaterialXGenShader/HwShaderGenerator.h
@@ -69,15 +69,15 @@ Uniform variables :
                                                                                        The LightData struct is built dynamically depending on requirements for
                                                                                        bound light shaders.
     $envMatrix                          u_envMatrix                         mat4       Rotation matrix for the environment.
-    $envIrradiance                      u_envIrradiance                     sampler2D  Combined sampler for the texture used for diffuse environment lighting.
-    $envIrradiance_texture              u_envIrradiance_texture             texture2D  Separated texture2D used for diffuse environment lighting.
-    $envIrradiance_sampler              u_envIrradiance_sampler             sampler    Separated sampler used for diffuse environment lighting.
-    $envRadiance                        u_envRadiance                       sampler2D  Combined sampler for the texture used for specular environment lighting.
-    $envRadiance_texture                u_envRadiance_texture               texture2D  Separated texture2D used for specular environment lighting.
-    $envRadiance_sampler                u_envRadiance_sampler               sampler    Separated sampler used for specular environment lighting.
+    $envIrradiance                      u_envIrradiance                     sampler2D  Sampler for the texture used for diffuse environment lighting.
+    $envIrradianceSampler2D             u_envIrradiance                     sampler2D  For split texture and sampler, takes form of sampler2D(tex, sampler)
+    $envRadiance                        u_envRadiance                       sampler2D  Sampler for the texture used for specular environment lighting.
+    $envRadianceSampler2D               u_envRadiance                       sampler2D  For split texture and sampler, takes form of sampler2D(tex, sampler)
     $envLightIntensity                  u_envLightIntensity                 float      Linear multiplier for environment lighting
     $envRadianceMips                    u_envRadianceMips                   int        Number of mipmaps used on the specular environment texture.
     $envRadianceSamples                 u_envRadianceSamples                int        Samples to use if Filtered Importance Sampling is used for specular environment lighting.
+    $texSamplerSampler2D                tex_sampler                         sampler2D  Texture sampler2D parameter. For split texture and sampler, calls sampler2D(tex_texture, tex_sampler).
+    $texSamplerSignature                sampler2D tex_sampler               signature  For function signature declaration.
 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -128,13 +128,11 @@ extern MX_GENSHADER_API const string T_ALPHA_THRESHOLD;
 extern MX_GENSHADER_API const string T_NUM_ACTIVE_LIGHT_SOURCES;
 extern MX_GENSHADER_API const string T_ENV_MATRIX;
 extern MX_GENSHADER_API const string T_ENV_RADIANCE;
-extern MX_GENSHADER_API const string T_ENV_RADIANCE_TEXTURE;
-extern MX_GENSHADER_API const string T_ENV_RADIANCE_SAMPLER;
+extern MX_GENSHADER_API const string T_ENV_RADIANCE_SAMPLER2D;
 extern MX_GENSHADER_API const string T_ENV_RADIANCE_MIPS;
 extern MX_GENSHADER_API const string T_ENV_RADIANCE_SAMPLES;
 extern MX_GENSHADER_API const string T_ENV_IRRADIANCE;
-extern MX_GENSHADER_API const string T_ENV_IRRADIANCE_TEXTURE;
-extern MX_GENSHADER_API const string T_ENV_IRRADIANCE_SAMPLER;
+extern MX_GENSHADER_API const string T_ENV_IRRADIANCE_SAMPLER2D;
 extern MX_GENSHADER_API const string T_ENV_LIGHT_INTENSITY;
 extern MX_GENSHADER_API const string T_ENV_PREFILTER_MIP;
 extern MX_GENSHADER_API const string T_REFRACTION_TWO_SIDED;
@@ -146,6 +144,8 @@ extern MX_GENSHADER_API const string T_SHADOW_MAP;
 extern MX_GENSHADER_API const string T_SHADOW_MATRIX;
 extern MX_GENSHADER_API const string T_VERTEX_DATA_INSTANCE;
 extern MX_GENSHADER_API const string T_LIGHT_DATA_INSTANCE;
+extern MX_GENSHADER_API const string T_TEX_SAMPLER_SAMPLER2D;
+extern MX_GENSHADER_API const string T_TEX_SAMPLER_SIGNATURE;
 
 /// Default names for identifiers.
 /// Replacing above tokens in final code.
@@ -190,13 +190,15 @@ extern MX_GENSHADER_API const string ALPHA_THRESHOLD;
 extern MX_GENSHADER_API const string NUM_ACTIVE_LIGHT_SOURCES;
 extern MX_GENSHADER_API const string ENV_MATRIX;
 extern MX_GENSHADER_API const string ENV_RADIANCE;
-extern MX_GENSHADER_API const string ENV_RADIANCE_TEXTURE;
-extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLER;
+extern MX_GENSHADER_API const string ENV_RADIANCE_SPLIT;
+extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLER2D;
+extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLER2D_SPLIT;
 extern MX_GENSHADER_API const string ENV_RADIANCE_MIPS;
 extern MX_GENSHADER_API const string ENV_RADIANCE_SAMPLES;
 extern MX_GENSHADER_API const string ENV_IRRADIANCE;
-extern MX_GENSHADER_API const string ENV_IRRADIANCE_TEXTURE;
-extern MX_GENSHADER_API const string ENV_IRRADIANCE_SAMPLER;
+extern MX_GENSHADER_API const string ENV_IRRADIANCE_SPLIT;
+extern MX_GENSHADER_API const string ENV_IRRADIANCE_SAMPLER2D;
+extern MX_GENSHADER_API const string ENV_IRRADIANCE_SAMPLER2D_SPLIT;
 extern MX_GENSHADER_API const string ENV_LIGHT_INTENSITY;
 extern MX_GENSHADER_API const string ENV_PREFILTER_MIP;
 extern MX_GENSHADER_API const string REFRACTION_TWO_SIDED;
@@ -209,6 +211,12 @@ extern MX_GENSHADER_API const string SHADOW_MATRIX;
 extern MX_GENSHADER_API const string VERTEX_DATA_INSTANCE;
 extern MX_GENSHADER_API const string LIGHT_DATA_INSTANCE;
 extern MX_GENSHADER_API const string LIGHT_DATA_MAX_LIGHT_SOURCES;
+
+/// Texture sampler parameters (for both combined and separate values)
+extern MX_GENSHADER_API const string TEX_SAMPLER_SAMPLER2D;
+extern MX_GENSHADER_API const string TEX_SAMPLER_SAMPLER2D_SPLIT;
+extern MX_GENSHADER_API const string TEX_SAMPLER_SIGNATURE;
+extern MX_GENSHADER_API const string TEX_SAMPLER_SIGNATURE_SPLIT;
 
 /// Variable blocks names.
 extern MX_GENSHADER_API const string VERTEX_INPUTS;    // Geometric inputs for vertex stage.


### PR DESCRIPTION
Produce cleaner generated shader code by removing use of #ifdef HW_SEPARATE_SAMPLERS to handle both combined and separate texture samplers.  This restores the generated shader code to look like it did before adding the ability to handle separate texture + sampler (for WGSL).

Methodology:
* Swaps out use of #ifdef HW_SEPARATE_SAMPLERS with token replacement.

Impact: 
* Improves readability of shader code
* Reduces number of lines of shader code
* Makes standard path (combined sampler2D) almost a pass-through
* Adds new tokens to the shader template code.

Shader code now uses these tokens instead of direct values:
    $envIrradiance
    $envIrradianceSampler2D
    $envRadiance
    $envRadianceSampler2D
    $texSamplerSampler2D
    $texSamplerSignature

The tokens values are specified in HwShaderGenerator.cpp for the general case and then overridden in WgslShaderGenerator.cpp for separating out the texture and sampler.