### PR TITLE
Support alpha in Standard Surface to glTF PBR translation

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -42,6 +42,7 @@
     <output name="normal_out" type="vector3" />
     <output name="tangent_out" type="vector3" />
     <output name="alpha_out" type="float" />
+    <output name="alpha_mode_out" type="integer" />
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -225,6 +226,13 @@
       <input name="index" type="integer" value="0" />
     </extract>
 
+    <ifequal name="alpha_mode_from_opacity_luminance" type="integer">
+      <input name="value1" type="float" nodename="opacity_luminance_float" />
+      <input name="value2" type="float" value="1.0" />
+      <input name="in1" type="integer" value="0" />
+      <input name="in2" type="integer" value="2" />
+    </ifequal>
+
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
@@ -243,6 +251,7 @@
     <output name="normal_out" type="vector3" nodename="normal" />
     <output name="tangent_out" type="vector3" nodename="tangent" />
     <output name="alpha_out" type="float" nodename="opacity_luminance_float" />
+    <output name="alpha_mode_out" type="integer" nodename="alpha_mode_from_opacity_luminance" />
 
   </nodegraph>
 </materialx>


### PR DESCRIPTION
closes #2579

This converts opacity to alpha as implemented in `standard_surface.mtlx`, i.e with the limitation of monochromatic opacity.

[standard_surface.mtlx#L411-L424](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/libraries/bxdf/standard_surface.mtlx#L411-L424)
```xml
    <!-- Surface construction with opacity -->
    <!-- Node <surface> only supports monochromatic opacity so use the luminance of input opacity color -->
    <luminance name="opacity_luminance" type="color3">
      <input name="in" type="color3" interfacename="opacity" />
    </luminance>
    <extract name="opacity_luminance_float" type="float">
      <input name="in" type="color3" nodename="opacity_luminance" />
      <input name="index" type="integer" value="0" />
    </extract>
```

**Opacity 1, 0, 0** 
|![](https://github.com/user-attachments/assets/f8978715-3644-4290-8758-f91a61ae3bc9)<br>Standard Surface |![](https://github.com/user-attachments/assets/5505bea5-ed03-469b-819d-582d84928ebd)<br>Translated to gltf_pbr, **_with alpha mode manual set to BLEND_** |![](https://github.com/user-attachments/assets/a740e03d-b669-4bd4-bb2d-868e72c611c9) **Diff**
|:-:|:-:|:-:|
