### PR TITLE
Fix missing origin annotations for MDL

### DIFF
--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -51,6 +51,7 @@ void ShaderGraph::addInputSockets(const InterfaceElement& elem, GenContext& cont
         {
             inputSocket->setUniform();
         }
+        inputSocket->setPath(input->getNamePath());
         GeomPropDefPtr geomprop = input->getDefaultGeomProp();
         if (geomprop)
         {
@@ -384,6 +385,12 @@ void ShaderGraph::addUnitTransformNode(ShaderInput* input, const UnitTransform& 
         shaderInput->setPath(input->getPath());
         shaderInput->setUnit(input->getUnit());
         shaderInput->setColorSpace(input->getColorSpace());
+
+        ShaderInput* shaderInput2 = unitTransformNode->getInput(1);
+        if (shaderInput2)
+        {
+            shaderInput2->setPath(input->getPath());
+        }
 
         if (input->isBindInput())
         {

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -386,12 +386,6 @@ void ShaderGraph::addUnitTransformNode(ShaderInput* input, const UnitTransform& 
         shaderInput->setUnit(input->getUnit());
         shaderInput->setColorSpace(input->getColorSpace());
 
-        ShaderInput* shaderInput2 = unitTransformNode->getInput(1);
-        if (shaderInput2)
-        {
-            shaderInput2->setPath(input->getPath());
-        }
-
         if (input->isBindInput())
         {
             ShaderOutput* oldConnection = input->getConnection();


### PR DESCRIPTION
These are based on the node paths and were missing for the second input of a unit transform node and input sockets of node graphs.