### PR TITLE
Reinstate prior API behavior for `NodeDef::getImplementation`

### DIFF
--- a/source/MaterialXCore/Definition.cpp
+++ b/source/MaterialXCore/Definition.cpp
@@ -57,20 +57,12 @@ const string& NodeDef::getType() const
     }
 }
 
-InterfaceElementPtr NodeDef::getImplementation(const string& target) const
+namespace
 {
-    vector<InterfaceElementPtr> interfaces = getDocument()->getMatchingImplementations(getQualifiedName(getName()));
-    vector<InterfaceElementPtr> secondary = getDocument()->getMatchingImplementations(getName());
-    interfaces.insert(interfaces.end(), secondary.begin(), secondary.end());
-
-    if (target.empty())
-    {
-        return !interfaces.empty() ? interfaces[0] : InterfaceElementPtr();
-    }
-
+InterfaceElementPtr selectImplementation(const vector<InterfaceElementPtr>& interfaces, const TargetDefPtr targetDef)
+{
     // Get all candidate targets matching the given target,
     // taking inheritance into account.
-    const TargetDefPtr targetDef = getDocument()->getTargetDef(target);
     const StringVec candidateTargets = targetDef ? targetDef->getMatchingTargets() : StringVec();
 
     // First, search for a target-specific match.
@@ -98,6 +90,35 @@ InterfaceElementPtr NodeDef::getImplementation(const string& target) const
     }
 
     return InterfaceElementPtr();
+}
+};
+
+InterfaceElementPtr NodeDef::getImplementation(const string& target) const
+{
+    vector<InterfaceElementPtr> interfaces = getDocument()->getMatchingImplementations(getQualifiedName(getName()));
+    vector<InterfaceElementPtr> secondary = getDocument()->getMatchingImplementations(getName());
+    interfaces.insert(interfaces.end(), secondary.begin(), secondary.end());
+
+    if (target.empty())
+    {
+        return !interfaces.empty() ? interfaces[0] : InterfaceElementPtr();
+    }
+
+    return selectImplementation(interfaces, getDocument()->getTargetDef(target));
+}
+
+InterfaceElementPtr NodeDef::getUnmappedImplementation(const string& target) const
+{
+    vector<InterfaceElementPtr> interfaces = getDocument()->getMatchingUnmappedImplementations(getQualifiedName(getName()));
+    vector<InterfaceElementPtr> secondary = getDocument()->getMatchingUnmappedImplementations(getName());
+    interfaces.insert(interfaces.end(), secondary.begin(), secondary.end());
+
+    if (target.empty())
+    {
+        return !interfaces.empty() ? interfaces[0] : InterfaceElementPtr();
+    }
+
+    return selectImplementation(interfaces, getDocument()->getTargetDef(target));
 }
 
 StringMap NodeDef::getInputHints() const

--- a/source/MaterialXCore/Definition.h
+++ b/source/MaterialXCore/Definition.h
@@ -138,13 +138,23 @@ class MX_CORE_API NodeDef : public InterfaceElement
     /// @{
 
     /// Return the first implementation for this nodedef, optionally filtered
-    /// by the given target name.
+    /// by the given target name. Resolving any indirection chain in the
+    /// implementations.
     /// @param target An optional target name, which will be used to filter
     ///    the implementations that are considered.
     /// @return An implementation for this nodedef, or an empty shared pointer
     ///    if none was found.  Note that a node implementation may be either
     ///    an Implementation element or a NodeGraph element.
     InterfaceElementPtr getImplementation(const string& target = EMPTY_STRING) const;
+
+    /// Return the first implementation for this nodedef, optionally filtered
+    /// by the given target name.
+    /// @param target An optional target name, which will be used to filter
+    ///    the implementations that are considered.
+    /// @return An implementation for this nodedef, or an empty shared pointer
+    ///    if none was found.  Note that a node implementation may be either
+    ///    an Implementation element or a NodeGraph element.
+    InterfaceElementPtr getUnmappedImplementation(const string& target = EMPTY_STRING) const;
 
     /// @}
     /// @name Hints

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -44,7 +44,8 @@ class Document::Cache
             // Clear the existing cache.
             portElementMap.clear();
             nodeDefMap.clear();
-            implementationMap.clear();
+            implementationDirectMap.clear();
+            implementationIndirectMap.clear();
 
             // Traverse the document to build a new cache.
             for (ElementPtr elem : doc.lock()->traverseTree())
@@ -88,12 +89,26 @@ class Document::Cache
                     {
                         if (interface->isA<NodeGraph>())
                         {
-                            implementationMap[interface->getQualifiedName(nodeDefString)].push_back(interface);
+                            implementationDirectMap[interface->getQualifiedName(nodeDefString)].push_back(interface);
+                            implementationIndirectMap[interface->getQualifiedName(nodeDefString)].push_back(interface);
                         }
                         ImplementationPtr impl = interface->asA<Implementation>();
                         if (impl)
                         {
-                            implementationMap[interface->getQualifiedName(nodeDefString)].push_back(interface);
+                            implementationDirectMap[interface->getQualifiedName(nodeDefString)].push_back(interface);
+
+                            // Check for implementation which specifies a nodegraph as the implementation
+                            const string& nodeGraphString = impl->getNodeGraph();
+                            if (!nodeGraphString.empty())
+                            {
+                                NodeGraphPtr nodeGraph = impl->getDocument()->getNodeGraph(nodeGraphString);
+                                if (nodeGraph)
+                                    implementationIndirectMap[interface->getQualifiedName(nodeDefString)].push_back(nodeGraph);
+                            }
+                            else
+                            {
+                                implementationIndirectMap[interface->getQualifiedName(nodeDefString)].push_back(interface);
+                            }
                         }
                     }
                 }
@@ -109,7 +124,8 @@ class Document::Cache
     bool valid;
     std::unordered_map<string, std::vector<PortElementPtr>> portElementMap;
     std::unordered_map<string, std::vector<NodeDefPtr>> nodeDefMap;
-    std::unordered_map<string, std::vector<InterfaceElementPtr>> implementationMap;
+    std::unordered_map<string, std::vector<InterfaceElementPtr>> implementationDirectMap;
+    std::unordered_map<string, std::vector<InterfaceElementPtr>> implementationIndirectMap;
 };
 
 //
@@ -374,9 +390,28 @@ vector<InterfaceElementPtr> Document::getMatchingImplementations(const string& n
     _cache->refresh();
 
     // Return all implementations matching the given nodedef string.
-    if (_cache->implementationMap.count(nodeDef))
+    if (_cache->implementationIndirectMap.count(nodeDef))
     {
-        matchingImplementations.insert(matchingImplementations.end(), _cache->implementationMap.at(nodeDef).begin(), _cache->implementationMap.at(nodeDef).end());
+        matchingImplementations.insert(matchingImplementations.end(), _cache->implementationIndirectMap.at(nodeDef).begin(), _cache->implementationIndirectMap.at(nodeDef).end());
+    }
+
+    return matchingImplementations;
+}
+
+vector<InterfaceElementPtr> Document::getMatchingUnmappedImplementations(const string& nodeDef) const
+{
+    // Recurse to data library if present.
+    vector<InterfaceElementPtr> matchingImplementations = hasDataLibrary() ?
+                                                          getDataLibrary()->getMatchingUnmappedImplementations(nodeDef) :
+                                                          vector<InterfaceElementPtr>();
+
+    // Refresh the cache.
+    _cache->refresh();
+
+    // Return all implementations matching the given nodedef string.
+    if (_cache->implementationDirectMap.count(nodeDef))
+    {
+        matchingImplementations.insert(matchingImplementations.end(), _cache->implementationDirectMap.at(nodeDef).begin(), _cache->implementationDirectMap.at(nodeDef).end());
     }
 
     return matchingImplementations;

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -548,8 +548,14 @@ class MX_CORE_API Document : public GraphElement
 
     /// Return a vector of all node implementations that match the given
     /// NodeDef string.  Note that a node implementation may be either an
-    /// Implementation element or NodeGraph element.
+    /// Implementation element or NodeGraph element. Resolving any inheritance
+    /// chain present in the implementations.
     vector<InterfaceElementPtr> getMatchingImplementations(const string& nodeDef) const;
+
+    /// Return a vector of all node implementations that match the given
+    /// NodeDef string.  Note that a node implementation may be either an
+    /// Implementation element or NodeGraph element.
+    vector<InterfaceElementPtr> getMatchingUnmappedImplementations(const string& nodeDef) const;
 
     /// @}
     /// @name UnitDef Elements

--- a/source/MaterialXGenOsl/LibsToOso.cpp
+++ b/source/MaterialXGenOsl/LibsToOso.cpp
@@ -398,7 +398,7 @@ int main(int argc, char* const argv[])
     {
         // Determine whether or not there's a valid implementation of the current `NodeDef` for the type associated
         // to our OSL shader generator, i.e. OSL, and if not, skip it.
-        mx::InterfaceElementPtr nodeImpl = nodeDef->getImplementation(oslShaderGen->getTarget());
+        mx::InterfaceElementPtr nodeImpl = nodeDef->getUnmappedImplementation(oslShaderGen->getTarget());
 
         if (!nodeImpl)
         {

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -323,20 +323,6 @@ ShaderNodeImplPtr ShaderGenerator::getImplementation(const NodeDef& nodedef, Gen
         {
             impl = getColorManagementSystem()->createImplementation(name);
         }
-        else if (implementationElement->hasNodeGraph())
-        {
-            const string& nodegraphElementName = implementationElement->getNodeGraph();
-            NodeGraphPtr nodegraph = implElement->getDocument()->getNodeGraph(nodegraphElementName);
-            if (nodegraph)
-            {
-                impl = createShaderNodeImplForNodeGraph(*nodegraph);
-                implElement = nodegraph;
-            }
-            else
-            {
-                return nullptr;
-            }
-        }
         else
         {
             // Try creating a new in the factory.


### PR DESCRIPTION
Reinstate prior API behavior for NodeDef.getImplementation() and introduce new accessor.

Based on feedback from Bernard here #2701.

Add new method to access the implementation elements directly.