### PR TITLE
Fix LibsToOso crash when not removing prefixes

### DIFF
--- a/source/MaterialXGenOsl/LibsToOso.cpp
+++ b/source/MaterialXGenOsl/LibsToOso.cpp
@@ -364,7 +364,7 @@ int main(int argc, char* const argv[])
         }
 
         // TODO: Check for the existence/validity of the `Node`?
-        mx::NodePtr node = librariesDoc->addNodeInstance(nodeDef, nodeName);
+        mx::NodePtr node = librariesDocGraph->addNodeInstance(nodeDef, nodeName);
 
         std::string oslShaderName = node->getName();
         oslShaderGen->getSyntax().makeValidName(oslShaderName);


### PR DESCRIPTION
In the offending LibsToOso code, node instances were meant to be inserted into an isolated nodegraph, but weren't due to a merge error during development.

This lead to name collisions when called with --removeNdPrefix false. This patch restores the intended behavior.