### PR TITLE
Passthrough Index of Refraction

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -19,6 +19,7 @@
     <input name="coat_roughness" type="float" value="0.1" />
     <input name="emission" type="float" value="0" />
     <input name="emission_color" type="color3" value="1, 1, 1" />
+    <input name="specular_IOR" type="float" value="1.5" doc="Specular Index of Refraction" />
 
     <output name="base_color_out" type="color3" />
     <output name="metallic_out" type="float" />
@@ -33,6 +34,7 @@
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
     <output name="emissive_out" type="color3" />
+    <output name="ior_out" type="float" />
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -191,6 +193,11 @@
       <input name="in2" type="float" interfacename="emission" />
     </multiply>
 
+    <!-- Specular Index of Refraction -->
+    <dot name="ior" type="float">
+      <input name="in" type="float" interfacename="specular_IOR" />
+    </dot>
+
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
@@ -204,6 +211,6 @@
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />
-
+    <output name="ior_out" type="float" nodename="ior" />
   </nodegraph>
 </materialx>


### PR DESCRIPTION
Passthrough of Index of Refraction.

Note that glTF uses IoR for Fresnel when Specular is 1.0. So if Specular is 1.0 in both gltf_pbr and standard_surface, the result will differ (more info in [KHR_materials_specular](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular) ), see last figure. However, if not the specular extension in glTF is used, the ior matches. 

Test material: (but with varying `Index of refraction` and specular in figure x)

**Index of Refraction 1.0**
|![](https://github.com/user-attachments/assets/cb2e297c-ce3b-4cad-8a37-73f2bf13d3f2)<br>Standard Surface: IoR= 1.0 |![](https://github.com/user-attachments/assets/3ec97878-17e1-42ba-9fc8-5aa3767288a4)<br>Translated to gltf_pbr|![](https://github.com/user-attachments/assets/9538af1f-a0bb-40e3-b6fa-cf72b5b0d991) **Diff**
|:-:|:-:|:-:|


**Index of Refraction 1.1**
|![](https://github.com/user-attachments/assets/81a51731-8382-473c-8cd0-3f899821c86f)<br>Standard Surface: IoR= 1.1 |![](https://github.com/user-attachments/assets/a1cd8a40-93c3-42af-a93a-eb03894d0878)<br>Translated to gltf_pbr|![](https://github.com/user-attachments/assets/f5dc4d7f-8c99-4abe-8ccf-832a74bd6c56) **Diff**
|:-:|:-:|:-:|

**Index of Refraction 1.5 **
|![](https://github.com/user-attachments/assets/a81b8167-38f6-4eef-9597-380fd0a9e757)<br>Standard Surface: IoR= 1.5 |![](https://github.com/user-attachments/assets/f50e17d2-546d-4e60-a53d-d387a75c413f)<br>Translated to gltf_pbr|![](https://github.com/user-attachments/assets/ab50d4a1-6851-464a-8661-29ee4f6684e3) **Diff**
|:-:|:-:|:-:|

**Index of Refraction 1.0 | Specular 1.0**
|![](https://github.com/user-attachments/assets/cb2e297c-ce3b-4cad-8a37-73f2bf13d3f2)<br>Standard Surface: IoR= 1.0 |![](https://github.com/user-attachments/assets/ae965515-6cd3-4a75-ad85-4daf2708681a)<br>Translated to gltf_pbr|![](https://github.com/user-attachments/assets/c28ad538-26c8-4768-bc0f-38cb8f61ab1b) **Diff**
|:-:|:-:|:-:|

