### PR TITLE
BUG:The link interface of target "MaterialX" contains: OpenGL::GL but…

### DIFF
--- a/cmake/modules/MaterialXConfig.cmake.in
+++ b/cmake/modules/MaterialXConfig.cmake.in
@@ -10,6 +10,13 @@
 
 include(CMakeFindDependencyMacro)
 
+if(NOT @MATERIALX_BUILD_SHARED_LIBS@)
+    if(NOT APPLE AND UNIX)
+        find_dependency(OpenGL)
+        find_dependency(X11)
+    endif()
+endif()
+
 # Gather MaterialX targets:
 include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@Targets.cmake")
 


### PR DESCRIPTION
… the target was not found.

CMake Error at /usr/lib/cmake/MaterialX/MaterialXTargets.cmake:70 (set_target_properties):                                         The link interface of target "MaterialX" contains:                                                                                                                                                                                                                  OpenGL::GL                                                                                                                                                                                                                                                      but the target was not found.  Possible reasons include:                                                                                                                                                                                                            * There is a typo in the target name.                                                                                            * A find_package call is missing for an IMPORTED target.                                                                         * An ALIAS target is missing.                                                                                                                                                                                                                                 Call Stack (most recent call first):                                                                                               /usr/lib/cmake/MaterialX/MaterialXConfig.cmake:48 (include)                                                                      build_files/cmake/platform/platform_unix.cmake:110 (find_package)                                                                build_files/cmake/platform/platform_unix.cmake:436 (find_package_wrapper)                                                        CMakeLists.txt:1574 (include)



This error is caused by the build option "MATERIALX_BUILD_MONOLITHIC", which does not exist before it is enabled. The solution is to add the following to "MaterialXConfig.cmake.in":