### PR TITLE
Fix MDL generation for empty materials

### DIFF
--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -238,6 +238,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
 
     // Emit function calls for "root" closure/shader nodes.
     // These will internally emit function calls for any dependent closure nodes upstream.
+    bool rootFunctionCallEmitted = false;
     for (ShaderGraphOutputSocket* socket : graph.getOutputSockets())
     {
         if (socket->getConnection())
@@ -248,6 +249,7 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
                  upstream->hasClassification(ShaderNode::Classification::SHADER)))
             {
                 emitFunctionCall(*upstream, context, stage);
+                rootFunctionCallEmitted = true;
             }
         }
     }
@@ -315,7 +317,15 @@ ShaderPtr MdlShaderGenerator::generate(const string& name, ElementPtr element, G
     }
     else
     {
-        emitLine(_syntax->getTypeSyntax(outputType).getName() + " finalOutput__ = " + result, stage);
+        if (rootFunctionCallEmitted)
+        {
+            emitLine(_syntax->getTypeSyntax(outputType).getName() + " finalOutput__ = " + result, stage);
+        }
+        else
+        {
+            // No code has been emitted for "result". Use default material as fallback.
+            emitLine(_syntax->getTypeSyntax(outputType).getName() + " finalOutput__ = material()", stage);
+        }
 
         // End shader body
         emitScopeEnd(stage);


### PR DESCRIPTION
Repro case: M_EmptySurface in surfacematerial_with_graph.mtlx

The test driver skips such materials, but they can be explicitly requested via the API and caused invalid MDL code to be generated.