### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXCore/Unit.cpp
+++ b/source/MaterialXCore/Unit.cpp
@@ -72,7 +72,7 @@ void LinearUnitConverter::write(DocumentPtr doc) const
             unitDef->setUnitType(_unitType);
 
             // Add in units to the definition
-            for (auto unitScale : _unitScale)
+            for (const auto& unitScale : _unitScale)
             {
                 const string& unitName = unitScale.first;
                 UnitPtr unitPtr = unitDef->addUnit(unitName);
@@ -223,7 +223,7 @@ void UnitConverterRegistry::clearUnitConverters()
 
 int UnitConverterRegistry::getUnitAsInteger(const string& unitName) const
 {
-    for (auto it : _unitConverters)
+    for (const auto& it : _unitConverters)
     {
         int value = it.second->getUnitAsInteger(unitName);
         if (value >= 0)
@@ -235,7 +235,7 @@ int UnitConverterRegistry::getUnitAsInteger(const string& unitName) const
 
 void UnitConverterRegistry::write(DocumentPtr doc) const
 {
-    for (auto it : _unitConverters)
+    for (const auto& it : _unitConverters)
     {
         it.second->write(doc);
     }

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -235,7 +235,7 @@ void OslShaderGenerator::registerShaderMetadata(const DocumentPtr& doc, GenConte
         { ValueElement::UI_STEP_ATTRIBUTE, "sensitivity" },
         { ValueElement::DOC_ATTRIBUTE, "help" }
     };
-    for (auto it : nameRemapping)
+    for (const auto& it : nameRemapping)
     {
         ShaderMetadata* data = registry->findMetadata(it.first);
         if (data)

--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -53,7 +53,7 @@ ShaderNodeImplPtr GenContext::findNodeImplementation(const string& name) const
 
 void GenContext::getNodeImplementationNames(StringSet& names)
 {
-    for (auto it : _nodeImpls)
+    for (const auto& it : _nodeImpls)
     {
         names.insert(it.first);
     }

--- a/source/MaterialXGenShader/UnitSystem.cpp
+++ b/source/MaterialXGenShader/UnitSystem.cpp
@@ -56,7 +56,7 @@ void ScalarUnitNode::emitFunctionDefinition(const ShaderNode& node, GenContext& 
         unitScales.reserve(_scalarUnitConverter->getUnitScale().size());
         auto unitScaleMap = _scalarUnitConverter->getUnitScale();
         unitScales.resize(unitScaleMap.size());
-        for (auto unitScale : unitScaleMap)
+        for (const auto& unitScale : unitScaleMap)
         {
             int location = _scalarUnitConverter->getUnitAsInteger(unitScale.first);
             unitScales[location] = unitScale.second;

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -507,7 +507,7 @@ float Graph::findAvgY(const std::vector<UiNodePtr>& nodes)
         total += ((size.y + pos.y) + pos.y) / 2;
         count++;
     }
-    return (total / count);
+    return count ? (total / count) : 0.0f;
 }
 
 void Graph::findYSpacing(float startY)

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -604,7 +604,7 @@ void RenderView::initContext(mx::GenContext& context)
     // Create the list of supported distance units.
     auto unitScales = _distanceUnitConverter->getUnitScale();
     _distanceUnitOptions.resize(unitScales.size());
-    for (auto unitScale : unitScales)
+    for (const auto& unitScale : unitScales)
     {
         int location = _distanceUnitConverter->getUnitAsInteger(unitScale.first);
         _distanceUnitOptions[location] = unitScale.first;

--- a/source/MaterialXRender/ImageHandler.cpp
+++ b/source/MaterialXRender/ImageHandler.cpp
@@ -159,7 +159,7 @@ bool ImageHandler::unbindImage(ImagePtr)
 
 void ImageHandler::unbindImages()
 {
-    for (auto iter : _imageCache)
+    for (const auto& iter : _imageCache)
     {
         unbindImage(iter.second);
     }

--- a/source/MaterialXRenderGlsl/GLTextureHandler.cpp
+++ b/source/MaterialXRenderGlsl/GLTextureHandler.cpp
@@ -139,7 +139,7 @@ void GLTextureHandler::releaseRenderResources(ImagePtr image)
 {
     if (!image)
     {
-        for (auto iter : _imageCache)
+        for (const auto& iter : _imageCache)
         {
             if (iter.second)
             {


### PR DESCRIPTION
This changelist addresses a handful of static analysis warnings flagged by PVS-Studio:

- Fix a potential division by zero in `Graph::findAvgY`.
- Replace `auto` with `const auto&` in loop variables for efficiency.