### PR TITLE
Fix `thin_walled` and `transmission_depth` in Standard Surface to glTF PBR

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -268,7 +268,7 @@
     <output name="anisotropy_strength_out" type="float" nodename="anisotropy_strength" />
     <output name="anisotropy_rotation_out" type="float" nodename="anisotropy_rotation" />
     <output name="transmission_out" type="float" nodename="transmission" />
-    <output name="thickness_out" type="float" nodename="thickness_from_thin_wall" />
+    <output name="thickness_out" type="float" nodename="thickness_from_thin_walled" />
     <output name="attenuation_color_out" type="color3" nodename="attenuation_color" />
     <output name="attenuation_distance_out" type="float" nodename="attenuation_distance" />
     <output name="sheen_color_out" type="color3" nodename="sheen_color" />


### PR DESCRIPTION
Thickness in glTF PBR is used to describe how thick a mesh is. If it's thin walled, thickness is 0, otherwise it should be a value corresponding to a mesh, in a ray tracer, you will have that info when rendering, for a rasterizer you either bake it or use an arbitrary value (such as longest side of the bounding box).

Since Thickness is a mesh related value, we can't translate to the expected value, unless the material is considered `thin_walled`. Then it should be 0. I have updated the translation graph from Standard surface to set thickness to 0 if thin walled, otherwise 1 (which is better then nothing).

Previously `transmission_depth` was used for thickness, which do not correspond to glTF PBRs thickness. I have changed it to be used for `attenuation_distance` which correspond to `transmission_depth`, (with the caveat that in glTF PBR it should >0, as `base_color` is used to color the surface even for `thin_walled` transmissive materials).

![](https://github.com/user-attachments/assets/1a011f63-2c72-48e5-9d97-7dbdfe998735)
From [Standard Surface - 3.8 Specular Transmission](https://autodesk.github.io/standard-surface/#closures/speculartransmission)

![](https://github.com/user-attachments/assets/6119d33a-2b9b-4bab-9414-1aa041fb8baa)
From [KHR_materials_volume](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_volume/README.md#properties)
