### PR TITLE
Fix dot node crash in code generation

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -911,7 +911,7 @@ void ShaderGraph::optimize()
         {
             // Filename dot nodes must be elided so they do not create extra samplers.
             ShaderInput* in = node->getInput("in");
-            if (in->getType() == Type::FILENAME)
+            if (in && in->getType() == Type::FILENAME)
             {
                 bypass(node, 0);
                 ++numEdits;


### PR DESCRIPTION
## Changes

Code attempts to use `in` on `dot` not without checking for existence on the node.

It will not be exposed (added) as a uniform input if it's connected as is the case with the `dot` nodes
used in the open_pbr to standard_surface conversion graph.

Simply add in a firewall check for existence first.

Fixes #2504.

## Test

Tried running with and without changes in MaterialXView. File loads and renders properly now.

<img width="2156" height="1605" alt="image" src="https://github.com/user-attachments/assets/114de172-1918-45d7-9b96-97df3eb046ef" />

