### PR TITLE
Improvements to `convert` node tables

### DIFF
--- a/documents/Specification/MaterialX.StandardNodes.md
+++ b/documents/Specification/MaterialX.StandardNodes.md
@@ -2105,40 +2105,37 @@ The valid range for `index` should be clamped to $[0,N)$ in the user interface, 
 ### `convert`
 Convert a stream from one data type to another.
 
-|Port |Description                                    |Type   |Default |
-|-----|-----------------------------------------------|-------|--------|
-|`in` |The input stream to convert                    |boolean|false   |
-|`out`|Output: the converted value, either 0.0 or 1.0 |float  |0.0     |
+|Port |Description                |Type           |Default |
+|-----|---------------------------|---------------|--------|
+|`in` |The input stream to convert|boolean        |false   |
+|`out`|Output: the converted value|float, integer |__zero__|
 
-|Port |Description                                    |Type   |Default |
-|-----|-----------------------------------------------|-------|--------|
-|`in` |The input stream to convert                    |integer|0       |
-|`out`|Output: the converted value                    |float  |0.0     |
+|Port |Description                              |Type   |Default|
+|-----|-----------------------------------------|-------|-------|
+|`in` |The input stream to convert              |integer|0      |
+|`out`|Output: true for any non-zero input value|boolean|false  |
 
-|Port |Description                                    |Type   |Default |
-|-----|-----------------------------------------------|-------|--------|
-|`in` |The input stream to convert                    |boolean|false   |
-|`out`|Output: the converted value, either 0 or 1     |integer|0       |
+|Port |Description                |Type   |Default|
+|-----|---------------------------|-------|-------|
+|`in` |The input stream to convert|integer|0      |
+|`out`|Output: the converted value|float  |0.0    |
 
-|Port |Description                                    |Type   |Default |
-|-----|-----------------------------------------------|-------|--------|
-|`in` |The input stream to convert                    |integer|0       |
-|`out`|Output: true for any non-zero input value      |boolean|false   |
+|Port |Description                             |Type                   |Default |
+|-----|----------------------------------------|-----------------------|--------|
+|`in` |The input stream to convert             |boolean, float, integer|__zero__|
+|`out`|Output: copy input value to all channels|colorN, vectorN        |__zero__|
 
-|Port |Description                                    |Type          |Default |
-|-----|-----------------------------------------------|--------------|--------|
-|`in` |The input stream to convert                    |float,integer |__zero__|
-|`out`|Output: copy input value to all channels       |colorN,vectorN|__zero__|
+|Port |Description                |Type           |Default |
+|-----|---------------------------|---------------|--------|
+|`in` |The input stream to convert|colorN, vectorN|__zero__|
+|`out`|Output: see below          |colorM, vectorM|__zero__|
 
-|Port |Description                                       |Type          |Default |
-|-----|--------------------------------------------------|--------------|--------|
-|`in` |The input stream to convert                       |boolean       |false   |
-|`out`|Output: 1 in all channels if `in`=true, 0 if false|colorN,vectorN|__zero__|
+|Port |Description                                                      |Type                                    |Default |
+|-----|-----------------------------------------------------------------|----------------------------------------|--------|
+|`in` |The input stream to convert                                      |boolean, integer, float, colorN, vectorN|__zero__|
+|`out`|Output: an unlit surface shader emitting the input value as color|surfaceshader                           |        |
 
-|Port |Description                  |Type          |Default |
-|-----|-----------------------------|--------------|--------|
-|`in` |The input stream to convert  |colorN,vectorN|__zero__|
-|`out`|Output: see below            |colorM,vectorM|__zero__|
+For boolean input values, all numeric output values will be either __zero__ or __one__.
 
 For colorN/vectorN to colorM/vectorM:
 


### PR DESCRIPTION
This changelist makes improvements to the specification tables for the `convert` node, aligning them more accurately with the standard data libraries, and expressing the type variations of the node more compactly.

With these changes, the number of differences between the standard node specification and data libraries reported by `comparenodedefs.py` is reduced from 46 to 38.