### PR TITLE
Add TSC stakeholder

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -70,6 +70,7 @@ The current Stakeholders of the MaterialX TSC are:
 - Lutz Kettner - NVIDIA
 - Chris Kulla - Epic Games
 - Bernard Kwok - Khronos Group
+- Karen Lucknavalai - Pixar USD
 - André Mazzone - ILM
 - Magnus Pettersson - IKEA
 - Dimitar Toshev - Chaos


### PR DESCRIPTION
This changelist adds Karen Lucknavalai as the Pixar USD stakeholder on the MaterialX TSC, as confirmed by vote at a recent TSC meeting.