### PR TITLE
Remove unused static members from ShaderNode class

### DIFF
--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -370,9 +370,6 @@ class MX_GENSHADER_API ShaderNode
     static const string BACKSURFACESHADER;
     static const string BSDF_R;
     static const string BSDF_T;
-    static const string TRANSFORM_POINT;
-    static const string TRANSFORM_VECTOR;
-    static const string TRANSFORM_NORMAL;
     static const string TEXTURE2D_GROUPNAME;
     static const string TEXTURE3D_GROUPNAME;
     static const string PROCEDURAL2D_GROUPNAME;


### PR DESCRIPTION
`TRANSFORM_POINT`, `TRANSFORM_VECTOR` and `TRANSFORM_NORMAL` are constant static members of `ShaderNode` that are both never used and never defined. 