### PR TITLE
Support emissive strength in Standard Surface to glTF PBR

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -33,6 +33,7 @@
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
     <output name="emissive_out" type="color3" />
+    <output name="emissive_strength_out" type="float" />
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -186,10 +187,12 @@
     </dot>
 
     <!-- Emission -->
-    <multiply name="emissive" type="color3">
-      <input name="in1" type="color3" interfacename="emission_color" />
-      <input name="in2" type="float" interfacename="emission" />
-    </multiply>
+    <dot name="emissive" type="color3">
+      <input name="in" type="color3" interfacename="emission_color" />
+    </dot>
+    <dot name="emissive_strength" type="float">
+      <input name="in" type="float" interfacename="emission" />
+    </dot>
 
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
@@ -204,6 +207,7 @@
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />
+    <output name="emissive_strength_out" type="float" nodename="emissive_strength" />
 
   </nodegraph>
 </materialx>


### PR DESCRIPTION
closes: #2584

Instead of multiplying the emissive color (factor) and the emission (strength) in the translation graph, we now pass them through to the `gltf_shader`, which do the multiplication, since [KHR_materials_emissive_strength](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_emissive_strength) is implemented in `gltf_pbr`.

The main difference in the current implementation between standard surface and gltf_pbr for emission is that standard surface takes the coat into consideration ([as emission is below the coat layer](https://autodesk.github.io/standard-surface/#closures/emission)). The gltf spec also layers emission below the coat, however not implemented in `gltf_pbr` currently, more info in issue: #2592. Even if the coat interaction differs a bit, I think we can just pass the emission and emission color through as both the shading models otherwise have the same implementation. 

Standard surface implementation:
<img width="1901" height="982" alt="image" src="https://github.com/user-attachments/assets/1e9794c0-48b1-488f-acc0-fee0803de9b7" />

gltf_pbr implementation:
<img width="1975" height="1314" alt="image" src="https://github.com/user-attachments/assets/0d3a6e0c-781a-4886-b448-a5bc8da5aae6" />
