### PR TITLE
Add guard to clean up Metal objects on exception

### DIFF
--- a/source/MaterialXView/RenderPipelineMetal.mm
+++ b/source/MaterialXView/RenderPipelineMetal.mm
@@ -453,6 +453,11 @@ void MetalRenderPipeline::renderFrame(void* color_texture, int shadowMapSize, co
     }
     
     MTL(beginCommandBuffer());
+    std::unique_ptr<void, void(*)(void *)> guard((void *)1, [](void *) {
+        // Clean up Metal objects in the event of an exception.
+        MTL(endCommandBuffer());
+    });
+
     MTLRenderPassDescriptor* renderpassDesc = [MTLRenderPassDescriptor new];
     if(useTiledPipeline)
     {
@@ -641,7 +646,8 @@ void MetalRenderPipeline::renderFrame(void* color_texture, int shadowMapSize, co
             atIndex:0];
         [MTL(renderCmdEncoder) drawPrimitives:MTLPrimitiveTypeTriangle vertexStart:0 vertexCount:3];
     }
-    
+
+    guard.release();
     MTL(endCommandBuffer());
     
     if(captureFrame)


### PR DESCRIPTION
This PR addresses the crash reported in #2473. It introduces a scope guard object that automatically ends the current command encoder and command buffer if the `renderFrame` method exits abnormally due to an exception. Without such a precaution, the viewer crashes shortly after the exception is handled, because the encoder is released by its autorelease pool before `endEncoding` is called on it, causing a hard assert in Metal.