### PR TITLE
Fix incorrect implementations of `splittb`, `ramptb`, and `ramp4`

### DIFF
--- a/libraries/stdlib/genglsl/mx_ramptb_float.glsl
+++ b/libraries/stdlib/genglsl/mx_ramptb_float.glsl
@@ -1,4 +1,4 @@
 void mx_ramptb_float(float valuet, float valueb, vec2 texcoord, out float result)
 {
-    result = mix (valuet, valueb, clamp(texcoord.y, 0.0, 1.0) );
+    result = mix (valueb, valuet, clamp(texcoord.y, 0.0, 1.0) );
 }

--- a/libraries/stdlib/genglsl/mx_ramptb_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_ramptb_vector2.glsl
@@ -1,4 +1,4 @@
 void mx_ramptb_vector2(vec2 valuet, vec2 valueb, vec2 texcoord, out vec2 result)
 {
-    result = mix (valuet, valueb, clamp(texcoord.y, 0.0, 1.0) );
+    result = mix (valueb, valuet, clamp(texcoord.y, 0.0, 1.0) );
 }

--- a/libraries/stdlib/genglsl/mx_ramptb_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_ramptb_vector3.glsl
@@ -1,4 +1,4 @@
 void mx_ramptb_vector3(vec3 valuet, vec3 valueb, vec2 texcoord, out vec3 result)
 {
-    result = mix (valuet, valueb, clamp(texcoord.y, 0.0, 1.0) );
+    result = mix (valueb, valuet, clamp(texcoord.y, 0.0, 1.0) );
 }

--- a/libraries/stdlib/genglsl/mx_ramptb_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_ramptb_vector4.glsl
@@ -1,4 +1,4 @@
 void mx_ramptb_vector4(vec4 valuet, vec4 valueb, vec2 texcoord, out vec4 result)
 {
-    result = mix (valuet, valueb, clamp(texcoord.y, 0.0, 1.0) );
+    result = mix (valueb, valuet, clamp(texcoord.y, 0.0, 1.0) );
 }

--- a/libraries/stdlib/genglsl/mx_splittb_float.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_float.glsl
@@ -2,5 +2,5 @@
 
 void mx_splittb_float(float valuet, float valueb, float center, vec2 texcoord, out float result)
 {
-    result = mix(valuet, valueb, mx_aastep(center, texcoord.y));
+    result = mix(valueb, valuet, mx_aastep(center, texcoord.y));
 }

--- a/libraries/stdlib/genglsl/mx_splittb_vector2.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector2.glsl
@@ -2,5 +2,5 @@
 
 void mx_splittb_vector2(vec2 valuet, vec2 valueb, float center, vec2 texcoord, out vec2 result)
 {
-    result = mix(valuet, valueb, mx_aastep(center, texcoord.y));
+    result = mix(valueb, valuet, mx_aastep(center, texcoord.y));
 }

--- a/libraries/stdlib/genglsl/mx_splittb_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector3.glsl
@@ -2,5 +2,5 @@
 
 void mx_splittb_vector3(vec3 valuet, vec3 valueb, float center, vec2 texcoord, out vec3 result)
 {
-    result = mix(valuet, valueb, mx_aastep(center, texcoord.y));
+    result = mix(valueb, valuet, mx_aastep(center, texcoord.y));
 }

--- a/libraries/stdlib/genglsl/mx_splittb_vector4.glsl
+++ b/libraries/stdlib/genglsl/mx_splittb_vector4.glsl
@@ -2,5 +2,5 @@
 
 void mx_splittb_vector4(vec4 valuet, vec4 valueb, float center, vec2 texcoord, out vec4 result)
 {
-    result = mix(valuet, valueb, mx_aastep(center, texcoord.y));
+    result = mix(valueb, valuet, mx_aastep(center, texcoord.y));
 }

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -100,12 +100,12 @@
   <implementation name="IM_ramplr_vector4_genosl" nodedef="ND_ramplr_vector4" target="genosl" sourcecode="mix({{valuel}}, {{valuer}}, clamp({{texcoord}}.x, 0, 1))" />
 
   <!-- <ramptb> -->
-  <implementation name="IM_ramptb_float_genosl" nodedef="ND_ramptb_float" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, clamp({{texcoord}}.y, 0, 1))" />
-  <implementation name="IM_ramptb_color3_genosl" nodedef="ND_ramptb_color3" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, clamp({{texcoord}}.y, 0, 1))" />
-  <implementation name="IM_ramptb_color4_genosl" nodedef="ND_ramptb_color4" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, clamp({{texcoord}}.y, 0, 1))" />
-  <implementation name="IM_ramptb_vector2_genosl" nodedef="ND_ramptb_vector2" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, clamp({{texcoord}}.y, 0, 1))" />
-  <implementation name="IM_ramptb_vector3_genosl" nodedef="ND_ramptb_vector3" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, clamp({{texcoord}}.y, 0, 1))" />
-  <implementation name="IM_ramptb_vector4_genosl" nodedef="ND_ramptb_vector4" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, clamp({{texcoord}}.y, 0, 1))" />
+  <implementation name="IM_ramptb_float_genosl" nodedef="ND_ramptb_float" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, clamp({{texcoord}}.y, 0, 1))" />
+  <implementation name="IM_ramptb_color3_genosl" nodedef="ND_ramptb_color3" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, clamp({{texcoord}}.y, 0, 1))" />
+  <implementation name="IM_ramptb_color4_genosl" nodedef="ND_ramptb_color4" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, clamp({{texcoord}}.y, 0, 1))" />
+  <implementation name="IM_ramptb_vector2_genosl" nodedef="ND_ramptb_vector2" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, clamp({{texcoord}}.y, 0, 1))" />
+  <implementation name="IM_ramptb_vector3_genosl" nodedef="ND_ramptb_vector3" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, clamp({{texcoord}}.y, 0, 1))" />
+  <implementation name="IM_ramptb_vector4_genosl" nodedef="ND_ramptb_vector4" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, clamp({{texcoord}}.y, 0, 1))" />
 
   <!-- <splitlr> -->
   <implementation name="IM_splitlr_float_genosl" nodedef="ND_splitlr_float" target="genosl" sourcecode="mix({{valuel}}, {{valuer}}, aastep({{center}}, {{texcoord}}.x))" />
@@ -116,12 +116,12 @@
   <implementation name="IM_splitlr_vector4_genosl" nodedef="ND_splitlr_vector4" target="genosl" sourcecode="mix({{valuel}}, {{valuer}}, aastep({{center}}, {{texcoord}}.x))" />
 
   <!-- <splittb> -->
-  <implementation name="IM_splittb_float_genosl" nodedef="ND_splittb_float" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, aastep({{center}}, {{texcoord}}.y))" />
-  <implementation name="IM_splittb_color3_genosl" nodedef="ND_splittb_color3" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, aastep({{center}}, {{texcoord}}.y))" />
-  <implementation name="IM_splittb_color4_genosl" nodedef="ND_splittb_color4" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, aastep({{center}}, {{texcoord}}.y))" />
-  <implementation name="IM_splittb_vector2_genosl" nodedef="ND_splittb_vector2" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, aastep({{center}}, {{texcoord}}.y))" />
-  <implementation name="IM_splittb_vector3_genosl" nodedef="ND_splittb_vector3" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, aastep({{center}}, {{texcoord}}.y))" />
-  <implementation name="IM_splittb_vector4_genosl" nodedef="ND_splittb_vector4" target="genosl" sourcecode="mix({{valuet}}, {{valueb}}, aastep({{center}}, {{texcoord}}.y))" />
+  <implementation name="IM_splittb_float_genosl" nodedef="ND_splittb_float" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, aastep({{center}}, {{texcoord}}.y))" />
+  <implementation name="IM_splittb_color3_genosl" nodedef="ND_splittb_color3" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, aastep({{center}}, {{texcoord}}.y))" />
+  <implementation name="IM_splittb_color4_genosl" nodedef="ND_splittb_color4" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, aastep({{center}}, {{texcoord}}.y))" />
+  <implementation name="IM_splittb_vector2_genosl" nodedef="ND_splittb_vector2" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, aastep({{center}}, {{texcoord}}.y))" />
+  <implementation name="IM_splittb_vector3_genosl" nodedef="ND_splittb_vector3" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, aastep({{center}}, {{texcoord}}.y))" />
+  <implementation name="IM_splittb_vector4_genosl" nodedef="ND_splittb_vector4" target="genosl" sourcecode="mix({{valueb}}, {{valuet}}, aastep({{center}}, {{texcoord}}.y))" />
 
   <!-- <noise2d> -->
   <implementation name="IM_noise2d_float_genosl" nodedef="ND_noise2d_float" file="mx_noise2d_float.osl" function="mx_noise2d_float" target="genosl" />

--- a/libraries/stdlib/stdlib_ng.mtlx
+++ b/libraries/stdlib/stdlib_ng.mtlx
@@ -1372,8 +1372,8 @@
       <input name="mix" type="float" nodename="N_s_float" />
     </mix>
     <mix name="N_mix_float" type="float">
-      <input name="bg" type="float" nodename="N_mixtop_float" />
-      <input name="fg" type="float" nodename="N_mixbot_float" />
+      <input name="bg" type="float" nodename="N_mixbot_float" />
+      <input name="fg" type="float" nodename="N_mixtop_float" />
       <input name="mix" type="float" nodename="N_t_float" />
     </mix>
     <output name="out" type="float" nodename="N_mix_float" />
@@ -1401,8 +1401,8 @@
       <input name="mix" type="float" nodename="N_s_color3" />
     </mix>
     <mix name="N_mix_color3" type="color3">
-      <input name="bg" type="color3" nodename="N_mixtop_color3" />
-      <input name="fg" type="color3" nodename="N_mixbot_color3" />
+      <input name="bg" type="color3" nodename="N_mixbot_color3" />
+      <input name="fg" type="color3" nodename="N_mixtop_color3" />
       <input name="mix" type="float" nodename="N_t_color3" />
     </mix>
     <output name="out" type="color3" nodename="N_mix_color3" />
@@ -1430,8 +1430,8 @@
       <input name="mix" type="float" nodename="N_s_color4" />
     </mix>
     <mix name="N_mix_color4" type="color4">
-      <input name="bg" type="color4" nodename="N_mixtop_color4" />
-      <input name="fg" type="color4" nodename="N_mixbot_color4" />
+      <input name="bg" type="color4" nodename="N_mixbot_color4" />
+      <input name="fg" type="color4" nodename="N_mixtop_color4" />
       <input name="mix" type="float" nodename="N_t_color4" />
     </mix>
     <output name="out" type="color4" nodename="N_mix_color4" />
@@ -1459,8 +1459,8 @@
       <input name="mix" type="float" nodename="N_s_vector2" />
     </mix>
     <mix name="N_mix_vector2" type="vector2">
-      <input name="bg" type="vector2" nodename="N_mixtop_vector2" />
-      <input name="fg" type="vector2" nodename="N_mixbot_vector2" />
+      <input name="bg" type="vector2" nodename="N_mixbot_vector2" />
+      <input name="fg" type="vector2" nodename="N_mixtop_vector2" />
       <input name="mix" type="float" nodename="N_t_vector2" />
     </mix>
     <output name="out" type="vector2" nodename="N_mix_vector2" />
@@ -1488,8 +1488,8 @@
       <input name="mix" type="float" nodename="N_s_vector3" />
     </mix>
     <mix name="N_mix_vector3" type="vector3">
-      <input name="bg" type="vector3" nodename="N_mixtop_vector3" />
-      <input name="fg" type="vector3" nodename="N_mixbot_vector3" />
+      <input name="bg" type="vector3" nodename="N_mixbot_vector3" />
+      <input name="fg" type="vector3" nodename="N_mixtop_vector3" />
       <input name="mix" type="float" nodename="N_t_vector3" />
     </mix>
     <output name="out" type="vector3" nodename="N_mix_vector3" />
@@ -1517,8 +1517,8 @@
       <input name="mix" type="float" nodename="N_s_vector4" />
     </mix>
     <mix name="N_mix_vector4" type="vector4">
-      <input name="bg" type="vector4" nodename="N_mixtop_vector4" />
-      <input name="fg" type="vector4" nodename="N_mixbot_vector4" />
+      <input name="bg" type="vector4" nodename="N_mixbot_vector4" />
+      <input name="fg" type="vector4" nodename="N_mixtop_vector4" />
       <input name="mix" type="float" nodename="N_t_vector4" />
     </mix>
     <output name="out" type="vector4" nodename="N_mix_vector4" />

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -991,7 +991,7 @@ export float mx_ramptb_float(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	return math::lerp(mxp_valueb, mxp_valuet, math::clamp(mxp_texcoord.y, 0.0, 1.0));
 }
 
 export color mx_ramptb_color3(
@@ -1003,7 +1003,7 @@ export color mx_ramptb_color3(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	return math::lerp(mxp_valueb, mxp_valuet, math::clamp(mxp_texcoord.y, 0.0, 1.0));
 }
 
 export core::color4 mx_ramptb_color4(
@@ -1015,8 +1015,8 @@ export core::color4 mx_ramptb_color4(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	color rgb = math::lerp(mxp_valuet.rgb, mxp_valueb.rgb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
-	float a = math::lerp(mxp_valuet.a, mxp_valueb.a, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	color rgb = math::lerp(mxp_valueb.rgb, mxp_valuet.rgb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	float a = math::lerp(mxp_valueb.a, mxp_valuet.a, math::clamp(mxp_texcoord.y, 0.0, 1.0));
 	return core::color4(rgb, a);}
 
 export float2 mx_ramptb_vector2(
@@ -1028,7 +1028,7 @@ export float2 mx_ramptb_vector2(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	return math::lerp(mxp_valueb, mxp_valuet, math::clamp(mxp_texcoord.y, 0.0, 1.0));
 }
 
 export float3 mx_ramptb_vector3(
@@ -1040,7 +1040,7 @@ export float3 mx_ramptb_vector3(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	return math::lerp(mxp_valueb, mxp_valuet, math::clamp(mxp_texcoord.y, 0.0, 1.0));
 }
 
 export float4 mx_ramptb_vector4(
@@ -1052,7 +1052,7 @@ export float4 mx_ramptb_vector4(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::clamp(mxp_texcoord.y, 0.0, 1.0));
+	return math::lerp(mxp_valueb, mxp_valuet, math::clamp(mxp_texcoord.y, 0.0, 1.0));
 }
 
 // Nodedef: ND_ramp4_float is represented by a nodegraph: NG_ramp4_float
@@ -1215,7 +1215,7 @@ export float mx_splittb_float(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
+	return math::lerp(mxp_valueb, mxp_valuet, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
 }
 
 export color mx_splittb_color3(
@@ -1237,7 +1237,7 @@ export color mx_splittb_color3(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
+	return math::lerp(mxp_valueb, mxp_valuet, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
 }
 
 export core::color4 mx_splittb_color4(
@@ -1259,7 +1259,7 @@ export core::color4 mx_splittb_color4(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	color rgb = math::lerp(mxp_valuet.rgb, mxp_valueb.rgb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));	float a = math::lerp(mxp_valuet.a, mxp_valueb.a, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));	return core::color4(rgb, a);
+	color rgb = math::lerp(mxp_valueb.rgb, mxp_valuet.rgb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));	float a = math::lerp(mxp_valueb.a, mxp_valuet.a, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));	return core::color4(rgb, a);
 }
 
 export float2 mx_splittb_vector2(
@@ -1281,7 +1281,7 @@ export float2 mx_splittb_vector2(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
+	return math::lerp(mxp_valueb, mxp_valuet, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
 }
 
 export float3 mx_splittb_vector3(
@@ -1303,7 +1303,7 @@ export float3 mx_splittb_vector3(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
+	return math::lerp(mxp_valueb, mxp_valuet, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
 }
 
 export float4 mx_splittb_vector4(
@@ -1325,7 +1325,7 @@ export float4 mx_splittb_vector4(
 		anno::description("Node Group: procedural2d")
 	]]
 {
-	return math::lerp(mxp_valuet, mxp_valueb, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
+	return math::lerp(mxp_valueb, mxp_valuet, math::step(mxp_center, math::clamp(mxp_texcoord.x,0,1)));
 }
 
 export float3 mx_position_vector3(


### PR DESCRIPTION
When the input value ('V' in MaterialX spec, texcoord.y in the GLSL and OSL code) is below the 'center' input value, then the output should be the bottom value ('valueb'), otherwise if it is above then the output should be the top value ('valuet'). Given a default 'center' value of 0.5, it means that a texcoord.y value of 0.0 should yield 'valueb' as the output, and a texcoord.y value of 1.0 should yield 'valuet' as the output. The glsl and OSL code seem to do the opposite: mix in GLSL (and similarly in OSL) returns the first argument value when the third argument is 0.0. The third argument here is a call to mx_aastep(center, texcoord.y) which internlly uses smoothstep. For a default 'center' value of 0.5, a texcoord.y value of 0.0 yields 0.0 so the third argument to mix() is 0.0, meaning the first argument to mix() is returned. texcoord.y being 0.0 is below 'center' of 0.5 so the MaterialX spec states that 'valueb' should be returned, and yet the returned first argument to mix() is 'valuet'. Similarly, when texcoord.y is 1.0 being above a 'center' value of 0.5 the MaterilX spec states that 'valuet' should be returned, and yet this glsl implementtion returns 'valueb' in this case. The same applies to `ramptb` and `ramp4` nodes, and also in the MDL backend. This commit fixes this issue at the source OSL, GLSL and MDL files for `splittb` and `ramptb` nodes, and the node-graph implementation for `ramp4` node.