### PR TITLE
Fix typo in Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -182,7 +182,7 @@ export class Scene
 
                 if (!child.geometry.attributes.normal)
                 {
-                    var startNormalTime = performance.new();
+                    var startNormalTime = performance.now();
                     child.geometry.computeVertexNormals();
                     normalTime += performance.now() - startNormalTime;
                 }


### PR DESCRIPTION
This changelist fixes a typo in the JavaScript code for the Web Viewer, replacing `performance.new()` with `performance.now()`.

Previously, this would have triggered an error when loading a mesh without normals into the Web Viewer, which is a relatively rare edge case.