### PR TITLE
Add minimum error threshold to render tests

### DIFF
--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -174,7 +174,6 @@ def main(args=None):
                 fh.write("<table>\n")
                 curPath = path1
 
-
             def prependFileUri(filepath: str) -> str:
                 if os.path.isabs(filepath):
                     return 'file:///' + filepath

--- a/python/MaterialXTest/tests_to_html.py
+++ b/python/MaterialXTest/tests_to_html.py
@@ -52,6 +52,7 @@ def main(args=None):
     parser.add_argument('-l1', '--lang1', dest='lang1', action='store', help='First target language for comparison. Default is glsl', default="glsl")
     parser.add_argument('-l2', '--lang2', dest='lang2', action='store', help='Second target language for comparison. Default is osl', default="osl")
     parser.add_argument('-l3', '--lang3', dest='lang3', action='store', help='Third target language for comparison. Default is empty', default="")
+    parser.add_argument('-e', '--error', dest='error', action='store', help='Filter out results with RMS less than this. Negative means all results are kept.', default=-1, type=float)
 
     args = parser.parse_args(args)
 
@@ -84,7 +85,7 @@ def main(args=None):
         args.inputdir3 = args.inputdir1
 
     useThirdLang = args.lang3
-    
+
     if useThirdLang:
         fh.write("<h3>" + args.lang1 + " (in: " + args.inputdir1 + ") vs "+ args.lang2 + " (in: " + args.inputdir2 + ") vs "+ args.lang3 + " (in: " + args.inputdir3 + ")</h3>\n")
     else:
@@ -120,7 +121,7 @@ def main(args=None):
     for file1, path1 in zip(langFiles1, langPaths1):
         # Allow for just one language to be shown if source and dest are the same.
         # Otherwise add in equivalent name with dest language replacement if
-        # pointing to the same directory 
+        # pointing to the same directory
         if args.inputdir1 != args.inputdir2 or args.lang1 != args.lang2:
             file2 = file1[:-len(postFix)] + args.lang2 + ".png"
             path2 = os.path.join(args.inputdir2, path1[len(args.inputdir1)+1:])
@@ -149,13 +150,6 @@ def main(args=None):
             diffPath1 = diffPath2 = diffPath3 = None
             diffRms1 = diffRms2 = diffRms3 = None
 
-            if curPath != path1:
-                if curPath != "":
-                    fh.write("</table>\n")
-                fh.write("<p>" + os.path.normpath(path1) + ":</p>\n")
-                fh.write("<table>\n")
-                curPath = path1
-
             if file1 and file2 and DIFF_ENABLED and args.CREATE_DIFF:
                 diffPath1 = fullPath1[0:-8] + "_" + args.lang1 + "-1_vs_" + args.lang2 + "-2_diff.png"
                 diffRms1 = computeDiff(fullPath1, fullPath2, diffPath1)
@@ -165,6 +159,21 @@ def main(args=None):
                 diffRms2 = computeDiff(fullPath1, fullPath3, diffPath2)
                 diffPath3 = fullPath1[0:-8] + "_" + args.lang2 + "-2_vs_" + args.lang3 + "-3_diff.png"
                 diffRms3 = computeDiff(fullPath2, fullPath3, diffPath3)
+
+            if args.error >= 0:
+                ok1 = (not diffPath1) or (not diffRms1) or (diffRms1 and diffRms1 <= args.error)
+                ok2 = (not diffPath2) or (not diffRms2) or (diffRms2 and diffRms2 <= args.error)
+                ok3 = (not diffPath3) or (not diffRms3) or (diffRms3 and diffRms3 <= args.error)
+                if ok1 and ok2 and ok3:
+                    continue
+
+            if curPath != path1:
+                if curPath != "":
+                    fh.write("</table>\n")
+                fh.write("<p>" + os.path.normpath(path1) + ":</p>\n")
+                fh.write("<table>\n")
+                curPath = path1
+
 
             def prependFileUri(filepath: str) -> str:
                 if os.path.isabs(filepath):


### PR DESCRIPTION
Added an error (`-e`) parameter to `tests_to_html`. When set to any non-negative values, all tests with all of the RMS errors lower or equal to this treshold are skipped, producing html with only failing tests. It is off by default.