### PR TITLE
Fix property editor not working in `MaterialXGraphEditor`

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3604,6 +3604,14 @@ void Graph::propertyEditor()
                             if (!input->getConnected())
                             {
                                 showPropertyEditorValue(_currUiNode, input->getInput(), uiProperties);
+
+                                // Update pin to reference the node's input if one was created
+                                // during editing, so that subsequent frames read the correct value.
+                                mx::InputPtr nodeInput = _currUiNode->getNode()->getInput(input->getName());
+                                if (nodeInput && nodeInput != input->getInput())
+                                {
+                                    input->setElement(nodeInput);
+                                }
                             }
                             else
                             {

--- a/source/MaterialXGraphEditor/UiNode.h
+++ b/source/MaterialXGraphEditor/UiNode.h
@@ -79,6 +79,7 @@ class UiPin
     std::shared_ptr<UiNode> getUiNode() const { return _pinNode; }
     ed::PinKind getKind() const { return _kind; }
     mx::PortElementPtr getElement() const { return _element; }
+    void setElement(mx::PortElementPtr element) { _element = element; }
     mx::InputPtr getInput() const;
     mx::OutputPtr getOutput() const;
 


### PR DESCRIPTION
Fixes an issue where the property editor in `MaterialXGraphEditor` was not working.