### PR TITLE
Remove duplicate includes

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsElement.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsElement.cpp
@@ -7,11 +7,6 @@
 #include <JsMaterialX/Helpers.h>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Geom.h>
-#include <MaterialXCore/Look.h>
-#include <MaterialXCore/Material.h>
-#include <MaterialXCore/Node.h>
-#include <MaterialXCore/Traversal.h>
 
 #include <emscripten/bind.h>
 

--- a/source/JsMaterialX/JsMaterialXGenShader/JsGenContext.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsGenContext.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXCore/Unit.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/DefaultColorManagementSystem.h>
 #include <MaterialXFormat/Util.h>
 

--- a/source/JsMaterialX/JsMaterialXGenShader/JsShader.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsShader.cpp
@@ -6,7 +6,6 @@
 #include <JsMaterialX/Helpers.h>
 
 #include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/ShaderStage.h>
 
 #include <emscripten/bind.h>
 

--- a/source/JsMaterialX/JsMaterialXGenShader/JsShaderGenerator.cpp
+++ b/source/JsMaterialX/JsMaterialXGenShader/JsShaderGenerator.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 
 #include <emscripten/bind.h>
 

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXCore/Element.h>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Util.h>
 
 #include <iterator>
 

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXCore/Node.h>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Material.h>
 
 #include <deque>
 

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -7,8 +7,6 @@
 
 #include <MaterialXFormat/External/PugiXML/pugixml.hpp>
 
-#include <MaterialXCore/Types.h>
-
 #include <cstring>
 #include <fstream>
 #include <sstream>

--- a/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/EsslShaderGenerator.cpp
@@ -6,8 +6,6 @@
 #include <MaterialXGenGlsl/EsslShaderGenerator.h>
 #include <MaterialXGenGlsl/EsslSyntax.h>
 
-#include <MaterialXGenHw/HwConstants.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 const string EsslShaderGenerator::TARGET = "essl";

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXGenGlsl/GlslSyntax.h>
 
-#include <MaterialXGenHw/HwLightShaders.h>
 #include <MaterialXGenHw/Nodes/HwImageNode.h>
 #include <MaterialXGenHw/Nodes/HwGeomColorNode.h>
 #include <MaterialXGenHw/Nodes/HwGeomPropValueNode.h>
@@ -27,7 +26,6 @@
 #include <MaterialXGenHw/Nodes/HwNumLightsNode.h>
 #include <MaterialXGenHw/Nodes/HwSurfaceNode.h>
 
-#include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/Nodes/MaterialNode.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenGlsl/VkShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/VkShaderGenerator.cpp
@@ -5,7 +5,6 @@
 
 #include <MaterialXGenGlsl/VkShaderGenerator.h>
 #include <MaterialXGenGlsl/VkSyntax.h>
-#include <MaterialXGenHw/HwConstants.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenGlsl/WgslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/WgslShaderGenerator.cpp
@@ -6,8 +6,6 @@
 #include <MaterialXGenGlsl/WgslShaderGenerator.h>
 #include <MaterialXGenGlsl/WgslSyntax.h>
 
-#include <MaterialXGenHw/HwConstants.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 const string WgslShaderGenerator::LIGHTDATA_TYPEVAR_STRING = "light_type";

--- a/source/MaterialXGenHw/HwShaderGenerator.cpp
+++ b/source/MaterialXGenHw/HwShaderGenerator.cpp
@@ -5,14 +5,7 @@
 
 #include <MaterialXGenHw/HwShaderGenerator.h>
 
-#include <MaterialXGenHw/HwConstants.h>
-#include <MaterialXGenHw/HwLightShaders.h>
 #include <MaterialXGenHw/Nodes/HwLightCompoundNode.h>
-#include <MaterialXGenShader/Nodes/CompoundNode.h>
-#include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
-#include <MaterialXCore/Definition.h>
-#include <MaterialXCore/Document.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwBitangentNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwBitangentNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwGeomColorNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwGeomColorNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwGeomPropValueNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwGeomPropValueNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwLightNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwLightNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwLightShaderNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwLightShaderNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwNormalNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwNormalNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwPositionNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwPositionNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwTangentNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwTangentNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwTexCoordNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwTexCoordNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenHw/Nodes/HwTransformNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwTransformNode.cpp
@@ -5,7 +5,6 @@
 
 #include <MaterialXGenHw/Nodes/HwTransformNode.h>
 
-#include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/Shader.h>
 

--- a/source/MaterialXGenHw/Nodes/HwViewDirectionNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwViewDirectionNode.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -16,9 +16,6 @@
 #include <MaterialXGenMdl/Nodes/CustomNodeMdl.h>
 #include <MaterialXGenMdl/Nodes/ImageNodeMdl.h>
 
-#include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/Util.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenMdl/MdlSyntax.cpp
+++ b/source/MaterialXGenMdl/MdlSyntax.cpp
@@ -7,8 +7,6 @@
 
 #include <MaterialXGenShader/ShaderGenerator.h>
 
-#include <MaterialXFormat/File.h>
-
 #include <sstream>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.cpp
@@ -6,10 +6,7 @@
 #include <MaterialXGenMdl/Nodes/ClosureCompoundNodeMdl.h>
 #include <MaterialXGenMdl/MdlSyntax.h>
 
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
-
-#include <MaterialXCore/Definition.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.cpp
@@ -6,12 +6,6 @@
 #include <MaterialXGenMdl/Nodes/ClosureLayerNodeMdl.h>
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 
-#include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderNode.h>
-#include <MaterialXGenShader/ShaderStage.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
-#include <MaterialXGenShader/TypeDesc.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 const string StringConstantsMdl::TOP = "top";

--- a/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CompoundNodeMdl.cpp
@@ -7,10 +7,7 @@
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 #include <MaterialXGenMdl/MdlSyntax.h>
 
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
-
-#include <MaterialXCore/Definition.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenMdl/Nodes/ConvolutionNode.cpp
+++ b/source/MaterialXGenMdl/Nodes/ConvolutionNode.cpp
@@ -6,9 +6,6 @@
 #include <MaterialXGenMdl/Nodes/ConvolutionNode.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderNode.h>
-#include <MaterialXGenShader/ShaderStage.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/Util.h>
 

--- a/source/MaterialXGenMdl/Nodes/CustomNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/CustomNodeMdl.cpp
@@ -8,9 +8,6 @@
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
-#include <MaterialXGenShader/ShaderNode.h>
-#include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/Util.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/MaterialNodeMdl.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXGenMdl/Nodes/MaterialNodeMdl.h>
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 #include <MaterialXGenMdl/MdlSyntax.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/GenContext.h>
 

--- a/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
+++ b/source/MaterialXGenMdl/Nodes/SourceCodeNodeMdl.cpp
@@ -8,9 +8,6 @@
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
-#include <MaterialXGenShader/ShaderNode.h>
-#include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/Util.h>
 
 #include <MaterialXFormat/Util.h>

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXGenMsl/MslShaderGenerator.h>
 #include <MaterialXGenMsl/MslSyntax.h>
 
-#include <MaterialXGenHw/HwLightShaders.h>
 #include <MaterialXGenHw/Nodes/HwImageNode.h>
 #include <MaterialXGenHw/Nodes/HwGeomColorNode.h>
 #include <MaterialXGenHw/Nodes/HwGeomPropValueNode.h>
@@ -26,7 +25,6 @@
 #include <MaterialXGenHw/Nodes/HwSurfaceNode.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/Nodes/MaterialNode.h>
 
 #include "MslResourceBindingContext.h"

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -8,8 +8,6 @@
 
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/TypeDesc.h>
-#include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>
 
 

--- a/source/MaterialXGenShader/ColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/ColorManagementSystem.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXGenShader/ColorManagementSystem.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenShader/GenContext.cpp
+++ b/source/MaterialXGenShader/GenContext.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -4,12 +4,7 @@
 //
 
 #include <MaterialXGenShader/Nodes/CompoundNode.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
-
-#include <MaterialXCore/Library.h>
-#include <MaterialXCore/Definition.h>
-#include <MaterialXCore/Document.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenShader/Nodes/OcioNode.cpp
+++ b/source/MaterialXGenShader/Nodes/OcioNode.cpp
@@ -8,13 +8,8 @@
 #include <MaterialXGenShader/Nodes/OcioNode.h>
 #include <MaterialXGenShader/OcioColorManagementSystem.h>
 
-#include <MaterialXCore/Interface.h>
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
-#include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Library.h>
-#include <MaterialXGenShader/ShaderNode.h>
 #include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/ShaderStage.h>
 
 #include <cstring>
 

--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -5,9 +5,6 @@
 
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderNode.h>
-#include <MaterialXGenShader/ShaderStage.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXFormat/Util.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenShader/OcioColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/OcioColorManagementSystem.cpp
@@ -9,8 +9,6 @@
 
 #include <MaterialXGenShader/OcioColorManagementSystem.h>
 
-#include <MaterialXCore/Definition.h>
-#include <MaterialXGenShader/ColorManagementSystem.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Nodes/OcioNode.h>
 

--- a/source/MaterialXGenShader/Shader.cpp
+++ b/source/MaterialXGenShader/Shader.cpp
@@ -6,12 +6,7 @@
 #include <MaterialXGenShader/Shader.h>
 
 #include <MaterialXGenShader/ShaderGenerator.h>
-#include <MaterialXGenShader/Syntax.h>
 #include <MaterialXGenShader/Util.h>
-
-#include <MaterialXCore/Document.h>
-#include <MaterialXCore/Node.h>
-#include <MaterialXCore/Value.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -6,16 +6,9 @@
 #include <MaterialXGenShader/ShaderGenerator.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderNodeImpl.h>
 #include <MaterialXGenShader/Nodes/CompoundNode.h>
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>
 #include <MaterialXGenShader/Util.h>
-
-#include <MaterialXFormat/File.h>
-
-#include <MaterialXCore/Document.h>
-#include <MaterialXCore/Node.h>
-#include <MaterialXCore/Value.h>
 
 #include <sstream>
 

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXGenShader/ShaderGraph.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
 #include <iostream>

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXGenShader/ShaderNode.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/Util.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenShader/ShaderNodeImpl.cpp
+++ b/source/MaterialXGenShader/ShaderNodeImpl.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
-#include <MaterialXGenShader/ShaderNode.h>
 #include <MaterialXGenShader/GenContext.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXGenShader/ShaderStage.cpp
+++ b/source/MaterialXGenShader/ShaderStage.cpp
@@ -7,10 +7,7 @@
 
 #include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Syntax.h>
 #include <MaterialXGenShader/Util.h>
-
-#include <MaterialXCore/Value.h>
 
 #include <MaterialXFormat/Util.h>
 

--- a/source/MaterialXGenShader/ShaderTranslator.cpp
+++ b/source/MaterialXGenShader/ShaderTranslator.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXGenShader/ShaderTranslator.h>
 
-#include <MaterialXCore/Material.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 //

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -4,11 +4,8 @@
 //
 
 #include <MaterialXGenShader/Syntax.h>
-#include <MaterialXGenShader/TypeDesc.h>
 #include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
-
-#include <MaterialXCore/Value.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXGenShader/UnitSystem.cpp
+++ b/source/MaterialXGenShader/UnitSystem.cpp
@@ -6,8 +6,6 @@
 #include <MaterialXGenShader/UnitSystem.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
-#include <MaterialXGenShader/ShaderStage.h>
 #include <MaterialXGenShader/Shader.h>
 #include <MaterialXGenShader/Nodes/SourceCodeNode.h>
 

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -5,7 +5,6 @@
 
 #include <MaterialXGraphEditor/Graph.h>
 #include <MaterialXFormat/Environ.h>
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
 #include <imgui_impl_glfw.h>

--- a/source/MaterialXRender/Image.cpp
+++ b/source/MaterialXRender/Image.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXRender/Types.h>
 #include <MaterialXGenShader/Util.h>
-#include <MaterialXCore/Exception.h>
 
 #include <cstring>
 #include <fstream>

--- a/source/MaterialXRender/LightHandler.cpp
+++ b/source/MaterialXRender/LightHandler.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXRender/LightHandler.h>
 
 #include <MaterialXGenHw/HwShaderGenerator.h>
-#include <MaterialXGenShader/GenContext.h>
 
 MATERIALX_NAMESPACE_BEGIN
 

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <MaterialXRender/TinyObjLoader.h>
-#include <MaterialXCore/Util.h>
 
 #if defined(__GNUC__) && !defined(__clang__)
     #pragma GCC diagnostic push

--- a/source/MaterialXRender/Util.cpp
+++ b/source/MaterialXRender/Util.cpp
@@ -5,8 +5,6 @@
 
 #include <MaterialXRender/Util.h>
 
-#include <MaterialXGenShader/ShaderGenerator.h>
-
 MATERIALX_NAMESPACE_BEGIN
 
 const Color3 DEFAULT_SCREEN_COLOR_SRGB(0.3f, 0.3f, 0.32f);

--- a/source/MaterialXRenderGlsl/GLFramebuffer.cpp
+++ b/source/MaterialXRenderGlsl/GLFramebuffer.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXRenderGlsl/GlslProgram.h>
 #include <MaterialXRenderGlsl/GlslRenderer.h>
-#include <MaterialXRenderGlsl/GLTextureHandler.h>
 
 #include <MaterialXRenderGlsl/External/Glad/glad.h>
 

--- a/source/MaterialXRenderGlsl/GlslMaterial.cpp
+++ b/source/MaterialXRenderGlsl/GlslMaterial.cpp
@@ -9,10 +9,6 @@
 #include <MaterialXRenderGlsl/GLTextureHandler.h>
 #include <MaterialXRenderGlsl/GLUtil.h>
 
-#include <MaterialXRender/Util.h>
-
-#include <MaterialXGenHw/HwConstants.h>
-
 #include <MaterialXFormat/Util.h>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXRenderGlsl/GLTextureHandler.h>
 #include <MaterialXRenderGlsl/GLUtil.h>
 
-#include <MaterialXRender/LightHandler.h>
 #include <MaterialXRender/ShaderRenderer.h>
 
 #include <MaterialXGenHw/HwConstants.h>

--- a/source/MaterialXRenderGlsl/GlslRenderer.cpp
+++ b/source/MaterialXRenderGlsl/GlslRenderer.cpp
@@ -9,7 +9,6 @@
 #include <MaterialXRenderGlsl/GLContext.h>
 #include <MaterialXRenderGlsl/GLUtil.h>
 
-#include <MaterialXRenderHw/SimpleWindow.h>
 #include <MaterialXRender/TinyObjLoader.h>
 #include <MaterialXGenHw/HwConstants.h>
 

--- a/source/MaterialXRenderHw/SimpleWindowWindows.cpp
+++ b/source/MaterialXRenderHw/SimpleWindowWindows.cpp
@@ -6,7 +6,6 @@
 #if defined(_WIN32)
 
 #include <MaterialXRenderHw/SimpleWindow.h>
-#include <MaterialXRenderHw/WindowWrapper.h>
 #include <string>
 
 MATERIALX_NAMESPACE_BEGIN

--- a/source/MaterialXRenderOsl/OslRenderer.cpp
+++ b/source/MaterialXRenderOsl/OslRenderer.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
 #include <fstream>

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXCore/Document.h>
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
-#include <MaterialXFormat/XmlIo.h>
 
 namespace mx = MaterialX;
 

--- a/source/MaterialXTest/MaterialXCore/Material.cpp
+++ b/source/MaterialXTest/MaterialXCore/Material.cpp
@@ -6,7 +6,6 @@
 #include <MaterialXTest/External/Catch/catch.hpp>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Value.h>
 #include <MaterialXFormat/XmlIo.h>
 #include <MaterialXFormat/Util.h>
 

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -9,12 +9,9 @@
 
 #include <MaterialXGenGlsl/EsslShaderGenerator.h>
 #include <MaterialXGenGlsl/EsslSyntax.h>
-#include <MaterialXGenGlsl/GlslShaderGenerator.h>
-#include <MaterialXGenGlsl/GlslSyntax.h>
 #include <MaterialXGenGlsl/GlslResourceBindingContext.h>
 #include <MaterialXGenGlsl/VkShaderGenerator.h>
 #include <MaterialXGenGlsl/WgslShaderGenerator.h>
-#include <MaterialXGenHw/HwConstants.h>
 
 namespace mx = MaterialX;
 

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.cpp
@@ -6,18 +6,12 @@
 #include <MaterialXTest/External/Catch/catch.hpp>
 #include <MaterialXTest/MaterialXGenMdl/GenMdl.h>
 
-#include <MaterialXCore/Document.h>
-
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
 #include <MaterialXGenMdl/MdlShaderGenerator.h>
 #include <MaterialXGenMdl/MdlSyntax.h>
 
-#include <MaterialXGenShader/DefaultColorManagementSystem.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Util.h>
-
 
 namespace mx = MaterialX;
 

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.cpp
@@ -10,13 +10,7 @@
 #include <MaterialXGenMsl/MslShaderGenerator.h>
 #include <MaterialXGenMsl/MslSyntax.h>
 #include <MaterialXGenMsl/MslResourceBindingContext.h>
-#include <MaterialXGenHw/HwConstants.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/TypeDesc.h>
-
-#include <MaterialXFormat/File.h>
-
-#include <MaterialXCore/Document.h>
 
 namespace mx = MaterialX;
 

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -6,14 +6,11 @@
 #include <MaterialXTest/External/Catch/catch.hpp>
 #include <MaterialXTest/MaterialXGenOsl/GenOsl.h>
 
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
-#include <MaterialXGenShader/TypeDesc.h>
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/Shader.h>
 
-#include <MaterialXGenOsl/OslShaderGenerator.h>
 #include <MaterialXGenOsl/OslSyntax.h>
 
 namespace mx = MaterialX;

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -6,16 +6,12 @@
 #include <MaterialXTest/External/Catch/catch.hpp>
 #include <MaterialXTest/MaterialXGenShader/GenShaderUtil.h>
 
-#include <MaterialXCore/Document.h>
-
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
 #include <MaterialXGenHw/HwConstants.h>
 
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/ShaderTranslator.h>
-#include <MaterialXGenShader/Util.h>
 
 #ifdef MATERIALX_BUILD_GEN_GLSL
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -10,18 +10,11 @@
 #include <MaterialXGenHw/HwShaderGenerator.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/TypeDesc.h>
-#include <MaterialXGenShader/Util.h>
 #ifdef MATERIALX_BUILD_OCIO
 #include <MaterialXGenShader/OcioColorManagementSystem.h>
 #endif
 
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
-
-#include <MaterialXCore/Material.h>
-#include <MaterialXCore/Unit.h>
 
 #include <iostream>
 

--- a/source/MaterialXTest/MaterialXRender/Render.cpp
+++ b/source/MaterialXTest/MaterialXRender/Render.cpp
@@ -9,7 +9,6 @@
 #include <MaterialXRender/ShaderRenderer.h>
 #include <MaterialXRender/StbImageLoader.h>
 #include <MaterialXRender/TinyObjLoader.h>
-#include <MaterialXRender/Types.h>
 
 #include <MaterialXFormat/Util.h>
 

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -8,9 +8,7 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 #include <MaterialXRenderGlsl/GlslRenderer.h>
-#include <MaterialXRenderGlsl/GLTextureHandler.h>
 
-#include <MaterialXRender/GeometryHandler.h>
 #include <MaterialXRender/StbImageLoader.h>
 #if defined(MATERIALX_BUILD_OIIO)
 #include <MaterialXRender/OiioImageLoader.h>

--- a/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/GenReference.cpp
@@ -6,12 +6,7 @@
 #include <MaterialXTest/External/Catch/catch.hpp>
 #include <MaterialXTest/MaterialXGenShader/GenShaderUtil.h>
 
-#include <MaterialXCore/Document.h>
-
-#include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
-
-#include <MaterialXGenShader/ShaderStage.h>
 
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 #include <MaterialXGenOsl/OslSyntax.h>

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -5,9 +5,7 @@
 
 #include <MaterialXView/Viewer.h>
 
-#include <MaterialXRender/Util.h>
 #include <MaterialXFormat/Util.h>
-#include <MaterialXCore/Util.h>
 
 #include <iostream>
 

--- a/source/MaterialXView/RenderPipelineGL.cpp
+++ b/source/MaterialXView/RenderPipelineGL.cpp
@@ -9,7 +9,6 @@
 
 #include <MaterialXGenGlsl/GlslShaderGenerator.h>
 #include <MaterialXRenderGlsl/TextureBaker.h>
-#include <MaterialXRenderGlsl/GLFramebuffer.h>
 #include <MaterialXRenderGlsl/GlslMaterial.h>
 
 #include <nanogui/messagedialog.h>

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -4,7 +4,6 @@
 //
 
 #include <MaterialXView/Viewer.h>
-#include <MaterialXView/RenderPipeline.h>
 
 #ifdef MATERIALXVIEW_METAL_BACKEND
 #include <MaterialXView/RenderPipelineMetal.h>

--- a/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyElement.cpp
@@ -6,11 +6,6 @@
 #include <PyMaterialX/PyMaterialX.h>
 
 #include <MaterialXCore/Document.h>
-#include <MaterialXCore/Geom.h>
-#include <MaterialXCore/Look.h>
-#include <MaterialXCore/Material.h>
-#include <MaterialXCore/Node.h>
-#include <MaterialXCore/Traversal.h>
 
 #define BIND_ELEMENT_FUNC_INSTANCE(T)                                                                           \
 .def("_addChild" #T, &mx::Element::addChild<mx::T>)                                                             \

--- a/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyUtil.cpp
@@ -6,7 +6,6 @@
 #include <PyMaterialX/PyMaterialX.h>
 
 #include <MaterialXCore/Node.h>
-#include <MaterialXCore/Util.h>
 
 #include <MaterialXFormat/File.h>
 

--- a/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
+++ b/source/PyMaterialX/PyMaterialXFormat/PyXmlIo.cpp
@@ -6,7 +6,6 @@
 #include <PyMaterialX/PyMaterialX.h>
 
 #include <MaterialXFormat/XmlIo.h>
-#include <MaterialXCore/Document.h>
 
 namespace py = pybind11;
 namespace mx = MaterialX;

--- a/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenGlsl/PyGlslShaderGenerator.cpp
@@ -10,8 +10,6 @@
 #include <MaterialXGenGlsl/EsslShaderGenerator.h>
 #include <MaterialXGenGlsl/VkShaderGenerator.h>
 #include <MaterialXGenGlsl/WgslShaderGenerator.h>
-#include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 
 namespace py = pybind11;
 namespace mx = MaterialX;

--- a/source/PyMaterialX/PyMaterialXGenMsl/PyMslShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenMsl/PyMslShaderGenerator.cpp
@@ -7,8 +7,6 @@
 
 #include <MaterialXGenMsl/MslShaderGenerator.h>
 #include <MaterialXGenMsl/MslResourceBindingContext.h>
-#include <MaterialXGenShader/Shader.h>
-#include <MaterialXGenShader/ShaderGenerator.h>
 #include <MaterialXGenShader/GenContext.h>
 
 namespace py = pybind11;

--- a/source/PyMaterialX/PyMaterialXGenShader/PyColorManagement.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyColorManagement.cpp
@@ -8,7 +8,6 @@
 #include <MaterialXGenShader/ColorManagementSystem.h>
 #include <MaterialXGenShader/DefaultColorManagementSystem.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGraph.h>
 
 #ifdef MATERIALX_BUILD_OCIO
 #include <MaterialXGenShader/OcioColorManagementSystem.h>

--- a/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyHwShaderGenerator.cpp
@@ -6,7 +6,6 @@
 #include <PyMaterialX/PyMaterialX.h>
 
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/GenUserData.h>
 #include <MaterialXGenHw/HwShaderGenerator.h>
 
 namespace py = pybind11;

--- a/source/PyMaterialX/PyMaterialXGenShader/PyUnitSystem.cpp
+++ b/source/PyMaterialX/PyMaterialXGenShader/PyUnitSystem.cpp
@@ -7,7 +7,6 @@
 
 #include <MaterialXGenShader/UnitSystem.h>
 #include <MaterialXGenShader/GenContext.h>
-#include <MaterialXGenShader/ShaderGraph.h>
 
 namespace py = pybind11;
 namespace mx = MaterialX;

--- a/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
+++ b/source/PyMaterialX/PyMaterialXRenderGlsl/PyTextureBaker.cpp
@@ -6,7 +6,6 @@
 #include <PyMaterialX/PyMaterialX.h>
 
 #include <MaterialXRenderGlsl/TextureBaker.h>
-#include <MaterialXCore/Material.h>
 
 namespace py = pybind11;
 namespace mx = MaterialX;


### PR DESCRIPTION
This changelist removes duplicate includes across the MaterialX C++ codebase, specifically targeting cases where a header has been included both transitively and directly within the same source file.

No functional changes to the codebase have been made, and no changes in build behavior are expected on any platform, though build times may be slightly improved.