### PR TITLE
Use high precision in generated ESSL

### DIFF
--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -1,8 +1,4 @@
-#ifdef GL_ES
-    #define M_FLOAT_EPS 0.0001
-#else
-    #define M_FLOAT_EPS 1e-8
-#endif
+#define M_FLOAT_EPS 1e-8
 
 #define mx_mod mod
 #define mx_inverse inverse


### PR DESCRIPTION
## Change

- Specify `highp` to use 32-bit precision with ESSL

Fixes: #2655, #2654.

### Details

High Precision Change

The minimum ESSL version required is 3.0 , where `highp` precision is mandatory in fragment shaders, so the switch is safe.
Instead of IEEE 754 half‑precision (16‑bit) we now use single‑precision (32‑bit). This avoids cases of underflow/overflow and reduces accumulated math errors (for Std surface, OpenPBR and glTF).

### Results

I have pushed locally to: https://kwokcb.github.io/MaterialX/

| Viewer on Samsung | Viewer on Desktop |
| :--: | :--: |
|  <img width="50%" alt="image" src="https://github.com/user-attachments/assets/a54077e6-967c-4e4f-823d-d877442ec683" />  <img width="50%" alt="image" src="https://github.com/user-attachments/assets/4e72ef50-4888-4520-b500-ce4166f7da70" /> |   <img width="100%" alt="image" src="https://github.com/user-attachments/assets/fa812747-79c3-4dce-b11e-6931841026b3" /> |

Specific testing for specular roughness shows that this is now working:

| Viewer on Samsung | Test | 
| :--: | :--: |
| <img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/90386558-e3a4-4a3d-8c50-a9182a19085f" /> | Metalness up and specular roughness to 0 |
|  ![screenshot_20260228_095800_duckduckgo_720](https://github.com/user-attachments/assets/cb5fc0c0-edcc-4fba-b47d-6e5781fe94cd) | Same test glTF|
|  ![screenshot_20260228_095644_duckduckgo_720](https://github.com/user-attachments/assets/e29856b3-d7c9-4454-bf75-78eb666539e3) | Same test OpenPBR |
 |  ![screenshot_20260228_095603_duckduckgo_720](https://github.com/user-attachments/assets/579ed865-d552-460d-aae9-7bfe2212090b) | Same test USDPreview |

