### PR TITLE
Update string constants to avoid global constructors - Option 1

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsElement.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsElement.cpp
@@ -135,11 +135,19 @@ EMSCRIPTEN_BINDINGS(element)
         BIND_ELEMENT_CHILD_FUNC_INSTANCE(VariantAssign, mx::VariantAssign)
         BIND_ELEMENT_CHILD_FUNC_INSTANCE(VariantSet, mx::VariantSet)
         BIND_ELEMENT_CHILD_FUNC_INSTANCE(Variant, mx::Variant)
-        .function("setAttribute", &mx::Element::setAttribute)
-        .function("hasAttribute", &mx::Element::hasAttribute)
-        .function("getAttribute", &mx::Element::getAttribute)
+        .function("setAttribute", ems::optional_override([](mx::Element& self, const std::string& attrib, const std::string& value) {
+            self.setAttribute(attrib, value);
+        }))
+        .function("hasAttribute", ems::optional_override([](const mx::Element& self, const std::string& attrib) {
+            return self.hasAttribute(attrib);
+        }))
+        .function("getAttribute", ems::optional_override([](const mx::Element& self, const std::string& attrib) -> const std::string& {
+            return self.getAttribute(attrib);
+        }))
         .function("getAttributeNames", &mx::Element::getAttributeNames)
-        .function("removeAttribute", &mx::Element::removeAttribute)
+        .function("removeAttribute", ems::optional_override([](mx::Element& self, const std::string& attrib) {
+            self.removeAttribute(attrib);
+        }))
         .function("getSelf", ems::select_overload<mx::ConstElementPtr()const>(&mx::Element::getSelf))
         .function("getParent", ems::select_overload<mx::ConstElementPtr()const>(&mx::Element::getParent))
         .function("getRoot", ems::select_overload<mx::ConstElementPtr()const>(&mx::Element::getRoot))

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -190,8 +190,9 @@ void Element::removeChild(const string& name)
     unregisterChildElement(it->second);
 }
 
-void Element::setAttribute(const string& attrib, const string& value)
+void Element::setAttribute(std::string_view attrib_sv, const string& value)
 {
+    string attrib = string(attrib_sv);
     getDocument()->invalidateCache();
 
     if (!_attributeMap.count(attrib))
@@ -201,9 +202,9 @@ void Element::setAttribute(const string& attrib, const string& value)
     _attributeMap[attrib] = value;
 }
 
-void Element::removeAttribute(const string& attrib)
+void Element::removeAttribute(std::string_view attrib)
 {
-    StringMap::iterator it = _attributeMap.find(attrib);
+    StringMap::iterator it = _attributeMap.find(string(attrib));
     if (it != _attributeMap.end())
     {
         getDocument()->invalidateCache();

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -479,19 +479,19 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @{
 
     /// Set the value string of the given attribute.
-    void setAttribute(const string& attrib, const string& value);
+    void setAttribute(std::string_view attrib, const string& value);
 
     /// Return true if the given attribute is present.
-    bool hasAttribute(const string& attrib) const
+    bool hasAttribute(std::string_view attrib) const
     {
-        return _attributeMap.count(attrib) != 0;
+        return _attributeMap.count(string(attrib)) != 0;
     }
 
     /// Return the value string of the given attribute.  If the given attribute
     /// is not present, then an empty string is returned.
-    const string& getAttribute(const string& attrib) const
+    const string& getAttribute(std::string_view attrib) const
     {
-        StringMap::const_iterator it = _attributeMap.find(attrib);
+        StringMap::const_iterator it = _attributeMap.find(string(attrib));
         return (it != _attributeMap.end()) ? it->second : EMPTY_STRING;
     }
 
@@ -528,7 +528,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     }
 
     /// Remove the given attribute, if present.
-    void removeAttribute(const string& attrib);
+    void removeAttribute(std::string_view attrib);
 
     /// @}
     /// @name Self And Ancestor Elements

--- a/source/MaterialXCore/Property.cpp
+++ b/source/MaterialXCore/Property.cpp
@@ -7,11 +7,6 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-const string PropertyAssign::PROPERTY_ATTRIBUTE = "property";
-const string PropertyAssign::GEOM_ATTRIBUTE = "geom";
-const string PropertyAssign::COLLECTION_ATTRIBUTE = "collection";
-const string PropertySetAssign::PROPERTY_SET_ATTRIBUTE = "propertyset";
-
 //
 // PropertyAssign methods
 //

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -141,9 +141,9 @@ class MX_CORE_API PropertyAssign : public ValueElement
 
   public:
     static const string CATEGORY;
-    static const string PROPERTY_ATTRIBUTE;
-    static const string GEOM_ATTRIBUTE;
-    static const string COLLECTION_ATTRIBUTE;
+    static constexpr std::string_view PROPERTY_ATTRIBUTE = "property";
+    static constexpr std::string_view GEOM_ATTRIBUTE = "geom";
+    static constexpr std::string_view COLLECTION_ATTRIBUTE = "collection";
 };
 
 /// @class PropertySet
@@ -263,7 +263,7 @@ class MX_CORE_API PropertySetAssign : public GeomElement
 
   public:
     static const string CATEGORY;
-    static const string PROPERTY_SET_ATTRIBUTE;
+    static constexpr std::string_view PROPERTY_SET_ATTRIBUTE = "propertyset";
 };
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
As part of the work to make adopting MaterialX easier for us and lowering the number of internal patches we have to carry for security and performance reasons, this PR proposes a method we could use to avoid the global constructor/destructor calls for std::string constants.

There are actually two different possible approaches here - the other is in #2694 

This PR only applies the change to a single source file `Property.cpp/h`, but if/when one of the two options is selected it would be my intention to apply the same pattern at least to the rest of `MaterialXCore`, and then eventually elsewhere. 

This approach is probably my preferred one, it uses `constexpr std::string_view` instead of `const std::string`, but it does need API change to the attribute interface on `Element`. Everything compiles, so I believe it to be compatible with the existing source.  Also some changes were necessary in the Javascript bindings, which I'm not familiar with  - hoping experts there can highlight any problems, if they exist. 
