### PR TITLE
Static analysis fixes

### DIFF
--- a/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
@@ -52,8 +52,6 @@ void HwSurfaceNode::emitFunctionCall(const ShaderNode& node, GenContext& context
 
     const string& vec2 = syntax.getTypeName(Type::VECTOR2);
     const string& vec3 = syntax.getTypeName(Type::VECTOR3);
-    const string vec2_zero = syntax.getValue(Type::VECTOR2, HW::VEC3_ZERO);
-    const string vec2_one = syntax.getValue(Type::VECTOR2, HW::VEC3_ONE);
     const string vec3_zero = syntax.getValue(Type::VECTOR3, HW::VEC3_ZERO);
     const string vec3_one = syntax.getValue(Type::VECTOR3, HW::VEC3_ONE);
 

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3381,7 +3381,6 @@ void Graph::showPropertyEditorOutputConnections(UiNodePtr node)
 {
     if (node->_showOutputsInEditor)
     {
-        std::vector<UiPinPtr> pinList = node->outputPins;
         size_t pinCount = 0;
         for (UiPinPtr outputPin : node->outputPins)
         {

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -1849,7 +1849,7 @@ void Viewer::loadStandardLibraries()
     // Create the list of supported distance units.
     auto unitScales = _distanceUnitConverter->getUnitScale();
     _distanceUnitOptions.resize(unitScales.size());
-    for (auto unitScale : unitScales)
+    for (const auto& unitScale : unitScales)
     {
         int location = _distanceUnitConverter->getUnitAsInteger(unitScale.first);
         _distanceUnitOptions[location] = unitScale.first;


### PR DESCRIPTION
This changelist addresses a handful of static analysis warnings flagged by PVS-Studio:

- Remove unused intermediate variables in `HwSurfaceNode::emitFunctionCall` and `Graph::showPropertyEditorOutputConnection`.
- Iterate over key-value pairs by const reference for efficiency in `Viewer::loadStandardLibraries`.