### PR TITLE
Update presentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ The following packages contain pre-built binaries for the latest release, includ
 - The [Developer Guide](http://www.materialx.org/docs/api/index.html) contains a developer-oriented overview of MaterialX with Build and API documentation.
 - The [Python Scripts](python/Scripts) folder contains standalone examples of MaterialX Python code.
 - The [JavaScript](javascript) folder contains details on building JavaScript bindings for MaterialX.
-- Presentations at [ASWF Open Source Days](https://materialx.org/assets/ASWF_OSD2024_MaterialX_Final.pdf) and the [SIGGRAPH Physically Based Shading Course](https://blog.selfshadow.com/publications/s2020-shading-course/#materialx) provide details on the roadmap for MaterialX development.
+- Presentations at [ASWF Open Source Days](https://materialx.org/assets/ASWF_OSD2025_MaterialX_Final.pdf) and the [SIGGRAPH Physically Based Shading Course](https://blog.selfshadow.com/publications/s2020-shading-course/#materialx) provide details on the roadmap for MaterialX development.


### PR DESCRIPTION
This changelist updates a presentation link on the front page, bringing it up to date with the latest slide deck for ASWF Open Source Days 2025.