### PR TITLE
Remove NodeGraph dependency in ShaderTranslation

### DIFF
--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -19,7 +19,7 @@ void ShaderTranslator::connectTranslationInputs(NodePtr shader, NodeDefPtr trans
     std::set<OutputPtr> origOutputs;
     for (InputPtr shaderInput : origInputs)
     {
-        if (translationNodeDef->getInput(shaderInput->getName()))
+        if (translationNodeDef->getActiveInput(shaderInput->getName()))
         {
             InputPtr input = _translationNode->addInput(shaderInput->getName(), shaderInput->getType());
 
@@ -85,7 +85,7 @@ void ShaderTranslator::connectTranslationOutputs(NodePtr shader)
     }
 
     // Iterate through outputs of the translation graph.
-    for (OutputPtr translationGraphOutput : nodeDef->getOutputs())
+    for (OutputPtr translationGraphOutput : nodeDef->getActiveOutputs())
     {
         // Convert output name to input name, using a hardcoded naming convention for now.
         string outputName = translationGraphOutput->getName();


### PR DESCRIPTION
While working on some side experiments - I bumped in to a case where the shader translation tests were failing because I did not have a nodegraph to implement the translation node. 

I don't think this should be a requirement, and we only seem to be using the NodeGraph to find the outputs, which are also available on the NodeDef object.

This appears to pass all the tests, but I do have a question about the code [here](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/source/MaterialXGenShader/ShaderTranslator.cpp#L106). The comment suggests perhaps a NodeGraph is a requirement - but I haven't seen this documented anywhere, and I'm not familiar enough with the context the comment is referring to to understand what it means.  If there is some requirement in the system like this, it would be great to have a unit tests that validates it, so we ensure we don't regress. 

