### PR TITLE
Fix merge conflict

### DIFF
--- a/source/MaterialXGenOsl/OslNetworkShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslNetworkShaderGenerator.cpp
@@ -25,7 +25,7 @@ OslNetworkShaderGenerator::OslNetworkShaderGenerator(TypeSystemPtr typeSystem) :
 {
 }
 
-ShaderNodeImplPtr OslNetworkShaderGenerator::createShaderNodeImplForImplementation(const NodeDef& /* nodedef */) const
+ShaderNodeImplPtr OslNetworkShaderGenerator::createShaderNodeImplForImplementation(const Implementation& /* implElement */) const
 {
     return OsoNode::create();
 }

--- a/source/MaterialXGenOsl/OslNetworkShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslNetworkShaderGenerator.h
@@ -36,7 +36,7 @@ class MX_GENOSL_API OslNetworkShaderGenerator : public ShaderGenerator
         return std::make_shared<OslNetworkShaderGenerator>(typeSystem ? typeSystem : TypeSystem::create());
     }
 
-    ShaderNodeImplPtr createShaderNodeImplForImplementation(const NodeDef& nodedef) const override;
+    ShaderNodeImplPtr createShaderNodeImplForImplementation(const Implementation& implElement) const override;
 
     /// Return a unique identifier for the target this generator is for
     const string& getTarget() const override { return TARGET; }


### PR DESCRIPTION
This changelist fixes a merge conflict between two recent changes to OSL shader generation, aligning a method signature in OslNetworkShaderGenerator to match that of its base class.