### PR TITLE
Improve UDIM support in viewer

### DIFF
--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1496,15 +1496,17 @@ void Viewer::loadDocument(const mx::FilePath& filename, mx::DocumentPtr librarie
                 }
             }
 
-            // Apply implicit udim assignments, if any.
+            // Apply UDIM assignments, if any.
             for (mx::MaterialPtr mat : newMaterials)
             {
                 mx::NodePtr materialNode = mat->getMaterialNode();
                 if (materialNode)
                 {
+                    // First check for implicit UDIM assignments.
                     std::string udim = mat->getUdim();
                     if (udim.empty())
                     {
+                        // Fall back to name-based UDIM assignments.
                         for (const std::string& token : mx::splitString(materialNode->getName(), UDIM_SEPARATORS))
                         {
                             if (token.size() == 4 && std::all_of(token.begin(), token.end(), isdigit))


### PR DESCRIPTION
This changelist improves the support for multi-UDIM materials in the MaterialX Viewer, allowing materials with explicit UDIM-associated names to be bound to implicit geometric UDIMs.

Although explicit UDIM-associated names are not a recommended convention for multi-UDIM materials, they are common enough in studio pipelines that it's valuable to support them as an alternative.