### PR TITLE
OSL Network Generator updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(MATERIALX_BUILD_OCIO "Build OpenColorIO support for shader generators." O
 option(MATERIALX_BUILD_TESTS "Build unit tests." OFF)
 option(MATERIALX_BUILD_BENCHMARK_TESTS "Build benchmark tests." OFF)
 option(MATERIALX_BUILD_OSOS "Build OSL .oso's of standard library shaders for the OSL Network generator" OFF)
+option(MATERIALX_BUILD_NODEGRAPH_OSOS "Build NodeGraphs as OSOs, if disabled then NodeGraphs are not compiled as OSOs " OFF)
 option(MATERIALX_BUILD_PERFETTO_TRACING "Build with Perfetto tracing support for performance analysis." OFF)
 
 option(MATERIALX_BUILD_SHARED_LIBS "Build MaterialX libraries as shared rather than static." OFF)

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -35,6 +35,11 @@ if(MATERIALX_BUILD_DATA_LIBRARY)
 
         set(SENTINEL_FILE ${CMAKE_CURRENT_BINARY_DIR}/buildosos.sentinel)
 
+        set(SKIP_BUILDING_NODEGRAPHS "")
+        if (NOT MATERIALX_BUILD_NODEGRAPH_OSOS)
+            set(SKIP_BUILDING_NODEGRAPHS "--skipConvertingNodegraphs")
+        endif()
+
         add_custom_command(
                 OUTPUT ${SENTINEL_FILE}
                 COMMAND touch ${SENTINEL_FILE}
@@ -46,7 +51,7 @@ if(MATERIALX_BUILD_DATA_LIBRARY)
                             --oslCompilerPath ${MATERIALX_OSL_BINARY_OSLC}
                             --oslIncludePath ${MATERIALX_OSL_INCLUDE_PATH}
                             --libraryRelativeOsoPath libraries/targets/genoslnetwork/osos
-                            --removeNdPrefix true
+                            ${SKIP_BUILDING_NODEGRAPHS}
                 DEPENDS ${MATERIALX_DATA_LIBRARY_SOURCE_FILES} MaterialXGenOsl_LibsToOso
         )
 

--- a/resources/Materials/TestSuite/_options.mtlx
+++ b/resources/Materials/TestSuite/_options.mtlx
@@ -62,7 +62,7 @@
     <input name="extraLibraryPaths" type="string" value="" />
 
     <!-- List of document paths for render tests -->
-    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/Examples/OpenPbr,resources/Materials/Examples/UsdPreviewSurface,resources/Materials/TestSuite/pbrlib/bsdf,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/nprlib" />
+    <input name="renderTestPaths" type="string" value="resources/Materials/Examples/StandardSurface,resources/Materials/Examples/OpenPbr,resources/Materials/Examples/UsdPreviewSurface,resources/Materials/TestSuite/pbrlib/bsdf,resources/Materials/TestSuite/pbrlib/surfaceshader,resources/Materials/TestSuite/stdlib/procedural,resources/Materials/TestSuite/stdlib/color_management,resources/Materials/TestSuite/stdlib/convolution,resources/Materials/TestSuite/nprlib" />
 
     <!-- List of document base names to exclude from render tests.
          The render test suite operates on standalone materials, so look

--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -31,6 +31,8 @@
 #include <cctype>
 #include <cerrno>
 #include <cstring>
+#include <random>
+#include <filesystem>
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -389,6 +391,60 @@ FileSearchPath getEnvironmentPath(const string& sep)
 {
     string searchPathEnv = getEnviron(MATERIALX_SEARCH_PATH_ENV_VAR);
     return FileSearchPath(searchPathEnv, sep);
+}
+
+FilePath FilePath::createTemporaryDirectory(const FilePath& parentDir)
+{
+    // Get the parent directory - use system temp if empty
+    FilePath tempParent = parentDir;
+    if (tempParent.isEmpty())
+    {
+        tempParent = getSystemTemporaryDirectory();
+    }
+
+    // Ensure parent directory exists
+    if (!tempParent.exists())
+    {
+        tempParent.createDirectory(true);
+    }
+
+    if (!tempParent.isDirectory())
+    {
+        throw Exception("Parent path is not a directory: " + tempParent.asString());
+    }
+
+    // Generate a unique temporary directory name using std::filesystem
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(100000, 999999);
+
+    constexpr int maxAttempts = 1000;
+    for (int attempt = 0; attempt < maxAttempts; ++attempt)
+    {
+        string tempDirName = "materialx_tmp_" + std::to_string(dis(gen));
+        FilePath tempDirPath = tempParent / tempDirName;
+
+        if (!tempDirPath.isDirectory())
+        {
+            tempDirPath.createDirectory(true);
+            return tempDirPath;
+        }
+    }
+
+    throw Exception("Failed to create temporary directory after " + std::to_string(maxAttempts) + " attempts");
+}
+
+FilePath FilePath::getSystemTemporaryDirectory()
+{
+    try
+    {
+        std::filesystem::path tempPath = std::filesystem::temp_directory_path();
+        return FilePath(tempPath.string());
+    }
+    catch (const std::filesystem::filesystem_error& ex)
+    {
+        throw Exception("Error getting system temporary directory: " + string(ex.what()));
+    }
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -209,6 +209,18 @@ class MX_FORMAT_API FilePath
     /// Return the directory containing the executable module.
     static FilePath getModulePath();
 
+    /// Create a temporary directory with a unique name.
+    /// @param parentDir The parent directory for the temporary directory.
+    ///    If empty, uses the system's default temporary directory.
+    /// @return A FilePath to the created temporary directory.
+    /// @throws Exception if the temporary directory cannot be created.
+    static FilePath createTemporaryDirectory(const FilePath& parentDir = FilePath());
+
+    /// Return the system's default temporary directory.
+    /// @return A FilePath to the system temporary directory.
+    /// @throws Exception if the system temporary directory cannot be determined.
+    static FilePath getSystemTemporaryDirectory();
+
   private:
     StringVec _vec;
     Type _type;

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -355,6 +355,13 @@ void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const XmlWriteOptio
 
 void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOptions* writeOptions)
 {
+    if (writeOptions && writeOptions->createDirectories)
+    {
+        if (!filename.getParentPath().isDirectory())
+        {
+            filename.getParentPath().createDirectory(true);
+        }
+    }
     std::ofstream ofs(filename.asString());
     writeToXmlStream(doc, ofs, writeOptions);
 }

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -73,6 +73,10 @@ class MX_FORMAT_API XmlWriteOptions
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
+
+    /// If true, any necessary directories will be created to write the
+    /// file.
+    bool createDirectories = false;
 };
 
 /// @class ExceptionParseError

--- a/source/MaterialXGenOsl/CMakeLists.txt
+++ b/source/MaterialXGenOsl/CMakeLists.txt
@@ -14,6 +14,20 @@ mx_add_library(MaterialXGenOsl
     EXPORT_DEFINE
         MATERIALX_GENOSL_EXPORTS)
 
+if (OSL_FOUND)
+    target_link_libraries(${TARGET_NAME}
+            PRIVATE
+            OSL::oslcomp)
+    target_compile_definitions(${TARGET_NAME}
+            PRIVATE
+            USE_OSLCOMP)
+endif()
+
+target_compile_definitions(${TARGET_NAME} PRIVATE
+        MATERIALX_OSL_BINARY_OSLC=\"${MATERIALX_OSL_BINARY_OSLC}\"
+        MATERIALX_OSL_INCLUDE_PATH=\"${MATERIALX_OSL_INCLUDE_PATH}\"
+)
+
 if (MATERIALX_BUILD_OSOS)
     file(GLOB GenNodes_SRC "${CMAKE_CURRENT_SOURCE_DIR}/LibsToOso.cpp")
 

--- a/source/MaterialXGenOsl/LibsToOso.cpp
+++ b/source/MaterialXGenOsl/LibsToOso.cpp
@@ -16,7 +16,7 @@
 #include <MaterialXGenShader/Shader.h>
 
 #include <MaterialXGenOsl/OslShaderGenerator.h>
-#include <MaterialXGenOsl/OslSyntax.h>
+#include <MaterialXGenOsl/OslNetworkShaderGenerator.h>
 
 #ifdef USE_OSLCOMP
 #include <OSL/oslcomp.h>
@@ -26,162 +26,57 @@ namespace mx = MaterialX;
 
 const std::string argOptions =
     " Options: \n"
-    "    --outputOsoPath [DIRPATH]       TODO\n"
-    "    --libraryRelativeOsoPath [DIRPATH]       TODO\n"
-    "    --outputMtlxPath [DIRPATH]      TODO\n"
-    "    --oslCompilerPath [FILEPATH]    TODO\n"
+    "    --outputOsoPath [DIRPATH]            Directory where compiled OSO files will be written\n"
+    "    --libraryRelativeOsoPath [DIRPATH]   Relative path used in MaterialX implementation elements to reference OSO files\n"
+    "    --outputMtlxPath [DIRPATH]           Directory where MaterialX implementation documents will be written\n"
+    "    --oslCompilerPath [FILEPATH]         Path to the OSL compiler executable (oslc)\n"
 #ifdef USE_OSLCOMP
-    "    --useOslC                       TODO\n"
+    "    --useOslC                            Use external OSL compiler instead of liboslcomp (when available)\n"
 #endif
-    "    --skipWritingOSLSource          TODO\n"
-    "    --skipWritingMtlxDoc            TODO\n"
-    "    --oslIncludePath [DIRPATH]      TODO\n"
-    "    --path [FILEPATH]              Specify an additional data search path location (e.g. '/projects/MaterialX').  This absolute path will be queried when locating data libraries, XInclude references, and referenced images.\n"
-    "    --library [FILEPATH]           Specify an additional data library folder (e.g. 'vendorlib', 'studiolib').  This relative path will be appended to each location in the data search path when loading data libraries.\n"
-    "    --osoNameStrategy [STRING]      TODO - either 'implementation' or 'nodedef' (default:'implementation')\n"
-    "    --help                          Display the complete list of command-line options\n";
+    "    --skipWritingOSLSource               Skip writing OSL source files to disk during compilation\n"
+    "    --skipWritingMtlxDoc                 Skip writing MaterialX implementation documents\n"
+    "    --skipConvertingNodegraphs           Skip converting nodegraph implementations to OSL shaders\n"
+    "    --oslIncludePath [DIRPATH]           Directory containing OSL include files\n"
+    "    --path [FILEPATH]                    Specify an additional data search path location (e.g. '/projects/MaterialX').  This absolute path will be queried when locating data libraries, XInclude references, and referenced images.\n"
+    "    --library [FILEPATH]                 Specify an additional data library folder (e.g. 'vendorlib', 'studiolib').  This relative path will be appended to each location in the data search path when loading data libraries.\n"
+    "    --osoNameStrategy [STRING]           Naming strategy for OSO files - either 'implementation' or 'nodedef' (default:'implementation')\n"
+    "    --help                               Display the complete list of command-line options\n";
 
-class ExceptionCompileError : public mx::Exception
+
+void createMtlxImplementationElementForOsoNode(mx::ConstNodeDefPtr nodeDef, mx::ShaderPtr oslShader, const std::string& oslShaderName, mx::DocumentPtr mtlxDoc, const std::string& osoPath)
 {
-public:
-    ExceptionCompileError(const std::string& msg, const mx::StringVec& errorLog = mx::StringVec()) :
-        Exception(msg),
-        _errorLog(errorLog)
+    mx::ImplementationPtr impl = mtlxDoc->addImplementation(oslShaderName);
+    impl->setNodeDef(nodeDef);
+    impl->setFile(osoPath);
+
+    impl->setFunction(oslShaderName);
+    impl->setAttribute("sourcecode", "dummy");
+    impl->setTarget(mx::OslNetworkShaderGenerator::TARGET);
+
+    // Compare the shader input names in the source (variable)
+    // with the names of the corresponding port.
+    // If there is a difference then we use the "implname"
+    // attribute to record that difference so that the OSLNetwork generator
+    // can use it.
+    mx::ShaderGraph& graph = oslShader->getGraph();
+    for (mx::ShaderGraphInputSocket* inputSocket : graph.getInputSockets())
     {
-    }
+        std::string name = inputSocket->getName();
+        std::string variable = inputSocket->getVariable();
 
-    ExceptionCompileError(const ExceptionCompileError& e) :
-        Exception(e),
-        _errorLog(e._errorLog)
-    {
-    }
-
-    ExceptionCompileError& operator=(const ExceptionCompileError& e)
-    {
-        Exception::operator=(e);
-        _errorLog = e._errorLog;
-        return *this;
-    }
-
-    const mx::StringVec& errorLog() const
-    {
-        return _errorLog;
-    }
-
-private:
-    mx::StringVec _errorLog;
-};
-
-// A set of options for controlling the behavior of OSL compilation.
-class OslCompileOptions
-{
-public:
-    OslCompileOptions() = default;
-    ~OslCompileOptions() = default;
-
-    mx::FilePath oslCompilerPath;
-    mx::FileSearchPath oslIncludePath;
-    bool useOslComp = false;
-    bool writeSourceToDisk = true;
-};
-
-bool compileOSL(const std::string& oslSourceCode, const mx::FilePath& oslFilePath, const OslCompileOptions& options)
-{
-    if (!options.useOslComp && !options.writeSourceToDisk)
-    {
-        throw mx::Exception("If OslComp library is not being used the source must be written to disk");
-    }
-
-    if (options.writeSourceToDisk)
-    {
-        std::ofstream oslFile;
-        oslFile.open(oslFilePath);
-        oslFile << oslSourceCode;
-        oslFile.close();
-    }
-
-    mx::FilePath osoFilePath = oslFilePath;
-    osoFilePath.removeExtension();
-    osoFilePath.addExtension("oso");
-
-    // build up a vector of compiler arguments that will be
-    // used in both compiler modes.
-    std::vector<std::string> oslCompilerArgs;
-    oslCompilerArgs.emplace_back("-o");
-    oslCompilerArgs.emplace_back(osoFilePath);
-    for (mx::FilePath p : options.oslIncludePath)
-    {
-        oslCompilerArgs.emplace_back("-I" + p.asString() + "");
-    }
-
-#ifdef USE_OSLCOMP
-    if (options.useOslComp)
-    {
-        // Use OSL::oslcomp to compile the shader - this is significantly faster than using the system
-        // call to involke the `oslc` command line tool
-        OIIO::ErrorHandler errorHandler;
-        ::OSL::OSLCompiler compiler(&errorHandler);
-        if (options.writeSourceToDisk)
+        if (inputSocket->getType() == mx::Type::FILENAME)
         {
-            // Compile from the source file
-            compiler.compile(oslFilePath.asString(), oslCompilerArgs);
-        }
-        else
-        {
-            // Compile directly from the string buffer
-            std::string osoBuffer;
-            compiler.compile_buffer(oslSourceCode, osoBuffer, oslCompilerArgs, std::string_view(), oslFilePath.asString());
-
-            std::ofstream osoFile;
-            osoFile.open(osoFilePath.asString());
-            osoFile << osoBuffer;
-            osoFile.close();
-        }
-    }
-    else
-#endif
-    {
-        // If no command and include path specified then skip checking.
-        if (options.oslCompilerPath.isEmpty())
-        {
-            throw mx::Exception("OSL compiler path missing");
-        }
-        if (!options.oslCompilerPath.exists())
-        {
-            throw mx::Exception("OSL compiler doesn't exist at '" + options.oslCompilerPath.asString() + "'");
+            // We suffix the inputs of type FILENAME with "_resource" so we need to
+            // remove that here for the implName comparison
+            variable = std::string(variable, 0, variable.size() - std::string("_resource").size());
         }
 
-        // Use a known error file name to check
-        std::string errorFile(osoFilePath.asString() + "_compile_errors.txt");
-        const std::string redirectString(" 2>&1");
-
-        // Run the command and get back the result. If non-empty string throw exception with error
-        std::string command = options.oslCompilerPath.asString() + " -q " + oslFilePath.asString();
-        for (const auto& arg : oslCompilerArgs)
+        if (name != variable)
         {
-            command += " " + arg;
-        }
-        // command += " > " + errorFile + redirectString;
-
-        int returnValue = std::system(command.c_str());
-
-        std::ifstream errorStream(errorFile);
-        std::string result;
-        result.assign(std::istreambuf_iterator<char>(errorStream),
-                      std::istreambuf_iterator<char>());
-
-        if (!result.empty())
-        {
-            mx::StringVec errors;
-            errors.push_back("Command string: " + command);
-            errors.push_back("Command return code: " + std::to_string(returnValue));
-            errors.push_back("Shader failed to compile:");
-            errors.push_back(result);
-            throw ExceptionCompileError("OSL compilation error", errors);
+            mx::InputPtr implInput = impl->addInput(name, inputSocket->getType().getName());
+            implInput->setImplementationName(variable);
         }
     }
-
-    return true;
 }
 
 int main(int argc, char* const argv[])
@@ -204,6 +99,7 @@ int main(int argc, char* const argv[])
     std::string argOsoNameStrategy = "implementation";
     bool argSkipWritingSource = false;
     bool argSkipWritingMtlxDoc = false;
+    bool argSkipConvertingNodegraphs = false;
     bool argUseOslC = false;
 
     // Loop over the provided arguments, and store their associated values.
@@ -252,6 +148,10 @@ int main(int argc, char* const argv[])
         {
             argSkipWritingMtlxDoc = true;
         }
+        else if (token == "--skipConvertingNodegraphs")
+        {
+            argSkipConvertingNodegraphs = true;
+        }
         else if (token == "--useOslC")
         {
             argUseOslC = true;
@@ -277,9 +177,7 @@ int main(int argc, char* const argv[])
             continue;
         }
 
-        if (nextToken.empty())
-            std::cout << "Expected another token following command-line option: " << token << std::endl;
-        else
+        if (!nextToken.empty())
             i++;
     }
 
@@ -296,7 +194,7 @@ int main(int argc, char* const argv[])
     mx::FilePath outputOsoPath(argOutputOsoPath);
     if (!outputOsoPath.exists() || !outputOsoPath.isDirectory())
     {
-        outputOsoPath.createDirectory();
+        outputOsoPath.createDirectory(true);
 
         if (!outputOsoPath.exists() || !outputOsoPath.isDirectory())
         {
@@ -366,7 +264,7 @@ int main(int argc, char* const argv[])
     oslRendererIncludePaths.append(argSearchPath.find("libraries/stdlib/genosl/include"));
 
     // Create the OSL shader generator.
-    mx::ShaderGeneratorPtr oslShaderGen = mx::OslShaderGenerator::create();
+    mx::OslShaderGeneratorPtr oslShaderGen = std::static_pointer_cast<mx::OslShaderGenerator>(mx::OslShaderGenerator::create());
 
     // Register types from the libraries on the OSL shader generator.
     oslShaderGen->registerTypeDefs(librariesDoc);
@@ -379,7 +277,7 @@ int main(int argc, char* const argv[])
     context.getOptions().fileTextureVerticalFlip = false;
     context.getOptions().oslImplicitSurfaceShaderConversion = false;
 
-    OslCompileOptions options;
+    mx::OslNetworkShaderGenerator::OslCompileOptions options;
     options.oslIncludePath = oslRendererIncludePaths;
     options.writeSourceToDisk = !argSkipWritingSource;
     options.oslCompilerPath = argOslCompilerPath;
@@ -390,11 +288,8 @@ int main(int argc, char* const argv[])
     // We'll use this boolean to return an error code is one of the `NodeDef` failed to codegen/compile.
     bool hasFailed = false;
 
-    // We create and use a dedicated `NodeGraph` to avoid `NodeDef` names collision.
-    mx::NodeGraphPtr librariesDocGraph = librariesDoc->addNodeGraph("librariesDocGraph");
-
     // Loop over all the `NodeDef` gathered in our documents from the provided libraries.
-    for (mx::NodeDefPtr nodeDef : librariesDoc->getNodeDefs())
+    for (mx::ConstNodeDefPtr nodeDef : librariesDoc->getNodeDefs())
     {
         // Determine whether or not there's a valid implementation of the current `NodeDef` for the type associated
         // to our OSL shader generator, i.e. OSL, and if not, skip it.
@@ -405,53 +300,25 @@ int main(int argc, char* const argv[])
             std::cout << "The following `NodeDef` does not provide a valid OSL implementation, "
                          "and will be skipped: "
                       << nodeDef->getName() << std::endl;
-
             continue;
         }
 
-        // Intention is here is to name the new node the same as the genosl implementation name
-        // but replacing "_genosl" with "_genoslnetwork"
-        std::string nodeName;
-        if (argOsoNameStrategy == "implementation")
+        if (argSkipConvertingNodegraphs)
         {
-            // Name the node the same as the implementation with _genoslnetwork added as a suffix.
-            // NOTE : If the implementation currently has _genosl as a suffix then we remove it.
-            nodeName = nodeImpl->getName();
-            nodeName = mx::replaceSubstrings(nodeName, { { "_genosl", "" } });
-            nodeName += "_genoslnetwork";
-        }
-        else
-        {
-            // Name the node the same as the node definition
-            nodeName = nodeDef->getName();
+            // If we've been asked to skip converting nodegraphs - then we need to check
+            // what type of implementation we've been given.
+            if (nodeImpl->isA<mx::NodeGraph>())
+            {
+                std::cout << "Skipping " << nodeDef->getName() << " - NodeGraph implementation" << std::endl;
+                continue;
+            }
         }
 
-        mx::NodePtr node = librariesDocGraph->addNodeInstance(nodeDef, nodeName);
-        if (!node)
-        {
-            std::cerr << "Unable to create Node instance for NodeDef - '" << nodeDef->getName() << "'" << std::endl;
-            return 1;
-        }
-
-        std::string oslShaderName = node->getName();
-        oslShaderGen->getSyntax().makeValidName(oslShaderName);
-
-        const std::string oslFileName = oslShaderName + ".osl";
-        const std::string& oslFilePath = (outputOsoPath / oslFileName).asString();
-        std::ofstream oslFile;
-
-        // Codegen the `Node` to an `.osl` file.
         mx::ShaderPtr oslShader = nullptr;
         try
         {
             // Codegen the `Node` to OSL.
-            oslShader = oslShaderGen->generate(node->getName(), node, context);
-
-            // TODO: Check that we have a valid/opened file descriptor before doing anything with it?
-            oslFile.open(oslFilePath);
-            // Dump the content of the codegen'd `NodeDef` to our `.osl` file.
-            oslFile << oslShader->getSourceCode();
-            oslFile.close();
+            oslShader =  mx::OslNetworkShaderGenerator::generateOSLShader(nodeDef, oslShaderGen, context, argOsoNameStrategy);
         }
         // Catch any codegen/compilation related exceptions.
         catch (mx::ExceptionShaderGenError& exc)
@@ -460,31 +327,30 @@ int main(int argc, char* const argv[])
                          "following node: "
                       << nodeDef->getName() << std::endl;
             std::cerr << exc.what() << std::endl;
+        }
 
+        if (!oslShader)
+        {
+            std::cerr << "Failed to generate shader for the "
+                         "following node: "
+                      << nodeDef->getName() << std::endl;
             hasFailed = true;
         }
 
-        // Compile the codegen'd `.osl` file.
+        const std::string oslFileName = oslShader->getName() + ".osl";
+        const std::string& oslFilePath = (outputOsoPath / oslFileName).asString();
+        std::ofstream oslFile;
+
         try
         {
             // Compile the `.osl` file to a `.oso` file next to it.
-            compileOSL(oslShader->getSourceCode(), oslFilePath, options);
+            mx::OslNetworkShaderGenerator::compileOSL(oslShader->getSourceCode(), oslFilePath, options);
 
-            {
-                std::string implName = "IMPL_" + nodeName + "_" + target;
-                auto impl = implMtlxDoc->addImplementation(implName);
-                impl->setNodeDef(nodeDef);
-                // TODO: stash the the OSO path here.
-                // This is writing the absolute path - which we don't want
-                impl->setFile(argLibraryRelativeOsoPath);
-
-                impl->setFunction(oslShaderName);
-                impl->setAttribute("sourcecode", "dummy");
-                impl->setTarget(target);
-            }
+            // Create the MaterialX Implementation element
+            createMtlxImplementationElementForOsoNode(nodeDef, oslShader, oslShader->getName(), implMtlxDoc, argLibraryRelativeOsoPath);
         }
         // Catch any codegen/compilation related exceptions.
-        catch (ExceptionCompileError& exc)
+        catch (mx::ExceptionOslCompileError& exc)
         {
             std::cerr << "Encountered a shader compilation related exception for the "
                          "following node: "

--- a/source/MaterialXGenOsl/Nodes/OsoNode.cpp
+++ b/source/MaterialXGenOsl/Nodes/OsoNode.cpp
@@ -13,6 +13,11 @@ ShaderNodeImplPtr OsoNode::create()
     return std::make_shared<OsoNode>();
 }
 
+ShaderNodeImplPtr OsoNode::create(const string& osoName, const string& osoPath)
+{
+    return std::make_shared<OsoNode>(osoName, osoPath);
+}
+
 void OsoNode::initialize(const InterfaceElement& element, GenContext& context)
 {
     ShaderNodeImpl::initialize(element, context);
@@ -23,9 +28,15 @@ void OsoNode::initialize(const InterfaceElement& element, GenContext& context)
     }
     const Implementation& impl = static_cast<const Implementation&>(element);
 
-    // Implementation's function attr is the oso filename, file attr is its directory
-    _osoName = impl.getFunction();
-    _osoPath = impl.getFile();
+    // We guard setting up the node to allow statically created nodes to be registered.
+    // We use this in the unit testing for OslNetwork generator for handling the modified
+    // bitangent and tangent nodes.
+    if (_osoName.empty())
+    {
+        // Implementation's function attr is the oso filename, file attr is its directory
+        _osoName = impl.getFunction();
+        _osoPath = impl.getFile();
+    }
 
     // Set hash using the oso name.
     _hash = std::hash<string>{}(_osoName);

--- a/source/MaterialXGenOsl/Nodes/OsoNode.h
+++ b/source/MaterialXGenOsl/Nodes/OsoNode.h
@@ -15,7 +15,12 @@ MATERIALX_NAMESPACE_BEGIN
 class MX_GENOSL_API OsoNode : public ShaderNodeImpl
 {
 public:
+    OsoNode() {}
+    OsoNode(const string& osoName, const string& osoPath) :
+        _osoName(osoName), _osoPath(osoPath) {}
+
     static ShaderNodeImplPtr create();
+    static ShaderNodeImplPtr create(const string& osoName, const string& osoPath);
 
     void initialize(const InterfaceElement& element, GenContext& context) override;
 

--- a/source/MaterialXGenOsl/OslNetworkSyntax.h
+++ b/source/MaterialXGenOsl/OslNetworkSyntax.h
@@ -24,16 +24,48 @@ class MX_GENOSL_API OslNetworkSyntax : public Syntax
 
     static SyntaxPtr create(TypeSystemPtr typeSystem) { return std::make_shared<OslNetworkSyntax>(typeSystem); }
 
-    const string& getOutputQualifier() const override;
-    const string& getConstantQualifier() const override { return EMPTY_STRING; };
-    const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
+    StructTypeSyntaxPtr createStructSyntax(const string& structTypeName, const string& defaultValue,
+                                           const string& uniformDefaultValue, const string& typeAlias,
+                                           const string& typeDefinition) const override;
 
-    static const string OUTPUT_QUALIFIER;
-    static const string SOURCE_FILE_EXTENSION;
+    const string& getOutputQualifier() const override { return EMPTY_STRING; };
+    const string& getConstantQualifier() const override { return EMPTY_STRING; };
+    const string& getSourceFileExtension() const override { return EMPTY_STRING; };
+
     static const StringVec VECTOR_MEMBERS;
     static const StringVec VECTOR2_MEMBERS;
     static const StringVec VECTOR4_MEMBERS;
     static const StringVec COLOR4_MEMBERS;
+};
+
+/// Interface class for exporting OSL commands for parameters
+class MX_GENOSL_API OslNetworkSyntaxEmit
+{
+public:
+    struct EmitParamPart
+    {
+        EmitParamPart(const string& type, const string& name, const string& value) :
+            typeName(type), paramName(name), paramValue(value) { }
+        string typeName;
+        string paramName;
+        string paramValue;
+    };
+    using EmitParamPartVec = vector<EmitParamPart>;
+
+    virtual EmitParamPartVec getEmitParamParts(const string& name, TypeDesc typeDesc, const Value& value) const = 0;
+};
+
+
+/// Specialization of TypeSyntax for struct types.
+class MX_GENOSL_API OslNetworkStructTypeSyntax : public StructTypeSyntax, public OslNetworkSyntaxEmit
+{
+public:
+    OslNetworkStructTypeSyntax(const Syntax* parent, const string& name, const string& defaultValue, const string& uniformDefaultValue,
+                     const string& typeAlias = EMPTY_STRING, const string& typeDefinition = EMPTY_STRING,
+                     const StringVec& members = EMPTY_MEMBERS);
+    virtual ~OslNetworkStructTypeSyntax();
+
+    EmitParamPartVec getEmitParamParts(const string& name, TypeDesc typeDesc, const Value& value) const override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -26,6 +26,21 @@ OslShaderGenerator::OslShaderGenerator(TypeSystemPtr typeSystem) :
 {
 }
 
+OslShaderGenerator::OslShaderGenerator(TypeSystemPtr typeSystem, OslSyntaxPtr syntax) :
+    ShaderGenerator(typeSystem, syntax)
+{
+}
+
+ShaderGeneratorPtr OslShaderGenerator::create(TypeSystemPtr typeSystem, OslSyntaxPtr syntax)
+{
+    if (!typeSystem)
+        typeSystem = TypeSystem::create();
+    if (!syntax)
+        syntax = std::static_pointer_cast<OslSyntax>(OslSyntax::create(typeSystem));
+
+    return std::make_shared<OslShaderGenerator>(typeSystem, syntax);
+}
+
 ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, GenContext& context) const
 {
     ShaderPtr shader = createShader(name, element, context);
@@ -37,7 +52,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
 
     if (context.getOptions().oslConnectCiWrapper)
     {
-        addSetCiTerminalNode(graph, element->getDocument(), context);
+        addSetCiTerminalNode(graph, element->getDocument(), getTypeSystem(), context);
     }
 
     ShaderStage& stage = shader->getStage(Stage::PIXEL);
@@ -144,7 +159,7 @@ ShaderPtr OslShaderGenerator::generate(const string& name, ElementPtr element, G
         if (input->getType() == Type::FILENAME)
         {
             // Construct the textureresource variable.
-            const string newVariableName = input->getVariable() + "_";
+            const string newVariableName = input->getVariable() + "_resource";
             const string& type = _syntax->getTypeName(input->getType());
             emitLine(type + newVariableName + " = {" + input->getVariable() + ", " + input->getVariable() + "_colorspace}", stage);
 
@@ -469,8 +484,7 @@ void OslShaderGenerator::emitMetadata(const ShaderPort* port, ShaderStage& stage
     }
 }
 
-
-void OslShaderGenerator::addSetCiTerminalNode(ShaderGraph& graph, ConstDocumentPtr document, GenContext& context) const
+void OslShaderGenerator::addSetCiTerminalNode(ShaderGraph& graph, ConstDocumentPtr document, TypeSystemPtr typeSystem, GenContext& context)
 {
     string setCiNodeDefName = "ND_osl_set_ci";
     NodeDefPtr setCiNodeDef = document->getNodeDef(setCiNodeDefName);
@@ -482,7 +496,7 @@ void OslShaderGenerator::addSetCiTerminalNode(ShaderGraph& graph, ConstDocumentP
         string inputName = input->getName();
         if (stringStartsWith(inputName, "input_"))
         {
-            TypeDesc inputType = _typeSystem->getType(input->getType());
+            TypeDesc inputType = typeSystem->getType(input->getType());
             outputModeMap[inputType] = std::make_shared<TypedValue<int>>(index++);
         }
     }
@@ -499,7 +513,6 @@ void OslShaderGenerator::addSetCiTerminalNode(ShaderGraph& graph, ConstDocumentP
         typeInput->setValue(outputModeValue);
     }
 }
-
 
 namespace OSL
 {

--- a/source/MaterialXGenOsl/OslShaderGenerator.h
+++ b/source/MaterialXGenOsl/OslShaderGenerator.h
@@ -15,6 +15,9 @@
 
 MATERIALX_NAMESPACE_BEGIN
 
+class OslSyntax;
+using OslSyntaxPtr = shared_ptr<OslSyntax>;
+
 using OslShaderGeneratorPtr = shared_ptr<class OslShaderGenerator>;
 
 /// @class OslShaderGenerator
@@ -25,16 +28,17 @@ class MX_GENOSL_API OslShaderGenerator : public ShaderGenerator
   public:
     /// Constructor.
     OslShaderGenerator(TypeSystemPtr typeSystem);
+    OslShaderGenerator(TypeSystemPtr typeSystem, OslSyntaxPtr syntax);
 
     /// Creator function.
     /// If a TypeSystem is not provided it will be created internally.
     /// Optionally pass in an externally created TypeSystem here,
     /// if you want to keep type descriptions alive after the lifetime
     /// of the shader generator.
-    static ShaderGeneratorPtr create(TypeSystemPtr typeSystem = nullptr)
-    {
-        return std::make_shared<OslShaderGenerator>(typeSystem ? typeSystem : TypeSystem::create());
-    }
+    /// If a OslSyntax is not provided it will be created internally.
+    /// Optionally pass in an externally created OslSyntax here,
+    /// if you want to modify the syntax object before code generation.
+    static ShaderGeneratorPtr create(TypeSystemPtr typeSystem = nullptr, OslSyntaxPtr syntax = nullptr);
 
     /// Return a unique identifier for the target this generator is for
     const string& getTarget() const override { return TARGET; }
@@ -52,6 +56,8 @@ class MX_GENOSL_API OslShaderGenerator : public ShaderGenerator
     /// Register metadata that should be exported to the generated shaders.
     void registerShaderMetadata(const DocumentPtr& doc, GenContext& context) const override;
 
+    static void addSetCiTerminalNode(ShaderGraph& graph, ConstDocumentPtr document, TypeSystemPtr typeSystem, GenContext& context);
+
   protected:
     /// Create and initialize a new OSL shader for shader generation.
     virtual ShaderPtr createShader(const string& name, ElementPtr element, GenContext& context) const;
@@ -67,8 +73,6 @@ class MX_GENOSL_API OslShaderGenerator : public ShaderGenerator
 
     /// Emit metadata for a shader parameter.
     virtual void emitMetadata(const ShaderPort* port, ShaderStage& stage) const;
-
-    void addSetCiTerminalNode(ShaderGraph& graph, ConstDocumentPtr document, GenContext& context) const;
 };
 
 namespace OSL

--- a/source/MaterialXGenShader/GenContext.h
+++ b/source/MaterialXGenShader/GenContext.h
@@ -70,6 +70,13 @@ class MX_GENSHADER_API GenContext
         _sourceCodeSearchPath.append(path);
     }
 
+    /// Return the search path used for finding source code during
+    /// code generation
+    const FileSearchPath& getSourceCodeSearchPath() const
+    {
+        return _sourceCodeSearchPath;
+    }
+
     /// Resolve a source code filename, first checking the given local path
     /// then checking any file paths registered by the user.
     FilePath resolveSourceFile(const FilePath& filename, const FilePath& localPath) const

--- a/source/MaterialXGenShader/GenOptions.h
+++ b/source/MaterialXGenShader/GenOptions.h
@@ -99,7 +99,8 @@ class MX_GENSHADER_API GenOptions
         hwWriteEnvPrefilter(false),
         hwImplicitBitangents(true),
         oslImplicitSurfaceShaderConversion(true),
-        oslConnectCiWrapper(false)
+        oslConnectCiWrapper(false),
+        oslTempOsoPath("")
     {
     }
     virtual ~GenOptions() { }
@@ -225,6 +226,9 @@ class MX_GENSHADER_API GenOptions
     // for OSL targets.
     // Defaults to false.
     bool oslConnectCiWrapper;
+
+    // Directory used to write temporary oso files to.
+    FilePath oslTempOsoPath;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -361,6 +361,8 @@ ShaderNodeImplPtr ShaderGenerator::getImplementation(const NodeDef& nodedef, Gen
 
     impl->initialize(*implElement, context);
 
+    addPortImplementationNames(implElement, *impl);
+
     // Cache it.
     context.addNodeImplementation(name, impl);
 
@@ -431,7 +433,7 @@ void ShaderGenerator::registerTypeDefs(const DocumentPtr& doc)
             typeAlias,
             typeDefinition);
 
-        _syntax->registerTypeSyntax(typeDesc, structTypeSyntax);
+        _syntax->registerTypeSyntax(typeDesc, structTypeSyntax, true);
     }
 }
 

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -282,6 +282,29 @@ class MX_GENSHADER_API ShaderGenerator
     friend ShaderGraph;
 };
 
+template <typename T>
+void addPortImplementationNames(ConstInterfaceElementPtr implElement, T& dest)
+{
+    if (implElement)
+    {
+        for (const auto& port : implElement->getActiveInputs())
+        {
+            if (port->hasImplementationName())
+            {
+                dest.addPortImplName(port->getName(), port->getImplementationName());
+            }
+        }
+
+        for (const auto& port : implElement->getActiveOutputs())
+        {
+            if (port->hasImplementationName())
+            {
+                dest.addPortImplName(port->getName(), port->getImplementationName());
+            }
+        }
+    }
+}
+
 MATERIALX_NAMESPACE_END
 
 #endif // MATERIALX_SHADERGENERATOR_H

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -915,7 +915,16 @@ ShaderGraphEdgeIterator ShaderGraph::traverseUpstream(ShaderOutput* output)
 
 void ShaderGraph::addNode(ShaderNodePtr node)
 {
-    _nodeMap[node->getUniqueId()] = node;
+    // The node map holds the only owning reference to each node, while the node
+    // order holds raw pointers. Overwriting an existing entry would free that
+    // node and leave the dangling pointer behind, so reject duplicate ids.
+    const string& uniqueId = node->getUniqueId();
+    if (_nodeMap.count(uniqueId))
+    {
+        throw ExceptionShaderGenError("A node with unique id '" + uniqueId + "' already exists in graph '" + getName() + "'");
+    }
+
+    _nodeMap[uniqueId] = node;
     _nodeOrder.push_back(node.get());
 }
 
@@ -1382,10 +1391,21 @@ void ShaderGraph::flattenGraph()
 void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode* compoundNodeImpl)
 {
     string parentNodeName = parentNode->getName();
+    string parentNodeId = parentNode->getUniqueId();
 
     auto getNewNodeName = [parentNodeName](const ShaderNode* node) -> string
     {
         return parentNodeName + "_" + node->getName();
+    };
+
+    // Node names are only unique within their parent graph, so the flattened
+    // copies must be keyed by unique id rather than by name. Otherwise sibling
+    // compound nodes sharing a name would map to the same key, and adding the
+    // second set of copies would release the first set while the graph still
+    // holds raw pointers to them.
+    auto getNewNodeId = [parentNodeId](const ShaderNode* node) -> string
+    {
+        return parentNodeId + "_" + node->getUniqueId();
     };
 
     ShaderGraph* compoundGraph = compoundNodeImpl->getGraph();
@@ -1395,6 +1415,7 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
     for (ShaderNode* node : compoundGraph->getNodes())
     {
         ShaderNodePtr newNode = ShaderNode::create(this, getNewNodeName(node), node->getImplementationPtr(), node->getClassification());
+        newNode->_uniqueId = getNewNodeId(node);
         addNode(newNode);
 
         for (const ShaderInput* port : node->getInputs())
@@ -1413,7 +1434,7 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
     // Loop all the newly created nodes and build all necessary connections, or data from the exterior ports.
     for (ShaderNode* node : compoundGraph->getNodes())
     {
-        ShaderNode* newNode = getNode(getNewNodeName(node));
+        ShaderNode* newNode = getNode(getNewNodeId(node));
 
         for (const ShaderInput* port : node->getInputs())
         {
@@ -1435,7 +1456,7 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
                 // NOTE : we handle connections to the compoundGraph later when we
                 // loop the input sockets.
                 string newUpstreamConnectedNodeName = getNewNodeName(upstreamConnectedNode);
-                ShaderNode* newUpstreamConnectedNode = getNode(newUpstreamConnectedNodeName);
+                ShaderNode* newUpstreamConnectedNode = getNode(getNewNodeId(upstreamConnectedNode));
                 if (!newUpstreamConnectedNode)
                 {
                     throw ExceptionShaderGenError("Could not find expected upstream connected node '"+newUpstreamConnectedNodeName+"'");
@@ -1474,7 +1495,7 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
                 const ShaderNode* downstreamConnectedNode = downstreamConnection->getNode();
                 string newDownstreamConnectedNodeName = getNewNodeName(downstreamConnectedNode);
 
-                ShaderNode* newDownstreamNode = getNode(newDownstreamConnectedNodeName);
+                ShaderNode* newDownstreamNode = getNode(getNewNodeId(downstreamConnectedNode));
                 if (!newDownstreamNode)
                 {
                     throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
@@ -1498,7 +1519,7 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
                 const ShaderNode* downstreamNode = downstreamConnection->getNode();
                 string newDownstreamConnectedNodeName = getNewNodeName(downstreamNode);
 
-                ShaderNode* newDownstreamNode = getNode(newDownstreamConnectedNodeName);
+                ShaderNode* newDownstreamNode = getNode(getNewNodeId(downstreamNode));
                 if (!newDownstreamNode)
                 {
                     throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
@@ -1526,7 +1547,7 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
         ShaderNode* upstreamConnectedNode = upstreamConnection->getNode();
         string newUpstreamConnectedNodeName = getNewNodeName(upstreamConnectedNode);
 
-        ShaderNode* newUpstreamNode = getNode(newUpstreamConnectedNodeName);
+        ShaderNode* newUpstreamNode = getNode(getNewNodeId(upstreamConnectedNode));
         if (!newUpstreamNode)
         {
             throw ExceptionShaderGenError("Could not find expected upstream node '"+newUpstreamConnectedNodeName+"'");

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -9,6 +9,7 @@
 #include <MaterialXGenShader/GenContext.h>
 #include <MaterialXGenShader/ShaderGraphRefactor.h>
 #include <MaterialXGenShader/Util.h>
+#include <MaterialXGenShader/Nodes/CompoundNode.h>
 
 #include <MaterialXTrace/Tracing.h>
 
@@ -636,6 +637,57 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
         // Set root for upstream dependency traversal
         root = node;
     }
+    else if (element->isA<NodeDef>())
+    {
+        NodeDefPtr nodeDef = element->asA<NodeDef>();
+
+        graph = std::make_shared<ShaderGraph>(parent, name, element->getDocument(), context);
+
+        // Create input sockets
+        graph->addInputSockets(*nodeDef, context);
+
+        // Create output sockets
+        graph->addOutputSockets(*nodeDef, context);
+
+        // Create this shader node in the graph.
+        ShaderNodePtr newNode = ShaderNode::create(graph.get(), name, *nodeDef, context);
+        graph->addNode(newNode);
+
+        // Share metadata.
+        graph->setMetadata(newNode->getMetadata());
+
+        // Connect it to the graph outputs
+        for (size_t i = 0; i < newNode->numOutputs(); ++i)
+        {
+            ShaderGraphOutputSocket* outputSocket = graph->getOutputSocket(i);
+            outputSocket->makeConnection(newNode->getOutput(i));
+        }
+
+        // Handle node input ports
+        for (const InputPtr& nodedefInput : nodeDef->getActiveInputs())
+        {
+            ShaderGraphInputSocket* inputSocket = graph->getInputSocket(nodedefInput->getName());
+            ShaderInput* input = newNode->getInput(nodedefInput->getName());
+            if (!inputSocket || !input)
+            {
+                throw ExceptionShaderGenError("Node input '" + nodedefInput->getName() + "' doesn't match an existing input on graph '" + graph->getName() + "'");
+            }
+
+            input->setBindInput();
+
+            // Connect graph socket to the node input
+            inputSocket->makeConnection(input);
+
+            // Share metadata.
+            inputSocket->setMetadata(input->getMetadata());
+        }
+
+        ImplementationPtr implElement = nodeDef->getImplementation(context.getShaderGenerator().getTarget())->asA<Implementation>();
+        addPortImplementationNames(implElement, *graph);
+
+        // NodeDef generation has no traversal
+        root = nullptr;
+    }
 
     if (!graph)
     {
@@ -865,6 +917,18 @@ void ShaderGraph::addNode(ShaderNodePtr node)
 {
     _nodeMap[node->getUniqueId()] = node;
     _nodeOrder.push_back(node.get());
+}
+
+void ShaderGraph::removeNode(const string& uniqueId)
+{
+    ShaderNodePtr nodePtr = _nodeMap[uniqueId];
+    if (nodePtr)
+    {
+        disconnect(nodePtr.get());
+        _nodeMap.erase(uniqueId);
+        auto it = std::find(_nodeOrder.begin(), _nodeOrder.end(), nodePtr.get());
+        _nodeOrder.erase(it);
+    }
 }
 
 ShaderNode* ShaderGraph::getNode(const string& uniqueId)
@@ -1166,25 +1230,25 @@ void ShaderGraph::setVariableNames(GenContext& context)
 
     for (ShaderGraphInputSocket* inputSocket : getInputSockets())
     {
-        const string variable = syntax.getVariableName(inputSocket->getName(), inputSocket->getType(), _identifiers);
+        const string variable = syntax.getVariableName(getPortName(inputSocket->getName()), inputSocket->getType(), _identifiers);
         inputSocket->setVariable(variable);
     }
     for (ShaderGraphOutputSocket* outputSocket : getOutputSockets())
     {
-        const string variable = syntax.getVariableName(outputSocket->getName(), outputSocket->getType(), _identifiers);
+        const string variable = syntax.getVariableName(getPortName(outputSocket->getName()), outputSocket->getType(), _identifiers);
         outputSocket->setVariable(variable);
     }
     for (ShaderNode* node : getNodes())
     {
         for (ShaderInput* input : node->getInputs())
         {
-            string variable = input->getFullName();
+            string variable = node->getName() + "_" + node->getPortName(input->getName());
             variable = syntax.getVariableName(variable, input->getType(), _identifiers);
             input->setVariable(variable);
         }
         for (ShaderOutput* output : node->getOutputs())
         {
-            string variable = output->getFullName();
+            string variable = node->getName() + "_" + node->getPortName(output->getName());
             variable = syntax.getVariableName(variable, output->getType(), _identifiers);
             output->setVariable(variable);
         }
@@ -1289,6 +1353,219 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
             }
         }
     }
+}
+
+void ShaderGraph::flattenGraph()
+{
+    bool foundCompoundNode = true;
+    // Use a while loop to handle the nested compound nodes
+    while (foundCompoundNode)
+    {
+        foundCompoundNode = false;
+        vector<ShaderNode*> nodes = getNodes();
+        for (ShaderNode* node : nodes)
+        {
+            if (!node)
+                continue;
+
+            const ShaderNodeImpl& impl = node->getImplementation();
+            const CompoundNode* compoundNodeImpl = dynamic_cast<const CompoundNode*>(&impl);
+            if (!compoundNodeImpl)
+                continue;
+
+            expandCompoundNode(node, compoundNodeImpl);
+            foundCompoundNode = true;
+        }
+    }
+}
+
+void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode* compoundNodeImpl)
+{
+    string parentNodeName = parentNode->getName();
+
+    auto getNewNodeName = [parentNodeName](const ShaderNode* node) -> string
+    {
+        return parentNodeName + "_" + node->getName();
+    };
+
+    ShaderGraph* compoundGraph = compoundNodeImpl->getGraph();
+
+    // Initially just create copies of each of the nodes inside the compound graph with
+    // a prefixed name and copy all the non-connection data.
+    for (ShaderNode* node : compoundGraph->getNodes())
+    {
+        ShaderNodePtr newNode = ShaderNode::create(this, getNewNodeName(node), node->getImplementationPtr(), node->getClassification());
+        addNode(newNode);
+
+        for (const ShaderInput* port : node->getInputs())
+        {
+            ShaderInput* newPort = newNode->addInput(port->getName(), port->getType());
+            port->copyToPort(newPort);
+        }
+
+        for (const ShaderOutput* port : node->getOutputs())
+        {
+            ShaderOutput* newPort = newNode->addOutput(port->getName(), port->getType());
+            port->copyToPort(newPort);
+        }
+    }
+
+    // Loop all the newly created nodes and build all necessary connections, or data from the exterior ports.
+    for (ShaderNode* node : compoundGraph->getNodes())
+    {
+        ShaderNode* newNode = getNode(getNewNodeName(node));
+
+        for (const ShaderInput* port : node->getInputs())
+        {
+            const ShaderOutput* upstreamConnection = port->getConnection();
+            if (!upstreamConnection)
+                continue;
+
+            ShaderInput* newDownstreamInput = newNode->getInput(port->getName());
+            if (!newDownstreamInput)
+            {
+                throw ExceptionShaderGenError("Could not find expected input port on new node '"+port->getName()+"'");
+            }
+
+            const ShaderNode* upstreamConnectedNode = upstreamConnection->getNode();
+
+            if (upstreamConnectedNode != compoundGraph)
+            {
+                // Connect to another node inside the graph
+                // NOTE : we handle connections to the compoundGraph later when we
+                // loop the input sockets.
+                string newUpstreamConnectedNodeName = getNewNodeName(upstreamConnectedNode);
+                ShaderNode* newUpstreamConnectedNode = getNode(newUpstreamConnectedNodeName);
+                if (!newUpstreamConnectedNode)
+                {
+                    throw ExceptionShaderGenError("Could not find expected upstream connected node '"+newUpstreamConnectedNodeName+"'");
+                }
+
+                ShaderOutput* newUpstreamConnectedOutput = newUpstreamConnectedNode->getOutput(upstreamConnection->getName());
+                if (!newUpstreamConnectedOutput)
+                {
+                    throw ExceptionShaderGenError("Could not find expected upstream output '"+newUpstreamConnectedNodeName+"."+upstreamConnection->getName()+"'");
+                }
+
+                newDownstreamInput->makeConnection(newUpstreamConnectedOutput);
+            }
+        }
+    }
+
+    for (ShaderGraphInputSocket* inputSocket : compoundGraph->getInputSockets())
+    {
+        ShaderInputVec downstreamConnections = inputSocket->getConnections();
+        if (downstreamConnections.empty())
+            continue;
+
+        ShaderInput* parentNodeInput = parentNode->getInput(inputSocket->getName());
+        if (!parentNodeInput)
+        {
+            throw ExceptionShaderGenError("Could not find expected input port '"+parentNodeName+"."+inputSocket->getName()+"'");
+        }
+
+        ShaderOutput* upstreamConnectedOutput = parentNodeInput->getConnection();
+        if (!upstreamConnectedOutput)
+        {
+            // If we have no upstream incoming connection then we have to copy the value
+            // to all the downstream internal connected inputs
+            for (const ShaderInput* downstreamConnection : downstreamConnections)
+            {
+                const ShaderNode* downstreamConnectedNode = downstreamConnection->getNode();
+                string newDownstreamConnectedNodeName = getNewNodeName(downstreamConnectedNode);
+
+                ShaderNode* newDownstreamNode = getNode(newDownstreamConnectedNodeName);
+                if (!newDownstreamNode)
+                {
+                    throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
+                }
+
+                ShaderInput* newDownstreamInput = newDownstreamNode->getInput(downstreamConnection->getName());
+                if (!newDownstreamInput)
+                {
+                    throw ExceptionShaderGenError("Could not find expected downstream input '"+newDownstreamConnectedNodeName+"."+downstreamConnection->getName()+"'");
+                }
+
+                newDownstreamInput->setValue(parentNodeInput->getValue());
+            }
+        }
+        else
+        {
+            // connect the upstream output port to each of the downstream internal
+            // connected inputs
+            for (const ShaderInput* downstreamConnection : downstreamConnections)
+            {
+                const ShaderNode* downstreamNode = downstreamConnection->getNode();
+                string newDownstreamConnectedNodeName = getNewNodeName(downstreamNode);
+
+                ShaderNode* newDownstreamNode = getNode(newDownstreamConnectedNodeName);
+                if (!newDownstreamNode)
+                {
+                    throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
+                }
+                ShaderInput* newDownstreamInput = newDownstreamNode->getInput(downstreamConnection->getName());
+                if (!newDownstreamInput)
+                {
+                    throw ExceptionShaderGenError("Could not find expected downstream input '"+newDownstreamConnectedNodeName+"."+downstreamConnection->getName()+"'");
+                }
+
+                newDownstreamInput->makeConnection(upstreamConnectedOutput);
+            }
+
+            // finally we remove the prior connection
+            upstreamConnectedOutput->breakConnection(parentNodeInput);
+        }
+    }
+
+    for (ShaderGraphOutputSocket* outputSocket : compoundGraph->getOutputSockets())
+    {
+        ShaderOutput* upstreamConnection = outputSocket->getConnection();
+        if (!upstreamConnection)
+            continue;
+
+        ShaderNode* upstreamConnectedNode = upstreamConnection->getNode();
+        string newUpstreamConnectedNodeName = getNewNodeName(upstreamConnectedNode);
+
+        ShaderNode* newUpstreamNode = getNode(newUpstreamConnectedNodeName);
+        if (!newUpstreamNode)
+        {
+            throw ExceptionShaderGenError("Could not find expected upstream node '"+newUpstreamConnectedNodeName+"'");
+        }
+        ShaderOutput* newUpstreamOutput = newUpstreamNode->getOutput(upstreamConnection->getName());
+        if (!newUpstreamOutput)
+        {
+            throw ExceptionShaderGenError("Could not find expected upstream output '"+newUpstreamConnectedNodeName+"."+upstreamConnection->getName()+"'");
+        }
+
+        ShaderOutput* parentNodeOutput = parentNode->getOutput(outputSocket->getName());
+        if (!parentNodeOutput)
+        {
+            throw ExceptionShaderGenError("Could not find expected output port '"+parentNodeName+"."+outputSocket->getName()+"'");
+        }
+
+        // Loop all downstream connected inputs and connect to the corresponding output on the newly created nodes
+        ShaderInputVec downstreamConnectedInputs = parentNodeOutput->getConnections();
+        for (ShaderInput* downstreamConnectedInput : downstreamConnectedInputs)
+        {
+            downstreamConnectedInput->makeConnection(newUpstreamOutput);
+        }
+    }
+
+    removeNode(parentNode->getUniqueId());
+}
+
+void ShaderGraph::addPortImplName(const string& portName, const string& implName)
+{
+    _portImplNames[portName] = implName;
+}
+
+const string& ShaderGraph::getPortName(const string& portName) const
+{
+    if (_impl)
+        return _impl->getPortName(portName);
+
+    auto it = _portImplNames.find(portName);
+    return it != _portImplNames.end() ? it->second : portName;
 }
 
 namespace

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -1473,6 +1473,43 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
         }
     }
 
+    // Resolve the flattened inputs that a connection from an input socket should be
+    // applied to. Normally this is the matching input on the copy of the child node,
+    // but an input socket may also connect straight to an output socket, in which case
+    // the compound graph just passes the value through. Output sockets are stored as
+    // inputs on the graph itself, so such a connection resolves to the inputs that are
+    // downstream of the parent node's matching output.
+    auto getNewDownstreamInputs = [this, compoundGraph, parentNode, parentNodeName, &getNewNodeName, &getNewNodeId](const ShaderInput* downstreamConnection) -> ShaderInputVec
+    {
+        const ShaderNode* downstreamNode = downstreamConnection->getNode();
+        if (downstreamNode == compoundGraph)
+        {
+            ShaderOutput* parentNodeOutput = parentNode->getOutput(downstreamConnection->getName());
+            if (!parentNodeOutput)
+            {
+                throw ExceptionShaderGenError("Could not find expected output port '"+parentNodeName+"."+downstreamConnection->getName()+"'");
+            }
+
+            // Return a copy, since connecting to these inputs modifies the connection list.
+            return parentNodeOutput->getConnections();
+        }
+
+        string newDownstreamConnectedNodeName = getNewNodeName(downstreamNode);
+        ShaderNode* newDownstreamNode = getNode(getNewNodeId(downstreamNode));
+        if (!newDownstreamNode)
+        {
+            throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
+        }
+
+        ShaderInput* newDownstreamInput = newDownstreamNode->getInput(downstreamConnection->getName());
+        if (!newDownstreamInput)
+        {
+            throw ExceptionShaderGenError("Could not find expected downstream input '"+newDownstreamConnectedNodeName+"."+downstreamConnection->getName()+"'");
+        }
+
+        return ShaderInputVec{ newDownstreamInput };
+    };
+
     for (ShaderGraphInputSocket* inputSocket : compoundGraph->getInputSockets())
     {
         ShaderInputVec downstreamConnections = inputSocket->getConnections();
@@ -1492,22 +1529,10 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
             // to all the downstream internal connected inputs
             for (const ShaderInput* downstreamConnection : downstreamConnections)
             {
-                const ShaderNode* downstreamConnectedNode = downstreamConnection->getNode();
-                string newDownstreamConnectedNodeName = getNewNodeName(downstreamConnectedNode);
-
-                ShaderNode* newDownstreamNode = getNode(getNewNodeId(downstreamConnectedNode));
-                if (!newDownstreamNode)
+                for (ShaderInput* newDownstreamInput : getNewDownstreamInputs(downstreamConnection))
                 {
-                    throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
+                    newDownstreamInput->setValue(parentNodeInput->getValue());
                 }
-
-                ShaderInput* newDownstreamInput = newDownstreamNode->getInput(downstreamConnection->getName());
-                if (!newDownstreamInput)
-                {
-                    throw ExceptionShaderGenError("Could not find expected downstream input '"+newDownstreamConnectedNodeName+"."+downstreamConnection->getName()+"'");
-                }
-
-                newDownstreamInput->setValue(parentNodeInput->getValue());
             }
         }
         else
@@ -1516,21 +1541,10 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
             // connected inputs
             for (const ShaderInput* downstreamConnection : downstreamConnections)
             {
-                const ShaderNode* downstreamNode = downstreamConnection->getNode();
-                string newDownstreamConnectedNodeName = getNewNodeName(downstreamNode);
-
-                ShaderNode* newDownstreamNode = getNode(getNewNodeId(downstreamNode));
-                if (!newDownstreamNode)
+                for (ShaderInput* newDownstreamInput : getNewDownstreamInputs(downstreamConnection))
                 {
-                    throw ExceptionShaderGenError("Could not find expected downstream node '"+newDownstreamConnectedNodeName+"'");
+                    newDownstreamInput->makeConnection(upstreamConnectedOutput);
                 }
-                ShaderInput* newDownstreamInput = newDownstreamNode->getInput(downstreamConnection->getName());
-                if (!newDownstreamInput)
-                {
-                    throw ExceptionShaderGenError("Could not find expected downstream input '"+newDownstreamConnectedNodeName+"."+downstreamConnection->getName()+"'");
-                }
-
-                newDownstreamInput->makeConnection(upstreamConnectedOutput);
             }
 
             // finally we remove the prior connection
@@ -1545,6 +1559,12 @@ void ShaderGraph::expandCompoundNode(ShaderNode* parentNode, const CompoundNode*
             continue;
 
         ShaderNode* upstreamConnectedNode = upstreamConnection->getNode();
+
+        // A pass-through output socket is fed by an input socket rather than by a child
+        // node, and has already been rewired when the input sockets were processed above.
+        if (upstreamConnectedNode == compoundGraph)
+            continue;
+
         string newUpstreamConnectedNodeName = getNewNodeName(upstreamConnectedNode);
 
         ShaderNode* newUpstreamNode = getNode(getNewNodeId(upstreamConnectedNode));

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -27,6 +27,7 @@ class ShaderGraphEdge;
 class ShaderGraphEdgeIterator;
 class GenOptions;
 class ShaderGraphRefactor;
+class CompoundNode;
 
 /// An internal input socket in a shader graph,
 /// used for connecting internal nodes to the outside
@@ -144,6 +145,13 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     /// Rewire all downstream connections from one output to another.
     void replaceOutput(ShaderOutput* oldOutput, ShaderOutput* newOutput);
 
+    /// Inplace expands all Compound nodes, which can be created by nodegraph
+    /// elements in the document or nodes that use a nodegraph implementation
+    void flattenGraph();
+
+    void addPortImplName(const string& portName, const string& implName);
+    const string& getPortName(const string& portName) const override;
+
   protected:
     /// Create node connections corresponding to the connection between a pair of elements.
     /// @param downstreamElement Element representing the node to connect to.
@@ -157,6 +165,9 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
 
     /// Add a node to the graph, keyed by the node's unique identifier.
     void addNode(ShaderNodePtr node);
+
+    /// Remove a node from the graph by its unique identifier.
+    void removeNode(const string& uniqueId);
 
     /// Add input sockets from an interface element (nodedef, nodegraph or node)
     void addInputSockets(const InterfaceElement& elem, GenContext& context);
@@ -201,6 +212,12 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     /// Break all connections on a node
     void disconnect(ShaderNode* node) const;
 
+private:
+    void expandCompoundNode(ShaderNode* shaderNode, const CompoundNode* compoundNodeImpl);
+
+    // This "protected" should probably be "private" - this change compiles fine for the MaterialX codebase
+    // but would change possible downstream use of the class outside the project.
+protected:
     ConstDocumentPtr _document;
     std::unordered_map<string, ShaderNodePtr> _nodeMap;
     std::vector<ShaderNode*> _nodeOrder;
@@ -215,6 +232,9 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     std::vector<std::pair<ShaderOutput*, ColorSpaceTransform>> _outputColorTransformMap;
     // Temporary storage for outputs that require unit transformations
     std::vector<std::pair<ShaderOutput*, UnitTransform>> _outputUnitTransformMap;
+
+private:
+    std::unordered_map<string, string> _portImplNames;
 };
 
 /// @class ShaderGraphEdge

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -39,6 +39,18 @@ string ShaderPort::getValueString() const
     return getValue() ? getValue()->getValueString() : EMPTY_STRING;
 }
 
+void ShaderPort::copyToPort(ShaderPort* to) const
+{
+    to->setPath(getPath());
+    to->setSemantic(getSemantic());
+    to->setValue(getValue());
+    to->setUnit(getUnit());
+    to->setColorSpace(getColorSpace());
+    to->setGeomProp(getGeomProp());
+    to->setMetadata(getMetadata());
+    to->setFlags(getFlags());
+}
+
 //
 // ShaderInput methods
 //
@@ -559,6 +571,11 @@ ShaderOutput* ShaderNode::addOutput(const string& name, TypeDesc type)
     _outputOrder.push_back(output.get());
 
     return output.get();
+}
+
+const string& ShaderNode::getPortName(const string& portName) const
+{
+    return _impl ? _impl->getPortName(portName) : portName;
 }
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -251,6 +251,9 @@ class MX_GENSHADER_API ShaderPort : public std::enable_shared_from_this<ShaderPo
     /// Get the metadata vector.
     const ShaderMetadataVecPtr& getMetadata() const { return _metadata; }
 
+    /// Copy all the local data to the target port.
+    void copyToPort(ShaderPort* to) const;
+
   protected:
     ShaderNode* _node;
     TypeDesc _type;
@@ -443,6 +446,10 @@ class MX_GENSHADER_API ShaderNode
     {
         return *_impl;
     }
+    ShaderNodeImplPtr getImplementationPtr() const
+    {
+        return _impl;
+    }
 
     /// Initialize this shader node with all required data
     /// from the given node and nodedef.
@@ -496,6 +503,8 @@ class MX_GENSHADER_API ShaderNode
     {
         return (!_impl || _impl->isEditable(input));
     }
+
+    virtual const string& getPortName(const string& portName) const;
 
   protected:
     /// Create metadata from the nodedef according to registered metadata.

--- a/source/MaterialXGenShader/ShaderNodeImpl.cpp
+++ b/source/MaterialXGenShader/ShaderNodeImpl.cpp
@@ -34,6 +34,17 @@ void ShaderNodeImpl::initialize(const InterfaceElement& element, GenContext&)
     _hash = std::hash<string>{}(_name);
 }
 
+void ShaderNodeImpl::addPortImplName(const string& portName, const string& implName)
+{
+    _portImplNames[portName] = implName;
+}
+
+const string& ShaderNodeImpl::getPortName(const string& portName) const
+{
+    auto it = _portImplNames.find(portName);
+    return it != _portImplNames.end() ? it->second : portName;
+}
+
 void ShaderNodeImpl::addInputs(ShaderNode&, GenContext&) const
 {
 }

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -97,6 +97,9 @@ class MX_GENSHADER_API ShaderNodeImpl
         return true;
     }
 
+    void addPortImplName(const string& portName, const string& implName);
+    const string& getPortName(const string& portName) const;
+
   protected:
     /// Protected constructor
     ShaderNodeImpl();
@@ -109,6 +112,9 @@ class MX_GENSHADER_API ShaderNodeImpl
   protected:
     string _name;
     size_t _hash;
+
+  private:
+    std::unordered_map<string, string> _portImplNames;
 };
 
 /// A no operation node, to be used for organizational nodes that has no code to execute.

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -39,7 +39,7 @@ Syntax::Syntax(TypeSystemPtr typeSystem) :
 {
 }
 
-void Syntax::registerTypeSyntax(TypeDesc type, TypeSyntaxPtr syntax)
+void Syntax::registerTypeSyntax(TypeDesc type, TypeSyntaxPtr syntax, bool isCustomSyntax)
 {
     auto it = _typeSyntaxIndexByType.find(type);
     if (it != _typeSyntaxIndexByType.end())
@@ -49,6 +49,10 @@ void Syntax::registerTypeSyntax(TypeDesc type, TypeSyntaxPtr syntax)
     else
     {
         _typeSyntaxes.push_back(syntax);
+        if (isCustomSyntax)
+        {
+            _customTypeSyntaxes.push_back({type,syntax});
+        }
         _typeSyntaxIndexByType[type] = _typeSyntaxes.size() - 1;
     }
 

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -57,7 +57,7 @@ class MX_GENSHADER_API Syntax
 
     /// Register syntax handling for a data type.
     /// Required to be set for all supported data types.
-    void registerTypeSyntax(TypeDesc type, TypeSyntaxPtr syntax);
+    void registerTypeSyntax(TypeDesc type, TypeSyntaxPtr syntax, bool isCustomSyntax=false);
     [[deprecated]] void registerTypeSyntax(const TypeDesc* type, TypeSyntaxPtr syntax) { registerTypeSyntax(*type, syntax); }
 
     /// Register names that are reserved words not to be used by a code generator when naming
@@ -83,6 +83,9 @@ class MX_GENSHADER_API Syntax
 
     /// Returns an array of all registered type syntax objects
     const vector<TypeSyntaxPtr>& getTypeSyntaxes() const { return _typeSyntaxes; }
+
+    /// Returns an array of all the custom type syntaxes registered and their corresponding TypeDesc objects
+    const vector<std::pair<TypeDesc,TypeSyntaxPtr>>& getCustomTypeSyntaxes() const { return _customTypeSyntaxes; }
 
     /// Return a type description for the given type name.
     TypeDesc getType(const string& name) const { return _typeSystem->getType(name); }
@@ -208,6 +211,7 @@ class MX_GENSHADER_API Syntax
 
     TypeSystemPtr _typeSystem;
     vector<TypeSyntaxPtr> _typeSyntaxes;
+    vector<std::pair<TypeDesc,TypeSyntaxPtr>> _customTypeSyntaxes;
     std::unordered_map<TypeDesc, size_t, TypeDesc::Hasher> _typeSyntaxIndexByType;
 
     StringSet _reservedWords;

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -13,6 +13,7 @@
 #include <MaterialXRender/OiioImageLoader.h>
 #endif
 
+#include <MaterialXGenOsl/Nodes/OsoNode.h>
 #include <MaterialXGenOsl/OslShaderGenerator.h>
 #include <MaterialXGenOsl/OslNetworkShaderGenerator.h>
 
@@ -72,6 +73,30 @@ class BitangentOsl : public mx::ShaderNodeImpl
     }
 };
 
+class TangentOslNetwork : public mx::OsoNode
+{
+public:
+    TangentOslNetwork() : OsoNode("IM_tangent_vector3_genoslnetwork_test","")
+    {}
+
+    static mx::ShaderNodeImplPtr create()
+    {
+        return std::make_shared<TangentOslNetwork>();
+    }
+};
+
+class BitangentOslNetwork : public mx::OsoNode
+{
+public:
+    BitangentOslNetwork() : OsoNode("IM_bitangent_vector3_genoslnetwork_test","")
+    {}
+
+    static mx::ShaderNodeImplPtr create()
+    {
+        return std::make_shared<BitangentOslNetwork>();
+    }
+};
+
 } // anonymous namespace
 
 class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
@@ -99,20 +124,6 @@ class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
 
     void addSkipFiles() override
     {
-        if (_useOslCmdStr)
-        {
-            _skipFiles.insert("filename_cm_test.mtlx");
-            _skipFiles.insert("shader_ops.mtlx");
-            _skipFiles.insert("chiang_hair_surfaceshader.mtlx");
-            _skipFiles.insert("network_surfaceshader.mtlx");
-            _skipFiles.insert("sheen.mtlx");
-            _skipFiles.insert("toon_shade.mtlx");
-            _skipFiles.insert("bsdf_graph.mtlx");
-            _skipFiles.insert("varying_ior.mtlx");
-            _skipFiles.insert("vertical_layering.mtlx");
-            _skipFiles.insert("mix_bsdf.mtlx");
-        }
-
         RenderUtil::ShaderRenderTester::addSkipFiles();
     }
 
@@ -201,6 +212,7 @@ RenderUtil::RenderProfileResult OslShaderRenderTester::runRenderer(
     mx::TypedElementPtr element = item.element;
     const GenShaderUtil::TestSuiteOptions& testOptions = session.testOptions;
     std::ostream& log = session.log;
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
 
     std::cout << "Validating OSL rendering for: " << doc->getSourceUri() << std::endl;
 
@@ -228,9 +240,18 @@ RenderUtil::RenderProfileResult OslShaderRenderTester::runRenderer(
                 contextOptions.targetColorSpaceOverride = "lin_rec709";
                 contextOptions.oslConnectCiWrapper = true;
 
-                // Apply local overrides for shader generation.
-                shadergen.registerImplementation("IM_tangent_vector3_" + mx::OslShaderGenerator::TARGET, TangentOsl::create);
-                shadergen.registerImplementation("IM_bitangent_vector3_" + mx::OslShaderGenerator::TARGET, BitangentOsl::create);
+                if (_useOslCmdStr)
+                {
+                    // Apply local overrides for shader generation.
+                    shadergen.registerImplementation("IM_tangent_vector3_" + mx::OslNetworkShaderGenerator::TARGET, TangentOslNetwork::create);
+                    shadergen.registerImplementation("IM_bitangent_vector3_" + mx::OslNetworkShaderGenerator::TARGET, BitangentOslNetwork::create);
+                }
+                else
+                {
+                    // Apply local overrides for shader generation.
+                    shadergen.registerImplementation("IM_tangent_vector3_" + mx::OslShaderGenerator::TARGET, TangentOsl::create);
+                    shadergen.registerImplementation("IM_bitangent_vector3_" + mx::OslShaderGenerator::TARGET, BitangentOsl::create);
+                }
 
                 shader = shadergen.generate(shaderName, element, context);
             }
@@ -249,6 +270,12 @@ RenderUtil::RenderProfileResult OslShaderRenderTester::runRenderer(
             CHECK(shader->getSourceCode().length() > 0);
 
             std::string oslCmdStr = shader->getSourceCode();
+
+            // Because we're embedding the command string inside the XML scene template we need
+            // to replace any invalid characters.
+            const mx::StringMap xmlReplaceMapping = { { "<", "&lt;" }, { ">", "&gt;" } };
+            oslCmdStr = mx::replaceSubstrings(oslCmdStr, xmlReplaceMapping);
+
 
             std::string shaderPath;
             mx::FilePath outputFilePath = item.outputPath;
@@ -302,9 +329,10 @@ RenderUtil::RenderProfileResult OslShaderRenderTester::runRenderer(
                 const mx::ShaderStage& stage = shader->getStage(mx::Stage::PIXEL);
 
                 // Bind IBL image name overrides.
+                mx::FilePath envmapPath = searchPath.find(mx::FilePath(testOptions.radianceIBLPath));
                 mx::StringVec envOverrides;
                 std::string envmap_filename("string envmap_filename \"");
-                envmap_filename += testOptions.radianceIBLPath;
+                envmap_filename += envmapPath.asString();
                 envmap_filename += "\";\n";
                 envOverrides.push_back(envmap_filename);
 
@@ -334,7 +362,6 @@ RenderUtil::RenderProfileResult OslShaderRenderTester::runRenderer(
                     }
 
                     // Set scene template file. For now we only have the constant color scene file
-                    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
                     mx::FilePath sceneTemplatePath = searchPath.find("resources/Utilities/");
                     sceneTemplatePath = sceneTemplatePath / sceneTemplateFile;
                     _renderer->setOslTestRenderSceneTemplateFile(sceneTemplatePath.asString());

--- a/source/MaterialXTest/MaterialXRenderOsl/Utilities/IM_bitangent_vector3_genoslnetwork_test.osl
+++ b/source/MaterialXTest/MaterialXRenderOsl/Utilities/IM_bitangent_vector3_genoslnetwork_test.osl
@@ -1,0 +1,9 @@
+shader IM_bitangent_vector3_genoslnetwork_test
+(
+    string space = "object",
+    int index = 0,
+    output vector out = vector(0.0)
+)
+{
+    out = normalize(cross(N, vector(N[2], 0, -N[0])));
+}

--- a/source/MaterialXTest/MaterialXRenderOsl/Utilities/IM_tangent_vector3_genoslnetwork_test.osl
+++ b/source/MaterialXTest/MaterialXRenderOsl/Utilities/IM_tangent_vector3_genoslnetwork_test.osl
@@ -1,0 +1,9 @@
+shader IM_tangent_vector3_genoslnetwork_test
+(
+    string space = "object",
+    int index = 0,
+    output vector out = vector(0.0)
+)
+{
+    out = normalize(vector(N[2], 0, -N[0]));
+}

--- a/source/MaterialXTest/MaterialXRenderOsl/Utilities/scene_template_oslcmd.xml
+++ b/source/MaterialXTest/MaterialXRenderOsl/Utilities/scene_template_oslcmd.xml
@@ -1,6 +1,9 @@
 <!-- Template for a lit scene in testrender -->
 <World>
-   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.334" />
+   <!-- The camera FOV is compensated for [-0.5, 0.5] screen coordinates,
+        and matches a 45 degree FOV with [-1, 1] screen coordinates.
+        FOV = atan(2 * tan(45 * PI/360)) * 360/PI = 79.27854 -->
+   <Camera eye="0, 0, 3" dir="0, 0, -1" fov="79.27854" />
 
    <!-- Background environment map. -->
    <ShaderGroup>


### PR DESCRIPTION
Update OSL Network generator to provide parity with OSL Source generator.

This is a pretty large commit, but most of it is all pretty intertwined, so I'll do my best to outline here all the different changes.

### LibsToOso
* The tool now supports selecting using the NodeDef name or the Implementation name as the basis for the name of the new OSL Network generator implementation and corresponding OSO.
* OSL code and corresponding OSO is now generated directly from the NodeDef element.
* `implname` functionality added is used to define the renamed ports.
* NodeGraph elements can now be skipped during processing.

### OSLNetworkGenerator
* Generator now directly inherits from `ShaderGenerator` as there is no common functionality shared with the `OSLShaderGenerator`.
* Provides API to compile OSL source, and also to generate a Shader from a NodeDef element, this is consolidated from the `LibsToOso` tool source.
* The generator can now create a new ShaderNodeImpl object on demand (and the corresponding compiled OSO file) if a locally defined OSL Source Implementation element is discovered. This includes correctly constructing an OSL Source generator object with all the corresponding custom types defined to allow for the correct shader generation to occur.
* `liboslcomp` can be optionally used for the on-demand compilation for better performance, and avoids writing the shader source to disk to compile.
* New `ShaderGraph::flattenGraph()` function is used to correctly expand any locally defined NodeGraph elements in to the corresponding nodes. We do not on-demand compile non-functional NodeGraph elements in to OSOs as they do not have corresponding NodeDef elements to fully name and decorate the interface. Once the `ShaderGraph` is flattened then we are left with a fully expanded graph of individual nodes.
* `OslNetworkSyntax` has been refactored.
  * It no longer has any reserved words, as the grammar used to describe the network has no restrictions on words that are used.
  * Parameter value emitting code has been refactored to better support the "built-in" struct types more cleanly, and removes dependency on the OSL Source syntax, as they are fundamentally two different exports. Including better error handling for types that do not have direct parameter export.

### MaterialXGenShader
* New API method `GenContext::getSourceCodeSearchPath()`, needed to allow dynamic construction of derived generators that share the source code search path.
* New `GenOptions` option `oslTempOsoPath` to allow control over where on-demand OSOs are compiled to. If unspecified the system will fallback to a uniquely generated temp directory in the system temporary directory.
* Support added for `implname` attribute during shader generation. This is described in the specification, but not yet implemented. During OSL source generation when compiling the OSOs its possible input names such as `normal` may be modified to avoid clashes with reserved words. Adding `implname` support allows this to be described in the generated Implementation elements and respected during OSL Network generation. New `getPortName()` function is added in support for the implementation of this feature. This is also needs to be stored in two separate classes, the actual implementation can be either a `ShaderGraph` or a `ShaderNodeImpl`.
* New API method `ShaderGraph::flattenGraph()` will walk the graph and expand any `CompoundNode` entities discovered. Care is taken to generate unique names for newly generated nodes by prefixing the names with the name of the prior parent `CompoundNode`, and also to ensure all connections are retained.
* `ShaderGraph::create()` can now accept and populate the created graph directly from a NodeDef element, which is simpler than the current Node source, as there are no local modifications.
* `Syntax` base class now tracks custom registered syntaxes so they can be easily queried. This is necessary to support dynamic creation of a derived generator, specifically to allow the OSL Network generator to create the OSL Source generator for on-demand compilation of locally defined nodes.

Other supporting changes are outlined below.

### Cmake
* Add CMake option to control if NodeGraph implementations are compiled down to OSOs, or left as NodeGraphs.

### MaterialXFormat
* Add optional `recursive` argument to FilePath::createDirectory(), to allow for recursive directory creation if necessary.
* Add API to FilePath to return the system temporary directory, as well as create a new temporary directory. This is used for on-the-fly compilation of OSL source implementation to OSOs if defined locally in a document and not in a pre-compiled standard library.
* Add a new `createDirectories` option to XmlWriteOptions to allow for any necessary directories to be created while writing a new file.

### MaterialXTest/MaterialXRenderOsl
* Add new test specific implementations for tangent and bitangent nodes for the OSL Network generator. These may become obsolete if the OSL render testing moves to using the OBJ file (see XXXX).
* Update the OSL Network scene template to align the cameras after the OSL Source template was changed.
* Remove the OSL Network specific tests that were skipped - we now have complete one-to-one parity with OSL Source generator.
* Write fully expanded paths in to the template file for easier testing.
* Introduce string processing to the command string that needs to be embedded in a legal XML file to replace illegal XML characters `<` and `>`.