### PR TITLE
Fix cmake rebuild for MaterialXRenderGlsl. Fix PyTinyObjectLoader.load. 

### DIFF
--- a/source/MaterialXRenderGlsl/CMakeLists.txt
+++ b/source/MaterialXRenderGlsl/CMakeLists.txt
@@ -1,5 +1,7 @@
-file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.c*")
-file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
+file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
+file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+message(STATUS "The value of MY_VARIABLE is: ${materialx_source}")
 
 if(POLICY CMP0072)
     cmake_policy(SET CMP0072 NEW)

--- a/source/PyMaterialX/PyMaterialXRender/PyTinyObjLoader.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyTinyObjLoader.cpp
@@ -6,14 +6,24 @@
 #include <PyMaterialX/PyMaterialX.h>
 
 #include <MaterialXRender/TinyObjLoader.h>
+#include <utility>
 
 namespace py = pybind11;
 namespace mx = MaterialX;
+
+std::pair<bool, mx::MeshList> load_meshes_wrapper_tuple(mx::TinyObjLoader& self,
+                                                        const mx::FilePath& filePath,
+                                                        bool texcoordVerticalFlip)
+{
+    mx::MeshList meshList;
+    bool success = self.load(filePath, meshList, texcoordVerticalFlip);
+    return {success, meshList};
+}
 
 void bindPyTinyObjLoader(py::module& mod)
 {
     py::class_<mx::TinyObjLoader, mx::TinyObjLoaderPtr, mx::GeometryLoader>(mod, "TinyObjLoader")
         .def_static("create", &mx::TinyObjLoader::create)
         .def(py::init<>())
-        .def("load", &mx::TinyObjLoader::load);
+        .def("load", &load_meshes_wrapper_tuple);
 }


### PR DESCRIPTION
You need to take care about adding files from now on but that is normal.
Fix PyTinyObjLoader.load so that it returns meshes instead of not returning meshes.
These are the first patches toward getting Python rendering working which should be a lot of fun.