### PR TITLE
Assign source URI to generated OCIO NodeDefs

### DIFF
--- a/source/MaterialXGenShader/OcioColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/OcioColorManagementSystem.cpp
@@ -27,6 +27,7 @@ namespace OCIO = OCIO_NAMESPACE;
 MATERIALX_NAMESPACE_BEGIN
 
 const string OcioColorManagementSystem::IMPL_PREFIX = "IMPL_MXOCIO_";
+const string OcioColorManagementSystem::OCIO_SOURCE_URI = "materialx://OcioColorManagementSystem.cpp";
 const string ND_PREFIX = "ND_MXOCIO_";
 
 namespace
@@ -162,6 +163,7 @@ NodeDefPtr OcioColorManagementSystemImpl::getNodeDef(const ColorSpaceTransform& 
     {
         nodeDef = document->addNodeDef(nodeDefName, "", functionName);
         nodeDef->setNodeGroup("colortransform");
+        nodeDef->setSourceUri(OcioColorManagementSystem::OCIO_SOURCE_URI);
 
         nodeDef->addInput("in", transform.type.getName());
         nodeDef->addOutput("out", transform.type.getName());
@@ -169,6 +171,7 @@ NodeDefPtr OcioColorManagementSystemImpl::getNodeDef(const ColorSpaceTransform& 
         auto implementation = document->addImplementation(implName);
         implementation->setTarget(_target);
         implementation->setNodeDef(nodeDef);
+        implementation->setSourceUri(OcioColorManagementSystem::OCIO_SOURCE_URI);
     }
 
     _implementations.emplace(implName, gpuProcessor);

--- a/source/MaterialXGenShader/OcioColorManagementSystem.h
+++ b/source/MaterialXGenShader/OcioColorManagementSystem.h
@@ -56,6 +56,9 @@ class MX_GENSHADER_API OcioColorManagementSystem : public DefaultColorManagement
     /// Prefix common to all implementation names
     static const string IMPL_PREFIX;
 
+    /// SourceUri common to all OCIO NodeDefs and Implementations:
+    static const string OCIO_SOURCE_URI;
+
   protected:
     /// Returns a nodedef for a given transform
     NodeDefPtr getNodeDef(const ColorSpaceTransform& transform) const override;


### PR DESCRIPTION
Also Implementations. Without a source URI these can not be distinguished from user created nodes and filtered out when writing.