### PR TITLE
Update OSL version checks

### DIFF
--- a/libraries/pbrlib/genosl/mx_chiang_hair_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_chiang_hair_bsdf.osl
@@ -2,7 +2,7 @@ void mx_chiang_hair_bsdf(color tint_R, color tint_TT, color tint_TRT, float ior,
                          vector2 roughness_R, vector2 roughness_TT, vector2 roughness_TRT,
                          float cuticle_angle, vector absorption_coefficient, normal N, vector U, output BSDF bsdf)
 {
-#if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
+#if (OSL_VERSION_MAJOR == 1 && OSL_VERSION_MINOR >= 14) || (OSL_VERSION_MAJOR > 1)
     bsdf = chiang_hair_bsdf(N, U, tint_R, tint_TT, tint_TRT, ior,
                             roughness_R.x, roughness_TT.x, roughness_TRT.x, roughness_R.y, roughness_TT.y, roughness_TRT.y,
                             cuticle_angle, absorption_coefficient);

--- a/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
+++ b/libraries/pbrlib/genosl/mx_subsurface_bsdf.osl
@@ -1,6 +1,6 @@
 void mx_subsurface_bsdf(float weight, color albedo, color radius, float anisotropy, normal N, output BSDF bsdf)
 {
-#if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
+#if (OSL_VERSION_MAJOR == 1 && OSL_VERSION_MINOR >= 14) || (OSL_VERSION_MAJOR > 1)
     bsdf = weight * subsurface_bssrdf(N, albedo, radius, anisotropy);
 #else
     bsdf = weight * subsurface_bssrdf(N, albedo, 1.0, radius, anisotropy);

--- a/libraries/stdlib/genosl/mx_image_color3.osl
+++ b/libraries/stdlib/genosl/mx_image_color3.osl
@@ -16,7 +16,7 @@ void mx_image_color3(textureresource file, string layer, color default_value, ve
                   "subimage", layer, "interp", filtertype,
                   "missingcolor", missingColor,
                   "swrap", uaddressmode, "twrap", vaddressmode
-#if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
+#if (OSL_VERSION_MAJOR == 1 && OSL_VERSION_MINOR >= 14) || (OSL_VERSION_MAJOR > 1)
                   , "colorspace", file.colorspace
 #endif
                   );

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -18,7 +18,7 @@ void mx_image_color4(textureresource file, string layer, color4 default_value, v
                         "subimage", layer, "interp", filtertype,
                         "missingcolor", missingColor, "missingalpha", missingAlpha,
                         "swrap", uaddressmode, "twrap", vaddressmode
-#if OSL_VERSION_MAJOR >= 1 && OSL_VERSION_MINOR >= 14
+#if (OSL_VERSION_MAJOR == 1 && OSL_VERSION_MINOR >= 14) || (OSL_VERSION_MAJOR > 1)
                         , "colorspace", file.colorspace
 #endif
                         );


### PR DESCRIPTION
This changelist updates all OSL version checks in the MaterialX data libraries, extending support to OSL versions beyond 1.x.