### PR TITLE
Support Specular and Specular Color in Standard Surface to glTF PBR 

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -5,6 +5,8 @@
     <input name="base" type="float" value="1" />
     <input name="base_color" type="color3" value="0.8, 0.8, 0.8" />
     <input name="metalness" type="float" value="0" />
+    <input name="specular" type="float" value="1" />
+    <input name="specular_color" type="color3" value="1, 1, 1" />
     <input name="specular_anisotropy" type="float" value="0.0" />
     <input name="specular_rotation" type="float" value="0.0" />
     <input name="specular_roughness" type="float" value="0.2" />
@@ -23,12 +25,12 @@
     <input name="normal" type="vector3" defaultgeomprop="Nworld" />
     <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
     <input name="opacity" type="color3" value="1, 1, 1" />
-    <input name="specular" type="float" value="1" />
-    <input name="specular_color" type="color3" value="1, 1, 1" />
 
     <output name="base_color_out" type="color3" />
     <output name="metallic_out" type="float" />
     <output name="roughness_out" type="float" />
+    <output name="specular_out" type="float" />
+    <output name="specular_color_out" type="color3" />
     <output name="ior_out" type="float" />
     <output name="anisotropy_strength_out" type="float" />
     <output name="anisotropy_rotation_out" type="float" />
@@ -45,8 +47,6 @@
     <output name="tangent_out" type="vector3" />
     <output name="alpha_out" type="float" />
     <output name="alpha_mode_out" type="integer" />
-    <output name="specular_out" type="float" />
-    <output name="specular_color_out" type="color3" />
   </nodedef>
 
   <nodegraph name="NG_standard_surface_to_gltf_pbr" nodedef="ND_standard_surface_to_gltf_pbr">
@@ -207,6 +207,14 @@
       <input name="in" type="float" interfacename="emission" />
     </dot>
 
+    <!-- Specular -->
+    <dot name="specular" type="float">
+      <input name="in" type="float" interfacename="specular" />
+    </dot>
+    <dot name="specular_color" type="color3">
+      <input name="in" type="color3" interfacename="specular_color" />
+    </dot>
+
     <!-- Specular Index of Refraction -->
     <dot name="ior" type="float">
       <input name="in" type="float" interfacename="specular_IOR" />
@@ -237,17 +245,11 @@
       <input name="in2" type="integer" value="2" />
     </ifequal>
 
-    <!-- Specular -->
-    <dot name="specular" type="float">
-      <input name="in" type="float" interfacename="specular" />
-    </dot>
-    <dot name="specular_color" type="color3">
-      <input name="in" type="color3" interfacename="specular_color" />
-    </dot>
-
     <output name="base_color_out" type="color3" nodename="base_color" />
     <output name="metallic_out" type="float" nodename="metallic" />
     <output name="roughness_out" type="float" nodename="roughness" />
+    <output name="specular_out" type="float" nodename="specular" />
+    <output name="specular_color_out" type="color3" nodename="specular_color" />
     <output name="ior_out" type="float" nodename="ior" />
     <output name="anisotropy_strength_out" type="float" nodename="anisotropy_strength" />
     <output name="anisotropy_rotation_out" type="float" nodename="anisotropy_rotation" />
@@ -264,8 +266,6 @@
     <output name="tangent_out" type="vector3" nodename="tangent" />
     <output name="alpha_out" type="float" nodename="opacity_luminance_float" />
     <output name="alpha_mode_out" type="integer" nodename="alpha_mode_from_opacity_luminance" />
-    <output name="specular_out" type="float" nodename="specular" />
-    <output name="specular_color_out" type="color3" nodename="specular_color" />
 
   </nodegraph>
 </materialx>


### PR DESCRIPTION
closes #2581 

## Summary
This PR passthrough the specular weight and the specular color from standard surface to gltf_pbr. 

This translation will not produce completely matching result, even if specular and specular_color control similar aspects in both the shading models, there are some fundamental differences. It will successfully translate the specular weight, so if you have a material with roughness 0, and specular 0, it will be a diffuse material (similar to roughness 1). But the difference will be in the specular_color, both for dielectric materials (non-metals) and conductors (metals).

## Specular Color in glTF
In glTF `specular_color` will only affect dielectric materials and not conductors. The `specular_color` will tint the highlights of _f0_. The _f90_ highlighs (grazing angles) are always white, and not controllable using artistic parameters. For angles between _f0_ and _f90_ the color will be interpolated between `specular_color` and white. 
More info in: [KHR_materials_specular](https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_materials_specular)

**Red base_color, green specular_color**
|![](https://github.com/user-attachments/assets/7d7c1e25-f88b-4539-b9f4-c0ffb8aeef15)<br>Dielectric - gltf_pbr material. Green _f0_, White _f90_ |![](https://github.com/user-attachments/assets/ca1a9b37-8f81-4195-8888-f2b86b68bd23)<br>Conductor - gltf_pbr, uneffected by the specular color.|
|:-:|:-:|

## Specular Color in Standard Surface
In Standard surface the `specular_color` will affect both dielectrics and conductors.

For dielectrics `specular_color` will tint both the _f0_ and the _f90_. Meaning that the same specular_color in standard surface tint all the highlights regardless of angle and be more impact full compare to glTF. 
 
For conductors the _f90_ will be colored using the `specular_color`, the _f0_ seems to be the same as base color, but I cannot find what is expected in the docs.

More info: [Autodesk Standard Surface](https://autodesk.github.io/standard-surface/)

**Red base color, green specular color** 
|![](https://github.com/user-attachments/assets/01e09b8c-e814-452e-b2b8-49cde9c0b102)<br>Dielectric - Standard Surface |![](https://github.com/user-attachments/assets/95c934c0-f851-4bde-9548-7138e20fa333)<br>Conductor- Standard Surface |
|:-:|:-:|

## Result of translation

There are some differences in the result which we cannot account for in the translation graph. For dielectrics after translation we get a big difference when using a `specular_color` far from white, as _f90_ highlights are not colored by the specular_color in gltf_pbr.

For conductors after translation, we will not get a tinted fresnel.

**Dielectrics** 
|![](https://github.com/user-attachments/assets/7273f87c-f94a-4f40-9669-45a6054d9669)<br>Standard Surface |![](https://github.com/user-attachments/assets/7d7c1e25-f88b-4539-b9f4-c0ffb8aeef15)<br>Translated to gltf_pbr |![](https://github.com/user-attachments/assets/cb899201-2457-4ba9-8e48-1acd0751d2d6) **Diff**
|:-:|:-:|:-:|

**Conductors** 
|![](https://github.com/user-attachments/assets/95c934c0-f851-4bde-9548-7138e20fa333)<br>Standard Surface |![](https://github.com/user-attachments/assets/ca1a9b37-8f81-4195-8888-f2b86b68bd23)<br>Translated to gltf_pbr |![](https://github.com/user-attachments/assets/7aa63be6-4415-4b10-bf29-c2f2dd4c4dec) **Diff**
|:-:|:-:|:-:|

**Specular Weight = 0, Roughness = 0**
|![](https://github.com/user-attachments/assets/8bbcf24b-2c4d-40ec-8e93-a9f28005706e)<br>Standard Surface |![](https://github.com/user-attachments/assets/6e8abc5b-e4a2-45be-af37-abbbba17ea96)<br>Translated to gltf_pbr |![](https://github.com/user-attachments/assets/e426dab0-00eb-4061-9498-fce4ee6fa56e) **Diff**
|:-:|:-:|:-:|

The material used in the renders are 
```xml
  <standard_surface name="standard_surface0" type="surfaceshader" nodedef="ND_standard_surface_surfaceshader">
    <input name="base" type="float" value="1.0" />
    <input name="base_color" type="color3" value="0.266356, 0.022174, 0.022174" />
    <input name="metalness" type="float" value="1.0" /> <!-- Varying between examples -->
    <input name="specular" type="float" value="1.0" /> <!-- Varying between examples -->
    <input name="specular_color" type="color3" value="0.0, 1.0, 0.0" />
    <input name="specular_roughness" type="float" value="0.0" />
  </standard_surface>
```