### PR TITLE
Fix Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/source/MaterialXGraphEditor/External/Glfw/src/context.c
+++ b/source/MaterialXGraphEditor/External/Glfw/src/context.c
@@ -404,10 +404,10 @@ GLFWbool _glfwRefreshContextAttribs(_GLFWwindow* window,
         }
     }
 
-    if (!sscanf(version, "%d.%d.%d",
-                &window->context.major,
-                &window->context.minor,
-                &window->context.revision))
+    if (sscanf(version, "%d.%d.%d",
+               &window->context.major,
+               &window->context.minor,
+               &window->context.revision) < 3)
     {
         if (window->context.client == GLFW_OPENGL_API)
         {


### PR DESCRIPTION
https://github.com/AcademySoftwareFoundation/MaterialX/blob/1c773699b9d165c1b0616bb15c829df7ea59d2f2/source/MaterialXGraphEditor/External/Glfw/src/context.c#L407-L410
fix the problem, the code should check that the return value of `sscanf` is equal to 3, which is the number of expected matches for the format string `"%d.%d.%d"`. If the return value is less than 3, it means that not all expected values were successfully parsed, and the error handling code should be executed. The change should be made in the region around line 407 in `source/MaterialXGraphEditor/External/Glfw/src/context.c`, replacing the current check with one that verifies the return value is less than 3.

#### References
[ERR62-CPP. Detect errors when converting a string to a number](https://wiki.sei.cmu.edu/confluence/display/cplusplus/ERR62-CPP.+Detect+errors+when+converting+a+string+to+a+number)
[ERR33-C. Detect and handle standard library errors](https://wiki.sei.cmu.edu/confluence/display/c/ERR33-C.+Detect+and+handle+standard+library+errors)
[scanf, fscanf, sscanf, scanf_s, fscanf_s, sscanf_s](https://en.cppreference.com/w/c/io/fscanf)
