### PR TITLE
Add Python 3.14 to GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,17 +30,17 @@ jobs:
           python: 3.9
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON -DMATERIALX_BUILD_MONOLITHIC=ON
 
-        - name: Linux_GCC_14_Python312
-          os: ubuntu-24.04
-          compiler: gcc
-          compiler_version: "14"
-          python: 3.12
-
         - name: Linux_GCC_14_Python313
           os: ubuntu-24.04
           compiler: gcc
           compiler_version: "14"
           python: 3.13
+
+        - name: Linux_GCC_14_Python314
+          os: ubuntu-24.04
+          compiler: gcc
+          compiler_version: "14"
+          python: 3.14
           test_render: ON
 
         - name: Linux_GCC_CoverageAnalysis
@@ -58,11 +58,11 @@ jobs:
           python: 3.9
           cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
 
-        - name: Linux_Clang_18_Python313
+        - name: Linux_Clang_18_Python314
           os: ubuntu-24.04
           compiler: clang
           compiler_version: "18"
-          python: 3.13
+          python: 3.14
           clang_format: ON
 
         - name: MacOS_Xcode_15_Python311
@@ -80,11 +80,11 @@ jobs:
           test_shaders: ON
           test_render: ON
 
-        - name: MacOS_Xcode_26_Python313
+        - name: MacOS_Xcode_26_Python314
           os: macos-26
           compiler: xcode
           compiler_version: "26.0"
-          python: 3.13
+          python: 3.14
           static_analysis: ON
           cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMATERIALX_BUILD_DATA_LIBRARY=ON
 
@@ -114,15 +114,21 @@ jobs:
           architecture: x64
           python: 3.13
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
-          test_shaders: ON
           extended_build_mdl_sdk: ON
+
+        - name: Windows_VS2022_x64_Python314
+          os: windows-2025
+          architecture: x64
+          python: 3.14
+          cmake_config: -G "Visual Studio 17 2022" -A "x64"
+          test_shaders: ON
+          extended_build_oiio: ON
 
         - name: Windows_VS2022_x64_SharedLibs
           os: windows-2025
           architecture: x64
           python: None
           cmake_config: -G "Visual Studio 17 2022" -A "x64" -DMATERIALX_BUILD_SHARED_LIBS=ON
-          extended_build_oiio: ON
           upload_shaders: ON
 
     steps:


### PR DESCRIPTION
This changelist adds initial Python 3.14 jobs to the GitHub CI build matrix for MaterialX.