### PR TITLE
Align the MSL texture mag filter with GLSL

### DIFF
--- a/source/MaterialXRenderMsl/MetalTextureHandler.mm
+++ b/source/MaterialXRenderMsl/MetalTextureHandler.mm
@@ -45,8 +45,7 @@ id<MTLSamplerState> MetalTextureHandler::getSamplerState(const ImageSamplingProp
         MTLSamplerMinMagFilter minmagFilter;
         MTLSamplerMipFilter mipFilter;
         mapFilterTypeToMetal(samplingProperties.filterType, samplingProperties.enableMipmaps, minmagFilter, mipFilter);
-        // Magnification filters are more restrictive than minification
-        [samplerDesc setMagFilter:MTLSamplerMinMagFilterLinear];
+        [samplerDesc setMagFilter:minmagFilter];
         [samplerDesc setMinFilter:minmagFilter];
         [samplerDesc setMipFilter:mipFilter];
         [samplerDesc setMaxAnisotropy:16];


### PR DESCRIPTION
Looks like when the GLSL texture magnification filter was updated [here](https://github.com/AcademySoftwareFoundation/MaterialX/commit/a52687dd5fc0825431b664c48ea8d33334cef95a), the corresponding change wasn't made on the MSL side. 

This is the cause of several render differences in the test suite between MSL and GLSL - discovered in #2697 

I've been running the full test suite and example materials 

### Before 
[glsl_vs_msl_before.pdf](https://github.com/user-attachments/files/23888923/glsl_vs_msl_before.pdf)

### After
[glsl_vs_msl_after.pdf](https://github.com/user-attachments/files/23888929/glsl_vs_msl_after.pdf)

