### PR TITLE
Fix GLSL type in LightCompoundData node

### DIFF
--- a/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
+++ b/source/MaterialXGenGlsl/Nodes/LightCompoundNodeGlsl.cpp
@@ -73,7 +73,7 @@ void LightCompoundNodeGlsl::emitFunctionDefinition(const ShaderNode& /*node*/, G
         // closure/shader nodes and need to be emitted first.
         shadergen.emitFunctionCalls(*_rootGraph, context, stage, ShaderNode::Classification::TEXTURE);
 
-        shadergen.emitLine("ClosureData closureData = ClosureData(CLOSURE_TYPE_EMISSION, float3(0), -L, light.direction, float3(0), 0)", stage);
+        shadergen.emitLine("ClosureData closureData = ClosureData(CLOSURE_TYPE_EMISSION, vec3(0), -L, light.direction, vec3(0), 0)", stage);
         shadergen.emitFunctionCalls(*_rootGraph, context, stage, ShaderNode::Classification::SHADER | ShaderNode::Classification::LIGHT);
 
         shadergen.emitFunctionBodyEnd(*_rootGraph, context, stage);


### PR DESCRIPTION
In prep for the Slang merge, I was looking how close are the remaining Nodes between GenMsl and GenGlsl. And I found that the GenGlsl one was using `float3` type instead of the `vec3`. I don't believe there is any alias for that, and even if there was, I think using the native type is the better idea. Also, it seems like there is no test coverage for this node, as I was running it with full tests (modified the `_options` to just point to `resources/Materials`) and this didn't come up.