### PR TITLE
Initial VDF support in hardware shading

### DIFF
--- a/libraries/pbrlib/genglsl/mx_anisotropic_vdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_anisotropic_vdf.glsl
@@ -1,6 +1,11 @@
 #include "lib/mx_closure_type.glsl"
 
-void mx_anisotropic_vdf(ClosureData closureData, vec3 absorption, vec3 scattering, float anisotropy, inout BSDF bsdf)
+void mx_anisotropic_vdf(ClosureData closureData, vec3 absorption, vec3 scattering, float anisotropy, inout VDF vdf)
 {
-    // TODO: Add some approximation for volumetric light absorption.
+    // TODO: Add support for scattering and anisotropy.
+    if (closureData.closureType == CLOSURE_TYPE_TRANSMISSION)
+    {
+        vdf.response = vec3(0.0);
+        vdf.throughput = exp(-absorption);
+    }
 }

--- a/libraries/pbrlib/genglsl/mx_layer_vdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_layer_vdf.glsl
@@ -1,7 +1,7 @@
 #include "lib/mx_closure_type.glsl"
 
-void mx_layer_vdf(ClosureData closureData, BSDF top, BSDF base, out BSDF result)
+void mx_layer_vdf(ClosureData closureData, BSDF top, VDF base, out BSDF result)
 {
-    result.response = top.response + base.response;
-    result.throughput = top.throughput + base.throughput;
+    result.response = top.response * base.throughput;
+    result.throughput = top.throughput * base.throughput;
 }

--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -299,9 +299,11 @@ GlslSyntax::GlslSyntax(TypeSystemPtr typeSystem) :
         Type::VDF,
         std::make_shared<AggregateTypeSyntax>(
             this,
-            "BSDF",
-            "BSDF(vec3(0.0),vec3(1.0))",
-            EMPTY_STRING));
+            "VDF",
+            "VDF(vec3(0.0),vec3(1.0))",
+            EMPTY_STRING,
+            EMPTY_STRING,
+            "struct VDF { vec3 response; vec3 throughput; };"));
 
     registerTypeSyntax(
         Type::SURFACESHADER,

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -280,9 +280,11 @@ MslSyntax::MslSyntax(TypeSystemPtr typeSystem) : Syntax(typeSystem)
         Type::VDF,
         std::make_shared<AggregateTypeSyntax>(
             this,
-            "BSDF",
-            "BSDF{float3(0.0),float3(1.0)}",
-            EMPTY_STRING));
+            "VDF",
+            "VDF{float3(0.0),float3(1.0)}",
+            EMPTY_STRING,
+            EMPTY_STRING,
+            "struct VDF { float3 response; float3 throughput; };"));
 
     registerTypeSyntax(
         Type::SURFACESHADER,

--- a/source/MaterialXGenSlang/SlangSyntax.cpp
+++ b/source/MaterialXGenSlang/SlangSyntax.cpp
@@ -296,9 +296,11 @@ SlangSyntax::SlangSyntax(TypeSystemPtr typeSystem) :
         Type::VDF,
         std::make_shared<SlangAggregateTypeSyntax>(
             this,
-            "BSDF",
-            "BSDF(float3(0.0),float3(1.0))",
-            EMPTY_STRING));
+            "VDF",
+            "VDF(float3(0.0),float3(1.0))",
+            EMPTY_STRING,
+            EMPTY_STRING,
+            "struct VDF { float3 response; float3 throughput; };"));
 
     registerTypeSyntax(
         Type::SURFACESHADER,


### PR DESCRIPTION
This changelist adds initial support for Volume Distribution Functions (VDFs) in hardware shader generation, giving the VDF type its own struct, and approximating volumetric light absorption for the transmissive term.  The following specific changes are included:

- Add a dedicated VDF struct to GLSL, MSL, and Slang, replacing the previous use of the BSDF struct as an alias for the VDF type.
- Add a simple approximation of volumetric absorption to `mx_anisotropic_vdf`, computing throughput using Beer's law in the transmissive lighting term.
- Fix `mx_layer_vdf` to multiply the surface response and throughput by the volume throughput, replacing the previous placeholder math.