### PR TITLE
Align `REFRACTION_TWO_SIDED` in GLSL and MSL rendering

### DIFF
--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -741,6 +741,7 @@ void MslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr imag
             }
         }
     }
+    bindUniform(HW::REFRACTION_TWO_SIDED, Value::createValue(lightHandler->getRefractionTwoSided()), false);
 
     // Bind direct lighting properties.
     if (hasUniform(HW::NUM_ACTIVE_LIGHT_SOURCES))


### PR DESCRIPTION
While investigating render differences between GLSL and MSL in #2697 I noticed the dielectric transmission case wasn't matching. After a little investigation it appears that in the MSL render module we're missing setting `HW::REFRACTION_TWO_SIDED `. Which causes a different path to be taken through the shader code [here](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/libraries/pbrlib/genglsl/lib/mx_transmission_refract.glsl#L9).

If more differences appear like this, it may be worth investigating a `MaterialXRenderHW` module to encapsulate the common code.