### PR TITLE
Update `artistic_ior` specification to match implementation

### DIFF
--- a/documents/Specification/MaterialX.PBRSpec.md
+++ b/documents/Specification/MaterialX.PBRSpec.md
@@ -388,8 +388,8 @@ Note that the standard library includes definitions for [**`displacement`**](./M
 * **`artistic_ior`**: Converts the artistic parameterization reflectivity and edge_color to complex IOR values. To be used with the [&lt;conductor_bsdf>](#node-conductor-bsdf) node.
     * `reflectivity` (color3): Reflectivity per color component at facing angles. Defaults to (0.947, 0.776, 0.371).
     * `edge_color` (color3): Reflectivity per color component at grazing angles. Defaults to (1.0, 0.982, 0.753).
-    * `ior` (**output**, vector3): Computed index of refraction.
-    * `extinction` (**output**, vector3): Computed extinction coefficient.
+    * `ior` (**output**, color3): Computed index of refraction.
+    * `extinction` (**output**, color3): Computed extinction coefficient.
 
 <a id="node-chiang-hair-roughness"> </a>
 


### PR DESCRIPTION
## Issue #2564 

The docs say the `artistic_ior` node returns `vector3`s, but the implementation actually returns `color3`s. 

Docs: https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.PBRSpec.md

* **`artistic_ior`**: Converts the artistic parameterization reflectivity and edge_color to complex IOR values. To be used with the [&lt;conductor_bsdf>](#node-conductor-bsdf) node.
    * `reflectivity` (color3): Reflectivity per color component at facing angles. Defaults to (0.947, 0.776, 0.371).
    * `edge_color` (color3): Reflectivity per color component at grazing angles. Defaults to (1.0, 0.982, 0.753).
    * `ior` (**output**, vector3): Computed index of refraction.
    * `extinction` (**output**, vector3): Computed extinction coefficient.

Library: https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/libraries/pbrlib/pbrlib_defs.mtlx

```
  <nodedef name="ND_artistic_ior" node="artistic_ior" nodegroup="pbr" doc="Converts the artistic parameterization reflectivity and edge_color to  complex IOR values.">
    <input name="reflectivity" type="color3" value="0.944, 0.776, 0.373" colorspace="lin_rec709" />
    <input name="edge_color" type="color3" value="0.998, 0.981, 0.751" colorspace="lin_rec709" />
    <output name="ior" type="color3" />
    <output name="extinction" type="color3" />
  </nodedef>
```

## Fix
Change output types from `vector3` to `color3` in the `artistic_ior` specification.