### PR TITLE
Introduce NanoColor names to default color management

### DIFF
--- a/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
@@ -20,7 +20,21 @@ const StringMap COLOR_SPACE_REMAP =
     { "gamma18", "g18_rec709" },
     { "gamma22", "g22_rec709" },
     { "gamma24", "rec709_display" },
-    { "lin_ap1", "acescg" }
+    { "lin_ap1", "acescg" },
+
+    // In 1.39 we remap namespaces from ASWF recommended color interop spaces
+    //  See https://github.com/AcademySoftwareFoundation/ColorInterop
+    // This should improve interop with the nanocolor spaces found in USD.
+    {"lin_ap1_scene",       "acescg"},
+    {"lin_rec709_scene",    "lin_rec709"},
+    {"lin_p3d65_scene",     "lin_displayp3"},
+    {"lin_adobergb_scene",  "lin_adobergb"},
+    {"srgb_rec709_scene",   "srgb_texture"},
+    {"g22_rec709_scene",    "g22_rec709"},
+    {"g18_rec709_scene",    "g18_rec709"},
+    {"g22_ap1_scene",       "g22_ap1"},
+    {"srgb_p3d65_scene",    "srgb_displayp3"},
+    {"g22_adobergb_scene",  "adobergb"}
 };
 
 } // anonymous namespace


### PR DESCRIPTION
For 1.39 we only remap to existing color spaces.

Todo: For 1.40:
  - rename node defs/graphs to make nanocolor names the default
  - implement an upgrade path for legacy color spaces names
  - provide new nodegraphs for lin_ap0_scene, lin_rec2020_scene, and srgb_ap1_scene