### PR TITLE
Fix direct lighting in `MslProgram::bindLighting`

### DIFF
--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -687,8 +687,7 @@ void MslProgram::bindLighting(LightHandlerPtr lightHandler, ImageHandlerPtr imag
 
     // Set the number of active light sources
     size_t lightCount = lightHandler->getLightSources().size();
-    auto numActiveLightSourcesInput = uniformList.find(HW::NUM_ACTIVE_LIGHT_SOURCES);
-    if (numActiveLightSourcesInput == uniformList.end())
+    if (!hasUniform(HW::NUM_ACTIVE_LIGHT_SOURCES))
     {
         // No lighting information so nothing further to do
         lightCount = 0;


### PR DESCRIPTION
This changelist fixes a uniform name mismatch in `MslProgram::bindLighting`, which was causing the direct lighting term to be missing on MacOS, as reported in https://github.com/AcademySoftwareFoundation/MaterialX/issues/2769.

In the MSL rendering path, uniforms are stored with a `GlobalContext` struct prefix, and the `hasUniform` and `bindUniform` methods correctly resolve these prefixed names through the global uniform name map.