### PR TITLE
Graph Editor : Solved crashes when selecting nodes in functional graphs

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -792,6 +792,14 @@ void Graph::setRenderMaterial(UiNodePtr node)
         }
         else if (mtlxNodeGraph)
         {
+            // As above, there is no logic to support traversing from inside a functional graph.
+            // We add a check for output nodes to make sure it's accounted for in this case.
+            if(mtlxOutput){     
+                if (mtlxNodeGraph->getNodeDef())
+                {
+                    return;
+                }
+            }
             testPaths.insert(mtlxNodeGraph->getNamePath());
         }
 


### PR DESCRIPTION
Closes: https://github.com/AcademySoftwareFoundation/MaterialX/issues/2428

### Issue
There was an issue where when you click on an output node in Functional Graphs in the materialX graph editor, it would crash.

### Fix
The reason for this was that output nodes return a nullptr on getNode() calls, and so were being missed by the check for that determines if the node was inside a functional graph. I've added this check for output nodes, and now this crash doesn't occur.