### PR TITLE
Optimizations to Standard Surface graph

### DIFF
--- a/libraries/bxdf/standard_surface.mtlx
+++ b/libraries/bxdf/standard_surface.mtlx
@@ -226,7 +226,7 @@
       <input name="normal" type="vector3" interfacename="normal" />
     </oren_nayar_diffuse_bsdf>
     <translucent_bsdf name="translucent_bsdf" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
+      <input name="weight" type="float" interfacename="subsurface" />
       <input name="color" type="color3" nodename="coat_affected_subsurface_color" />
       <input name="normal" type="vector3" interfacename="normal" />
     </translucent_bsdf>
@@ -235,7 +235,7 @@
       <input name="in2" type="float" interfacename="subsurface_scale" />
     </multiply>
     <subsurface_bsdf name="subsurface_bsdf" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
+      <input name="weight" type="float" interfacename="subsurface" />
       <input name="color" type="color3" nodename="coat_affected_subsurface_color" />
       <input name="radius" type="color3" nodename="subsurface_radius_scaled" />
       <input name="anisotropy" type="float" interfacename="subsurface_anisotropy" />
@@ -249,11 +249,17 @@
       <input name="bg" type="BSDF" nodename="subsurface_bsdf" />
       <input name="mix" type="float" nodename="subsurface_selector" />
     </mix>
-    <mix name="subsurface_mix" type="BSDF">
-      <input name="fg" type="BSDF" nodename="selected_subsurface_bsdf" />
-      <input name="bg" type="BSDF" nodename="diffuse_bsdf" />
-      <input name="mix" type="float" interfacename="subsurface" />
-    </mix>
+    <invert name="subsurface_inv" type="float">
+      <input name="in" type="float" interfacename="subsurface" />
+    </invert>
+    <multiply name="diffuse_bsdf_non_subsurface" type="BSDF">
+      <input name="in1" type="BSDF" nodename="diffuse_bsdf" />
+      <input name="in2" type="float" nodename="subsurface_inv" />
+    </multiply>
+    <add name="subsurface_blend" type="BSDF">
+      <input name="in1" type="BSDF" nodename="selected_subsurface_bsdf" />
+      <input name="in2" type="BSDF" nodename="diffuse_bsdf_non_subsurface" />
+    </add>
 
     <!-- Sheen Layer -->
     <sheen_bsdf name="sheen_bsdf" type="BSDF">
@@ -264,12 +270,12 @@
     </sheen_bsdf>
     <layer name="sheen_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="sheen_bsdf" />
-      <input name="base" type="BSDF" nodename="subsurface_mix" />
+      <input name="base" type="BSDF" nodename="subsurface_blend" />
     </layer>
 
     <!-- Transmission Layer -->
     <dielectric_bsdf name="transmission_bsdf" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
+      <input name="weight" type="float" interfacename="transmission" />
       <input name="tint" type="color3" interfacename="transmission_color" />
       <input name="ior" type="float" interfacename="specular_IOR" />
       <input name="roughness" type="vector2" nodename="transmission_roughness" />
@@ -278,11 +284,17 @@
       <input name="distribution" type="string" value="ggx" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
-    <mix name="transmission_mix" type="BSDF">
-      <input name="fg" type="BSDF" nodename="transmission_bsdf" />
-      <input name="bg" type="BSDF" nodename="sheen_layer" />
-      <input name="mix" type="float" interfacename="transmission" />
-    </mix>
+    <invert name="transmission_inv" type="float">
+      <input name="in" type="float" interfacename="transmission" />
+    </invert>
+    <multiply name="sheen_layer_non_transmission" type="BSDF">
+      <input name="in1" type="BSDF" nodename="sheen_layer" />
+      <input name="in2" type="float" nodename="transmission_inv" />
+    </multiply>
+    <add name="transmission_blend" type="BSDF">
+      <input name="in1" type="BSDF" nodename="transmission_bsdf" />
+      <input name="in2" type="BSDF" nodename="sheen_layer_non_transmission" />
+    </add>
 
     <!-- Specular Layer -->
     <dielectric_bsdf name="specular_bsdf" type="BSDF">
@@ -299,7 +311,7 @@
     </dielectric_bsdf>
     <layer name="specular_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="specular_bsdf" />
-      <input name="base" type="BSDF" nodename="transmission_mix" />
+      <input name="base" type="BSDF" nodename="transmission_blend" />
     </layer>
 
     <!-- Metal Layer -->
@@ -316,7 +328,7 @@
       <input name="edge_color" type="color3" nodename="metal_edgecolor" />
     </artistic_ior>
     <conductor_bsdf name="metal_bsdf" type="BSDF">
-      <input name="weight" type="float" value="1.0" />
+      <input name="weight" type="float" interfacename="metalness" />
       <input name="ior" type="color3" nodename="artistic_ior" output="ior" />
       <input name="extinction" type="color3" nodename="artistic_ior" output="extinction" />
       <input name="roughness" type="vector2" nodename="main_roughness" />
@@ -326,11 +338,17 @@
       <input name="thinfilm_thickness" type="float" interfacename="thin_film_thickness" />
       <input name="thinfilm_ior" type="float" interfacename="thin_film_IOR" />
     </conductor_bsdf>
-    <mix name="metalness_mix" type="BSDF">
-      <input name="fg" type="BSDF" nodename="metal_bsdf" />
-      <input name="bg" type="BSDF" nodename="specular_layer" />
-      <input name="mix" type="float" interfacename="metalness" />
-    </mix>
+    <invert name="metalness_inv" type="float">
+      <input name="in" type="float" interfacename="metalness" />
+    </invert>
+    <multiply name="specular_layer_non_metal" type="BSDF">
+      <input name="in1" type="BSDF" nodename="specular_layer" />
+      <input name="in2" type="float" nodename="metalness_inv" />
+    </multiply>
+    <add name="metalness_blend" type="BSDF">
+      <input name="in1" type="BSDF" nodename="metal_bsdf" />
+      <input name="in2" type="BSDF" nodename="specular_layer_non_metal" />
+    </add>
 
     <!-- Coat Layer -->
     <mix name="coat_attenuation" type="color3">
@@ -339,7 +357,7 @@
       <input name="mix" type="float" interfacename="coat" />
     </mix>
     <multiply name="thin_film_layer_attenuated" type="BSDF">
-      <input name="in1" type="BSDF" nodename="metalness_mix" />
+      <input name="in1" type="BSDF" nodename="metalness_blend" />
       <input name="in2" type="color3" nodename="coat_attenuation" />
     </multiply>
     <roughness_anisotropy name="coat_roughness_vector" type="vector2">


### PR DESCRIPTION
This changelist implements optimizations to the graph for Standard Surface, replacing `mix` operations on leaf BSDFs with pre-multiplied `add` operations.  Pre-multiplied `add` operations take better advantage of dynamic branching in hardware shading languages, and should have a neutral or positive impact on software shading languages.

Performance tests were conducted on an NVIDIA RTX A6000 at 4K resolution, and the following timing improvements were seen:

Standard Surface Marble: 3ms -> 1ms
Standard Surface Carpaint: 3ms -> 1ms
Standard Surface Glass: 5ms -> 3ms
Standard Surface Plastic: 2ms -> 1ms
Standard Surface Brushed Metal: 2ms -> 1ms
Standard Surface Chess Set: 9ms -> 4ms