### PR TITLE
Fix grammar errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,7 +575,7 @@ if(NOT SKBUILD)
         # Export aliases for the MaterialX modules built in this monolithic build
         # to be less disruptive to downstream projects.
         get_property(MATERIALX_MODULES GLOBAL PROPERTY MATERIALX_MODULES)
-        set(EXPORT_ALIASES "# Aliased targets for the the monolithic build\n")
+        set(EXPORT_ALIASES "# Aliased targets for the monolithic build\n")
         foreach (MODULE ${MATERIALX_MODULES})
             string(APPEND EXPORT_ALIASES "add_library(${MODULE} ALIAS MaterialX)\n")
         endforeach ()

--- a/documents/DeveloperGuide/GraphEditor.md
+++ b/documents/DeveloperGuide/GraphEditor.md
@@ -21,7 +21,7 @@ Select the `MATERIALX_BUILD_GRAPH_EDITOR` option in CMake to build the MaterialX
 
 ## Buttons
 
-To display a new material and graph, click the `Load Material` button and and navigate to the [Materials/Examples](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Materials/Examples) folder, which contains a selection of materials in the MTLX format, and select a document to load.  The Graph Editor will display the graph hierarchy of the selected document for visualization and editing.
+To display a new material and graph, click the `Load Material` button and navigate to the [Materials/Examples](https://github.com/AcademySoftwareFoundation/MaterialX/tree/main/resources/Materials/Examples) folder, which contains a selection of materials in the MTLX format, and select a document to load.  The Graph Editor will display the graph hierarchy of the selected document for visualization and editing.
 
 To save out changes to the graphs as MTLX files click the `Save Material` button.  This will save the position of the nodes in the graph for future use as well.
 

--- a/documents/Specification/MaterialX.GeomExts.md
+++ b/documents/Specification/MaterialX.GeomExts.md
@@ -406,7 +406,7 @@ VariantAssign elements have the following attributes:
 * `variantset` (string, required): the name of the variantset to apply the variant from
 * `variant` (string, required): the name of the variant within `variantset` to use
 
-In the above example, the input/token values defined within variant "var1" will be applied to and and all identically-named inputs/tokens found in either "material1" or "material2" unless restricted by a `node` or `nodedef` attribute defined in the &lt;variantset>, while values defined within variant "var2" will only be applied to matching-named bindings in "material1".  VariantAssigns are applied in the order specified within a scope, with those within a &lt;materialassign> taking precedence over those which are direct children of the &lt;look>.
+In the above example, the input/token values defined within variant "var1" will be applied to all identically-named inputs/tokens found in either "material1" or "material2" unless restricted by a `node` or `nodedef` attribute defined in the &lt;variantset>, while values defined within variant "var2" will only be applied to matching-named bindings in "material1".  VariantAssigns are applied in the order specified within a scope, with those within a &lt;materialassign> taking precedence over those which are direct children of the &lt;look>.
 
 
 ### Visibility Elements

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -160,7 +160,7 @@ RenderView::RenderView(mx::DocumentPtr doc,
     _genContext.getOptions().fileTextureVerticalFlip = true;
     _genContext.getOptions().hwShadowMap = true;
     // Make sure all uniforms are added so value updates can
-    // find the the corresponding uniform.
+    // find the corresponding uniform.
     _genContext.getOptions().shaderInterfaceType = mx::SHADER_INTERFACE_COMPLETE;
 
     setDocument(doc);


### PR DESCRIPTION
This changelist fixes a handful of grammatical errors that were detected in text analysis of the MaterialX project.