### PR TITLE
Modify OIIOImageLoader CMake 

### DIFF
--- a/source/MaterialXRender/CMakeLists.txt
+++ b/source/MaterialXRender/CMakeLists.txt
@@ -2,10 +2,6 @@ file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 file(GLOB_RECURSE materialx_inlined "${CMAKE_CURRENT_SOURCE_DIR}/*.inl")
 file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
 
-if(NOT MATERIALX_BUILD_OIIO)
-    list(REMOVE_ITEM materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/OiioImageLoader.cpp")
-endif()
-
 mx_add_library(MaterialXRender
     SOURCE_FILES
         ${materialx_source}
@@ -29,5 +25,5 @@ endif()
 if(MATERIALX_BUILD_OIIO)
     find_package(OpenImageIO CONFIG REQUIRED)
     target_link_libraries(${TARGET_NAME} PRIVATE OpenImageIO::OpenImageIO OpenImageIO::OpenImageIO_Util)
-    target_compile_definitions(MaterialXRender PUBLIC MATERIALX_BUILD_OIIO)
+    target_compile_definitions(${TARGET_NAME} PUBLIC MATERIALX_BUILD_OIIO)
 endif()

--- a/source/MaterialXRender/OiioImageLoader.cpp
+++ b/source/MaterialXRender/OiioImageLoader.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#ifdef MATERIALX_BUILD_OIIO
+
 #include <MaterialXRender/OiioImageLoader.h>
 
 #if defined(_MSC_VER)
@@ -116,3 +118,5 @@ ImagePtr OiioImageLoader::loadImage(const FilePath& filePath)
 }
 
 MATERIALX_NAMESPACE_END
+
+#endif

--- a/source/MaterialXRender/OiioImageLoader.h
+++ b/source/MaterialXRender/OiioImageLoader.h
@@ -6,7 +6,7 @@
 #ifndef MATERIALX_OIIOIMAGELOADER_H
 #define MATERIALX_OIIOIMAGELOADER_H
 
-#if MATERIALX_BUILD_OIIO
+#ifdef MATERIALX_BUILD_OIIO
 
 /// @file
 /// Image loader wrapper using OpenImageIO


### PR DESCRIPTION
This PR fixes a small error in the CMakeList.txt to set the `MATERIALX_BUILD_OIIO` compile flag.

`${TARGET_NAME}` needs to be used when modifying a target after being declared, this is to ensure the monolithic build operates correctly too.

We also have some internal build systems that are less happy about how the guards are structured - and it turns out the approach take for the `OCIONode` works well - so I'm proposing here we align the `OIIOImageLoader` guard with that one.

Tagging @JGamache-autodesk - because it looks like you touched this most recently. 