### PR TITLE
Modernize CMake handling of OIIO dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,9 +229,6 @@ if(MATERIALX_BUILD_RENDER AND MATERIALX_BUILD_GEN_OSL AND MATERIALX_BUILD_TESTS)
 endif()
 
 # Add global definitions
-if(MATERIALX_BUILD_OIIO)
-    add_definitions(-DMATERIALX_BUILD_OIIO)
-endif()
 if(MATERIALX_TEST_RENDER)
     add_definitions(-DMATERIALX_TEST_RENDER)
 endif()

--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -26,7 +26,7 @@ if(UNIX)
 endif()
 
 if(MATERIALX_BUILD_OIIO)
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/External/OpenImageIO")
     find_package(OpenImageIO CONFIG REQUIRED)
     target_link_libraries(${TARGET_NAME} PRIVATE OpenImageIO::OpenImageIO OpenImageIO::OpenImageIO_Util)
+    target_compile_definitions(MaterialXGraphEditor PUBLIC MATERIALX_BUILD_OIIO)
 endif()


### PR DESCRIPTION
By asking CMake to write MATERIALX_BUILD_OIIO in the generated CMake files if MaterialXRender was built with OpenImageIO support.