### PR TITLE
Update string constants to avoid global constructors - Option 2

### DIFF
--- a/source/JsMaterialX/JsMaterialXCore/JsProperty.cpp
+++ b/source/JsMaterialX/JsMaterialXCore/JsProperty.cpp
@@ -24,6 +24,10 @@ EMSCRIPTEN_BINDINGS(property)
         .smart_ptr<std::shared_ptr<const mx::Property>>("Property")
         .class_property("CATEGORY", &mx::Property::CATEGORY);
 
+    std::string mx__PropertyAssign__PROPERTY_ATTRIBUTE = mx::PropertyAssign::PROPERTY_ATTRIBUTE;
+    std::string mx__PropertyAssign__GEOM_ATTRIBUTE = mx::PropertyAssign::GEOM_ATTRIBUTE;
+    std::string mx__PropertyAssign__COLLECTION_ATTRIBUTE = mx::PropertyAssign::COLLECTION_ATTRIBUTE;
+
     ems::class_<mx::PropertyAssign, ems::base<mx::ValueElement>>("PropertyAssign")
         .smart_ptr_constructor("PropertyAssign", &std::make_shared<mx::PropertyAssign, mx::ElementPtr, const std::string &>)
         .smart_ptr<std::shared_ptr<const mx::PropertyAssign>>("PropertyAssign")
@@ -39,9 +43,9 @@ EMSCRIPTEN_BINDINGS(property)
         .function("setCollection", &mx::PropertyAssign::setCollection)
         .function("getCollection", &mx::PropertyAssign::getCollection)
         .class_property("CATEGORY", &mx::PropertyAssign::CATEGORY)
-        .class_property("PROPERTY_ATTRIBUTE", &mx::PropertyAssign::PROPERTY_ATTRIBUTE)
-        .class_property("GEOM_ATTRIBUTE", &mx::PropertyAssign::GEOM_ATTRIBUTE)
-        .class_property("COLLECTION_ATTRIBUTE", &mx::PropertyAssign::COLLECTION_ATTRIBUTE);
+        .class_property("PROPERTY_ATTRIBUTE", &mx__PropertyAssign__PROPERTY_ATTRIBUTE)
+        .class_property("GEOM_ATTRIBUTE", &mx__PropertyAssign__GEOM_ATTRIBUTE)
+        .class_property("COLLECTION_ATTRIBUTE", &mx__PropertyAssign__COLLECTION_ATTRIBUTE);
 
     ems::class_<mx::PropertySet, ems::base<mx::Element>>("PropertySet")
         .smart_ptr_constructor("PropertySet", &std::make_shared<mx::PropertySet, mx::ElementPtr, const std::string &>)
@@ -67,7 +71,9 @@ EMSCRIPTEN_BINDINGS(property)
         BIND_PROPERTYSET_TYPE_INSTANCE(StringArray, mx::StringVec)
         .function("getPropertyValue", &mx::PropertySet::getPropertyValue)
         .class_property("CATEGORY", &mx::Property::CATEGORY);
-        
+
+    std::string mx__PropertySetAssign__COLLECTION_ATTRIBUTE = mx::PropertySetAssign::PROPERTY_SET_ATTRIBUTE;
+
     ems::class_<mx::PropertySetAssign, ems::base<mx::GeomElement>>("PropertySetAssign")
         .smart_ptr_constructor("PropertySetAssign", &std::make_shared<mx::PropertySetAssign, mx::ElementPtr, const std::string &>)
         .smart_ptr<std::shared_ptr<const mx::PropertySetAssign>>("PropertySetAssign")
@@ -77,5 +83,5 @@ EMSCRIPTEN_BINDINGS(property)
         .function("setPropertySet", &mx::PropertySetAssign::setPropertySet)
         .function("getPropertySet", &mx::PropertySetAssign::getPropertySet)
         .class_property("CATEGORY", &mx::PropertySetAssign::CATEGORY)
-        .class_property("PROPERTY_SET_ATTRIBUTE", &mx::PropertySetAssign::PROPERTY_SET_ATTRIBUTE);
+        .class_property("PROPERTY_SET_ATTRIBUTE", &mx__PropertySetAssign__COLLECTION_ATTRIBUTE);
 }

--- a/source/MaterialXCore/Property.cpp
+++ b/source/MaterialXCore/Property.cpp
@@ -7,10 +7,10 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
-const string PropertyAssign::PROPERTY_ATTRIBUTE = "property";
-const string PropertyAssign::GEOM_ATTRIBUTE = "geom";
-const string PropertyAssign::COLLECTION_ATTRIBUTE = "collection";
-const string PropertySetAssign::PROPERTY_SET_ATTRIBUTE = "propertyset";
+const char* PropertyAssign::PROPERTY_ATTRIBUTE = "property";
+const char* PropertyAssign::GEOM_ATTRIBUTE = "geom";
+const char* PropertyAssign::COLLECTION_ATTRIBUTE = "collection";
+const char* PropertySetAssign::PROPERTY_SET_ATTRIBUTE = "propertyset";
 
 //
 // PropertyAssign methods

--- a/source/MaterialXCore/Property.h
+++ b/source/MaterialXCore/Property.h
@@ -141,9 +141,9 @@ class MX_CORE_API PropertyAssign : public ValueElement
 
   public:
     static const string CATEGORY;
-    static const string PROPERTY_ATTRIBUTE;
-    static const string GEOM_ATTRIBUTE;
-    static const string COLLECTION_ATTRIBUTE;
+    static const char* PROPERTY_ATTRIBUTE;
+    static const char* GEOM_ATTRIBUTE;
+    static const char* COLLECTION_ATTRIBUTE;
 };
 
 /// @class PropertySet
@@ -263,7 +263,7 @@ class MX_CORE_API PropertySetAssign : public GeomElement
 
   public:
     static const string CATEGORY;
-    static const string PROPERTY_SET_ATTRIBUTE;
+    static const char* PROPERTY_SET_ATTRIBUTE;
 };
 
 MATERIALX_NAMESPACE_END


### PR DESCRIPTION
As part of the work to make adopting MaterialX easier for us and lowering the number of internal patches we have to carry for security and performance reasons, this PR proposes a method we could use to avoid the global constructor/destructor calls for std::string constants.

There are actually two different possible approaches here - the other is in #2693 

This PR only applies the change to a single source file `Property.cpp/h`, but if/when one of the two options is selected it would be my intention to apply the same pattern at least to the rest of `MaterialXCore`, and then eventually elsewhere. 

I think I prefer the other option, but this uses `const char*` instead of `const std::string`, it needs no other core API changes, it needs no other changes as `std::string` has a constructor that accepts `const char*`.  Also some changes were necessary in the Javascript bindings, which I'm not familiar with  - hoping experts there can highlight any problems, if they exist. 
