### PR TITLE
Fix data library build for slang

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
           compiler_version: "26.0"
           python: 3.13
           static_analysis: ON
-          cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMATERIALX_BUILD_DATA_LIBRARY=ON
 
         - name: MacOS_Xcode_DynamicAnalysis
           os: macos-26

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -13,7 +13,8 @@ if(MATERIALX_BUILD_DATA_LIBRARY)
          *.glsl
          *.osl
          *.h
-         *.metal)
+         *.metal
+         *.slang)
 
     foreach(SOURCE_FILE IN LISTS MATERIALX_DATA_LIBRARY_SOURCE_FILES)
         set(SOURCE_FILEPATH ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE})


### PR DESCRIPTION
The recent addition of the slang shader generator broke the data library build step.

This PR fixes that and adds a test case to the CI - so we don't break it again in the future.