### PR TITLE
Feature: Add `--report` output reference with shader gen info and errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 dist
 .DS_Store
+python/MaterialX/__pycache__
+python/MaterialX/*.so

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -15,6 +15,8 @@
 #include <MaterialXCore/Util.h>
 #include <MaterialXCore/Value.h>
 
+#include <vector>
+
 MATERIALX_NAMESPACE_BEGIN
 
 class Element;
@@ -753,6 +755,40 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     /// @}
     /// @name Validation
     /// @{
+
+    enum class ValidationSeverity
+    {
+        ERROR,
+        WARNING,
+        HINT
+    };
+
+    struct ValidationError
+    {
+        string message;
+        string path;
+        string source;
+        string file;
+        ValidationSeverity severity = ValidationSeverity::ERROR;
+    };
+
+    using ValidationErrors = vector<ValidationError>;
+
+    class MX_CORE_API ValidationErrorScope
+    {
+        public:
+            explicit ValidationErrorScope(ValidationErrors* errors);
+            ~ValidationErrorScope();
+
+        private:
+            ValidationErrors* _prev = nullptr;
+    };
+
+    static const char* validationSeverityToString(ValidationSeverity severity);
+    static string formatValidationErrorsJson(const ValidationErrors& errors);
+
+    /// Escape a string for safe inclusion in JSON output.
+    static string escapeJsonString(const string& input);
 
     /// Validate that the given element tree, including all descendants, is
     /// consistent with the MaterialX specification.

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -7,6 +7,7 @@
 #include <MaterialXFormat/Environ.h>
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
+#include <MaterialXGenShader/Util.h>
 
 #include <imgui_impl_glfw.h>
 #include <imgui_impl_opengl3.h>
@@ -34,6 +35,7 @@ const std::string options =
     "    --font [FILENAME]              Specify the name of the custom font file to use.  If not specified the default font will be used.\n"
     "    --fontSize [SIZE]              Specify font size to use for the custom font.  If not specified a default of 18 will be used.\n"
     "    --captureFilename [FILENAME]   Specify the filename to which the first rendered frame should be written\n"
+    "    --report [FORMAT]              Validate and analyze the material document, then exit. Format: text or json (defaults to json). Outputs to stderr.\n"
     "    --help                         Display the complete list of command-line options\n";
 
 template <class T> void parseToken(std::string token, std::string type, T& res)
@@ -73,6 +75,8 @@ int main(int argc, char* const argv[])
     std::string fontFilename;
     int fontSize = 18;
     std::string captureFilename;
+    bool reportMode = false;
+    std::string reportFormat = "json";
 
     for (size_t i = 0; i < tokens.size(); i++)
     {
@@ -119,6 +123,15 @@ int main(int argc, char* const argv[])
         {
             parseToken(nextToken, "string", captureFilename);
         }
+        else if (token == "--report")
+        {
+            reportMode = true;
+            if (!nextToken.empty() && nextToken[0] != '-')
+            {
+                reportFormat = nextToken;
+                i++;
+            }
+        }
         else if (token == "--help")
         {
             std::cout << " MaterialXGraphEditor version " << mx::getVersionString() << std::endl;
@@ -140,6 +153,11 @@ int main(int argc, char* const argv[])
         {
             i++;
         }
+    }
+
+    if (reportMode)
+    {
+        return mx::runMaterialReport(materialFilename, searchPath, reportFormat, std::cerr);
     }
 
     // Append the standard library folder, giving it a lower precedence than user-supplied libraries.

--- a/source/MaterialXView/Main.cpp
+++ b/source/MaterialXView/Main.cpp
@@ -8,8 +8,10 @@
 #include <MaterialXRender/Util.h>
 #include <MaterialXFormat/Util.h>
 #include <MaterialXCore/Util.h>
+#include <MaterialXGenShader/Util.h>
 
 #include <iostream>
+
 
 NANOGUI_FORCE_DISCRETE_GPU();
 
@@ -46,6 +48,7 @@ const std::string options =
     "    --remap [TOKEN1:TOKEN2]        Specify the remapping from one token to another when MaterialX document is loaded\n"
     "    --skip [NAME]                  Specify to skip elements matching the given name attribute\n"
     "    --terminator [STRING]          Specify to enforce the given terminator string for file prefixes\n"
+    "    --report [FORMAT]              Validate and analyze the material document, then exit. Format: text or json (defaults to json). Outputs to stderr.\n"
     "    --help                         Display the complete list of command-line options\n";
 
 template <class T> void parseToken(std::string token, std::string type, T& res)
@@ -103,6 +106,8 @@ int main(int argc, char* const argv[])
     std::string bakeFilename;
     float refresh = 50.0f;
     bool frameTiming = false;
+    bool reportMode = false;
+    std::string reportFormat = "json";
 
     for (size_t i = 0; i < tokens.size(); i++)
     {
@@ -248,6 +253,15 @@ int main(int argc, char* const argv[])
         {
             modifiers.filePrefixTerminator = nextToken;
         }
+        else if (token == "--report")
+        {
+            reportMode = true;
+            if (!nextToken.empty() && nextToken[0] != '-')
+            {
+                reportFormat = nextToken;
+                i++;
+            }
+        }
         else if (token == "--help")
         {
             std::cout << " MaterialXView version " << mx::getVersionString() << std::endl;
@@ -269,6 +283,11 @@ int main(int argc, char* const argv[])
         {
             i++;
         }
+    }
+
+    if (reportMode)
+    {
+        return mx::runMaterialReport(materialFilename, searchPath, reportFormat, std::cerr);
     }
 
     // Append the standard library folder, giving it a lower precedence than user-supplied libraries.


### PR DESCRIPTION
I experimented a bit with MaterialX validation, and the data provided by mxvalidate wasn't super helpful especially for shader-related problems, so here's an idea for a `--report` flag in core.

This PR adds the `--report` flag to MaterialXView and MaterialXGraphEditor, that helps in understanding errors and rendering results for shaders.

So far, this has proven useful in our CI for better automated validation tests of generated MaterialX files, and seeing if they render as expected when it comes to the various transparency modes.

Curious what you think!

## Examples

Here's a valid file:

```xml
{
    "materialXVersion": "1.39.4",
    "valid": true,
    "errors": [],
    "renderables": [
        {
            "path": "USD_Default",
            "file": "../resources/Materials/Examples/UsdPreviewSurface/usd_preview_surface_default.mtlx",
            "type": "material",
            "shaderNode": "UsdPreviewSurface",
            "shaderNodeDef": "ND_UsdPreviewSurface_surfaceshader",
            "shaderNodeDefVersion": "2.6",
            "isUnlit": false,
            "transparency": true,
            "alphaMode": "mask",
            "alphaCutoff": 0,
            "displacement": false,
            "transparencyInputs": [
                {
                    "name": "opacity",
                    "valueType": "float",
                    "value": "[connected:switch]",
                    "opaqueAt": 1
                }
            ]
        }
    ]
}
```

An invalid file:

```xml
{
    "materialXVersion": "1.39.4",
    "valid": false,
    "errors": [
        {
            "message": "Node input binds no value or connection",
            "path": "NG_MaterialXPlaceholder/blend_overwrite_1/mix",
            "source": "<input name=\"mix\" type=\"float\">",
            "file": "Color_Metallic.mtlx",
            "severity": "error"
        },
        {
            "message": "Node input binds no value or connection",
            "path": "NG_MaterialXPlaceholder/blend_overwrite_2/mix",
            "source": "<input name=\"mix\" type=\"float\">",
            "file": "Color_Metallic.mtlx",
            "severity": "error"
        }
    ],
    "renderables": [
        {
            "path": "Color_Metallic",
            "file": "Color_Metallic.mtlx",
            "type": "material",
            "shaderNode": "Needle_MaterialXPlaceholder",
            "shaderNodeDef": "ND_MaterialXPlaceholder",
            "isUnlit": false,
            "transparency": false,
            "alphaMode": "opaque",
            "displacement": false
        }
    ]
}
```