### PR TITLE
Fix sheen roughness in Standard Surface to glTF PBR translation

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -187,6 +187,9 @@
       <input name="in1" type="float" interfacename="sheen_roughness" />
       <input name="in2" type="float" value="0" />
     </ifgreater>
+    <sqrt name="sqrt_sheen_roughness" type="float">
+      <input name="in" type="float" nodename="sheen_roughness" />
+    </sqrt>
 
     <!-- Clearcoat -->
     <ifequal name="clearcoat" type="float">
@@ -257,7 +260,7 @@
     <output name="thickness_out" type="float" nodename="thickness" />
     <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />
     <output name="sheen_color_out" type="color3" nodename="sheen_color" />
-    <output name="sheen_roughness_out" type="float" nodename="sheen_roughness" />
+    <output name="sheen_roughness_out" type="float" nodename="sqrt_sheen_roughness" />
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
     <output name="emissive_out" type="color3" nodename="emissive" />


### PR DESCRIPTION
closes #2642 

**Sheen roughness** in glTF PBR is squared before the `sheen_bsdf` node compare to standard surface implementation.
In this PR the translation graph is updated to take the sqrt of the sheen roughness from standard surface to make sure the intended sheen roughness is translated properly.

_Screenshots of a black material with a red sheen effect with sheen roughness 0.5_ 
<table width="100%">
  <thead>
    <tr>
      <th width="33.33%">
        <img width="552" height="552" alt="Image" src="https://github.com/user-attachments/assets/e697305b-2106-45af-b7d6-add73cbe2bc7" />
        </th>
      <th width="33.33%"><img width="552" height="552" alt="Image" src="https://github.com/user-attachments/assets/2eb0c3ed-b8ab-469e-b7ec-33c936d214d2" /></th>
      <th width="33.33%"><img width="552" height="552" alt="Image" src="https://github.com/user-attachments/assets/f3489d29-8a0e-4739-9441-d6e18711003a" /></th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td width="33.33%">Standard surface</td>
      <td width="33.33%">Translated to glTF PBR</td>
      <td width="33.33%">Diff </td>
    </tr>
  </tbody>
</table>

glTF PBR sheen implementation
<img width="2416" height="1041" alt="image" src="https://github.com/user-attachments/assets/c7ad87dd-5692-48ff-83f6-1796dd61bddd" />

Standard surface sheen implementation
<img width="608" height="347" alt="sheen implementation standard surface" src="https://github.com/user-attachments/assets/2749e3f5-8493-4590-9357-d000aa835c10" />

Test material
```xml
<?xml version="1.0"?>
<materialx version="1.39" colorspace="lin_rec709">
  <constant name="sheen_intensity2" type="float" xpos="-0.144928" ypos="-6.344828">
    <input name="value" type="float" value="1" />
  </constant>
  <constant name="sheen_color2" type="color3" xpos="0.246377" ypos="-4.982759">
    <input name="value" type="color3" value="1, 0, 0" />
  </constant>
  <constant name="sheen_roughness2" type="float" xpos="0.362319" ypos="-3.310345">
    <input name="value" type="float" value="0.5" />
  </constant>
  <gltf_pbr name="issue_material2" type="surfaceshader" xpos="11.565217" ypos="3.370690">
    <input name="base_color" type="color3" value="0, 0, 0" />
    <input name="sheen_color" type="color3" output="sheen_color_out" nodename="standard_surface_to_gltf_pbr" />
    <input name="sheen_roughness" type="float" output="sheen_roughness_out" nodename="standard_surface_to_gltf_pbr" />
    <input name="metallic" type="float" value="0" />
    <input name="specular_color" type="color3" value="1, 1, 1" />
    <input name="specular" type="float" value="0" />
  </gltf_pbr>
  <standard_surface name="standard_surface_surfaceshader2" type="surfaceshader" xpos="11.318841" ypos="-8.551724">
    <input name="base_color" type="color3" value="0, 0, 0" />
    <input name="specular_roughness" type="float" value="1" />
    <input name="sheen" type="float" output="out" nodename="sheen_intensity2" />
    <input name="sheen_roughness" type="float" output="out" nodename="sheen_roughness2" />
    <input name="sheen_color" type="color3" output="out" nodename="sheen_color2" />
    <input name="specular" type="float" value="0" />
  </standard_surface>
  <standard_surface_to_gltf_pbr name="standard_surface_to_gltf_pbr" type="multioutput" xpos="6.231884" ypos="-0.060345">
    <input name="sheen_roughness" type="float" nodename="sheen_roughness2" />
    <input name="sheen_color" type="color3" nodename="sheen_color2" />
    <input name="sheen" type="float" nodename="sheen_intensity2" />
  </standard_surface_to_gltf_pbr>
</materialx>

```