### PR TITLE
Add missing initialization on document load in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -2853,6 +2853,8 @@ void Graph::initializeGraph()
     _state.graphElem = _graphDoc;
     _state.isCompoundNodeGraph = false;
     _prevUiNode = nullptr;
+    _currUiNode = nullptr;
+    _currRenderNode = nullptr;
 
     // Set the display name from the current material filename.
     mx::FilePath materialPath(_materialFilename);


### PR DESCRIPTION
## Fixes

Fixes: #2794.
There are references to the previous MaterialX documents on file load

### Change

- Clear `_currUiNode` : Would hold onto to last selection if any. This seems the root cause of the property editor crash.
- Clear `_currRenderNode` : Should also be cleared to prevent trying to render last node. This seems to also fix having extra renders when load and select nodegraph.

