### PR TITLE
Fix OSL ShaderGen for `textureresource` and `LamaSurface`

### DIFF
--- a/libraries/stdlib/genosl/mx_geompropvalue_filename.osl
+++ b/libraries/stdlib/genosl/mx_geompropvalue_filename.osl
@@ -1,9 +1,9 @@
 void mx_geompropvalue_filename(string geomprop, textureresource defaultVal, output textureresource out)
 {
-    // initialize to the default
+    // Initialize to the default
     out = defaultVal;
 
-    // replace the filename component from the geomprop
+    // Replace the filename component from the geomprop
     string defaultFilename = defaultVal.filename;
     if (getattribute(geomprop, defaultFilename) == 0)
         out.filename = defaultFilename;

--- a/libraries/stdlib/genosl/mx_geompropvalue_filename.osl
+++ b/libraries/stdlib/genosl/mx_geompropvalue_filename.osl
@@ -1,0 +1,10 @@
+void mx_geompropvalue_filename(string geomprop, textureresource defaultVal, output textureresource out)
+{
+    // initialize to the default
+    out = defaultVal;
+
+    // replace the filename component from the geomprop
+    string defaultFilename = defaultVal.filename;
+    if (getattribute(geomprop, defaultFilename) == 0)
+        out.filename = defaultFilename;
+}

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -174,7 +174,7 @@
 
   <!-- <geompropvalueuniform> -->
   <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalueuniform_string" file="mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
-  <implementation name="IM_geompropvalue_filename_genosl" nodedef="ND_geompropvalueuniform_filename" file="mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
+  <implementation name="IM_geompropvalue_filename_genosl" nodedef="ND_geompropvalueuniform_filename" file="mx_geompropvalue_filename.osl" function="mx_geompropvalue_filename" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Application nodes                                                        -->

--- a/source/MaterialXGenOsl/OslSyntax.cpp
+++ b/source/MaterialXGenOsl/OslSyntax.cpp
@@ -379,7 +379,7 @@ OslSyntax::OslSyntax(TypeSystemPtr typeSystem) : Syntax(typeSystem)
             this,
             "textureresource ",
             "textureresource (\"\", \"\")",
-            "(\"\", \"\")",
+            "{\"\", \"\"}",
             EMPTY_STRING,
             "struct textureresource { string filename; string colorspace; };"));
 

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -116,8 +116,12 @@ void CompoundNode::emitFunctionDefinition(const ShaderNode& node, GenContext& co
                 if (outputSocket->getConnection())
                 {
                     const ShaderNode* upstream = outputSocket->getConnection()->getNode();
+                    // Its important that the classification check here matches the logic inside
+                    // nodeOutputIsClosure() used above.
                     if (upstream->getParent() == _rootGraph.get() &&
-                        (upstream->hasClassification(ShaderNode::Classification::CLOSURE) || upstream->hasClassification(ShaderNode::Classification::SHADER)))
+                        (upstream->hasClassification(ShaderNode::Classification::CLOSURE) ||
+                            upstream->hasClassification(ShaderNode::Classification::SHADER) ||
+                            upstream->hasClassification(ShaderNode::Classification::MATERIAL)))
                     {
                         shadergen.emitFunctionCall(*upstream, context, stage);
                     }

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -39,9 +39,8 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
         {
             oslIncludePaths.append(oslStandardIncludePath);
         }
-        // Add in library include path for compile testing as the generated
-        // shader's includes added by the shader generator itself are not added with absolute paths.
-        // specifically "mx_funcs.h"
+        // Add in library include path for compile testing as the includes added by the shader
+        // generator itself are not added with absolute paths (specifically "mx_funcs.h").
         oslIncludePaths.append(searchPath.find("libraries/stdlib/genosl/include"));
         oslRenderer->setOslIncludePath(oslIncludePaths);
     }

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -23,8 +23,8 @@ namespace mx = MaterialX;
 TEST_CASE("GenReference: OSL Reference", "[genreference]")
 {
     mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
-    mx::DocumentPtr stdlib = mx::createDocument();
-    loadLibraries({ "libraries/targets", "libraries/stdlib" }, searchPath, stdlib);
+    mx::DocumentPtr datalib = mx::createDocument();
+    loadLibraries({ "libraries" }, searchPath, datalib);
 
     // Create renderer if requested.
     bool runCompileTest = !std::string(MATERIALX_OSL_BINARY_OSLC).empty();
@@ -40,7 +40,8 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
             oslIncludePaths.append(oslStandardIncludePath);
         }
         // Add in library include path for compile testing as the generated
-        // shader's includes are not added with absolute paths.
+        // shader's includes added by the shader generator itself are not added with absolute paths.
+        // specifically "mx_funcs.h"
         oslIncludePaths.append(searchPath.find("libraries/stdlib/genosl/include"));
         oslRenderer->setOslIncludePath(oslIncludePaths);
     }
@@ -49,7 +50,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     mx::ShaderGeneratorPtr generator = mx::OslShaderGenerator::create();
 
     // Register types from the library.
-    generator->registerTypeDefs(stdlib);
+    generator->registerTypeDefs(datalib);
 
     mx::GenContext context(generator);
     context.getOptions().addUpstreamDependencies = false;
@@ -67,26 +68,14 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
     logFile.open(logPath);
 
     // Generate reference shaders.
-    // Ignore the following nodes:
-    const mx::StringSet ignoreNodeList = { "surfacematerial", "volumematerial",
-                                           "constant_filename", "dot_filename",
-                                           "geompropvalueuniform_filename" };
-
     bool failedGeneration = false;
-    for (const mx::NodeDefPtr& nodedef : stdlib->getNodeDefs())
+    for (const mx::NodeDefPtr& nodedef : datalib->getNodeDefs())
     {
         std::string nodeName = nodedef->getName();
         std::string nodeNode = nodedef->getNodeString();
         if (nodeName.size() > 3 && nodeName.substr(0, 3) == "ND_")
         {
             nodeName = nodeName.substr(3);
-        }
-        if (nodeName == mx::MATERIAL_TYPE_STRING || 
-            ignoreNodeList.find(nodeName) != ignoreNodeList.end() ||
-            ignoreNodeList.find(nodeNode) != ignoreNodeList.end())
-        {
-            logFile << "Skip generating reference for'" << nodeName << "'" << std::endl;
-            continue;
         }
 
         mx::InterfaceElementPtr interface = nodedef->getImplementation(generator->getTarget());
@@ -96,7 +85,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
             continue;
         }
 
-        mx::NodePtr node = stdlib->addNodeInstance(nodedef, nodeName);
+        mx::NodePtr node = datalib->addNodeInstance(nodedef, nodeName);
         REQUIRE(node);
 
         const std::string filename = nodeName + ".osl";
@@ -133,7 +122,7 @@ TEST_CASE("GenReference: OSL Reference", "[genreference]")
             failedGeneration = true;
         }
 
-        stdlib->removeChild(node->getName());
+        datalib->removeChild(node->getName());
     }
 
     logFile.close();


### PR DESCRIPTION
As reported in #2588. 

The OSLShaderGenerator fails to generate the correct syntax for shader inputs of type `textureresource` aka `Type::FILENAME`.  Which makes me really curious if we're testing any texture code-path in the OSL unit tests.

Any node with a nodegraph implementation that output a `surfacematerial` type, including`LamaSurface` was also failing to generate because of a mis-match guard check. 

I am also updating the OSL reference generation to generate all nodes in the entire data library to ensure we don't regress in the future. I removed specific exceptions that were added so get the tests to pass, and expanded nods loaded from being only `stdlib` to the entire data library.