### PR TITLE
Fix crash in Shadergen for constant nodes with zero inputs

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -976,8 +976,13 @@ void ShaderGraph::optimize(GenContext& context)
     size_t numEdits = 0;
     for (ShaderNode* node : getNodes())
     {
-        if (node->matchClassification(ShaderNode::Classification::CONSTANT))
+        if (node->hasClassification(ShaderNode::Classification::CONSTANT))
         {
+            if (node->numInputs() == 0)
+            {
+                // Cannot elide a constant node with no inputs.
+                continue;
+            }
             // Constant nodes can be elided by moving their value downstream.
             bool canElide = context.getOptions().elideConstantNodes;
             if (!canElide)
@@ -996,8 +1001,13 @@ void ShaderGraph::optimize(GenContext& context)
                 ++numEdits;
             }
         }
-        else if (node->matchClassification(ShaderNode::Classification::DOT))
+        else if (node->hasClassification(ShaderNode::Classification::DOT))
         {
+            if (node->numInputs() == 0)
+            {
+                // Cannot elide a dot node with no inputs.
+                continue;
+            }
             // Filename dot nodes must be elided so they do not create extra samplers.
             ShaderInput* in = node->getInput("in");
             if (in && in->getType() == Type::FILENAME)

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -418,16 +418,10 @@ class MX_GENSHADER_API ShaderNode
         _classification |= c;
     }
 
-    /// Return true if this node has the given classification bits.
+    /// Return true if this node matches the given classification.
     bool hasClassification(uint32_t c) const
     {
         return (_classification & c) == c;
-    }
-
-    /// Return true if this node explicitly matches the given classification bits.
-    bool matchClassification(uint32_t c) const
-    {
-        return _classification == c;
     }
 
     /// Return the name of this node.


### PR DESCRIPTION
Closes #2745 

Please read Issue #2745 for more background details.

This PR skips optimization "bypassing" values from the input of a node, if the node don't contain any inputs.
This fixes a crash for documents where a custom node was defined which was classified as constant but had zero inputs.