### PR TITLE
Consolidate `toVec4` method in HW generators

### DIFF
--- a/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.cpp
@@ -621,31 +621,6 @@ void GlslShaderGenerator::emitLightFunctionDefinitions(const ShaderGraph& graph,
     }
 }
 
-void GlslShaderGenerator::toVec4(TypeDesc type, string& variable)
-{
-    if (type.isFloat3())
-    {
-        variable = "vec4(" + variable + ", 1.0)";
-    }
-    else if (type.isFloat2())
-    {
-        variable = "vec4(" + variable + ", 0.0, 1.0)";
-    }
-    else if (type == Type::FLOAT || type == Type::INTEGER || type == Type::BOOLEAN)
-    {
-        variable = "vec4(" + variable + ", " + variable + ", " + variable + ", 1.0)";
-    }
-    else if (type == Type::BSDF || type == Type::EDF)
-    {
-        variable = "vec4(" + variable + ", 1.0)";
-    }
-    else
-    {
-        // Can't understand other types. Just return black.
-        variable = "vec4(0.0, 0.0, 0.0, 1.0)";
-    }
-}
-
 void GlslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier,
                                                   GenContext&, ShaderStage& stage,
                                                   bool assignValue) const

--- a/source/MaterialXGenGlsl/GlslShaderGenerator.h
+++ b/source/MaterialXGenGlsl/GlslShaderGenerator.h
@@ -82,9 +82,6 @@ class MX_GENGLSL_API GlslShaderGenerator : public HwShaderGenerator
     /// Emit function definitions for lighting code
     virtual void emitLightFunctionDefinitions(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const;
 
-    static void toVec4(TypeDesc type, string& variable);
-    [[deprecated]] static void toVec4(const TypeDesc* type, string& variable) { toVec4(*type, variable); }
-
     /// Nodes used internally for light sampling.
     vector<ShaderNodePtr> _lightSamplingNodes;
 };

--- a/source/MaterialXGenHw/HwShaderGenerator.cpp
+++ b/source/MaterialXGenHw/HwShaderGenerator.cpp
@@ -424,4 +424,31 @@ void HwShaderGenerator::emitClosureDataParameter(const ShaderNode& node, GenCont
     }
 }
 
+void HwShaderGenerator::toVec4(TypeDesc type, string& variable) const
+{
+    const string& vec4 = _syntax->getTypeName(Type::VECTOR4);
+
+    if (type.isFloat3())
+    {
+        variable = vec4+"(" + variable + ", 1.0)";
+    }
+    else if (type.isFloat2())
+    {
+        variable = vec4+"(" + variable + ", 0.0, 1.0)";
+    }
+    else if (type == Type::FLOAT || type == Type::INTEGER || type == Type::BOOLEAN)
+    {
+        variable = vec4+"(" + variable + ", " + variable + ", " + variable + ", 1.0)";
+    }
+    else if (type == Type::BSDF || type == Type::EDF)
+    {
+        variable = vec4+"(" + variable + ", 1.0)";
+    }
+    else
+    {
+        // Can't understand other types. Just return black.
+        variable = vec4+"(0.0, 0.0, 0.0, 1.0)";
+    }
+}
+
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenHw/HwShaderGenerator.h
+++ b/source/MaterialXGenHw/HwShaderGenerator.h
@@ -86,6 +86,8 @@ class MX_GENHW_API HwShaderGenerator : public ShaderGenerator
 
     /// Create and initialize a new HW shader for shader generation.
     virtual ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;
+
+    void toVec4(TypeDesc type, string& variable) const;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenMsl/MslShaderGenerator.cpp
+++ b/source/MaterialXGenMsl/MslShaderGenerator.cpp
@@ -1140,31 +1140,6 @@ void MslShaderGenerator::emitLightFunctionDefinitions(const ShaderGraph& graph, 
     }
 }
 
-void MslShaderGenerator::toVec4(TypeDesc type, string& variable)
-{
-    if (type.isFloat3())
-    {
-        variable = "float4(" + variable + ", 1.0)";
-    }
-    else if (type.isFloat2())
-    {
-        variable = "float4(" + variable + ", 0.0, 1.0)";
-    }
-    else if (type == Type::FLOAT || type == Type::INTEGER)
-    {
-        variable = "float4(" + variable + ", " + variable + ", " + variable + ", 1.0)";
-    }
-    else if (type == Type::BSDF || type == Type::EDF)
-    {
-        variable = "float4(" + variable + ", 1.0)";
-    }
-    else
-    {
-        // Can't understand other types. Just return black.
-        variable = "float4(0.0, 0.0, 0.0, 1.0)";
-    }
-}
-
 void MslShaderGenerator::emitVariableDeclaration(const ShaderPort* variable, const string& qualifier,
                                                  GenContext&, ShaderStage& stage,
                                                  bool assignValue) const

--- a/source/MaterialXGenMsl/MslShaderGenerator.h
+++ b/source/MaterialXGenMsl/MslShaderGenerator.h
@@ -109,9 +109,6 @@ class MX_GENMSL_API MslShaderGenerator : public HwShaderGenerator
     /// Emit function definitions for lighting code
     virtual void emitLightFunctionDefinitions(const ShaderGraph& graph, GenContext& context, ShaderStage& stage) const;
 
-    static void toVec4(TypeDesc type, string& variable);
-    [[deprecated]] static void toVec4(const TypeDesc* type, string& variable) { toVec4(*type, variable); }
-
     /// Nodes used internally for light sampling.
     vector<ShaderNodePtr> _lightSamplingNodes;
 };


### PR DESCRIPTION
While looking at some of the GLSL vs MSL differences @bernardkwok raised in #2697. I noticed that the `GLSLShaderGenerator::toVec4()` and the `MSLShaderGenerator::toVec4()` have gotten out of sync. I think it makes sense to continue the consolidation work and move this to `HWShaderGenerator` to be more easily maintained.

I think there could be future work here to follow the pattern introduced in #2661, and instead of having the conversion shader code hard-coded in the shader generator - we could add a new node to the data library that performs the conversion and just update the shader generator to insert it when necessary.