### PR TITLE
Add ShaderGen option for Airy Fresnel iterations

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -374,7 +374,7 @@ vec3 mx_fresnel_airy(float cosTheta, FresnelData fd)
 
     // Reflectance term for m>0 (pairs of diracs)
     Cm = Rs - T121.x;
-    for (int m=1; m<=2; m++)
+    for (int m = 1; m <= AIRY_FRESNEL_ITERATIONS; m++)
     {
         Cm *= r123p;
         Sm  = 2.0 * mx_eval_sensitivity(float(m) * opd, float(m)*(phi23p+vec3(phi21.x)));
@@ -389,7 +389,7 @@ vec3 mx_fresnel_airy(float cosTheta, FresnelData fd)
 
     // Reflectance term for m>0 (pairs of diracs)
     Cm = Rp - T121.y;
-    for (int m=1; m<=2; m++)
+    for (int m = 1; m <= AIRY_FRESNEL_ITERATIONS; m++)
     {
         Cm *= r123s;
         Sm  = 2.0 * mx_eval_sensitivity(float(m) * opd, float(m)*(phi23s+vec3(phi21.y)));

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -404,6 +404,10 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
         emitLineBreak(stage);
     }
 
+    // Define Airy Fresnel iterations
+    emitLine("#define AIRY_FRESNEL_ITERATIONS " + std::to_string(context.getOptions().hwAiryFresnelIterations), stage, false);
+    emitLineBreak(stage);
+
     // Add lighting support
     if (lighting)
     {

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -874,6 +874,10 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
         emitLineBreak(stage);
     }
 
+    // Define Airy Fresnel iterations
+    emitLine("#define AIRY_FRESNEL_ITERATIONS " + std::to_string(context.getOptions().hwAiryFresnelIterations), stage, false);
+    emitLineBreak(stage);
+
     // Add lighting support
     if (lighting)
     {

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -85,6 +85,7 @@ class MX_GENSHADER_API GenOptions
         hwSpecularEnvironmentMethod(SPECULAR_ENVIRONMENT_FIS),
         hwDirectionalAlbedoMethod(DIRECTIONAL_ALBEDO_ANALYTIC),
         hwTransmissionRenderMethod(TRANSMISSION_REFRACTION),
+        hwAiryFresnelIterations(2),
         hwSrgbEncodeOutput(false),
         hwWriteDepthMoments(false),
         hwShadowMap(false),
@@ -152,6 +153,11 @@ class MX_GENSHADER_API GenOptions
     /// Sets the method to use for transmission rendering
     /// for HW shader targets.
     HwTransmissionRenderMethod hwTransmissionRenderMethod;
+
+    /// Sets the number of iterations for Airy Fresnel reflection calculations.
+    /// Higher values provide more accurate thin-film interference patterns
+    /// but increase computational cost. Defaults to 2.
+    unsigned int hwAiryFresnelIterations;
 
     /// Enables an sRGB encoding for the color output on HW shader targets.
     /// Defaults to false.

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -65,6 +65,9 @@ const bool USE_FLOAT_BUFFER = false;
 const int MIN_ENV_SAMPLE_COUNT = 4;
 const int MAX_ENV_SAMPLE_COUNT = 1024;
 
+const int MIN_AIRY_FRESNEL_ITERATIONS = 1;
+const int MAX_AIRY_FRESNEL_ITERATIONS = 8;
+
 const int SHADOW_MAP_SIZE = 2048;
 const int ALBEDO_TABLE_SIZE = 128;
 const int IRRADIANCE_MAP_WIDTH = 256;
@@ -890,6 +893,26 @@ void Viewer::createAdvancedSettings(ng::ref<Widget> parent)
     sampleBox->set_callback([this](int index)
     {
         _lightHandler->setEnvSampleCount(MIN_ENV_SAMPLE_COUNT * (int) std::pow(4, index));
+    });
+
+    ng::ref<ng::Widget> fresnelGroup = new Widget(settingsGroup);
+    fresnelGroup->set_layout(new ng::BoxLayout(ng::Orientation::Horizontal));
+    new ng::Label(fresnelGroup, "Airy Fresnel Iterations:");
+    mx::StringVec fresnelOptions;
+    for (int i = MIN_AIRY_FRESNEL_ITERATIONS; i <= MAX_AIRY_FRESNEL_ITERATIONS; i *= 2)
+    {
+        fresnelOptions.push_back(std::to_string(i));
+    }
+    ng::ref<ng::ComboBox> fresnelBox = new ng::ComboBox(fresnelGroup, fresnelOptions);
+    fresnelBox->set_chevron_icon(-1);
+    fresnelBox->set_selected_index((int)std::log2(_genContext.getOptions().hwAiryFresnelIterations / MIN_AIRY_FRESNEL_ITERATIONS));
+    fresnelBox->set_callback([this](int index)
+    {
+        _genContext.getOptions().hwAiryFresnelIterations = MIN_AIRY_FRESNEL_ITERATIONS * (int)std::pow(2, index);
+#ifndef MATERIALXVIEW_METAL_BACKEND
+        _genContextEssl.getOptions().hwAiryFresnelIterations = _genContext.getOptions().hwAiryFresnelIterations;
+#endif
+        reloadShaders();
     });
 
     ng::ref<ng::Label> lightingLabel = new ng::Label(settingsGroup, "Lighting Options");


### PR DESCRIPTION
This changelist adds a ShaderGen option for the number of iterations used to compute Airy Fresnel reflections for iridescent materials in hardware shading languages.

The visual difference between iteration counts turns out to be very small for many iridescent materials, and this option should give applications more control over the tradeoff between performance and reference-quality accuracy.