### PR TITLE
Additional optimization to glTF PBR graph

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -135,12 +135,16 @@
     </mix>
 
     <!-- Dielectric -->
+    <invert name="transmission_inv" type="float">
+      <input name="in" type="float" interfacename="transmission" />
+    </invert>
     <oren_nayar_diffuse_bsdf name="diffuse_bsdf" type="BSDF">
+      <input name="weight" type="float" nodename="transmission_inv" />
       <input name="color" type="color3" interfacename="base_color" />
       <input name="normal" type="vector3" interfacename="normal" />
     </oren_nayar_diffuse_bsdf>
     <dielectric_bsdf name="transmission_bsdf" type="BSDF">
-      <input name="weight" type="float" value="1" />
+      <input name="weight" type="float" interfacename="transmission" />
       <input name="tint" type="color3" interfacename="base_color" />
       <input name="ior" type="float" interfacename="ior" />
       <input name="roughness" type="vector2" nodename="roughness_uv" />
@@ -148,11 +152,10 @@
       <input name="tangent" type="vector3" nodename="selected_tangent" />
       <input name="scatter_mode" type="string" value="T" />
     </dielectric_bsdf>
-    <mix name="transmission_mix" type="BSDF">
-      <input name="bg" type="BSDF" nodename="diffuse_bsdf" />
-      <input name="fg" type="BSDF" nodename="transmission_bsdf" />
-      <input name="mix" type="float" interfacename="transmission" />
-    </mix>
+    <add name="transmission_blend" type="BSDF">
+      <input name="in1" type="BSDF" nodename="diffuse_bsdf" />
+      <input name="in2" type="BSDF" nodename="transmission_bsdf" />
+    </add>
     <invert name="iridescence_inv" type="float">
       <input name="in" type="float" interfacename="iridescence" />
     </invert>
@@ -182,7 +185,7 @@
     </add>
     <layer name="dielectric_layer" type="BSDF">
       <input name="top" type="BSDF" nodename="reflection_bsdf_blend" />
-      <input name="base" type="BSDF" nodename="transmission_mix" />
+      <input name="base" type="BSDF" nodename="transmission_blend" />
     </layer>
 
     <!-- Metal -->


### PR DESCRIPTION
This changelist implements one additional optimization to the graph for glTF PBR, ensuring that the render cost of the transmissive `dielectric_bsdf` node can be skipped for materials with no transmissive component.

Performance tests were conducted on an NVIDIA RTX A6000 at 4K resolution, and the following timing improvements were seen:

glTF PBR Carpaint: 11ms -> 8ms
glTF PBR Plastic: 8ms -> 5ms
glTF PBR Gold: 9ms -> 6ms
glTF PBR Boombox: 4ms -> 3ms