### PR TITLE
Refactor HwSurfaceNode AO texture orientation

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -463,12 +463,6 @@ void GlslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& c
         _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv.glsl";
     }
 
-    // Emit uv transform code globally if needed.
-    if (context.getOptions().hwAmbientOcclusion)
-    {
-        emitLibraryInclude("stdlib/genglsl/lib/" + _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV], context, stage);
-    }
-
     emitLightFunctionDefinitions(graph, context, stage);
 
     // Emit function definitions for all nodes in the graph.

--- a/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
@@ -127,7 +127,11 @@ void HwSurfaceNode::emitFunctionCall(const ShaderNode& node, GenContext& context
             if (context.getOptions().hwAmbientOcclusion)
             {
                 ShaderPort* texcoord = vertexData[HW::T_TEXCOORD + "_0"];
-                shadergen.emitLine("vec2 ambOccUv = mx_transform_uv(" + prefix + texcoord->getVariable() + ", vec2(1.0), vec2(0.0))", stage);
+                shadergen.emitLine("vec2 ambOccUv = " + prefix + texcoord->getVariable(), stage);
+                if (context.getOptions().fileTextureVerticalFlip)
+                {
+                    shadergen.emitLine("ambOccUv = vec2(ambOccUv.x, 1.0 - ambOccUv.y)", stage);
+                }
                 shadergen.emitLine("occlusion = mix(1.0, texture(" + HW::T_AMB_OCC_MAP + ", ambOccUv).x, " + HW::T_AMB_OCC_GAIN + ")", stage);
             }
             else

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -959,12 +959,6 @@ void MslShaderGenerator::emitPixelStage(const ShaderGraph& graph, GenContext& co
             _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV] = "mx_transform_uv.glsl";
         }
 
-        // Emit uv transform code globally if needed.
-        if (context.getOptions().hwAmbientOcclusion)
-        {
-            emitLibraryInclude("stdlib/genglsl/lib/" + _tokenSubstitutions[ShaderGenerator::T_FILE_TRANSFORM_UV], context, stage);
-        }
-
         emitLightFunctionDefinitions(graph, context, stage);
 
         // Emit function definitions for all nodes in the graph.


### PR DESCRIPTION
The use of explicit paths to source files in the data library is fragile, and something we should look to try and reduce where possible. 

This PR removes the inclusion of the uv transform source file in HW shader generators in favor of directly transforming the UVs when the generator option is enabled.  Also elides an unnecessary addition and multiple, that the compiler was likely removing - but less code is generally better :) 
