### PR TITLE
Refine naming convention guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,13 +200,13 @@ with these guidelines.
 #### Naming Conventions
 
 Class names should use PascalCase, as in `NodeGraph` or `ShaderGenerator`.
-Method names should use camelCase starting with a lowercase letter, for
-example `getNode` or `setName`. Protected and private member variables should
-use an underscore prefix, such as `_name` or `_parent`. Constants should be
-written in UPPER_CASE with underscores separating words, as in `EMPTY_STRING`
-or `CATEGORY`. Type aliases should append appropriate suffixes to indicate
-their purpose, using `Ptr` for pointers, `Vec` for vectors, `Map` for maps,
-and `Set` for sets.
+Variable and function names should use camelCase starting with a lowercase
+letter, as in `childName` or `getNode`. Protected and private member variables
+additionally require an underscore prefix, as in `_parent` or `_childMap`.
+Constants should be written in UPPER_CASE with underscores separating words,
+as in `EMPTY_STRING` or `CATEGORY`. Type aliases should append appropriate
+suffixes to indicate their purpose, using `Ptr` for pointers, `Vec` for
+vectors, `Map` for maps, and `Set` for sets.
 
 #### Static Constants and Class Organization
 


### PR DESCRIPTION
This changelist makes additional refinements to the guidelines for naming conventions, including the following:

- Clarify that all variable and function names use camel case, not just method names.
- Clarify that protected and private member variable names also use camel case.