### PR TITLE
Remove global constructor for Traversal constants

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsTraversal.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsTraversal.cpp
@@ -64,8 +64,5 @@ EMSCRIPTEN_BINDINGS(traversal)
         .smart_ptr_constructor("InheritanceIterator", &std::make_shared<mx::InheritanceIterator, mx::ConstElementPtr>)
         BIND_ITERABLE_PROTOCOL(InheritanceIterator)
 
-    // Avoid binding complex sentinels by value at static init time; fetch at runtime
-    ems::function("getNullEdge", ems::optional_override([](){ return mx::NULL_EDGE; }));
-    // Iterator sentinels are complex non-POD types; avoid binding by value as constants
-    // to prevent costly copies during module initialization under newer Emscripten.
+    ems::function("getNullEdge", &mx::getNullEdge);
 }

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -509,7 +509,7 @@ GraphIterator Element::traverseGraph() const
 
 Edge Element::getUpstreamEdge(size_t) const
 {
-    return NULL_EDGE;
+    return getNullEdge();
 }
 
 ElementPtr Element::getUpstreamElement(size_t index) const

--- a/source/MaterialXCore/Interface.cpp
+++ b/source/MaterialXCore/Interface.cpp
@@ -327,7 +327,7 @@ Edge Output::getUpstreamEdge(size_t index) const
         return Edge(getSelfNonConst(), nullptr, getConnectedNode());
     }
 
-    return NULL_EDGE;
+    return getNullEdge();
 }
 
 bool Output::hasUpstreamCycle() const

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -126,7 +126,7 @@ Edge Node::getUpstreamEdge(size_t index) const
         }
     }
 
-    return NULL_EDGE;
+    return getNullEdge();
 }
 
 OutputPtr Node::getNodeDefOutput(ElementPtr connectingElement)

--- a/source/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXCore/Traversal.cpp
@@ -9,11 +9,23 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-const Edge NULL_EDGE(nullptr, nullptr, nullptr);
+const Edge& getNullEdge() {
+    static const auto ret = new Edge(nullptr, nullptr, nullptr);
+    return *ret;
+}
 
-const TreeIterator NULL_TREE_ITERATOR(nullptr);
-const GraphIterator NULL_GRAPH_ITERATOR(nullptr);
-const InheritanceIterator NULL_INHERITANCE_ITERATOR(nullptr);
+const TreeIterator& getNullTreeIterator() {
+    static const auto ret = new TreeIterator(nullptr);
+    return *ret;
+}
+const GraphIterator& getNullGraphIterator() {
+    static const auto ret = new GraphIterator(nullptr);
+    return *ret;
+}
+const InheritanceIterator& getNullInheritanceIterator() {
+    static const auto ret = new InheritanceIterator(nullptr);
+    return *ret;
+}
 
 //
 // Edge methods
@@ -21,7 +33,7 @@ const InheritanceIterator NULL_INHERITANCE_ITERATOR(nullptr);
 
 Edge::operator bool() const
 {
-    return *this != NULL_EDGE;
+    return *this != getNullEdge();
 }
 
 string Edge::getName() const
@@ -35,7 +47,7 @@ string Edge::getName() const
 
 const TreeIterator& TreeIterator::end()
 {
-    return NULL_TREE_ITERATOR;
+    return getNullTreeIterator();
 }
 
 TreeIterator& TreeIterator::operator++()
@@ -97,7 +109,7 @@ size_t GraphIterator::getNodeDepth() const
 
 const GraphIterator& GraphIterator::end()
 {
-    return NULL_GRAPH_ITERATOR;
+    return getNullGraphIterator();
 }
 
 GraphIterator& GraphIterator::operator++()
@@ -189,7 +201,7 @@ bool GraphIterator::skipOrMarkAsVisited(const Edge& edge)
 
 const InheritanceIterator& InheritanceIterator::end()
 {
-    return NULL_INHERITANCE_ITERATOR;
+    return getNullInheritanceIterator();
 }
 
 InheritanceIterator& InheritanceIterator::operator++()

--- a/source/MaterialXCore/Traversal.h
+++ b/source/MaterialXCore/Traversal.h
@@ -392,11 +392,11 @@ class MX_CORE_API ExceptionFoundCycle : public Exception
     using Exception::Exception;
 };
 
-extern MX_CORE_API const Edge NULL_EDGE;
+MX_CORE_API const Edge& getNullEdge();
 
-extern MX_CORE_API const TreeIterator NULL_TREE_ITERATOR;
-extern MX_CORE_API const GraphIterator NULL_GRAPH_ITERATOR;
-extern MX_CORE_API const InheritanceIterator NULL_INHERITANCE_ITERATOR;
+MX_CORE_API const TreeIterator& getNullTreeIterator();
+MX_CORE_API const GraphIterator& getNullGraphIterator();
+MX_CORE_API const InheritanceIterator& getNullInheritanceIterator();
 
 MATERIALX_NAMESPACE_END
 

--- a/source/MaterialXTest/MaterialXCore/Traversal.cpp
+++ b/source/MaterialXTest/MaterialXCore/Traversal.cpp
@@ -14,14 +14,14 @@ namespace mx = MaterialX;
 TEST_CASE("IntraGraph Traversal", "[traversal]")
 {
     // Test null iterators.
-    mx::TreeIterator nullTree = mx::NULL_TREE_ITERATOR;
-    mx::GraphIterator nullGraph = mx::NULL_GRAPH_ITERATOR;
+    mx::TreeIterator nullTree = mx::getNullTreeIterator();
+    mx::GraphIterator nullGraph = mx::getNullGraphIterator();
     REQUIRE(*nullTree == nullptr);
-    REQUIRE(*nullGraph == mx::NULL_EDGE);
+    REQUIRE(*nullGraph == mx::getNullEdge());
     ++nullTree;
     ++nullGraph;
-    REQUIRE((nullTree == mx::NULL_TREE_ITERATOR));
-    REQUIRE((nullGraph == mx::NULL_GRAPH_ITERATOR));
+    REQUIRE((nullTree == mx::getNullTreeIterator()));
+    REQUIRE((nullGraph == mx::getNullGraphIterator()));
 
     // Create a document.
     mx::DocumentPtr doc = mx::createDocument();


### PR DESCRIPTION
When we ship MaterialX in apple ecosystem we maintain a number of patches to avoid global constructors and destructors on exit. (`-Wglobal-constructors -Wexit-time-destructor`)

This PR proposed one of these patches, if this is merged, I'll propose some others moving forwards. This will help us lower the burden of ongoing maintenance for MaterialX integration in the apple ecosystem.
