### PR TITLE
add an enhanced validation to catch addition problems.

### DIFF
--- a/python/Scripts/mxvalidate.py
+++ b/python/Scripts/mxvalidate.py
@@ -13,6 +13,7 @@ def main():
     parser.add_argument("--resolve", dest="resolve", action="store_true", help="Resolve inheritance and string substitutions.")
     parser.add_argument("--verbose", dest="verbose", action="store_true", help="Print summary of elements found in the document.")
     parser.add_argument("--stdlib", dest="stdlib", action="store_true", help="Import standard MaterialX libraries into the document.")
+    parser.add_argument("--enhanced", dest="enhanced", action="store_true", help="Perform enhanced validation including surface shader checks, node connections, and material structure.")
     parser.add_argument(dest="inputFilename", help="Filename of the input document.")
     opts = parser.parse_args()
 
@@ -35,12 +36,39 @@ def main():
     except mx.ExceptionFileMissing as err:
         print(err)
         sys.exit(0)
+    
+    # Basic validation
     valid, message = doc.validate()
     if (valid):
         print("%s is a valid MaterialX document in v%s" % (opts.inputFilename, mx.getVersionString()))
     else:
         print("%s is not a valid MaterialX document in v%s" % (opts.inputFilename, mx.getVersionString()))
         print(message)
+        sys.exit(1)
+
+    # Perform enhanced validation if requested
+    if opts.enhanced:
+        errors, warnings = perform_enhanced_validation(doc)
+        
+        # Print validation results
+        if errors:
+            print("\nEnhanced Validation Errors:")
+            for error in errors:
+                print("  ❌ %s" % error)
+        
+        if warnings:
+            print("\nEnhanced Validation Warnings:")
+            for warning in warnings:
+                print("  ⚠️  %s" % warning)
+        
+        # Exit with error code if there are errors
+        if errors:
+            print("\nEnhanced validation FAILED")
+            sys.exit(1)
+        elif warnings:
+            print("\nEnhanced validation PASSED with warnings")
+        else:
+            print("\nEnhanced validation PASSED")
 
     # Generate verbose output if requested.
     if opts.verbose:
@@ -74,6 +102,202 @@ def main():
         print("%4d LookGroup%s%s" % (len(lookgroups), pl(lookgroups), listContents(lookgroups, opts.resolve)))
         print("%4d Top-level backdrop%s%s" % (len(backdrops), pl(backdrops), listContents(backdrops, opts.resolve)))
         print("----------------------------------")
+
+def perform_enhanced_validation(doc):
+    """
+    Perform enhanced validation checks beyond basic MaterialX validation.
+    
+    Args:
+        doc: MaterialX document to validate
+        
+    Returns:
+        tuple: (errors, warnings) lists
+    """
+    errors = []
+    warnings = []
+    
+    # Validate surface shader setup (when surface shaders exist)
+    validate_surface_shader_setup(doc, errors, warnings)
+    
+    # Validate node connections
+    validate_node_connections(doc, errors, warnings)
+    
+    # Validate material structure (when materials exist)
+    validate_material_structure(doc, errors, warnings)
+    
+    return errors, warnings
+
+def validate_surface_shader_setup(doc, errors, warnings):
+    """Validate surface shader setup and connections when surface shaders exist."""
+    # Check for surface shader elements (any direct element can be a surface shader)
+    surface_shaders = []
+    
+    # Check for surface shader elements (direct elements, not nodes)
+    for elem in doc.getChildren():
+        # Any direct element can be a surface shader - we don't restrict to specific types
+        surface_shaders.append(elem.getName())
+    
+    # Check for incorrect node-based surface shader usage
+    # Only flag known shader types that should be direct elements, not nodes
+    known_direct_shaders = ["standard_surface", "gltf_pbr", "disney_principled", "open_pbr_surface"]
+    for node in doc.getNodes():
+        if node.getType() in known_direct_shaders:
+            errors.append(f"Invalid {node.getType()} node '{node.getName()}' found - {node.getType()} should be a direct element, not a node")
+    
+    # Only validate material connections if surface shaders exist
+    if surface_shaders:
+        # Check material connections to surface shaders
+        materials = doc.getMaterialNodes()
+        for material in materials:
+            material_has_shader = False
+            for input_elem in material.getInputs():
+                if input_elem.getType() == "surfaceshader" and input_elem.getNodeName():
+                    material_has_shader = True
+                    # Verify the referenced element exists
+                    shader_elem = doc.getChild(input_elem.getNodeName())
+                    if shader_elem:
+                        # Any direct element can be a surface shader - we don't restrict types
+                        break
+                    else:
+                        errors.append(f"Material '{material.getName()}' references non-existent surface shader '{input_elem.getNodeName()}'")
+                    break
+            
+            if not material_has_shader:
+                warnings.append(f"Material '{material.getName()}' has no 'surfaceshader' input connection")
+
+def validate_node_connections(doc, errors, warnings):
+    """Validate node connections."""
+    nodes = doc.getNodes()
+    disconnected_nodes = []
+    orphaned_inputs = []
+    nonexistent_references = []
+    
+    for node in nodes:
+        node_has_connections = False
+        node_has_values = False
+        
+        for input_elem in node.getInputs():
+            if input_elem.getNodeName():
+                node_has_connections = True
+                # Check if referenced node exists
+                referenced_node = doc.getNode(input_elem.getNodeName())
+                if not referenced_node:
+                    nonexistent_references.append(f"Node '{node.getName()}' references non-existent node '{input_elem.getNodeName()}'")
+            elif input_elem.getValueString():
+                node_has_values = True
+            elif input_elem.getNodeGraphString():
+                # Input connects to a nodegraph output - this is valid
+                node_has_connections = True
+            elif not input_elem.getConnectedOutput():
+                # Input has no value and no connection
+                orphaned_inputs.append(f"Node '{node.getName()}' input '{input_elem.getName()}' has no value or connection")
+        
+        # Check if node has any values or connections
+        # Skip standard_surface nodes (they should be direct elements, not nodes)
+        if node.getType() == "standard_surface":
+            continue
+        
+        # Enhanced validation for specific node types
+        node_type = node.getType()
+        node_name = node.getName()
+        
+        # Get the actual node type from the element name
+        actual_node_type = None
+        try:
+            # Try to get the node type from the element name
+            if hasattr(node, 'getNodeString'):
+                actual_node_type = node.getNodeString()
+            else:
+                # Fallback: check if the node name suggests the type
+                if 'constant' in node_name.lower():
+                    actual_node_type = 'constant'
+                elif 'image' in node_name.lower():
+                    actual_node_type = 'image'
+                # Also check the element name directly
+                elif hasattr(node, 'getCategory'):
+                    actual_node_type = node.getCategory()
+        except:
+            pass
+        
+        # Check constant nodes - they must have values or connections
+        if actual_node_type == 'constant' or node_type in ['constant', 'ramplr', 'ramp4']:
+            has_value_or_connection = False
+            for input_elem in node.getInputs():
+                if input_elem.getValueString() or input_elem.getNodeName():
+                    has_value_or_connection = True
+                    break
+            
+            if not has_value_or_connection:
+                disconnected_nodes.append(f"Constant node '{node.getName()}' has no values or connections (check 'value' input)")
+        
+        # Check image nodes - they must have file input or connections
+        elif actual_node_type == 'image' or node_type == 'image':
+            has_file_or_connection = False
+            file_input = node.getInput('file')
+            if file_input and file_input.getValueString():
+                has_file_or_connection = True
+            
+            # Check if any input has a connection
+            for input_elem in node.getInputs():
+                if input_elem.getNodeName():
+                    has_file_or_connection = True
+                    break
+            
+            if not has_file_or_connection:
+                disconnected_nodes.append(f"Image node '{node.getName()}' has no file or connections (check 'file' input)")
+        
+        # Flag nodes that have inputs but no values or connections
+        elif len(node.getInputs()) > 0 and not node_has_connections and not node_has_values:
+            input_names = [inp.getName() for inp in node.getInputs()]
+            disconnected_nodes.append(f"Node '{node.getName()}' has inputs {input_names} but no values or connections")
+        
+        # Flag nodes that should have inputs but don't have any at all
+        elif len(node.getInputs()) == 0 and (actual_node_type in ['constant', 'image'] or node_type in ['constant', 'image']):
+            disconnected_nodes.append(f"Node '{node.getName()}' has no inputs at all (should have at least one input)")
+    
+    # Add detailed error messages for each issue
+    for node_name in disconnected_nodes:
+        errors.append(node_name)
+    
+    for orphaned_input in orphaned_inputs:
+        errors.append(orphaned_input)
+    
+    for ref in nonexistent_references:
+        errors.append(f"Reference error: {ref}")
+
+def validate_material_structure(doc, errors, warnings):
+    """Validate proper material structure when materials exist."""
+    materials = doc.getMaterialNodes()
+    
+    # Only validate if materials exist
+    if not materials:
+        return
+    
+    for material in materials:
+        # Check for surfaceshader input
+        surfaceshader_input = None
+        for input_elem in material.getInputs():
+            if input_elem.getType() == "surfaceshader":
+                surfaceshader_input = input_elem
+                break
+        
+        if not surfaceshader_input:
+            errors.append(f"Material '{material.getName()}' missing required 'surfaceshader' input")
+        elif not surfaceshader_input.getNodeName() and not surfaceshader_input.getNodeGraphString():
+            errors.append(f"Material '{material.getName()}' input 'surfaceshader' not connected to any node or nodegraph")
+        else:
+            # Check if the referenced node actually exists
+            referenced_node_name = surfaceshader_input.getNodeName()
+            if referenced_node_name:
+                referenced_node = doc.getChild(referenced_node_name)
+                if not referenced_node:
+                    errors.append(f"Material '{material.getName()}' references non-existent surface shader '{referenced_node_name}'")
+                # Don't restrict shader types - any direct element can be a surface shader
+            # Nodegraph connections are also valid
+        
+        # Check for proper material type
+        if material.getType() != "material":
+            warnings.append(f"Material '{material.getName()}' has incorrect type '{material.getType()}' (should be 'material')")
 
 def listContents(elemlist, resolve):
     if len(elemlist) == 0:


### PR DESCRIPTION
In creating my blender materialx exporter, I ran into a lot of issues with invalid mtlx files being generator.  In order to address that I created my own validator for mtlx file issues.  I've ported that back to the mxvalidate.py file and made this PR to contribute those additional validates back.

Basically just run "mxvalidate --enhanced glass.mtlx" and it will check now for the following:

- proper node connections.
- surface shader setup, if there is one.
- material structure, if there is one.

I've validated it against all example *.mtlx materials and they all pass, but I did find one warning:

open_pbr_default.mtlx: It has an empty displacementshader input, which I consider to be incorrect:

https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx#L5