### PR TITLE
Refactor LibToOSO tool

### DIFF
--- a/source/MaterialXGenOsl/CMakeLists.txt
+++ b/source/MaterialXGenOsl/CMakeLists.txt
@@ -14,22 +14,26 @@ mx_add_library(MaterialXGenOsl
     EXPORT_DEFINE
         MATERIALX_GENOSL_EXPORTS)
 
-# FIXME: LibsToOso has a dependency on the OslRenderer.
-if (MATERIALX_BUILD_OSOS AND MATERIALX_BUILD_RENDER)
+if (MATERIALX_BUILD_OSOS)
     file(GLOB GenNodes_SRC "${CMAKE_CURRENT_SOURCE_DIR}/LibsToOso.cpp")
-
-    set(MATERIALX_LIBRARIES
-        MaterialXCore
-        MaterialXFormat
-        MaterialXGenShader
-        MaterialXGenOsl
-        MaterialXRenderOsl)
 
     add_executable(MaterialXGenOsl_LibsToOso ${GenNodes_SRC})
 
-    target_link_libraries(
-        MaterialXGenOsl_LibsToOso
-        ${MATERIALX_LIBRARIES})
+    target_link_libraries(MaterialXGenOsl_LibsToOso
+        PRIVATE
+            MaterialXCore
+            MaterialXFormat
+            MaterialXGenShader
+            MaterialXGenOsl)
+
+    if (OSL_FOUND)
+        target_link_libraries(MaterialXGenOsl_LibsToOso
+            PRIVATE
+                OSL::oslcomp)
+        target_compile_definitions(MaterialXGenOsl_LibsToOso
+            PRIVATE
+                USE_OSLCOMP)
+    endif()
 
     set_target_properties(
         MaterialXGenOsl_LibsToOso PROPERTIES

--- a/source/MaterialXGenOsl/LibsToOso.cpp
+++ b/source/MaterialXGenOsl/LibsToOso.cpp
@@ -12,41 +12,176 @@
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
-#include <MaterialXGenShader/ShaderStage.h>
+#include <MaterialXGenShader/GenContext.h>
+#include <MaterialXGenShader/Shader.h>
 
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 #include <MaterialXGenOsl/OslSyntax.h>
 
-#include <MaterialXRenderOsl/OslRenderer.h>
+#ifdef USE_OSLCOMP
+#include <OSL/oslcomp.h>
+#endif
 
 namespace mx = MaterialX;
 
 const std::string options =
-    "    Options: \n"
-    "        --outputOsoPath [DIRPATH]       TODO\n"
-    "        --libraryRelativeOsoPath [DIRPATH]       TODO\n"
-    "        --outputMtlxPath [DIRPATH]      TODO\n"
-    "        --oslCompilerPath [FILEPATH]    TODO\n"
-    "        --oslIncludePath [DIRPATH]      TODO\n"
-    "        --libraries [STRING]            TODO\n"
-    "        --osoNameStrategy [STRING]      TODO - either 'implementation' or 'nodedef' (default:'implementation')\n"
-    "        --help                          Display the complete list of command-line options\n";
+    " Options: \n"
+    "    --outputOsoPath [DIRPATH]       TODO\n"
+    "    --libraryRelativeOsoPath [DIRPATH]       TODO\n"
+    "    --outputMtlxPath [DIRPATH]      TODO\n"
+    "    --oslCompilerPath [FILEPATH]    TODO\n"
+#ifdef USE_OSLCOMP
+    "    --useOslC                       TODO\n"
+#endif
+    "    --skipWritingOSLSource          TODO\n"
+    "    --skipWritingMtlxDoc            TODO\n"
+    "    --oslIncludePath [DIRPATH]      TODO\n"
+    "    --path [FILEPATH]              Specify an additional data search path location (e.g. '/projects/MaterialX').  This absolute path will be queried when locating data libraries, XInclude references, and referenced images.\n"
+    "    --library [FILEPATH]           Specify an additional data library folder (e.g. 'vendorlib', 'studiolib').  This relative path will be appended to each location in the data search path when loading data libraries.\n"
+    "    --osoNameStrategy [STRING]      TODO - either 'implementation' or 'nodedef' (default:'implementation')\n"
+    "    --help                          Display the complete list of command-line options\n";
 
-template <class T> void parseToken(std::string token, std::string type, T& res)
+class ExceptionCompileError : public mx::Exception
 {
-    if (token.empty())
-        return;
-
-    mx::ValuePtr value = mx::Value::createValueFromStrings(token, type);
-
-    if (!value)
+public:
+    ExceptionCompileError(const std::string& msg, const mx::StringVec& errorLog = mx::StringVec()) :
+        Exception(msg),
+        _errorLog(errorLog)
     {
-        std::cout << "Unable to parse token " << token << " as type " << type << std::endl;
-
-        return;
     }
 
-    res = value->asA<T>();
+    ExceptionCompileError(const ExceptionCompileError& e) :
+        Exception(e),
+        _errorLog(e._errorLog)
+    {
+    }
+
+    ExceptionCompileError& operator=(const ExceptionCompileError& e)
+    {
+        Exception::operator=(e);
+        _errorLog = e._errorLog;
+        return *this;
+    }
+
+    const mx::StringVec& errorLog() const
+    {
+        return _errorLog;
+    }
+
+private:
+    mx::StringVec _errorLog;
+};
+
+// A set of options for controlling the behavior of OSL compilation.
+class OslCompileOptions
+{
+public:
+    OslCompileOptions() = default;
+    ~OslCompileOptions() = default;
+
+    mx::FilePath oslCompilerPath;
+    mx::FileSearchPath oslIncludePath;
+    bool useOslComp = false;
+    bool writeSourceToDisk = true;
+};
+
+bool compileOSL(const std::string& oslSourceCode, const mx::FilePath& oslFilePath, const OslCompileOptions& options)
+{
+    if (!options.useOslComp && !options.writeSourceToDisk)
+    {
+        throw mx::Exception("If OslComp library is not being used the source must be written to disk");
+    }
+
+    if (options.writeSourceToDisk)
+    {
+        std::ofstream oslFile;
+        oslFile.open(oslFilePath);
+        oslFile << oslSourceCode;
+        oslFile.close();
+    }
+
+    mx::FilePath osoFilePath = oslFilePath;
+    osoFilePath.removeExtension();
+    osoFilePath.addExtension("oso");
+
+    // build up a vector of compiler arguments that will be
+    // used in both compiler modes.
+    std::vector<std::string> oslCompilerArgs;
+    oslCompilerArgs.emplace_back("-o");
+    oslCompilerArgs.emplace_back(osoFilePath);
+    for (mx::FilePath p : options.oslIncludePath)
+    {
+        oslCompilerArgs.emplace_back("-I" + p.asString() + "");
+    }
+
+#ifdef USE_OSLCOMP
+    if (options.useOslComp)
+    {
+        // Use OSL::oslcomp to compile the shader - this is significantly faster than using the system
+        // call to involke the `oslc` command line tool
+        OIIO::ErrorHandler errorHandler;
+        ::OSL::OSLCompiler compiler(&errorHandler);
+        if (options.writeSourceToDisk)
+        {
+            // Compile from the source file
+            compiler.compile(oslFilePath.asString(), oslCompilerArgs);
+        }
+        else
+        {
+            // Compile directly from the string buffer
+            std::string osoBuffer;
+            compiler.compile_buffer(oslSourceCode, osoBuffer, oslCompilerArgs, std::string_view(), oslFilePath.asString());
+
+            std::ofstream osoFile;
+            osoFile.open(osoFilePath.asString());
+            osoFile << osoBuffer;
+            osoFile.close();
+        }
+    }
+    else
+#endif
+    {
+        // If no command and include path specified then skip checking.
+        if (options.oslCompilerPath.isEmpty())
+        {
+            throw mx::Exception("OSL compiler path missing");
+        }
+        if (!options.oslCompilerPath.exists())
+        {
+            throw mx::Exception("OSL compiler doesn't exist at '" + options.oslCompilerPath.asString() + "'");
+        }
+
+        // Use a known error file name to check
+        std::string errorFile(osoFilePath.asString() + "_compile_errors.txt");
+        const std::string redirectString(" 2>&1");
+
+        // Run the command and get back the result. If non-empty string throw exception with error
+        std::string command = options.oslCompilerPath.asString() + " -q " + oslFilePath.asString();
+        for (const auto& arg : oslCompilerArgs)
+        {
+            command += " " + arg;
+        }
+        // command += " > " + errorFile + redirectString;
+
+        int returnValue = std::system(command.c_str());
+
+        std::ifstream errorStream(errorFile);
+        std::string result;
+        result.assign(std::istreambuf_iterator<char>(errorStream),
+                      std::istreambuf_iterator<char>());
+
+        if (!result.empty())
+        {
+            mx::StringVec errors;
+            errors.push_back("Command string: " + command);
+            errors.push_back("Command return code: " + std::to_string(returnValue));
+            errors.push_back("Shader failed to compile:");
+            errors.push_back(result);
+            throw ExceptionCompileError("OSL compilation error", errors);
+        }
+    }
+
+    return true;
 }
 
 int main(int argc, char* const argv[])
@@ -59,13 +194,17 @@ int main(int argc, char* const argv[])
         tokens.emplace_back(argv[i]);
     }
 
+    mx::FileSearchPath argSearchPath = mx::getDefaultDataSearchPath();
+    mx::FilePathVec argLibraryFolders;
     std::string argOutputOsoPath;
     std::string argOutputMtlxPath;
     std::string argLibraryRelativeOsoPath;
     std::string argOslCompilerPath;
     std::string argOslIncludePath;
-    std::string argLibraries;
     std::string argOsoNameStrategy = "implementation";
+    bool argSkipWritingSource = false;
+    bool argSkipWritingMtlxDoc = false;
+    bool argUseOslC = false;
 
     // Loop over the provided arguments, and store their associated values.
     for (size_t i = 0; i < tokens.size(); i++)
@@ -74,22 +213,56 @@ int main(int argc, char* const argv[])
         const std::string& nextToken = i + 1 < tokens.size() ? tokens[i + 1] : mx::EMPTY_STRING;
 
         if (token == "--outputOsoPath")
+        {
             argOutputOsoPath = nextToken;
+        }
         else if (token == "--outputMtlxPath")
+        {
             argOutputMtlxPath = nextToken;
+        }
         else if (token == "--libraryRelativeOsoPath")
+        {
             argLibraryRelativeOsoPath = nextToken;
+        }
         else if (token == "--oslCompilerPath")
+        {
             argOslCompilerPath = nextToken;
+        }
         else if (token == "--oslIncludePath")
+        {
             argOslIncludePath = nextToken;
-        else if (token == "--libraries")
-            argLibraries = nextToken;
+        }
+        else if (token == "--path")
+        {
+            argSearchPath.append(mx::FileSearchPath(nextToken));
+        }
+        else if (token == "--library")
+        {
+            argLibraryFolders.push_back(nextToken);
+        }
         else if (token == "--osoNameStrategy")
+        {
             argOsoNameStrategy = nextToken;
+        }
+        else if (token == "--skipWritingOSLSource")
+        {
+            argSkipWritingSource = true;
+        }
+        else if (token == "--skipWritingMtlxDoc")
+        {
+            argSkipWritingMtlxDoc = true;
+        }
+        else if (token == "--useOslC")
+        {
+            argUseOslC = true;
+        }
         else if (token == "--help")
         {
-            std::cout << "MaterialXGenOslNetwork - LibsToOso version " << mx::getVersionString() << std::endl;
+            std::cout << "MaterialXGenOslNetwork - LibsToOso version " << mx::getVersionString();
+#ifdef USE_OSLCOMP
+            std::cout << " - Compiled with liboslcomp";
+#endif
+            std::cout << std::endl;
             std::cout << options << std::endl;
 
             return 0;
@@ -112,10 +285,12 @@ int main(int argc, char* const argv[])
 
     if (!(argOsoNameStrategy == "implementation" || argOsoNameStrategy == "nodedef"))
     {
-        std::cerr << "Unrecognized value for --osoNameStrategy '" << argOsoNameStrategy <<
-            "'. Must be 'implementation' or 'nodedef'" << std::endl;
+        std::cerr << "Unrecognized value for --osoNameStrategy '" << argOsoNameStrategy << "'. Must be 'implementation' or 'nodedef'" << std::endl;
         return 1;
     }
+
+    // Append the standard library folder, giving it a lower precedence than user-supplied libraries.
+    argLibraryFolders.push_back("libraries");
 
     // Ensure we have a valid output path.
     mx::FilePath outputOsoPath(argOutputOsoPath);
@@ -134,7 +309,7 @@ int main(int argc, char* const argv[])
     }
 
     mx::FilePath outputMtlxPath(argOutputMtlxPath);
-    if (!outputMtlxPath.exists() || !outputMtlxPath.isDirectory())
+    if (argSkipWritingMtlxDoc && (!outputMtlxPath.exists() || !outputMtlxPath.isDirectory()))
     {
         outputMtlxPath.createDirectory();
 
@@ -165,43 +340,30 @@ int main(int argc, char* const argv[])
     }
 
     // Create the libraries search path and document.
-    mx::FileSearchPath librariesSearchPath = mx::getDefaultDataSearchPath();
     mx::DocumentPtr librariesDoc = mx::createDocument();
-
-    // If a list of comma separated libraries was provided, load them individually into our document.
-    if (!argLibraries.empty())
+    try
     {
-        // TODO: Should we check that we actually split something based on the separator, just to be sure?
-        const mx::StringVec& librariesVec = mx::splitString(argLibraries, ",");
-        mx::FilePathVec librariesPaths{ "libraries/targets" };
-
-        for (const std::string& library : librariesVec)
-            librariesPaths.emplace_back("libraries/" + library);
-
-        loadLibraries(librariesPaths, librariesSearchPath, librariesDoc);
+        mx::loadLibraries(argLibraryFolders, argSearchPath, librariesDoc);
     }
-    // Otherwise, simply load all the available libraries.
-    else
-        loadLibraries({ "libraries" }, librariesSearchPath, librariesDoc);
+    catch (std::exception& e)
+    {
+        std::cerr << "Failed to load standard data libraries: " << e.what() << std::endl;
+        return 1;
+    }
 
     const std::string target = "genoslnetwork";
-    mx::FilePath implMtlxDocFilePath = outputMtlxPath / "genoslnetwork_impl.mtlx";
-    mx::DocumentPtr implMtlxDoc = mx::createDocument();
+    mx::DocumentPtr implMtlxDoc = nullptr;
+    if (!argSkipWritingMtlxDoc)
+    {
+        implMtlxDoc = mx::createDocument();
+    }
 
-    // Create and setup the `OslRenderer` that will be used to both generate the `.osl` files as well as compile
-    // them to `.oso` files.
-    mx::OslRendererPtr oslRenderer = mx::OslRenderer::create();
-    oslRenderer->setOslCompilerExecutable(oslCompilerPath);
-
-    // Build the list of include paths that will be passed to the `OslRenderer`.
+    // Build the list of include paths that will be used to compile the shader.
     mx::FileSearchPath oslRendererIncludePaths;
-
     // Add the provided OSL include path.
     oslRendererIncludePaths.append(oslIncludePath);
     // Add the MaterialX's OSL include path.
-    oslRendererIncludePaths.append(librariesSearchPath.find("libraries/stdlib/genosl/include"));
-
-    oslRenderer->setOslIncludePath(oslRendererIncludePaths);
+    oslRendererIncludePaths.append(argSearchPath.find("libraries/stdlib/genosl/include"));
 
     // Create the OSL shader generator.
     mx::ShaderGeneratorPtr oslShaderGen = mx::OslShaderGenerator::create();
@@ -211,11 +373,19 @@ int main(int argc, char* const argv[])
 
     // Setup the context of the OSL shader generator.
     mx::GenContext context(oslShaderGen);
-    context.registerSourceCodeSearchPath(librariesSearchPath);
+    context.registerSourceCodeSearchPath(argSearchPath);
     // TODO: It might be good to find a way to not hardcode these options, especially the texture flip.
     context.getOptions().addUpstreamDependencies = false;
     context.getOptions().fileTextureVerticalFlip = false;
     context.getOptions().oslImplicitSurfaceShaderConversion = false;
+
+    OslCompileOptions options;
+    options.oslIncludePath = oslRendererIncludePaths;
+    options.writeSourceToDisk = !argSkipWritingSource;
+    options.oslCompilerPath = argOslCompilerPath;
+#ifdef USE_OSLCOMP
+    options.useOslComp = !argUseOslC;
+#endif
 
     // We'll use this boolean to return an error code is one of the `NodeDef` failed to codegen/compile.
     bool hasFailed = false;
@@ -247,7 +417,7 @@ int main(int argc, char* const argv[])
             // Name the node the same as the implementation with _genoslnetwork added as a suffix.
             // NOTE : If the implementation currently has _genosl as a suffix then we remove it.
             nodeName = nodeImpl->getName();
-            nodeName = mx::replaceSubstrings(nodeName, {{"_genosl", ""}});
+            nodeName = mx::replaceSubstrings(nodeName, { { "_genosl", "" } });
             nodeName += "_genoslnetwork";
         }
         else
@@ -271,10 +441,11 @@ int main(int argc, char* const argv[])
         std::ofstream oslFile;
 
         // Codegen the `Node` to an `.osl` file.
+        mx::ShaderPtr oslShader = nullptr;
         try
         {
             // Codegen the `Node` to OSL.
-            mx::ShaderPtr oslShader = oslShaderGen->generate(node->getName(), node, context);
+            oslShader = oslShaderGen->generate(node->getName(), node, context);
 
             // TODO: Check that we have a valid/opened file descriptor before doing anything with it?
             oslFile.open(oslFilePath);
@@ -297,7 +468,7 @@ int main(int argc, char* const argv[])
         try
         {
             // Compile the `.osl` file to a `.oso` file next to it.
-            oslRenderer->compileOSL(oslFilePath);
+            compileOSL(oslShader->getSourceCode(), oslFilePath, options);
 
             {
                 std::string implName = "IMPL_" + nodeName + "_" + target;
@@ -313,7 +484,7 @@ int main(int argc, char* const argv[])
             }
         }
         // Catch any codegen/compilation related exceptions.
-        catch (mx::ExceptionRenderError& exc)
+        catch (ExceptionCompileError& exc)
         {
             std::cerr << "Encountered a shader compilation related exception for the "
                          "following node: "
@@ -328,7 +499,12 @@ int main(int argc, char* const argv[])
         }
     }
 
-    mx::writeToXmlFile(implMtlxDoc, implMtlxDocFilePath);
+    if (implMtlxDoc)
+    {
+        // We only write the MaterialX document containing the implementations out if requested.
+        mx::FilePath implMtlxDocFilePath = outputMtlxPath / "genoslnetwork_impl.mtlx";
+        mx::writeToXmlFile(implMtlxDoc, implMtlxDocFilePath);
+    }
 
     // If something went wrong, return an appropriate error code.
     if (hasFailed)


### PR DESCRIPTION
* Localize the compileOSL() code, this removes the dependency on MaterialXRender
* Add optional dependency on liboslcomp, which allows compiling of the osos without using std::system. This significantly speeds up compilation time, on my machine dropping from about a minute for the entire data library to about 15 seconds.
* With liboslcomp, we can avoid writing the OSL source to disk - saving space. This is controlled by a command line argument
* Add command line arguments to specify data library location
* Add argument to avoid writing the MaterialX document for the implementation elements, this may be helpful for those not using MaterialX shader generation.