### PR TITLE
Align MaterialX to Color Interop recommendations

### DIFF
--- a/libraries/cmlib/cmlib_defs.mtlx
+++ b/libraries/cmlib/cmlib_defs.mtlx
@@ -7,6 +7,18 @@
     Declarations of the default color transforms in MaterialX.
   -->
 
+  <!-- Functions that keep the same name in both 1.38 and color interop naming schemes -->
+
+  <nodedef name="ND_lin_adobergb_to_lin_rec709_color3" node="lin_adobergb_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_lin_adobergb_to_lin_rec709_color4" node="lin_adobergb_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
   <nodedef name="ND_g18_rec709_to_lin_rec709_color3" node="g18_rec709_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
@@ -27,26 +39,6 @@
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="ND_rec709_display_to_lin_rec709_color3" node="rec709_display_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" />
-  </nodedef>
-
-  <nodedef name="ND_rec709_display_to_lin_rec709_color4" node="rec709_display_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
-    <output name="out" type="color4" />
-  </nodedef>
-
-  <nodedef name="ND_acescg_to_lin_rec709_color3" node="acescg_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <output name="out" type="color3" />
-  </nodedef>
-
-  <nodedef name="ND_acescg_to_lin_rec709_color4" node="acescg_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
-    <output name="out" type="color4" />
-  </nodedef>
-
   <nodedef name="ND_g22_ap1_to_lin_rec709_color3" node="g22_ap1_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
@@ -57,36 +49,118 @@
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="ND_srgb_texture_to_lin_rec709_color3" node="srgb_texture_to_lin_rec709" nodegroup="colortransform">
+  <!-- Functions introduced with color interop naming scheme -->
+
+  <nodedef name="ND_lin_ap1_to_lin_rec709_color3" node="lin_ap1_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="ND_srgb_texture_to_lin_rec709_color4" node="srgb_texture_to_lin_rec709" nodegroup="colortransform">
+  <nodedef name="ND_lin_ap1_to_lin_rec709_color4" node="lin_ap1_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="ND_lin_adobergb_to_lin_rec709_color3" node="lin_adobergb_to_lin_rec709" nodegroup="colortransform">
+  <nodedef name="ND_srgb_ap1_to_lin_rec709_color3" node="srgb_ap1_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="ND_lin_adobergb_to_lin_rec709_color4" node="lin_adobergb_to_lin_rec709" nodegroup="colortransform">
+  <nodedef name="ND_srgb_ap1_to_lin_rec709_color4" node="srgb_ap1_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
     <output name="out" type="color4" />
   </nodedef>
 
-  <nodedef name="ND_adobergb_to_lin_rec709_color3" node="adobergb_to_lin_rec709" nodegroup="colortransform">
+  <nodedef name="ND_srgb_p3d65_to_lin_rec709_color3" node="srgb_p3d65_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
   </nodedef>
 
-  <nodedef name="ND_adobergb_to_lin_rec709_color4" node="adobergb_to_lin_rec709" nodegroup="colortransform">
+  <nodedef name="ND_srgb_p3d65_to_lin_rec709_color4" node="srgb_p3d65_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
     <output name="out" type="color4" />
   </nodedef>
 
+  <nodedef name="ND_lin_p3d65_to_lin_rec709_color3" node="lin_p3d65_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_lin_p3d65_to_lin_rec709_color4" node="lin_p3d65_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <nodedef name="ND_srgb_rec709_to_lin_rec709_color3" node="srgb_rec709_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_srgb_rec709_to_lin_rec709_color4" node="srgb_rec709_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <nodedef name="ND_g22_adobergb_to_lin_rec709_color3" node="g22_adobergb_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_g22_adobergb_to_lin_rec709_color4" node="g22_adobergb_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <nodedef name="ND_lin_ap0_to_lin_rec709_color3" node="lin_ap0_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_lin_ap0_to_lin_rec709_color4" node="lin_ap0_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <nodedef name="ND_lin_rec2020_to_lin_rec709_color3" node="lin_rec2020_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_lin_rec2020_to_lin_rec709_color4" node="lin_rec2020_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <!-- Note: not adding lin_ciexyzd65_scene -->
+
+  <!-- DEPRECATED?? This color space is not part of color interop -->
+
+  <nodedef name="ND_rec709_display_to_lin_rec709_color3" node="rec709_display_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_rec709_display_to_lin_rec709_color4" node="rec709_display_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <!-- DEPRECATED FUNCTIONS: To be removed in 1.40. Names are kept in case
+       they were explicitly used in saved MaterialX data. The 1.40 upgrade
+       path will remap these to their color interop equivalents. -->
+
+  <!-- acescg becomes lin_ap1 -->
+  <nodedef name="ND_acescg_to_lin_rec709_color3" node="acescg_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_acescg_to_lin_rec709_color4" node="acescg_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <!-- displayp3 becomes p3d65 -->
   <nodedef name="ND_srgb_displayp3_to_lin_rec709_color3" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color3" value="0.0, 0.0, 0.0" />
     <output name="out" type="color3" />
@@ -103,6 +177,28 @@
   </nodedef>
 
   <nodedef name="ND_lin_displayp3_to_lin_rec709_color4" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <!-- srgb_texture becomes srgb_rec709 -->
+  <nodedef name="ND_srgb_texture_to_lin_rec709_color3" node="srgb_texture_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_srgb_texture_to_lin_rec709_color4" node="srgb_texture_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <output name="out" type="color4" />
+  </nodedef>
+
+  <!-- adobergb becomes g22_adobergb -->
+  <nodedef name="ND_adobergb_to_lin_rec709_color3" node="adobergb_to_lin_rec709" nodegroup="colortransform">
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <output name="out" type="color3" />
+  </nodedef>
+
+  <nodedef name="ND_adobergb_to_lin_rec709_color4" node="adobergb_to_lin_rec709" nodegroup="colortransform">
     <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
     <output name="out" type="color4" />
   </nodedef>

--- a/libraries/cmlib/cmlib_ng.mtlx
+++ b/libraries/cmlib/cmlib_ng.mtlx
@@ -225,7 +225,7 @@
   <nodegraph name="NG_srgb_p3d65_to_lin_rec709_color3">
     <constant name="mat" type="matrix33">
       <input name="value" type="matrix33"
-             value="1.22493029, -0.04205868, -0.01964128, -0.22492968, 1.04205894, -0.07864794, 0.00000006,-0.00000001, 1.09828925"/>
+             value="1.224940176281, -0.042056954710, -0.019637554590, -0.224940176281, 1.042056954710, -0.078636045551, -0.000000000000,  0.000000000000, 1.09827360014" />
     </constant>
     <!--  Use srgb_rec709_to_lin_rec709 to convert from sRGB to Lin before passing to the mat conversion -->
     <srgb_rec709_to_lin_rec709 name="srgb_transform" type="color3">
@@ -271,7 +271,7 @@
   <nodegraph name="NG_lin_p3d65_to_lin_rec709_color3">
     <constant name="mat" type="matrix33">
       <input name="value" type="matrix33"
-             value="1.22493029, -0.04205868, -0.01964128, -0.22492968, 1.04205894, -0.07864794, 0.00000006,-0.00000001, 1.09828925"/>
+             value="1.224940176281, -0.042056954710, -0.019637554590, -0.224940176281, 1.042056954710, -0.078636045551, -0.000000000000,  0.000000000000, 1.09827360014" />
     </constant>
     <convert name="asVec" type="vector3">
       <input name="in" type="color3" interfacename="in" />

--- a/libraries/cmlib/cmlib_ng.mtlx
+++ b/libraries/cmlib/cmlib_ng.mtlx
@@ -7,6 +7,43 @@
     Nodegraph implementations for the default color transforms in MaterialX.
   -->
 
+  <!-- Functions that keep the same name in both 1.38 and color interop naming schemes -->
+
+  <nodegraph name="NG_lin_adobergb_to_lin_rec709_color3" nodedef="ND_lin_adobergb_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33" value="1.39835574e+00, -2.50233861e-16,  2.77555756e-17, -3.98355744e-01,  1.00000000e+00, -4.29289893e-02, 0.00000000e+00,  0.00000000e+00,  1.04292899e+00" />
+    </constant>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" interfacename="in" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <nodegraph name="NG_lin_adobergb_to_lin_rec709_color4" nodedef="ND_lin_adobergb_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <lin_adobergb_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </lin_adobergb_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
   <nodegraph name="NG_g18_rec709_to_lin_rec709_color3" nodedef="ND_g18_rec709_to_lin_rec709_color3">
     <max name="max" type="color3">
       <input name="in1" type="color3" interfacename="in" />
@@ -67,71 +104,6 @@
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
-  <nodegraph name="NG_rec709_display_to_lin_rec709_color3" nodedef="ND_rec709_display_to_lin_rec709_color3">
-    <max name="max" type="color3">
-      <input name="in1" type="color3" interfacename="in" />
-      <input name="in2" type="float" value="0" />
-    </max>
-    <power name="gamma" type="color3">
-      <input name="in1" type="color3" nodename="max" />
-      <input name="in2" type="float" value="2.4" />
-    </power>
-    <output name="out" type="color3" nodename="gamma" />
-  </nodegraph>
-
-  <nodegraph name="NG_rec709_display_to_lin_rec709_color4" nodedef="ND_rec709_display_to_lin_rec709_color4">
-    <convert name="asColor3" type="color3">
-      <input name="in" type="color4" interfacename="in" />
-    </convert>
-    <rec709_display_to_lin_rec709 name="transform" type="color3">
-      <input name="in" type="color3" nodename="asColor3" />
-    </rec709_display_to_lin_rec709>
-    <extract name="alpha" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="index" type="integer" value="3" />
-    </extract>
-    <combine2 name="asColor4" type="color4">
-      <input name="in1" type="color3" nodename="transform" />
-      <input name="in2" type="float" nodename="alpha" />
-    </combine2>
-    <output name="out" type="color4" nodename="asColor4" />
-  </nodegraph>
-
-  <nodegraph name="NG_acescg_to_lin_rec709_color3" nodedef="ND_acescg_to_lin_rec709_color3">
-    <constant name="mat" type="matrix33">
-      <input name="value" type="matrix33" value="1.705050992658, -0.130256417507, -0.024003356805, -0.621792120657,  1.140804736575, -0.128968976065, -0.083258872001, -0.010548319068, 1.15297233287" />
-    </constant>
-    <convert name="asVec" type="vector3">
-      <input name="in" type="color3" interfacename="in" />
-    </convert>
-    <transformmatrix name="transform" type="vector3">
-      <input name="in" type="vector3" nodename="asVec" />
-      <input name="mat" type="matrix33" nodename="mat" />
-    </transformmatrix>
-    <convert name="asColor" type="color3">
-      <input name="in" type="vector3" nodename="transform" />
-    </convert>
-    <output name="out" type="color3" nodename="asColor" />
-  </nodegraph>
-
-  <nodegraph name="NG_acescg_to_lin_rec709_color4" nodedef="ND_acescg_to_lin_rec709_color4">
-    <convert name="asColor3" type="color3">
-      <input name="in" type="color4" interfacename="in" />
-    </convert>
-    <acescg_to_lin_rec709 name="transform" type="color3">
-      <input name="in" type="color3" nodename="asColor3" />
-    </acescg_to_lin_rec709>
-    <extract name="alpha" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="index" type="integer" value="3" />
-    </extract>
-    <combine2 name="asColor4" type="color4">
-      <input name="in1" type="color3" nodename="transform" />
-      <input name="in2" type="float" nodename="alpha" />
-    </combine2>
-    <output name="out" type="color4" nodename="asColor4" />
-  </nodegraph>
-
   <nodegraph name="NG_g22_ap1_to_lin_rec709_color3" nodedef="ND_g22_ap1_to_lin_rec709_color3">
     <max name="max" type="color3">
       <input name="in1" type="color3" interfacename="in" />
@@ -141,9 +113,9 @@
       <input name="in1" type="color3" nodename="max" />
       <input name="in2" type="float" value="2.2" />
     </power>
-    <acescg_to_lin_rec709 name="rec709" type="color3">
+    <lin_ap1_to_lin_rec709 name="rec709" type="color3">
       <input name="in" type="color3" nodename="gamma" />
-    </acescg_to_lin_rec709>
+    </lin_ap1_to_lin_rec709>
     <output name="out" type="color3" nodename="rec709" />
   </nodegraph>
 
@@ -165,7 +137,180 @@
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
-  <nodegraph name="NG_srgb_texture_to_lin_rec709_color3" nodedef="ND_srgb_texture_to_lin_rec709_color3">
+  <!-- Functions introduced with color interop naming scheme -->
+
+  <implementation name="IMPL_lin_ap1_to_lin_rec709_color3" nodedef="ND_lin_ap1_to_lin_rec709_color3" nodegraph="NG_lin_ap1_to_lin_rec709_color3" />
+  <implementation name="IMPL_acescg_to_lin_rec709_color3" nodedef="ND_acescg_to_lin_rec709_color3" nodegraph="NG_lin_ap1_to_lin_rec709_color3" />
+
+  <nodegraph name="NG_lin_ap1_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33" value="1.705050992658, -0.130256417507, -0.024003356805, -0.621792120657,  1.140804736575, -0.128968976065, -0.083258872001, -0.010548319068, 1.15297233287" />
+    </constant>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" interfacename="in" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <implementation name="IMPL_lin_ap1_to_lin_rec709_color4" nodedef="ND_lin_ap1_to_lin_rec709_color4" nodegraph="NG_lin_ap1_to_lin_rec709_color4" />
+  <implementation name="IMPL_acescg_to_lin_rec709_color4" nodedef="ND_acescg_to_lin_rec709_color4" nodegraph="NG_lin_ap1_to_lin_rec709_color4" />
+
+  <nodegraph name="NG_lin_ap1_to_lin_rec709_color4" nodedef="ND_lin_ap1_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <lin_ap1_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </lin_ap1_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <nodegraph name="NG_srgb_ap1_to_lin_rec709_color3" nodedef="ND_srgb_ap1_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33" value="1.705050992658, -0.130256417507, -0.024003356805, -0.621792120657,  1.140804736575, -0.128968976065, -0.083258872001, -0.010548319068, 1.15297233287" />
+    </constant>
+    <!--  Use srgb_rec709_to_lin_rec709 to convert from sRGB to Lin before passing to the mat conversion -->
+    <srgb_rec709_to_lin_rec709 name="srgb_transform" type="color3">
+      <input name="in" type="color3" interfacename="in" />
+    </srgb_rec709_to_lin_rec709>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" nodename="srgb_transform" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <nodegraph name="NG_srgb_ap1_to_lin_rec709_color4" nodedef="ND_srgb_ap1_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <srgb_ap1_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </srgb_ap1_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <implementation name="IMPL_srgb_p3d65_to_lin_rec709_color3" nodedef="ND_srgb_p3d65_to_lin_rec709_color3" nodegraph="NG_srgb_p3d65_to_lin_rec709_color3" />
+  <implementation name="IMPL_srgb_displayp3_to_lin_rec709_color3" nodedef="ND_srgb_displayp3_to_lin_rec709_color3" nodegraph="NG_srgb_p3d65_to_lin_rec709_color3" />
+
+  <nodegraph name="NG_srgb_p3d65_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33"
+             value="1.22493029, -0.04205868, -0.01964128, -0.22492968, 1.04205894, -0.07864794, 0.00000006,-0.00000001, 1.09828925"/>
+    </constant>
+    <!--  Use srgb_rec709_to_lin_rec709 to convert from sRGB to Lin before passing to the mat conversion -->
+    <srgb_rec709_to_lin_rec709 name="srgb_transform" type="color3">
+      <input name="in" type="color3" interfacename="in" />
+    </srgb_rec709_to_lin_rec709>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" nodename="srgb_transform" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <implementation name="IMPL_srgb_p3d65_to_lin_rec709_color4" nodedef="ND_srgb_p3d65_to_lin_rec709_color4" nodegraph="NG_srgb_p3d65_to_lin_rec709_color4" />
+  <implementation name="IMPL_srgb_displayp3_to_lin_rec709_color4" nodedef="ND_srgb_displayp3_to_lin_rec709_color4" nodegraph="NG_srgb_p3d65_to_lin_rec709_color4" />
+
+  <nodegraph name="NG_srgb_p3d65_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <srgb_p3d65_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </srgb_p3d65_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <implementation name="IMPL_lin_p3d65_to_lin_rec709_color3" nodedef="ND_lin_p3d65_to_lin_rec709_color3" nodegraph="NG_lin_p3d65_to_lin_rec709_color3" />
+  <implementation name="IMPL_lin_displayp3_to_lin_rec709_color3" nodedef="ND_lin_displayp3_to_lin_rec709_color3" nodegraph="NG_lin_p3d65_to_lin_rec709_color3" />
+
+  <nodegraph name="NG_lin_p3d65_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33"
+             value="1.22493029, -0.04205868, -0.01964128, -0.22492968, 1.04205894, -0.07864794, 0.00000006,-0.00000001, 1.09828925"/>
+    </constant>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" interfacename="in" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <implementation name="IMPL_lin_p3d65_to_lin_rec709_color4" nodedef="ND_lin_p3d65_to_lin_rec709_color4" nodegraph="NG_lin_p3d65_to_lin_rec709_color4" />
+  <implementation name="IMPL_lin_displayp3_to_lin_rec709_color4" nodedef="ND_lin_displayp3_to_lin_rec709_color4" nodegraph="NG_lin_p3d65_to_lin_rec709_color4" />
+
+  <nodegraph name="NG_lin_p3d65_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <lin_p3d65_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </lin_p3d65_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <implementation name="IMPL_srgb_rec709_to_lin_rec709_color3" nodedef="ND_srgb_rec709_to_lin_rec709_color3" nodegraph="NG_srgb_rec709_to_lin_rec709_color3" />
+  <implementation name="IMPL_srgb_texture_to_lin_rec709_color3" nodedef="ND_srgb_texture_to_lin_rec709_color3" nodegraph="NG_srgb_rec709_to_lin_rec709_color3" />
+
+  <nodegraph name="NG_srgb_rec709_to_lin_rec709_color3" nodedef="ND_srgb_rec709_to_lin_rec709_color3">
     <constant name="threshold" type="float">
       <input name="value" type="float" value="0.04045" />
     </constant>
@@ -223,13 +368,16 @@
     <output name="out" type="color3" nodename="mix" />
   </nodegraph>
 
-  <nodegraph name="NG_srgb_texture_to_lin_rec709_color4" nodedef="ND_srgb_texture_to_lin_rec709_color4">
+  <implementation name="IMPL_srgb_rec709_to_lin_rec709_color4" nodedef="ND_srgb_rec709_to_lin_rec709_color4" nodegraph="NG_srgb_rec709_to_lin_rec709_color4" />
+  <implementation name="IMPL_srgb_texture_to_lin_rec709_color4" nodedef="ND_srgb_texture_to_lin_rec709_color4" nodegraph="NG_srgb_rec709_to_lin_rec709_color4" />
+
+  <nodegraph name="NG_srgb_rec709_to_lin_rec709_color4" nodedef="ND_srgb_rec709_to_lin_rec709_color4">
     <convert name="asColor3" type="color3">
       <input name="in" type="color4" interfacename="in" />
     </convert>
-    <srgb_texture_to_lin_rec709 name="transform" type="color3">
+    <srgb_rec709_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
-    </srgb_texture_to_lin_rec709>
+    </srgb_rec709_to_lin_rec709>
     <extract name="alpha" type="float">
       <input name="in" type="color4" interfacename="in" />
       <input name="index" type="integer" value="3" />
@@ -241,42 +389,10 @@
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
-  <nodegraph name="NG_lin_adobergb_to_lin_rec709_color3" nodedef="ND_lin_adobergb_to_lin_rec709_color3">
-    <constant name="mat" type="matrix33">
-      <input name="value" type="matrix33" value="1.39835574e+00, -2.50233861e-16,  2.77555756e-17, -3.98355744e-01,  1.00000000e+00, -4.29289893e-02, 0.00000000e+00,  0.00000000e+00,  1.04292899e+00" />
-    </constant>
-    <convert name="asVec" type="vector3">
-      <input name="in" type="color3" interfacename="in" />
-    </convert>
-    <transformmatrix name="transform" type="vector3">
-      <input name="in" type="vector3" nodename="asVec" />
-      <input name="mat" type="matrix33" nodename="mat" />
-    </transformmatrix>
-    <convert name="asColor" type="color3">
-      <input name="in" type="vector3" nodename="transform" />
-    </convert>
-    <output name="out" type="color3" nodename="asColor" />
-  </nodegraph>
+  <implementation name="IMPL_g22_adobergb_to_lin_rec709_color3" nodedef="ND_g22_adobergb_to_lin_rec709_color3" nodegraph="NG_g22_adobergb_to_lin_rec709_color3" />
+  <implementation name="IMPL_adobergb_to_lin_rec709_color3" nodedef="ND_adobergb_to_lin_rec709_color3" nodegraph="NG_g22_adobergb_to_lin_rec709_color3" />
 
-  <nodegraph name="NG_lin_adobergb_to_lin_rec709_color4" nodedef="ND_lin_adobergb_to_lin_rec709_color4">
-    <convert name="asColor3" type="color3">
-      <input name="in" type="color4" interfacename="in" />
-    </convert>
-    <lin_adobergb_to_lin_rec709 name="transform" type="color3">
-      <input name="in" type="color3" nodename="asColor3" />
-    </lin_adobergb_to_lin_rec709>
-    <extract name="alpha" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="index" type="integer" value="3" />
-    </extract>
-    <combine2 name="asColor4" type="color4">
-      <input name="in1" type="color3" nodename="transform" />
-      <input name="in2" type="float" nodename="alpha" />
-    </combine2>
-    <output name="out" type="color4" nodename="asColor4" />
-  </nodegraph>
-
-  <nodegraph name="NG_adobergb_to_lin_rec709_color3" nodedef="ND_adobergb_to_lin_rec709_color3">
+  <nodegraph name="NG_g22_adobergb_to_lin_rec709_color3" nodedef="ND_g22_adobergb_to_lin_rec709_color3">
     <divide name="constant" type="float">
       <input name="in1" type="float" value="563.0" />
       <input name="in2" type="float" value="256.0" />
@@ -295,13 +411,16 @@
     <output name="out" type="color3" nodename="rec709" />
   </nodegraph>
 
-  <nodegraph name="NG_adobergb_to_lin_rec709_color4" nodedef="ND_adobergb_to_lin_rec709_color4">
+  <implementation name="IMPL_g22_adobergb_to_lin_rec709_color4" nodedef="ND_g22_adobergb_to_lin_rec709_color4" nodegraph="NG_g22_adobergb_to_lin_rec709_color4" />
+  <implementation name="IMPL_adobergb_to_lin_rec709_color4" nodedef="ND_adobergb_to_lin_rec709_color4" nodegraph="NG_g22_adobergb_to_lin_rec709_color4" />
+
+  <nodegraph name="NG_g22_adobergb_to_lin_rec709_color4" nodedef="ND_g22_adobergb_to_lin_rec709_color4">
     <convert name="asColor3" type="color3">
       <input name="in" type="color4" interfacename="in" />
     </convert>
-    <adobergb_to_lin_rec709 name="transform" type="color3">
+    <g22_adobergb_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
-    </adobergb_to_lin_rec709>
+    </g22_adobergb_to_lin_rec709>
     <extract name="alpha" type="float">
       <input name="in" type="color4" interfacename="in" />
       <input name="index" type="integer" value="3" />
@@ -313,50 +432,9 @@
     <output name="out" type="color4" nodename="asColor4" />
   </nodegraph>
 
-  <nodegraph name="NG_srgb_displayp3_to_lin_rec709_color3" nodedef="ND_srgb_displayp3_to_lin_rec709_color3">
+  <nodegraph name="NG_lin_ap0_to_lin_rec709_color3" nodedef="ND_lin_ap0_to_lin_rec709_color3">
     <constant name="mat" type="matrix33">
-      <input name="value" type="matrix33"
-             value="1.22493029, -0.04205868, -0.01964128, -0.22492968, 1.04205894, -0.07864794, 0.00000006,-0.00000001, 1.09828925"/>
-    </constant>
-    <!--  Use srgb_texture_to_lin_rec709 to convert from sRGB to Lin before passing to the mat conversion -->
-    <srgb_texture_to_lin_rec709 name="srgb_transform" type="color3">
-      <input name="in" type="color3" interfacename="in" />
-    </srgb_texture_to_lin_rec709>
-    <convert name="asVec" type="vector3">
-      <input name="in" type="color3" nodename="srgb_transform" />
-    </convert>
-    <transformmatrix name="transform" type="vector3">
-      <input name="in" type="vector3" nodename="asVec" />
-      <input name="mat" type="matrix33" nodename="mat" />
-    </transformmatrix>
-    <convert name="asColor" type="color3">
-      <input name="in" type="vector3" nodename="transform" />
-    </convert>
-    <output name="out" type="color3" nodename="asColor" />
-  </nodegraph>
-
-  <nodegraph name="NG_srgb_displayp3_to_lin_rec709_color4" nodedef="ND_srgb_displayp3_to_lin_rec709_color4">
-    <convert name="asColor3" type="color3">
-      <input name="in" type="color4" interfacename="in" />
-    </convert>
-    <srgb_displayp3_to_lin_rec709 name="transform" type="color3">
-      <input name="in" type="color3" nodename="asColor3" />
-    </srgb_displayp3_to_lin_rec709>
-    <extract name="alpha" type="float">
-      <input name="in" type="color4" interfacename="in" />
-      <input name="index" type="integer" value="3" />
-    </extract>
-    <combine2 name="asColor4" type="color4">
-      <input name="in1" type="color3" nodename="transform" />
-      <input name="in2" type="float" nodename="alpha" />
-    </combine2>
-    <output name="out" type="color4" nodename="asColor4" />
-  </nodegraph>
-
-  <nodegraph name="NG_lin_displayp3_to_lin_rec709_color3" nodedef="ND_lin_displayp3_to_lin_rec709_color3">
-    <constant name="mat" type="matrix33">
-      <input name="value" type="matrix33"
-             value="1.22493029, -0.04205868, -0.01964128, -0.22492968, 1.04205894, -0.07864794, 0.00000006,-0.00000001, 1.09828925"/>
+      <input name="value" type="matrix33" value="2.521686186744, -0.276479914230, -0.015378064966, -1.134130988240,  1.372719087668, -0.152975335867, -0.387555198504, -0.096239173438, 1.16835340083" />
     </constant>
     <convert name="asVec" type="vector3">
       <input name="in" type="color3" interfacename="in" />
@@ -371,13 +449,80 @@
     <output name="out" type="color3" nodename="asColor" />
   </nodegraph>
 
-  <nodegraph name="NG_lin_displayp3_to_lin_rec709_color4" nodedef="ND_lin_displayp3_to_lin_rec709_color4">
+  <nodegraph name="NG_lin_ap0_to_lin_rec709_color4" nodedef="ND_lin_ap0_to_lin_rec709_color4">
     <convert name="asColor3" type="color3">
       <input name="in" type="color4" interfacename="in" />
     </convert>
-    <lin_displayp3_to_lin_rec709 name="transform" type="color3">
+    <lin_ap0_to_lin_rec709 name="transform" type="color3">
       <input name="in" type="color3" nodename="asColor3" />
-    </lin_displayp3_to_lin_rec709>
+    </lin_ap0_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <nodegraph name="NG_lin_rec2020_to_lin_rec709_color3" nodedef="ND_lin_rec2020_to_lin_rec709_color3">
+    <constant name="mat" type="matrix33">
+      <input name="value" type="matrix33" value="1.660491002108, -0.124550474522, -0.018150763355, -0.587641138788,  1.132899897126, -0.100578898008, -0.072849863320, -0.008349422604, 1.11872966136" />
+    </constant>
+    <convert name="asVec" type="vector3">
+      <input name="in" type="color3" interfacename="in" />
+    </convert>
+    <transformmatrix name="transform" type="vector3">
+      <input name="in" type="vector3" nodename="asVec" />
+      <input name="mat" type="matrix33" nodename="mat" />
+    </transformmatrix>
+    <convert name="asColor" type="color3">
+      <input name="in" type="vector3" nodename="transform" />
+    </convert>
+    <output name="out" type="color3" nodename="asColor" />
+  </nodegraph>
+
+  <nodegraph name="NG_lin_rec2020_to_lin_rec709_color4" nodedef="ND_lin_rec2020_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <lin_rec2020_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </lin_rec2020_to_lin_rec709>
+    <extract name="alpha" type="float">
+      <input name="in" type="color4" interfacename="in" />
+      <input name="index" type="integer" value="3" />
+    </extract>
+    <combine2 name="asColor4" type="color4">
+      <input name="in1" type="color3" nodename="transform" />
+      <input name="in2" type="float" nodename="alpha" />
+    </combine2>
+    <output name="out" type="color4" nodename="asColor4" />
+  </nodegraph>
+
+  <!-- DEPRECATED?? This color space is not part of color interop -->
+
+  <nodegraph name="NG_rec709_display_to_lin_rec709_color3" nodedef="ND_rec709_display_to_lin_rec709_color3">
+    <max name="max" type="color3">
+      <input name="in1" type="color3" interfacename="in" />
+      <input name="in2" type="float" value="0" />
+    </max>
+    <power name="gamma" type="color3">
+      <input name="in1" type="color3" nodename="max" />
+      <input name="in2" type="float" value="2.4" />
+    </power>
+    <output name="out" type="color3" nodename="gamma" />
+  </nodegraph>
+
+  <nodegraph name="NG_rec709_display_to_lin_rec709_color4" nodedef="ND_rec709_display_to_lin_rec709_color4">
+    <convert name="asColor3" type="color3">
+      <input name="in" type="color4" interfacename="in" />
+    </convert>
+    <rec709_display_to_lin_rec709 name="transform" type="color3">
+      <input name="in" type="color3" nodename="asColor3" />
+    </rec709_display_to_lin_rec709>
     <extract name="alpha" type="float">
       <input name="in" type="color4" interfacename="in" />
       <input name="index" type="integer" value="3" />

--- a/resources/Materials/TestSuite/stdlib/color_management/deprecated_color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/deprecated_color_management.mtlx
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <!-- Common texcoord -->
+  <texcoord name="texcoord1" type="vector2" nodedef="ND_texcoord_vector2" />
+  <separate2 name="separate1" type="multioutput" nodedef="ND_separate2_vector2">
+    <input name="in" type="vector2" nodename="texcoord1" />
+  </separate2>
+  <multiply name="multiply1" type="float" nodedef="ND_multiply_float">
+    <input name="in2" type="float" value="8" />
+    <input name="in1" type="float" nodename="separate1" output="outy" />
+  </multiply>
+
+  <standard_surface name="standard_surface1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="switch1" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface1" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface1" />
+  </surfacematerial>
+  <!-- acescg becomes lin_ap1 -->
+  <acescg_to_lin_rec709 name="deprecated13" type="color3">
+    <input name="in" type="color3" value="0.3989, 0.1578, 0.0536" />
+  </acescg_to_lin_rec709>
+  <!-- displayp3 becomes p3d65 -->
+  <srgb_displayp3_to_lin_rec709 name="deprecated23" type="color3">
+    <input name="in" type="color3" value="0.7338, 0.4133, 0.2430" />
+  </srgb_displayp3_to_lin_rec709>
+  <lin_displayp3_to_lin_rec709 name="deprecated33" type="color3">
+    <input name="in" type="color3" value="0.4977, 0.1424, 0.0481" />
+  </lin_displayp3_to_lin_rec709>
+  <!-- srgb_texture becomes srgb_rec709 -->
+  <srgb_texture_to_lin_rec709 name="deprecated43" type="color3">
+    <input name="in" type="color3" value="0.7843, 0.3922, 0.1961" />
+  </srgb_texture_to_lin_rec709>
+  <!-- adobergb becomes g22_adobergb -->
+  <adobergb_to_lin_rec709 name="deprecated53" type="color3">
+    <input name="in" type="color3" value="0.6951, 0.3919, 0.2201" />
+  </adobergb_to_lin_rec709>
+  <switch name="switch1" type="color3">
+    <input name="in1" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in2" type="color3" nodename="deprecated13" />
+    <input name="in3" type="color3" nodename="deprecated23" />
+    <input name="in4" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in5" type="color3" nodename="deprecated33" />
+    <input name="in6" type="color3" nodename="deprecated43" />
+    <input name="in7" type="color3" nodename="deprecated53" />
+    <input name="in8" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface2" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="convert2" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface2" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface2" />
+  </surfacematerial>
+  <convert name="convert2" type="color3">
+    <input name="in" type="color4" nodename="switch2" />
+  </convert>
+  <!-- acescg becomes lin_ap1 -->
+  <acescg_to_lin_rec709 name="deprecated14" type="color4">
+    <input name="in" type="color4" value="0.3989, 0.1578, 0.0536, 1" />
+  </acescg_to_lin_rec709>
+  <!-- displayp3 becomes p3d65 -->
+  <srgb_displayp3_to_lin_rec709 name="deprecated24" type="color4">
+    <input name="in" type="color4" value="0.7338, 0.4133, 0.2430, 1" />
+  </srgb_displayp3_to_lin_rec709>
+  <lin_displayp3_to_lin_rec709 name="deprecated34" type="color4">
+    <input name="in" type="color4" value="0.4977, 0.1424, 0.0481, 1" />
+  </lin_displayp3_to_lin_rec709>
+  <!-- srgb_texture becomes srgb_rec709 -->
+  <srgb_texture_to_lin_rec709 name="deprecated44" type="color4">
+    <input name="in" type="color4" value="0.7843, 0.3922, 0.1961, 1" />
+  </srgb_texture_to_lin_rec709>
+  <!-- adobergb becomes g22_adobergb -->
+  <adobergb_to_lin_rec709 name="deprecated54" type="color4">
+    <input name="in" type="color4" value="0.6951, 0.3919, 0.2201, 1" />
+  </adobergb_to_lin_rec709>
+  <switch name="switch2" type="color4">
+    <input name="in1" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in2" type="color4" nodename="deprecated14" />
+    <input name="in3" type="color4" nodename="deprecated24" />
+    <input name="in4" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in5" type="color4" nodename="deprecated34" />
+    <input name="in6" type="color4" nodename="deprecated44" />
+    <input name="in7" type="color4" nodename="deprecated54" />
+    <input name="in8" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+
+</materialx>

--- a/resources/Materials/TestSuite/stdlib/color_management/interop_color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/interop_color_management.mtlx
@@ -1,0 +1,229 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709_scene">
+  <!-- Common texcoord -->
+  <texcoord name="texcoord1" type="vector2" nodedef="ND_texcoord_vector2" />
+  <separate2 name="separate1" type="multioutput" nodedef="ND_separate2_vector2">
+    <input name="in" type="vector2" nodename="texcoord1" />
+  </separate2>
+  <multiply name="multiply1" type="float" nodedef="ND_multiply_float">
+    <input name="in2" type="float" value="10" />
+    <input name="in1" type="float" nodename="separate1" output="outy" />
+  </multiply>
+
+  <standard_surface name="standard_surface1" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="convert1" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface1" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface1" />
+  </surfacematerial>
+  <convert name="convert1" type="color3">
+    <input name="in" type="color4" nodename="switch1" />
+  </convert>
+  <switch name="switch1" type="color4">
+    <input name="in1" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in2" type="color4" value="0.5776, 0.1274, 0.0319, 1" colorspace="lin_rec709" />
+    <input name="in3" type="color4" value="0.7792, 0.3920, 0.2089, 1" colorspace="g22_rec709" />
+    <input name="in4" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in5" type="color4" value="0.7372, 0.3184, 0.1475, 1" colorspace="g18_rec709" />
+    <input name="in6" type="color4" value="0.7956, 0.4238, 0.2380, 1" colorspace="rec709_display" />
+    <input name="in7" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in8" type="color4" value="0.3989, 0.1578, 0.0536, 1" colorspace="acescg" />
+    <input name="in9" type="color4" value="0.6585, 0.4320, 0.2645, 1" colorspace="g22_ap1" />
+    <input name="in10" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface2" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="convert2" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface2" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface2" />
+  </surfacematerial>
+  <convert name="convert2" type="color3">
+    <input name="in" type="color4" nodename="switch2" />
+  </convert>
+  <switch name="switch2" type="color4">
+    <input name="in1" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in2" type="color4" value="0.7843, 0.3922, 0.1961, 1" colorspace="srgb_texture" />
+    <input name="in3" type="color4" value="0.4493, 0.1274, 0.0358, 1" colorspace="lin_adobergb" />
+    <input name="in4" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in5" type="color4" value="0.6951, 0.3919, 0.2201, 1" colorspace="adobergb" />
+    <input name="in6" type="color4" value="0.7338, 0.4133, 0.2430, 1" colorspace="srgb_displayp3" />
+    <input name="in7" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in8" type="color4" value="0.4977, 0.1424, 0.0481, 1" colorspace="lin_displayp3" />
+    <input name="in9" type="color4" value="0.7372, 0.3184, 0.1475, 1" colorspace="gamma18" />
+    <input name="in10" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface3" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="convert3" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface3" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface3" />
+  </surfacematerial>
+  <convert name="convert3" type="color3">
+    <input name="in" type="color4" nodename="switch3" />
+  </convert>
+  <switch name="switch3" type="color4">
+    <input name="in1" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in2" type="color4" value="0.7792, 0.3920, 0.2089, 1" colorspace="gamma22" />
+    <input name="in3" type="color4" value="0.7956, 0.4238, 0.2380, 1" colorspace="gamma24" />
+    <input name="in4" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in5" type="color4" value="0.3989, 0.1578, 0.0536, 1" colorspace="lin_ap1" />
+    <input name="in6" type="color4" value="0.3989, 0.1578, 0.0536, 1" colorspace="lin_ap1_scene" />
+    <input name="in7" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in8" type="color4" value="0.3084, 0.1586, 0.0521, 1" colorspace="lin_ap0_scene" />
+    <input name="in9" type="color4" value="0.5776, 0.1274, 0.0319, 1" colorspace="lin_rec709_scene" />
+    <input name="in10" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface4" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="convert4" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface4" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface4" />
+  </surfacematerial>
+  <convert name="convert4" type="color3">
+    <input name="in" type="color4" nodename="switch4" />
+  </convert>
+  <switch name="switch4" type="color4">
+    <input name="in1" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in2" type="color4" value="0.4977, 0.1424, 0.0481, 1" colorspace="lin_p3d65_scene" />
+    <input name="in3" type="color4" value="0.4057, 0.1575, 0.0492, 1" colorspace="lin_rec2020_scene" />
+    <input name="in4" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in5" type="color4" value="0.4493, 0.1274, 0.0358, 1" colorspace="lin_adobergb_scene" />
+    <input name="in6" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in7" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in8" type="color4" value="0.7843, 0.3922, 0.1961, 1" colorspace="srgb_rec709_scene" />
+    <input name="in9" type="color4" value="0.7792, 0.3920, 0.2089, 1" colorspace="g22_rec709_scene" />
+    <input name="in10" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface5" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="convert5" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface5" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface5" />
+  </surfacematerial>
+  <convert name="convert5" type="color3">
+    <input name="in" type="color4" nodename="switch5" />
+  </convert>
+  <switch name="switch5" type="color4">
+    <input name="in1" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in2" type="color4" value="0.7372, 0.3184, 0.1475, 1" colorspace="g18_rec709_scene" />
+    <input name="in3" type="color4" value="0.6644, 0.4337, 0.2567, 1" colorspace="srgb_ap1_scene" />
+    <input name="in4" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in5" type="color4" value="0.6585, 0.4320, 0.2645, 1" colorspace="g22_ap1_scene" />
+    <input name="in6" type="color4" value="0.7338, 0.4133, 0.2430, 1" colorspace="srgb_p3d65_scene" />
+    <input name="in7" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="in8" type="color4" value="0.6951, 0.3919, 0.2201, 1" colorspace="g22_adobergb_scene" />
+    <input name="in9" type="color4" value="0.6951, 0.3919, 0.2201, 1" colorspace="g22_adobergb_scene" />
+    <input name="in10" type="color4" value="0.5776, 0.1274, 0.0319, 1" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface6" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="switch6" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface6" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface6" />
+  </surfacematerial>
+  <switch name="switch6" type="color3">
+     <input name="in1" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in2" type="color3" value="0.5776, 0.1274, 0.0319" colorspace="lin_rec709" />
+    <input name="in3" type="color3" value="0.7792, 0.3920, 0.2089" colorspace="g22_rec709" />
+    <input name="in4" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in5" type="color3" value="0.7372, 0.3184, 0.1475" colorspace="g18_rec709" />
+    <input name="in6" type="color3" value="0.7956, 0.4238, 0.2380" colorspace="rec709_display" />
+    <input name="in7" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in8" type="color3" value="0.3989, 0.1578, 0.0536" colorspace="acescg" />
+    <input name="in9" type="color3" value="0.6585, 0.4320, 0.2645" colorspace="g22_ap1" />
+    <input name="in10" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface7" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="switch7" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface7" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface7" />
+  </surfacematerial>
+  <switch name="switch7" type="color3">
+     <input name="in1" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in2" type="color3" value="0.7843, 0.3922, 0.1961" colorspace="srgb_texture" />
+    <input name="in3" type="color3" value="0.4493, 0.1274, 0.0358" colorspace="lin_adobergb" />
+    <input name="in4" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in5" type="color3" value="0.6951, 0.3919, 0.2201" colorspace="adobergb" />
+    <input name="in6" type="color3" value="0.7338, 0.4133, 0.2430" colorspace="srgb_displayp3" />
+    <input name="in7" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in8" type="color3" value="0.4977, 0.1424, 0.0481" colorspace="lin_displayp3" />
+    <input name="in9" type="color3" value="0.7372, 0.3184, 0.1475" colorspace="gamma18" />
+    <input name="in10" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface8" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="switch8" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface8" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface8" />
+  </surfacematerial>
+  <switch name="switch8" type="color3">
+    <input name="in1" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in2" type="color3" value="0.7792, 0.3920, 0.2089" colorspace="gamma22" />
+    <input name="in3" type="color3" value="0.7956, 0.4238, 0.2380" colorspace="gamma24" />
+    <input name="in4" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in5" type="color3" value="0.3989, 0.1578, 0.0536" colorspace="lin_ap1" />
+    <input name="in6" type="color3" value="0.3989, 0.1578, 0.0536" colorspace="lin_ap1_scene" />
+    <input name="in7" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in8" type="color3" value="0.3084, 0.1586, 0.0521" colorspace="lin_ap0_scene" />
+    <input name="in9" type="color3" value="0.5776, 0.1274, 0.0319" colorspace="lin_rec709_scene" />
+    <input name="in10" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface9" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="switch9" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface9" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface9" />
+  </surfacematerial>
+  <switch name="switch9" type="color3">
+    <input name="in1" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in2" type="color3" value="0.4977, 0.1424, 0.0481" colorspace="lin_p3d65_scene" />
+    <input name="in3" type="color3" value="0.4057, 0.1575, 0.0492" colorspace="lin_rec2020_scene" />
+    <input name="in4" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in5" type="color3" value="0.4493, 0.1274, 0.0358" colorspace="lin_adobergb_scene" />
+    <input name="in6" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in7" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in8" type="color3" value="0.7843, 0.3922, 0.1961" colorspace="srgb_rec709_scene" />
+    <input name="in9" type="color3" value="0.7792, 0.3920, 0.2089" colorspace="g22_rec709_scene" />
+    <input name="in10" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+  <standard_surface name="standard_surface10" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
+    <input name="base_color" type="color3" nodename="switch10" />
+  </standard_surface>
+  <surfacematerial name="Standard_Surface10" type="material" nodedef="ND_surfacematerial">
+    <input name="surfaceshader" type="surfaceshader" nodename="standard_surface10" />
+  </surfacematerial>
+  <switch name="switch10" type="color3">
+    <input name="in1" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in2" type="color3" value="0.7372, 0.3184, 0.1475" colorspace="g18_rec709_scene" />
+    <input name="in3" type="color3" value="0.6644, 0.4337, 0.2567" colorspace="srgb_ap1_scene" />
+    <input name="in4" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in5" type="color3" value="0.6585, 0.4320, 0.2645" colorspace="g22_ap1_scene" />
+    <input name="in6" type="color3" value="0.7338, 0.4133, 0.2430" colorspace="srgb_p3d65_scene" />
+    <input name="in7" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="in8" type="color3" value="0.6951, 0.3919, 0.2201" colorspace="g22_adobergb_scene" />
+    <input name="in9" type="color3" value="0.6951, 0.3919, 0.2201" colorspace="g22_adobergb_scene" />
+    <input name="in10" type="color3" value="0.5776, 0.1274, 0.0319" />
+    <input name="which" type="float" nodename="multiply1" />
+  </switch>
+
+
+</materialx>

--- a/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
@@ -13,6 +13,7 @@ namespace
 {
 
 const string CMS_NAME = "default_cms";
+const string INTEROP_SUFFIX = "_scene";
 
 // Remap from legacy color space names to their ACES 1.2 equivalents.
 const StringMap COLOR_SPACE_REMAP =
@@ -20,7 +21,13 @@ const StringMap COLOR_SPACE_REMAP =
     { "gamma18", "g18_rec709" },
     { "gamma22", "g22_rec709" },
     { "gamma24", "rec709_display" },
-    { "lin_ap1", "acescg" }
+
+    // Remap from 1.38 names to color interop equivalents (minus _scene suffix)
+    { "acescg", "lin_ap1" },
+    { "srgb_displayp3", "srgb_p3d65" },
+    { "lin_displayp3", "lin_p3d65" },
+    { "srgb_texture", "srgb_rec709" },
+    { "adobergb", "g22_adobergb" },
 };
 
 } // anonymous namespace
@@ -53,6 +60,23 @@ NodeDefPtr DefaultColorManagementSystem::getNodeDef(const ColorSpaceTransform& t
 
     string sourceSpace = COLOR_SPACE_REMAP.count(transform.sourceSpace) ? COLOR_SPACE_REMAP.at(transform.sourceSpace) : transform.sourceSpace;
     string targetSpace = COLOR_SPACE_REMAP.count(transform.targetSpace) ? COLOR_SPACE_REMAP.at(transform.targetSpace) : transform.targetSpace;
+
+    // Color interop short names systematically end in "_scene". We can truncate to keep as
+    // many names as possible from the 1.38 era.
+    if (stringEndsWith(sourceSpace, INTEROP_SUFFIX))
+    {
+        sourceSpace = sourceSpace.substr(0, sourceSpace.size() - INTEROP_SUFFIX.size());
+    }
+    if (stringEndsWith(targetSpace, INTEROP_SUFFIX))
+    {
+        targetSpace = targetSpace.substr(0, targetSpace.size() - INTEROP_SUFFIX.size());
+    }
+
+    if (sourceSpace == targetSpace)
+    {
+        return _document->getNodeDef("ND_dot_" + transform.type.getName());
+    }
+
     string nodeName = sourceSpace + "_to_" + targetSpace;
 
     for (NodeDefPtr nodeDef : _document->getMatchingNodeDefs(nodeName))

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1105,8 +1105,8 @@ void ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManage
         sourceColorSpace.empty() ||
         targetColorSpace.empty() ||
         sourceColorSpace == targetColorSpace ||
-        sourceColorSpace == "none" ||
-        targetColorSpace == "none")
+        sourceColorSpace == "none" || sourceColorSpace == "data"
+        targetColorSpace == "none" || targetColorSpace == "data")
     {
         return;
     }

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1105,7 +1105,7 @@ void ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManage
         sourceColorSpace.empty() ||
         targetColorSpace.empty() ||
         sourceColorSpace == targetColorSpace ||
-        sourceColorSpace == "none" || sourceColorSpace == "data"
+        sourceColorSpace == "none" || sourceColorSpace == "data" ||
         targetColorSpace == "none" || targetColorSpace == "data")
     {
         return;


### PR DESCRIPTION
I would recommend we wait for 1.39.5, but if there is a consensus to be bold, I don't see why it could not sneak in 1.39.4.

For more details, see the [Texture asset color space](https://github.com/AcademySoftwareFoundation/ColorInterop/blob/main/Recommendations/01_TextureAssetColorSpaces/TextureAssetColorSpaces.md) recommendations.

- All names are now based on color interop short names
- Deprecated names are now labeled as such
- Unit tests still covers all names even older legacy ones
- Introduced lin_ap0, lin_rec2020, and srgb_ap1 color spaces