### PR TITLE
Fixes alpha blending issue in `hextiledimage_color4`

### DIFF
--- a/libraries/stdlib/genglsl/mx_hextiledimage.glsl
+++ b/libraries/stdlib/genglsl/mx_hextiledimage.glsl
@@ -69,15 +69,9 @@ void mx_hextiledimage_color4(
     cw = mix(vec3(1.0), cw, vec3(falloff_contrast));
 
     vec3 w = mx_hextile_compute_blend_weights(cw, tile_data.weights, falloff);
-
-    // alpha
-    float a = (c1.a + c2.a + c3.a) / 3.0;
-    if (falloff != 0.5)
-    {
-        a = mx_schlick_gain(a, falloff);
-    }
+    vec3 aw = mx_hextile_compute_blend_weights(vec3(1.0), tile_data.weights, falloff);
 
     // blend
     result.rgb = w.x * c1.rgb + w.y * c2.rgb + w.z * c3.rgb;
-    result.a = a;
+    result.a = aw.x * c1.a + aw.y * c2.a + aw.z * c3.a;
 }

--- a/libraries/stdlib/genosl/mx_hextiledimage_color4.osl
+++ b/libraries/stdlib/genosl/mx_hextiledimage_color4.osl
@@ -51,15 +51,9 @@ void mx_hextiledimage_color4(
     // Luminance-based blend weights
     cw = mix(vector(1.0), cw, vector(falloffcontrast));
     vector w = mx_hextile_compute_blend_weights(cw, tile_data.weights, falloff);
-
-    // Alpha (average with optional falloff adjustment)
-    float a = (alpha[0] + alpha[1] + alpha[2]) / 3.0;
-    if (falloff != 0.5)
-    {
-        a = mx_schlick_gain(a, falloff);
-    }
+    vector aw = mx_hextile_compute_blend_weights(vector(1.0), tile_data.weights, falloff);
 
     // Blend colors
     result.rgb = w[0] * c[0] + w[1] * c[1] + w[2] * c[2];
-    result.a = a;
+    result.a = aw[0] * alpha[0] + aw[1] * alpha[1] + aw[2] * alpha[2];
 }

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_6.mdl
@@ -777,16 +777,11 @@ export core::color4 mx_hextiledimage_color4(
 	cw = math::lerp(float3(1.0), cw, float3(mxp_falloff_contrast));
 
 	float3 w = hextile::mx_hextile_compute_blend_weights(cw, tile_data.weights, mxp_falloff);
-
-	// alpha
-	float a = (c1.a + c2.a + c3.a) / 3.0;
-	if (mxp_falloff != 0.5)
-	{
-		a = hextile::mx_schlick_gain(a, mxp_falloff);
-	}
+	float3 aw = hextile::mx_hextile_compute_blend_weights(float3(1.0), tile_data.weights, mxp_falloff);
 
 	// blend
-	return core::mk_color4(w.x * c1.rgb + w.y * c2.rgb + w.z * c3.rgb, a);
+	return core::mk_color4(w.x * c1.rgb + w.y * c2.rgb + w.z * c3.rgb,
+	  					   aw.x * c1.a + aw.y * c2.a + aw.z * c3.a);
 }
 
 export float mx_constant_float(


### PR DESCRIPTION
Fixes the alpha blending issue in `hextiledimage_color4` reported [here](https://academysoftwarefdn.slack.com/archives/C0230LWBE2X/p1771037354472909).

This PR includes corresponding fixes in GLSL, OSL, and MDL implementations.