### PR TITLE
Improve get all files in directory unit test

### DIFF
--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -185,7 +185,7 @@ FilePathVec FilePath::getFilesInDirectory(const string& extension) const
 
 #if defined(_WIN32)
     WIN32_FIND_DATAA fd;
-    FilePath query = extension.empty() ? *this : (*this / ("*." + extension));
+    FilePath query = extension.empty() ? (*this / "*") : (*this / ("*." + extension));
     HANDLE hFind = FindFirstFileA(query.asString().c_str(), &fd);
     if (hFind != INVALID_HANDLE_VALUE)
     {

--- a/source/MaterialXTest/MaterialXFormat/File.cpp
+++ b/source/MaterialXTest/MaterialXFormat/File.cpp
@@ -185,18 +185,21 @@ TEST_CASE("Get all files in directory", "[file]")
     mx::FilePathVec results;
 
     results = lightsDir.getFilesInDirectory("mtlx");
+    REQUIRE(results.size() > 0);
     for (const mx::FilePath& filename : mtlxFilenames)
     {
         REQUIRE(std::find(results.begin(), results.end(), filename) != results.end());
     }
 
     results = lightsDir.getFilesInDirectory("hdr");
+    REQUIRE(results.size() > 0);
     for (const mx::FilePath& filename : hdrFilenames)
     {
         REQUIRE(std::find(results.begin(), results.end(), filename) != results.end());
     }
 
     results = lightsDir.getFilesInDirectory();
+    REQUIRE(results.size() > 0);
     for (const mx::FilePath& filename : allFilesnames)
     {
         REQUIRE(std::find(results.begin(), results.end(), filename) != results.end());


### PR DESCRIPTION
As reported in #2663 the get all files in directory unit test is not robust enough to OS generated files.

This PR inverts the validation logic to make it more robust.

Looks like this idea fails the windows CI - but im not sure why and don't have a windows machine to investigate. 