### PR TITLE
Revert TextureBakerPtr changes from #2301

### DIFF
--- a/source/MaterialXRenderGlsl/TextureBaker.h
+++ b/source/MaterialXRenderGlsl/TextureBaker.h
@@ -19,7 +19,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// A shared pointer to a TextureBaker
-using TextureBakerGlslPtr = shared_ptr<class TextureBakerGlsl>;
+using TextureBakerPtr = shared_ptr<class TextureBakerGlsl>;
 
 /// A vector of baked documents with their associated names.
 using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
@@ -29,9 +29,9 @@ using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
 class MX_RENDERGLSL_API TextureBakerGlsl : public TextureBaker<GlslRenderer, GlslShaderGenerator>
 {
   public:
-    static TextureBakerGlslPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
+    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
     {
-        return TextureBakerGlslPtr(new TextureBakerGlsl(width, height, baseType));
+        return TextureBakerPtr(new TextureBakerGlsl(width, height, baseType));
     }
 
     TextureBakerGlsl(unsigned int width, unsigned int height, Image::BaseType baseType);

--- a/source/MaterialXRenderMsl/TextureBaker.h
+++ b/source/MaterialXRenderMsl/TextureBaker.h
@@ -19,7 +19,7 @@
 MATERIALX_NAMESPACE_BEGIN
 
 /// A shared pointer to a TextureBakerMsl
-using TextureBakerMslPtr = shared_ptr<class TextureBakerMsl>;
+using TextureBakerPtr = shared_ptr<class TextureBakerMsl>;
 
 /// A vector of baked documents with their associated names.
 using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
@@ -31,9 +31,9 @@ using BakedDocumentVec = std::vector<std::pair<std::string, DocumentPtr>>;
 class MX_RENDERMSL_API TextureBakerMsl : public TextureBaker<MslRenderer, MslShaderGenerator>
 {
   public:
-    static TextureBakerMslPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
+    static TextureBakerPtr create(unsigned int width = 1024, unsigned int height = 1024, Image::BaseType baseType = Image::BaseType::UINT8)
     {
-        return TextureBakerMslPtr(new TextureBakerMsl(width, height, baseType));
+        return TextureBakerPtr(new TextureBakerMsl(width, height, baseType));
     }
 
   protected:

--- a/source/MaterialXView/RenderPipeline.h
+++ b/source/MaterialXView/RenderPipeline.h
@@ -19,6 +19,14 @@
 #include <MaterialXCore/Value.h>
 #include <MaterialXCore/Unit.h>
 
+MATERIALX_NAMESPACE_BEGIN
+#ifdef MATERIALXVIEW_METAL_BACKEND
+using TextureBakerPtr = shared_ptr<class TextureBakerMsl>;
+#else
+using TextureBakerPtr = shared_ptr<class TextureBakerGlsl>;
+#endif
+MATERIALX_NAMESPACE_END
+
 #include <memory>
 
 namespace mx = MaterialX;

--- a/source/MaterialXView/RenderPipelineGL.cpp
+++ b/source/MaterialXView/RenderPipelineGL.cpp
@@ -492,7 +492,7 @@ void GLRenderPipeline::bakeTextures()
         // Construct a texture baker.
         mx::Image::BaseType baseType = _viewer->_bakeHdr ? mx::Image::BaseType::FLOAT : mx::Image::BaseType::UINT8;
         mx::UnsignedIntPair bakingRes = _viewer->computeBakingResolution(doc);
-        mx::TextureBakerGlslPtr baker = std::static_pointer_cast<mx::TextureBakerGlsl>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
+        mx::TextureBakerPtr baker = std::static_pointer_cast<mx::TextureBakerPtr::element_type>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
         baker->setupUnitSystem(_viewer->_stdLib);
         baker->setDistanceUnit(_viewer->_genContext.getOptions().targetDistanceUnit);
         baker->setAverageImages(_viewer->_bakeAverage);

--- a/source/MaterialXView/RenderPipelineMetal.mm
+++ b/source/MaterialXView/RenderPipelineMetal.mm
@@ -665,7 +665,7 @@ void MetalRenderPipeline::bakeTextures()
         // Construct a texture baker.
         mx::Image::BaseType baseType = _viewer->_bakeHdr ? mx::Image::BaseType::FLOAT : mx::Image::BaseType::UINT8;
         mx::UnsignedIntPair bakingRes = _viewer->computeBakingResolution(doc);
-        mx::TextureBakerMslPtr baker = std::static_pointer_cast<mx::TextureBakerMsl>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
+        mx::TextureBakerPtr baker = std::static_pointer_cast<mx::TextureBakerPtr::element_type>(createTextureBaker(bakingRes.first, bakingRes.second, baseType));
         baker->setupUnitSystem(_viewer->_stdLib);
         baker->setDistanceUnit(_viewer->_genContext.getOptions().targetDistanceUnit);
         baker->setAverageImages(_viewer->_bakeAverage);

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
@@ -13,7 +13,7 @@ namespace mx = MaterialX;
 
 void bindPyTextureBaker(py::module& mod)
 {
-    py::class_<mx::TextureBakerGlsl, mx::GlslRenderer, mx::TextureBakerGlslPtr>(mod, "TextureBaker")
+    py::class_<mx::TextureBakerGlsl, mx::GlslRenderer, mx::TextureBakerPtr>(mod, "TextureBaker")
         .def_static("create", &mx::TextureBakerGlsl::create)
         .def("setExtension", &mx::TextureBakerGlsl::setExtension)
         .def("getExtension", &mx::TextureBakerGlsl::getExtension)

--- a/source/PyMaterialX/PyMaterialXRenderMsl/PyTextureBaker.mm
+++ b/source/PyMaterialX/PyMaterialXRenderMsl/PyTextureBaker.mm
@@ -13,7 +13,7 @@ namespace mx = MaterialX;
 
 void bindPyTextureBaker(py::module& mod)
 {
-    py::class_<mx::TextureBakerMsl, mx::MslRenderer, mx::TextureBakerMslPtr>(mod, "TextureBaker")
+    py::class_<mx::TextureBakerMsl, mx::MslRenderer, mx::TextureBakerPtr>(mod, "TextureBaker")
         .def_static("create", &mx::TextureBakerMsl::create)
         .def("setExtension", &mx::TextureBakerMsl::setExtension)
         .def("getExtension", &mx::TextureBakerMsl::getExtension)


### PR DESCRIPTION
This reverts commit cf6b196171d33475447ef22d11803941acfd462f for reasons outlined in https://github.com/AcademySoftwareFoundation/MaterialX/pull/2301