### PR TITLE
Assign write permission to JavaScript job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -376,6 +376,8 @@ jobs:
   javascript:
     name: JavaScript
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Sync Repository


### PR DESCRIPTION
This changelist assigns write permission to the JavaScript job in our GitHub CI, as this job needs write access to the gh-pages branch of the project.