### PR TITLE
Fix reference to `space` in specification

### DIFF
--- a/documents/Specification/MaterialX.StandardNodes.md
+++ b/documents/Specification/MaterialX.StandardNodes.md
@@ -676,7 +676,9 @@ Creates a black and white pattern of hexagons with a defined tiling and size (di
 Geometric nodes are used to reference local geometric properties from within a node graph:
 
 ```xml
-  <position name="wp1" type="vector3" space="world"/>
+  <position name="wp1" type="vector3">
+    <input name="space" type="string" value="world"/>
+  </position>
   <texcoord name="c1" type="vector2">
     <input name="index" type="integer" value="1"/>
   </texcoord>


### PR DESCRIPTION
This changelist fixes a reference to the `space` of a geometric node in the Standard Nodes specification, aligning an MTLX example with the stated syntax in the specification text.