### PR TITLE
Optimization to extended CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,6 @@ jobs:
           python: 3.13
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           test_shaders: ON
-          extended_build_oiio: ON
           extended_build_mdl_sdk: ON
 
         - name: Windows_VS2022_x64_SharedLibs
@@ -123,6 +122,7 @@ jobs:
           architecture: x64
           python: None
           cmake_config: -G "Visual Studio 17 2022" -A "x64" -DMATERIALX_BUILD_SHARED_LIBS=ON
+          extended_build_oiio: ON
           upload_shaders: ON
 
     steps:


### PR DESCRIPTION
This changelist implements a modest optimization to extended CI, splitting the MDL and OIIO build steps into separate jobs.  As a result, the total time of each extended build is reduced by roughly 20 minutes.