### PR TITLE
Glsl generation for shadow and env radiance

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_environment_fis.glsl
@@ -2,6 +2,8 @@
 
 vec3 mx_environment_radiance(vec3 N, vec3 V, vec3 X, vec2 alpha, int distribution, FresnelData fd)
 {
+    if ($envRadianceSamples == 0)
+        return vec3(0.0);
     // Generate tangent frame.
     X = normalize(X - dot(X, N) * N);
     vec3 Y = cross(N, X);

--- a/source/MaterialXGenShader/Nodes/HwSurfaceNode.cpp
+++ b/source/MaterialXGenShader/Nodes/HwSurfaceNode.cpp
@@ -111,7 +111,8 @@ void HwSurfaceNode::emitFunctionCall(const ShaderNode& node, GenContext& context
             shadergen.emitComment("Shadow occlusion", stage);
             if (context.getOptions().hwShadowMap)
             {
-                shadergen.emitLine("vec3 shadowCoord = mx_matrix_mul(" + HW::T_SHADOW_MATRIX + ", vec4(" + prefix + HW::T_POSITION_WORLD + ", 1.0)).xyz", stage);
+                shadergen.emitLine("vec4 shadowCoord4 = mx_matrix_mul(" + HW::T_SHADOW_MATRIX + ", vec4(" + prefix + HW::T_POSITION_WORLD + ", 1.0))", stage);
+                shadergen.emitLine("vec3 shadowCoord = shadowCoord4.xyz / shadowCoord4.w;", stage);
                 shadergen.emitLine("shadowCoord = shadowCoord * 0.5 + 0.5", stage);
                 shadergen.emitLine("vec2 shadowMoments = texture(" + HW::T_SHADOW_MAP + ", shadowCoord.xy).xy", stage);
                 shadergen.emitLine("occlusion = mx_variance_shadow_occlusion(shadowMoments, shadowCoord.z)", stage);
@@ -262,6 +263,9 @@ void HwSurfaceNode::emitLightLoop(const ShaderNode& node, GenContext& context, S
 
         shadergen.emitComment("Accumulate the light's contribution", stage);
         shadergen.emitLine(outColor + " += lightShader.intensity * " + bsdf->getOutput()->getVariable() + ".response", stage);
+
+        shadergen.emitComment("Clear shadow factor for next light", stage);
+        shadergen.emitLine("occlusion = 1.0", stage);
 
         shadergen.emitScopeEnd(stage);
         shadergen.emitLineBreak(stage);


### PR DESCRIPTION
shadow map projection for spot light (divide by shadowCoord.w)
shadow map only for the first light (occlusion =1 after the first light), 
environment_radiance in case  u_envRadianceSamples is 0 (in library returns 0)