### PR TITLE
Improve `Syntax::makeValidName` function

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -18,15 +18,10 @@ MATERIALX_NAMESPACE_BEGIN
 // ShaderGraph methods
 //
 
-ShaderGraph::ShaderGraph(const ShaderGraph* parent, const string& name, ConstDocumentPtr document, const StringSet& reservedWords) :
+ShaderGraph::ShaderGraph(const ShaderGraph* parent, const string& name, ConstDocumentPtr document, const StringSet& /*reservedWords*/) :
     ShaderNode(parent, name),
     _document(document)
 {
-    // Add all reserved words as taken identifiers
-    for (const string& n : reservedWords)
-    {
-        _identifiers[n] = 1;
-    }
 }
 
 void ShaderGraph::addInputSockets(const InterfaceElement& elem, GenContext& context)

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -153,6 +153,12 @@ void Syntax::makeValidName(string& name) const
 {
     std::replace_if(name.begin(), name.end(), isInvalidChar, '_');
     name = replaceSubstrings(name, _invalidTokens);
+    if (std::find(_reservedWords.begin(), _reservedWords.end(), name) != _reservedWords.end())
+    {
+        // We append "1" here because thats the prior behavior from makeIdentifier() below when
+        // the reservedWords were added to the identifiers list.
+        name = name+"1";
+    }
 }
 
 void Syntax::makeIdentifier(string& name, IdentifierMap& identifiers) const


### PR DESCRIPTION
This PR improves the logic around how valid names are generated with consideration for reserved words defined in specific Syntax objects.

Currently the shader generator calls `Syntax::makeIdentifier()` to ensure that variable names are legal. This compares the current name against a map of already used identifiers. The reserved words for a syntax are prepopulated in this map.

There are some places, namely [here](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/source/MaterialXGenShader/Nodes/CompoundNode.cpp#L40) and [here](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp#L70), where we generate names that need to be legal, but do not call `makeIdentifier()` but instead just call `makeValidName()`.  Which got me to thinking that make `makeValidName()` should be doing the reserved word check.  

Moving the check to `makeValidName()` means we do not have to copy all of the reserved words in to the identifier map for each `ShaderGraph` object we create, as well as plugging the potential bug of being able to generate illegal function names.

I didn't add a warning - but I wonder if we should emit a warning if a reserved word is used as a variable name? 