### PR TITLE
Clarity improvements to standard node tables

### DIFF
--- a/documents/Specification/MaterialX.StandardNodes.md
+++ b/documents/Specification/MaterialX.StandardNodes.md
@@ -1063,7 +1063,7 @@ The sine of the incoming value, which is expected to be expressed in radians.
 |Port |Description             |Type          |Default |
 |-----|------------------------|--------------|--------|
 |`in` |The primary input stream|float, vectorN|__zero__|
-|`out`|Output: sin of `in1`    |Same as `in`  |`in`    |
+|`out`|Output: sin of `in`     |Same as `in`  |`in`    |
 
 <a id="node-cos"> </a>
 
@@ -1073,7 +1073,7 @@ The cosine of the incoming value, which is expected to be expressed in radians.
 |Port |Description             |Type          |Default |
 |-----|------------------------|--------------|--------|
 |`in` |The primary input stream|float, vectorN|__zero__|
-|`out`|Output: cos of `in1`    |Same as `in`  |`in`    |
+|`out`|Output: cos of `in`     |Same as `in`  |`in`    |
 
 <a id="node-tan"> </a>
 
@@ -1083,7 +1083,7 @@ The tangent of the incoming value, which is expected to be expressed in radians.
 |Port |Description             |Type          |Default |
 |-----|------------------------|--------------|--------|
 |`in` |The primary input stream|float, vectorN|__zero__|
-|`out`|Output: cos of `in1`    |Same as `in`  |`in`    |
+|`out`|Output: tan of `in`     |Same as `in`  |`in`    |
 
 <a id="node-asin"> </a>
 
@@ -1093,7 +1093,7 @@ The arcsine of the incoming value. The output will be expressed in radians.
 |Port |Description             |Type          |Default |Accepted Values    |
 |-----|------------------------|--------------|--------|-------------------|
 |`in` |The primary input stream|float, vectorN|__zero__|[-__one__, __one__]|
-|`out`|Output: asin of `in1`   |Same as `in`  |`in`    |                   |
+|`out`|Output: asin of `in`    |Same as `in`  |`in`    |                   |
 
 <a id="node-acos"> </a>
 
@@ -1103,7 +1103,7 @@ The arccosine of the incoming value. The output will be expressed in radians.
 |Port |Description             |Type          |Default |Accepted Values    |
 |-----|------------------------|--------------|--------|-------------------|
 |`in` |The primary input stream|float, vectorN|__zero__|[-__one__, __one__]|
-|`out`|Output: acos of `in1`   |Same as `in`  |`in`    |                   |
+|`out`|Output: acos of `in`    |Same as `in`  |`in`    |                   |
 
 <a id="node-atan2"> </a>
 
@@ -1974,11 +1974,11 @@ Output the value of the `in1` or `in2` stream depending on whether the `value1` 
 |`in2`   |The value stream to output if `value1` <= `value2`|Same as `in1`                            |__zero__|
 |`out`   |Output: the result of the comparison              |Same as `in1`                            |`in1`   |
 
-|Port    |Description                                       |Type                                     |Default |
-|--------|--------------------------------------------------|-----------------------------------------|--------|
-|`value1`|the first value to be compared                    |float, integer                           |__one__ |
-|`value2`|the second value to be compared                   |Same as `value1`                         |__zero__|
-|`out`   |Output: true if `value1` > `value2                |boolean                                  |false   |
+|Port    |Description                        |Type            |Default |
+|--------|-----------------------------------|----------------|--------|
+|`value1`|The first value to be compared     |float, integer  |__one__ |
+|`value2`|The second value to be compared    |Same as `value1`|__zero__|
+|`out`   |Output: true if `value1` > `value2`|boolean         |false   |
 
 <a id="node-ifgreatereq"> </a>
 
@@ -1988,17 +1988,17 @@ Output the value of the `in1` or `in2` stream depending on whether the `value1` 
 
 |Port    |Description                                       |Type                                     |Default |
 |--------|--------------------------------------------------|-----------------------------------------|--------|
-|`value1`|the first value to be compared                    |float, integer                           |__one__ |
-|`value2`|the second value to be compared                   |Same as `value1`                         |__zero__|
+|`value1`|The first value to be compared                    |float, integer                           |__one__ |
+|`value2`|The second value to be compared                   |Same as `value1`                         |__zero__|
 |`in1`   |The value stream to output if `value1` >= `value2`|float, colorN, vectorN, matrixNN, integer|__zero__|
 |`in2`   |The value stream to output if `value1` < `value2` |Same as `in1`                            |__zero__|
 |`out`   |Output: the result of the comparison              |Same as `in1`                            |`in1`   |
 
-|Port    |Description                                       |Type                                     |Default |
-|--------|--------------------------------------------------|-----------------------------------------|--------|
-|`value1`|the first value to be compared                    |float, integer                           |__one__ |
-|`value2`|the second value to be compared                   |Same as `value1`                         |__zero__|
-|`out`   |Output: true if `value1` >= `value2               |boolean                                  |false   |
+|Port    |Description                         |Type            |Default |
+|--------|------------------------------------|----------------|--------|
+|`value1`|The first value to be compared      |float, integer  |__one__ |
+|`value2`|The second value to be compared     |Same as `value1`|__zero__|
+|`out`   |Output: true if `value1` >= `value2`|boolean         |false   |
 
 <a id="node-ifequal"> </a>
 
@@ -2008,8 +2008,8 @@ Output the value of the `in1` or `in2` stream depending on whether the `value1` 
 
 |Port    |Description                                       |Type                                     |Default |
 |--------|--------------------------------------------------|-----------------------------------------|--------|
-|`value1`|the first value to be compared                    |float, integer                           |__one__ |
-|`value2`|the second value to be compared                   |Same as `value1`                         |__zero__|
+|`value1`|The first value to be compared                    |float, integer                           |__one__ |
+|`value2`|The second value to be compared                   |Same as `value1`                         |__zero__|
 |`in1`   |The value stream to output if `value1` = `value2` |float, colorN, vectorN, matrixNN, integer|__zero__|
 |`in2`   |The value stream to output if `value1` != `value2`|Same as `in1`                            |__zero__|
 |`out`   |Output: the result of the comparison              |Same as `in1`                            |`in1`   |
@@ -2022,16 +2022,16 @@ Output the value of the `in1` or `in2` stream depending on whether the `value1` 
 |`in2`   |The value stream to output if `value1` != `value2`|Same as `in1`                            |__zero__|
 |`out`   |Output: the result of the comparison              |Same as `in1`                            |`in1`   |
 
-|Port    |Description                                       |Type                                     |Default |
-|--------|--------------------------------------------------|-----------------------------------------|--------|
-|`value1`|the first value to be compared                    |float, integer                           |__one__ |
-|`value2`|the second value to be compared                   |Same as `value1`                         |__zero__|
-|`out`   |Output: true if `value1` = `value2`               |boolean                                  |false   |
+|Port    |Description                        |Type            |Default |
+|--------|-----------------------------------|----------------|--------|
+|`value1`|The first value to be compared     |float, integer  |__one__ |
+|`value2`|The second value to be compared    |Same as `value1`|__zero__|
+|`out`   |Output: true if `value1` = `value2`|boolean         |false   |
 
 |Port    |Description                        |Type   |Default|
 |--------|-----------------------------------|-------|-------|
 |`value1`|The first value to be compared     |boolean|false  |
-|`value2`|The first value to be compared     |boolean|false  |
+|`value2`|The second value to be compared    |boolean|false  |
 |`out`   |Output: true if `value1` = `value2`|boolean|false  |
 
 <a id="node-switch"> </a>
@@ -2066,37 +2066,13 @@ Channel nodes are used to perform channel manipulations and data type conversion
 
 ### `extract`
 
-Isolate a single float channel from a __vectorN__ or __colorN__ stream. The output value is of type `float` with a default value of __zero__.
+Isolate a single float channel from a __vectorN__ or __colorN__ stream.
 
-|Port   |Description                                 |Type   |Default      |
-|-------|--------------------------------------------|-------|-------------|
-|`in`   |The input stream from which to extract `out`|color3 |0.0, 0.0, 0.0|
-|`index`|The index of the channel in `in` to extract |integer|0            |
-|`out`  |Output: the `index`th channel of `in`       |float  |0.0          |
-
-|Port   |Description                                 |Type   |Default           |
-|-------|--------------------------------------------|-------|------------------|
-|`in`   |The input stream from which to extract `out`|color4 |0.0, 0.0, 0.0, 0.0|
-|`index`|The index of the channel in `in` to extract |integer|0                 |
-|`out`  |Output: the `index`th channel of `in`       |float  |0.0               |
-
-|Port   |Description                                 |Type   |Default |
-|-------|--------------------------------------------|-------|--------|
-|`in`   |The input stream from which to extract `out`|vector2|0.0, 0.0|
-|`index`|The index of the channel in `in` to extract |integer|0       |
-|`out`  |Output: the `index`th channel of `in`       |float  |0.0     |
-
-|Port   |Description                                 |Type   |Default      |
-|-------|--------------------------------------------|-------|-------------|
-|`in`   |The input stream from which to extract `out`|vector3|0.0, 0.0, 0.0|
-|`index`|The index of the channel in `in` to extract |integer|0            |
-|`out`  |Output: the `index`th channel of `in`       |float  |0.0          |
-
-|Port   |Description                                 |Type   |Default           |
-|-------|--------------------------------------------|-------|------------------|
-|`in`   |The input stream from which to extract `out`|vector4|0.0, 0.0, 0.0, 0.0|
-|`index`|The index of the channel in `in` to extract |integer|0                 |
-|`out`  |Output: the `index`th channel of `in`       |float  |0.0               |
+|Port   |Description                                 |Type           |Default |
+|-------|--------------------------------------------|---------------|--------|
+|`in`   |The input stream from which to extract `out`|colorN, vectorN|__zero__|
+|`index`|The index of the channel in `in` to extract |integer        |0       |
+|`out`  |Output: the `index`th channel of `in`       |float          |0.0     |
 
 The valid range for `index` should be clamped to $[0,N)$ in the user interface, where __N__ is the size of the input vector stream. `index` is a uniform, non-varying value. Any `index` values outside of the valid range should result in an error.
 
@@ -2128,7 +2104,7 @@ Convert a stream from one data type to another.
 |Port |Description                |Type           |Default |
 |-----|---------------------------|---------------|--------|
 |`in` |The input stream to convert|colorN, vectorN|__zero__|
-|`out`|Output: see below          |colorM, vectorM|__zero__|
+|`out`|Output: the converted value|colorM, vectorM|__zero__|
 
 |Port |Description                                                      |Type                                    |Default |
 |-----|-----------------------------------------------------------------|----------------------------------------|--------|
@@ -2213,7 +2189,7 @@ Split the channels of a 2-channel stream into separate float outputs.
 |`outx`|Output: the x channel of `in`   |float  |0.0     |
 |`outy`|Output: the y channel of `in`   |float  |0.0     |
 
-For the vector2-input `in`, `outx` and `outy` correspond to the x- and y-components of `in`..
+For the vector2-input `in`, `outx` and `outy` correspond to the x- and y-components of `in`.
 
 <a id="node-separate3"> </a>
 


### PR DESCRIPTION
This changelist implements clarity improvements to the standard node tables in the specification, without altering their alignment with the standard data libraries.  The following clarity improvements are included:

- Fix typos in the output descriptions for the math nodes.
- Fix typos and letter case in the input descriptions for the comparison nodes.
- Merge signature tables for the `extract` node.