### PR TITLE
Add MaterialXGenShader2 — IShaderSource abstraction for shader graph …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.39.5] - Development
 
 ### Added
+- Added a new [MaterialXGenShader2](source/MaterialXGenShader2) module introducing an abstract `IShaderSource` interface that decouples shader graph construction from the MaterialX data model. Any system that can answer graph topology queries — a MaterialX Document, a USD/Hydra HdMaterialNetwork, a runtime node graph — can drive shader generation via `DataHandle` tokens without constructing a MaterialX Element hierarchy. Includes `MxElementAdapter` (the MX-backed reference implementation), `ShaderGraphBuilder` (BFS graph traversal replacing `ShaderGraph::addUpstreamDependencies`), and `GenContextCreate` (entry point). See [issue #2566](https://github.com/AcademySoftwareFoundation/MaterialX/issues/2566).
 - Added support for the [Slang shading language](https://github.com/AcademySoftwareFoundation/MaterialX/pull/2548) in MaterialX shader generation and rendering, with [language bindings](https://github.com/AcademySoftwareFoundation/MaterialX/pull/2679) for Python and JavaScript.
 - Added [OSL implementations](https://github.com/AcademySoftwareFoundation/MaterialX/pull/2734) for hex-tiled images, completing cross-language coverage for hextiling nodes.
 - Added an [OSL command string code generator](https://github.com/AcademySoftwareFoundation/MaterialX/pull/2603), enabling the mixing of external OSL shaders with MaterialX-generated nodes.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ endif()
 
 # Add shader generation subdirectories
 add_subdirectory(source/MaterialXGenShader)
+add_subdirectory(source/MaterialXGenShader2)
 if(MATERIALX_BUILD_GEN_GLSL OR MATERIALX_BUILD_GEN_OSL OR MATERIALX_BUILD_GEN_MDL OR MATERIALX_BUILD_GEN_MSL OR MATERIALX_BUILD_GEN_SLANG)
     if(MATERIALX_BUILD_GEN_GLSL OR MATERIALX_BUILD_GEN_MSL OR MATERIALX_BUILD_GEN_SLANG)
         add_subdirectory(source/MaterialXGenHw)

--- a/source/MaterialXGenShader2/CMakeLists.txt
+++ b/source/MaterialXGenShader2/CMakeLists.txt
@@ -1,0 +1,14 @@
+file(GLOB_RECURSE materialx_source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB_RECURSE materialx_headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h*")
+
+mx_add_library(MaterialXGenShader2
+    SOURCE_FILES
+        ${materialx_source}
+    HEADER_FILES
+        ${materialx_headers}
+    MTLX_MODULES
+        MaterialXGenShader
+        MaterialXFormat
+        MaterialXCore
+    EXPORT_DEFINE
+        MATERIALX_GENSHADER2_EXPORTS)

--- a/source/MaterialXGenShader2/DataHandle.h
+++ b/source/MaterialXGenShader2/DataHandle.h
@@ -1,0 +1,38 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_DATAHANDLE_H
+#define MATERIALX_GENSHADER2_DATAHANDLE_H
+
+/// @file
+/// Opaque 64-bit handle type used as the currency of the IShaderSource interface.
+///
+/// A DataHandle is an opaque token whose meaning is defined entirely by the
+/// IShaderSource implementation that produced it.  Implementations may store
+/// a raw pointer (cast to uint64_t), a string hash, an integer index, or any
+/// other compact representation that fits in 64 bits.
+///
+/// Handles are valid only for the lifetime of the IShaderSource that created
+/// them.  They must not be shared across IShaderSource instances.
+
+#include <MaterialXGenShader2/Export.h>
+
+#include <cstdint>
+
+MATERIALX_NAMESPACE_BEGIN
+
+/// Opaque 64-bit identifier representing any object in a shader source graph
+/// (node, input port, output port, NodeDef, etc.).
+using DataHandle = uint64_t;
+
+/// Sentinel value indicating an absent or invalid handle.
+static constexpr DataHandle InvalidHandle = 0;
+
+/// Returns true if the handle refers to a valid object.
+inline bool isValidHandle(DataHandle h) noexcept { return h != InvalidHandle; }
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_DATAHANDLE_H

--- a/source/MaterialXGenShader2/Export.h
+++ b/source/MaterialXGenShader2/Export.h
@@ -1,0 +1,22 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_EXPORT_H
+#define MATERIALX_GENSHADER2_EXPORT_H
+
+#include <MaterialXGenShader2/Library.h>
+
+/// @file
+/// Macros for declaring imported and exported symbols.
+
+#if defined(MATERIALX_GENSHADER2_EXPORTS)
+    #define MX_GENSHADER2_API MATERIALX_SYMBOL_EXPORT
+    #define MX_GENSHADER2_EXTERN_TEMPLATE(...) MATERIALX_EXPORT_EXTERN_TEMPLATE(__VA_ARGS__)
+#else
+    #define MX_GENSHADER2_API MATERIALX_SYMBOL_IMPORT
+    #define MX_GENSHADER2_EXTERN_TEMPLATE(...) MATERIALX_IMPORT_EXTERN_TEMPLATE(__VA_ARGS__)
+#endif
+
+#endif // MATERIALX_GENSHADER2_EXPORT_H

--- a/source/MaterialXGenShader2/GenContextCreate.cpp
+++ b/source/MaterialXGenShader2/GenContextCreate.cpp
@@ -1,0 +1,49 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXGenShader2/GenContextCreate.h>
+#include <MaterialXGenShader2/ShaderGraphBuilder.h>
+
+#include <MaterialXGenShader/Exception.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+GenContextCreate::GenContextCreate(ShaderGeneratorPtr generator,
+                                   std::unique_ptr<IShaderSource> source)
+    : _source(std::move(source))
+    , _genContext(generator)
+{
+}
+
+ShaderGraph2Ptr GenContextCreate::buildGraph(const string& name)
+{
+    ShaderGraphBuilder builder(*_source, _genContext);
+    return builder.build(name);
+}
+
+ShaderPtr GenContextCreate::buildShader(const string& name)
+{
+    // Resolve the MaterialX root element via the MX compatibility bridge.
+    // TODO: once emission is decoupled from ElementPtr, drive this step
+    //       directly from the IShaderSource + pre-built ShaderGraph2.
+    ConstDocumentPtr doc = _source->getMxDocument();
+    if (!doc)
+    {
+        throw ExceptionShaderGenError("GenContextCreate::buildShader: getMxDocument() returned nullptr. "
+                                      "Non-MX backends must provide their own buildShader() implementation.");
+    }
+
+    DataHandle root = _source->getRootElement();
+    ElementPtr mxElem = doc->getDescendant(_source->getElementPath(root));
+    if (!mxElem)
+    {
+        throw ExceptionShaderGenError("GenContextCreate::buildShader: could not resolve root element '" +
+                                      _source->getElementPath(root) + "' in document.");
+    }
+
+    return _genContext.getShaderGenerator().generate(name, mxElem, _genContext);
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader2/GenContextCreate.h
+++ b/source/MaterialXGenShader2/GenContextCreate.h
@@ -1,0 +1,77 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_GENCONTEXTCREATE_H
+#define MATERIALX_GENSHADER2_GENCONTEXTCREATE_H
+
+/// @file
+/// Phase 2 entry point for shader graph creation via IShaderSource.
+///
+/// GenContextCreate owns an IShaderSource and a GenContext, and provides
+/// buildGraph() to construct a ShaderGraph equivalent to what
+/// ShaderGraph::create() would produce from the same material.
+///
+/// Phase 3 will add a buildShader() method that drives code emission through
+/// a GenContextEmit, completing the two-phase pipeline.
+
+#include <MaterialXGenShader2/Export.h>
+#include <MaterialXGenShader2/IShaderSource.h>
+#include <MaterialXGenShader2/ShaderGraph2.h>
+
+#include <MaterialXGenShader/GenContext.h>
+#include <MaterialXGenShader/Shader.h>
+#include <MaterialXGenShader/ShaderGenerator.h>
+
+#include <memory>
+
+MATERIALX_NAMESPACE_BEGIN
+
+/// @class GenContextCreate
+/// Owns an IShaderSource and drives ShaderGraphBuilder to produce a ShaderGraph.
+///
+/// Usage:
+/// @code
+///   auto adapter = std::make_unique<MxElementAdapter>(doc, element);
+///   GenContextCreate ctx(GlslShaderGenerator::create(), std::move(adapter));
+///   ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+///
+///   ShaderGraph2Ptr graph = ctx.buildGraph("myShader");
+/// @endcode
+class MX_GENSHADER2_API GenContextCreate
+{
+  public:
+    /// Constructs a GenContextCreate with the given generator and source.
+    /// @param generator  The shader generator to use (e.g. GlslShaderGenerator::create()).
+    /// @param source     The abstract data source; ownership is transferred here.
+    GenContextCreate(ShaderGeneratorPtr generator, std::unique_ptr<IShaderSource> source);
+
+    /// Returns a mutable reference to the underlying GenContext.
+    /// Use this to register search paths, set options, etc.
+    GenContext& getGenContext() { return _genContext; }
+
+    /// Returns the IShaderSource provided at construction.
+    const IShaderSource& getSource() const { return *_source; }
+
+    /// Constructs and returns a fully-finalized ShaderGraph built from the
+    /// IShaderSource, equivalent to what ShaderGraph::create() produces from
+    /// the same material element.
+    ShaderGraph2Ptr buildGraph(const string& name);
+
+    /// Builds the ShaderGraph and emits shader source code, returning the
+    /// completed Shader equivalent to ShaderGenerator::generate().
+    ///
+    /// For MX-backed sources the root element is resolved via getMxDocument()
+    /// and forwarded to the generator's existing generate() method.
+    /// @see TODO in GenContextCreate.cpp for the path to full MX independence.
+    ShaderPtr buildShader(const string& name);
+
+  private:
+    std::unique_ptr<IShaderSource> _source;
+    GenContext                     _genContext;
+};
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_GENCONTEXTCREATE_H

--- a/source/MaterialXGenShader2/IShaderSource.h
+++ b/source/MaterialXGenShader2/IShaderSource.h
@@ -1,0 +1,318 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_ISHADERSOURCE_H
+#define MATERIALX_GENSHADER2_ISHADERSOURCE_H
+
+/// @file
+/// Abstract interface for providing shader graph data to MaterialXGenShader2.
+///
+/// IShaderSource decouples shader graph construction from the MaterialX data
+/// model.  Any system that can answer the queries below — a MaterialX Document,
+/// a USD/Hydra HdMaterialNetwork, a runtime node graph, etc. — can drive shader
+/// generation without ever constructing a MaterialX Element hierarchy.
+///
+/// ## Handle contract
+///
+/// Every object in the graph (nodes, inputs, outputs, NodeDefs, GeomPropDefs)
+/// is represented by a DataHandle — an opaque uint64_t whose interpretation is
+/// entirely up to the implementing class.  Implementations may store:
+///   • a raw pointer cast to uint64_t
+///   • a stable index into a flat array
+///   • a string hash
+///   • a packed (type, index) pair
+///
+/// Handles are valid for the lifetime of the IShaderSource that issued them.
+/// They are not transferable across IShaderSource instances.
+///
+/// InvalidHandle (0) is the sentinel for "absent / not found".
+
+#include <MaterialXGenShader2/DataHandle.h>
+
+#include <MaterialXCore/Document.h>
+#include <MaterialXCore/Node.h>
+#include <MaterialXCore/Types.h>
+
+#include <string>
+#include <vector>
+
+MATERIALX_NAMESPACE_BEGIN
+
+/// @class IShaderSource
+/// Read-only, pull-based interface used by ShaderGraphBuilder to construct a
+/// ShaderGraph without touching the MaterialX Element hierarchy directly.
+///
+/// All methods are const (the source is never mutated during generation).
+/// Methods that can fail return InvalidHandle or an empty string rather than
+/// throwing; callers must check isValidHandle() where appropriate.
+class MX_GENSHADER2_API IShaderSource
+{
+  public:
+    virtual ~IShaderSource() = default;
+
+    // ─── Root ─────────────────────────────────────────────────────────────────
+
+    /// Returns a handle to the root of the graph being generated.
+    /// This corresponds to the ElementPtr passed to ShaderGenerator::generate()
+    /// — typically an Output element or a surface/material Node.
+    virtual DataHandle getRootElement() const = 0;
+
+    // ─── Element classification ───────────────────────────────────────────────
+
+    /// True if the handle refers to a node instance (not a NodeDef).
+    virtual bool isNode(DataHandle elem) const = 0;
+
+    /// True if the handle refers to an Output element at the top of a NodeGraph
+    /// or Document (i.e. the root socket of a sub-graph).
+    virtual bool isOutput(DataHandle elem) const = 0;
+
+    /// True if the handle refers to a NodeGraph (a compound node with its own
+    /// internal graph and an associated NodeDef interface).
+    virtual bool isNodeGraph(DataHandle elem) const = 0;
+
+    // ─── Element identity ─────────────────────────────────────────────────────
+
+    /// Short name of the element (e.g. "base_color").
+    virtual string getElementName(DataHandle elem) const = 0;
+
+    /// Globally-unique dot-separated path (e.g. "SR_marble/fractal3d_1").
+    /// Used as the map key when de-duplicating nodes in ShaderGraph.
+    virtual string getElementPath(DataHandle elem) const = 0;
+
+    // ─── Node topology ────────────────────────────────────────────────────────
+
+    /// Number of active inputs on a node instance.
+    virtual size_t getNodeInputCount(DataHandle node) const = 0;
+
+    /// Returns the i-th active input handle on a node.
+    virtual DataHandle getNodeInput(DataHandle node, size_t index) const = 0;
+
+    /// Looks up an input by name on a node instance.
+    /// Returns InvalidHandle if not found.
+    virtual DataHandle getNodeInputByName(DataHandle node, const string& name) const = 0;
+
+    /// Returns the upstream node connected to a given input, or InvalidHandle
+    /// if the input carries a literal value (is not connected).
+    virtual DataHandle getInputConnectedNode(DataHandle input) const = 0;
+
+    /// When the upstream node has multiple outputs, this returns the name of
+    /// the specific output that feeds into this input.  Returns an empty string
+    /// when connected to the default (first) output.
+    virtual string getInputConnectedOutputName(DataHandle input) const = 0;
+
+    /// For an Output element at the root of a sub-graph, returns the upstream
+    /// node it is connected to (or InvalidHandle if unconnected).
+    virtual DataHandle getOutputConnectedNode(DataHandle output) const = 0;
+
+    /// Returns the parent container of a node: either a NodeGraph handle or
+    /// InvalidHandle if the node lives directly in the root document.
+    virtual DataHandle getNodeParentGraph(DataHandle node) const = 0;
+
+    // ─── Node definition lookup ───────────────────────────────────────────────
+
+    /// Returns the name of the NodeDef for a node (e.g. "ND_standard_surface_surfaceshader").
+    virtual string getNodeDefName(DataHandle node) const = 0;
+
+    /// Resolves and returns the NodeDef handle for a node instance.
+    /// Returns InvalidHandle if the NodeDef cannot be found.
+    virtual DataHandle getNodeDef(DataHandle node) const = 0;
+
+    /// Looks up a NodeDef by its fully-qualified name in the document/registry.
+    /// Returns InvalidHandle if not found.
+    virtual DataHandle getNodeDefByName(const string& nodeDefName) const = 0;
+
+    // ─── NodeDef interface ────────────────────────────────────────────────────
+
+    /// The output type string of the NodeDef (e.g. "surfaceshader", "color3").
+    virtual string getNodeDefType(DataHandle nodeDef) const = 0;
+
+    /// Number of inputs declared on a NodeDef.
+    virtual size_t getNodeDefInputCount(DataHandle nodeDef) const = 0;
+
+    /// Returns the i-th input handle from a NodeDef.
+    virtual DataHandle getNodeDefInput(DataHandle nodeDef, size_t index) const = 0;
+
+    /// Looks up an input by name on a NodeDef. Returns InvalidHandle if absent.
+    virtual DataHandle getNodeDefInputByName(DataHandle nodeDef, const string& name) const = 0;
+
+    /// Number of outputs declared on a NodeDef.
+    virtual size_t getNodeDefOutputCount(DataHandle nodeDef) const = 0;
+
+    /// Returns the i-th output handle from a NodeDef.
+    virtual DataHandle getNodeDefOutput(DataHandle nodeDef, size_t index) const = 0;
+
+    /// Looks up an output by name on a NodeDef. Returns InvalidHandle if absent.
+    virtual DataHandle getNodeDefOutputByName(DataHandle nodeDef, const string& name) const = 0;
+
+    /// Returns all value elements (both inputs and outputs) of a NodeDef,
+    /// needed to populate ShaderNode metadata and classification.
+    virtual size_t getNodeDefValueElementCount(DataHandle nodeDef) const = 0;
+    virtual DataHandle getNodeDefValueElement(DataHandle nodeDef, size_t index) const = 0;
+
+    /// True if the value element handle refers to an Output (vs. an Input).
+    virtual bool valueElementIsOutput(DataHandle valueElem) const = 0;
+
+    /// Named attribute on a NodeDef (e.g. doc, version, nodegroup).
+    virtual string getNodeDefAttribute(DataHandle nodeDef, const string& attrName) const = 0;
+    virtual void   getNodeDefAttributeNames(DataHandle nodeDef, StringVec& names) const = 0;
+
+    // ─── NodeGraph interface ──────────────────────────────────────────────────
+
+    /// Returns the NodeDef handle that defines the interface for a NodeGraph.
+    virtual DataHandle getNodeGraphNodeDef(DataHandle nodeGraph) const = 0;
+
+    /// The name of a NodeGraph element.
+    virtual string getNodeGraphName(DataHandle nodeGraph) const = 0;
+
+    /// Number of inputs declared directly on a NodeGraph element.
+    /// Used when the NodeGraph has no associated NodeDef.
+    virtual size_t getNodeGraphInputCount(DataHandle nodeGraph) const = 0;
+
+    /// Returns the i-th input on a NodeGraph.
+    virtual DataHandle getNodeGraphInput(DataHandle nodeGraph, size_t index) const = 0;
+
+    /// Returns the parent NodeGraph of an Output element, or InvalidHandle if
+    /// the Output lives directly in the root Document.
+    virtual DataHandle getOutputParentNodeGraph(DataHandle output) const = 0;
+
+    // ─── Port (Input / Output ValueElement) queries ───────────────────────────
+
+    /// Short name of the port (e.g. "base_color").
+    virtual string getPortName(DataHandle port) const = 0;
+
+    /// Type string of the port (e.g. "color3", "float").
+    virtual string getPortType(DataHandle port) const = 0;
+
+    /// Dot-separated path of the port element (used for metadata / error messages).
+    virtual string getPortPath(DataHandle port) const = 0;
+
+    /// Resolved value as a string, or empty if the port is connected / has no value.
+    /// This combines getResolvedValue()->getValueString() from the MX API.
+    virtual string getPortValueString(DataHandle port) const = 0;
+
+    /// True if the port has a literal value (i.e. not connected and not empty).
+    virtual bool portHasValue(DataHandle port) const = 0;
+
+    /// Retrieves a named XML attribute on a port element (e.g. "enum", "enumvalues",
+    /// "uifolder").  Returns an empty string if the attribute is absent.
+    virtual string getPortAttribute(DataHandle port, const string& attrName) const = 0;
+    virtual void   getPortAttributeNames(DataHandle port, StringVec& names) const = 0;
+
+    // ─── Interface binding (NodeGraph input propagation) ──────────────────────
+
+    /// True if a node instance input is bound to a named interface input.
+    virtual bool portHasInterfaceName(DataHandle port) const = 0;
+
+    /// The interface name this input is bound to (meaningful only when
+    /// portHasInterfaceName() returns true).
+    virtual string getPortInterfaceName(DataHandle port) const = 0;
+
+    /// Returns the interface input (on the enclosing NodeGraph/Document) that
+    /// this port is bound to, or InvalidHandle if unbound.
+    virtual DataHandle getPortInterfaceInput(DataHandle port) const = 0;
+
+    // ─── Geometric default property ───────────────────────────────────────────
+
+    /// True if the input has a defaultgeomprop that should drive its value
+    /// when no explicit value or connection is present.
+    virtual bool portHasDefaultGeomProp(DataHandle port) const = 0;
+
+    /// Returns a handle to the GeomPropDef referred to by a port's
+    /// defaultgeomprop attribute.  Returns InvalidHandle if not present.
+    virtual DataHandle getPortDefaultGeomProp(DataHandle port) const = 0;
+
+    // ─── Unit metadata ────────────────────────────────────────────────────────
+
+    virtual string getPortUnit(DataHandle port) const = 0;
+    virtual string getPortUnitType(DataHandle port) const = 0;
+
+    /// The resolved unit after applying document/scope overrides.
+    virtual string getPortActiveUnit(DataHandle port) const = 0;
+
+    // ─── Color space metadata ─────────────────────────────────────────────────
+
+    /// The color space declared directly on the port (may be empty).
+    virtual string getPortColorSpace(DataHandle port) const = 0;
+
+    /// The resolved color space after applying document/scope overrides.
+    virtual string getPortActiveColorSpace(DataHandle port) const = 0;
+
+    // ─── Uniformity ───────────────────────────────────────────────────────────
+
+    /// True if the input is declared uniform (constant across the geometry).
+    virtual bool portIsUniform(DataHandle port) const = 0;
+
+    // ─── GeomPropDef queries ──────────────────────────────────────────────────
+
+    /// The element name of the GeomPropDef (e.g. "geomprop_Nworld").
+    virtual string getGeomPropDefName(DataHandle geomPropDef) const = 0;
+
+    /// The geometric property being bound (e.g. "Nworld", "UV0").
+    virtual string getGeomPropDefProp(DataHandle geomPropDef) const = 0;
+
+    /// Dot-separated element path of the GeomPropDef.
+    virtual string getGeomPropDefPath(DataHandle geomPropDef) const = 0;
+
+    /// The coordinate space for the geometric property (e.g. "world", "object").
+    virtual string getGeomPropDefSpace(DataHandle geomPropDef) const = 0;
+
+    /// The index (for multi-set attributes like UV sets).
+    virtual string getGeomPropDefIndex(DataHandle geomPropDef) const = 0;
+
+    // ─── Document-level queries ───────────────────────────────────────────────
+
+    /// The active (resolved) color space for the document/network.
+    virtual string getActiveColorSpace() const = 0;
+
+    /// Looks up a UnitTypeDef by its type name (e.g. "distance").
+    /// Returns InvalidHandle if not found.  Used to drive unit transform nodes.
+    virtual DataHandle getUnitTypeDefByName(const string& unitTypeName) const = 0;
+
+    // ─── MX compatibility bridge ──────────────────────────────────────────────
+    // These optional methods allow ShaderGraphBuilder to fall back to the
+    // existing MaterialX Element API for steps not yet fully expressible through
+    // the pure IShaderSource queries above.
+    //
+    // getMxDocument()     — no longer required by ShaderGraphBuilder.
+    //                       Retained for compatibility.  Passing nullptr to the
+    //                       ShaderGraph2 constructor is now safe for GLSL/MDL.
+    //
+    // getMxNodeDef()      — required by both build() entry points and
+    //                       createConnectedNodes().  NodeDefs live in the loaded
+    //                       library, so any backend that can drive generation will
+    //                       have them available.
+    //
+    // getMxNodeDefByHandle() — required by addDefaultGeomNode2() to construct
+    //                       geomprop shader nodes.  Must be implemented alongside
+    //                       getNodeDefByName() for correct geomprop support.
+    //
+    // getMxNode()         — no longer required by ShaderGraphBuilder.
+    //                       Retained for compatibility; callers that need
+    //                       HwImageNode::setValues (UDIM UV normalization) still
+    //                       call createNode(ConstNodePtr) manually.
+    //
+    // Non-MX sources may leave any of these as nullptr; ShaderGraphBuilder will
+    // throw a descriptive error if a still-required method returns nullptr.
+
+    /// Returns the underlying MaterialX Document, or nullptr for non-MX sources.
+    virtual ConstDocumentPtr getMxDocument() const { return nullptr; }
+
+    /// Returns the MaterialX NodeDef for a node handle, or nullptr for non-MX sources.
+    virtual ConstNodeDefPtr getMxNodeDef(DataHandle /*node*/) const { return nullptr; }
+
+    /// Returns the MaterialX NodeDef for a NodeDef handle (not a Node handle).
+    /// Distinct from getMxNodeDef() which takes a Node handle and follows getNodeDef().
+    /// Used by addDefaultGeomNode2 to construct geomprop shader nodes.
+    virtual ConstNodeDefPtr getMxNodeDefByHandle(DataHandle /*nodeDefHandle*/) const { return nullptr; }
+
+    /// Returns the MaterialX Node element for a node handle, or nullptr for non-MX sources.
+    /// ShaderGraphBuilder no longer calls this; it is retained for callers that
+    /// need ShaderNodeImpl::setValues (e.g. HwImageNode UDIM normalization).
+    virtual ConstNodePtr getMxNode(DataHandle /*node*/) const { return nullptr; }
+};
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_ISHADERSOURCE_H

--- a/source/MaterialXGenShader2/Library.h
+++ b/source/MaterialXGenShader2/Library.h
@@ -1,0 +1,22 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_LIBRARY_H
+#define MATERIALX_GENSHADER2_LIBRARY_H
+
+/// @file
+/// Library-wide includes and types for MaterialXGenShader2.
+/// This file should be the first include for any public header in this library.
+
+#include <MaterialXGenShader/Library.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+// Forward declarations for new types introduced in this module.
+class IShaderSource;
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_LIBRARY_H

--- a/source/MaterialXGenShader2/MxElementAdapter.cpp
+++ b/source/MaterialXGenShader2/MxElementAdapter.cpp
@@ -1,0 +1,541 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXGenShader2/MxElementAdapter.h>
+
+#include <MaterialXCore/Node.h>
+#include <MaterialXCore/Interface.h>
+#include <MaterialXCore/Definition.h>
+#include <MaterialXCore/Geom.h>
+#include <MaterialXCore/Unit.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+// ─── Construction ─────────────────────────────────────────────────────────────
+
+MxElementAdapter::MxElementAdapter(ConstDocumentPtr document, ConstElementPtr root)
+    : _document(document)
+    , _root(root)
+{
+}
+
+// ─── Root ─────────────────────────────────────────────────────────────────────
+
+DataHandle MxElementAdapter::getRootElement() const
+{
+    return toHandle(_root.get());
+}
+
+// ─── Element classification ───────────────────────────────────────────────────
+
+bool MxElementAdapter::isNode(DataHandle elem) const
+{
+    const Element* e = toElement(elem);
+    return e && e->isA<Node>();
+}
+
+bool MxElementAdapter::isOutput(DataHandle elem) const
+{
+    const Element* e = toElement(elem);
+    return e && e->isA<Output>();
+}
+
+bool MxElementAdapter::isNodeGraph(DataHandle elem) const
+{
+    const Element* e = toElement(elem);
+    return e && e->isA<NodeGraph>();
+}
+
+// ─── Element identity ─────────────────────────────────────────────────────────
+
+string MxElementAdapter::getElementName(DataHandle elem) const
+{
+    const Element* e = toElement(elem);
+    return e ? e->getName() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getElementPath(DataHandle elem) const
+{
+    const Element* e = toElement(elem);
+    return e ? e->getNamePath() : EMPTY_STRING;
+}
+
+// ─── Node topology ────────────────────────────────────────────────────────────
+
+size_t MxElementAdapter::getNodeInputCount(DataHandle node) const
+{
+    const Element* e = toElement(node);
+    if (!e) return 0;
+    ConstNodePtr n = e->asA<Node>();
+    return n ? n->getActiveInputs().size() : 0;
+}
+
+DataHandle MxElementAdapter::getNodeInput(DataHandle node, size_t index) const
+{
+    const Element* e = toElement(node);
+    if (!e) return InvalidHandle;
+    ConstNodePtr n = e->asA<Node>();
+    if (!n) return InvalidHandle;
+    vector<InputPtr> inputs = n->getActiveInputs();
+    if (index >= inputs.size()) return InvalidHandle;
+    return toHandle(inputs[index].get());
+}
+
+DataHandle MxElementAdapter::getNodeInputByName(DataHandle node, const string& name) const
+{
+    const Element* e = toElement(node);
+    if (!e) return InvalidHandle;
+    ConstNodePtr n = e->asA<Node>();
+    if (!n) return InvalidHandle;
+    return toHandle(n->getInput(name).get());
+}
+
+DataHandle MxElementAdapter::getInputConnectedNode(DataHandle input) const
+{
+    const Element* e = toElement(input);
+    if (!e) return InvalidHandle;
+    ConstInputPtr inp = e->asA<Input>();
+    if (!inp) return InvalidHandle;
+    return toHandle(inp->getConnectedNode().get());
+}
+
+string MxElementAdapter::getInputConnectedOutputName(DataHandle input) const
+{
+    const Element* e = toElement(input);
+    if (!e) return EMPTY_STRING;
+    shared_ptr<const PortElement> pe = e->asA<PortElement>();
+    if (!pe) return EMPTY_STRING;
+    // getOutputString() returns the name of the specific output on the upstream
+    // node that feeds this input (e.g. "outr"/"outg"/"outb" for multi-output nodes).
+    // Returns empty string when connected to the default output.
+    return pe->getOutputString();
+}
+
+DataHandle MxElementAdapter::getOutputConnectedNode(DataHandle output) const
+{
+    const Element* e = toElement(output);
+    if (!e) return InvalidHandle;
+    ConstOutputPtr out = e->asA<Output>();
+    if (!out) return InvalidHandle;
+    return toHandle(out->getConnectedNode().get());
+}
+
+DataHandle MxElementAdapter::getNodeParentGraph(DataHandle node) const
+{
+    const Element* e = toElement(node);
+    if (!e) return InvalidHandle;
+    ConstElementPtr parent = e->getParent();
+    if (!parent || !parent->isA<NodeGraph>()) return InvalidHandle;
+    return toHandle(parent.get());
+}
+
+// ─── Node definition lookup ───────────────────────────────────────────────────
+
+string MxElementAdapter::getNodeDefName(DataHandle node) const
+{
+    const Element* e = toElement(node);
+    if (!e) return EMPTY_STRING;
+    ConstNodePtr n = e->asA<Node>();
+    if (!n) return EMPTY_STRING;
+    ConstNodeDefPtr nd = n->getNodeDef();
+    return nd ? nd->getName() : EMPTY_STRING;
+}
+
+DataHandle MxElementAdapter::getNodeDef(DataHandle node) const
+{
+    const Element* e = toElement(node);
+    if (!e) return InvalidHandle;
+    ConstNodePtr n = e->asA<Node>();
+    if (!n) return InvalidHandle;
+    return toHandle(n->getNodeDef().get());
+}
+
+DataHandle MxElementAdapter::getNodeDefByName(const string& nodeDefName) const
+{
+    return toHandle(_document->getNodeDef(nodeDefName).get());
+}
+
+// ─── NodeDef interface ────────────────────────────────────────────────────────
+
+string MxElementAdapter::getNodeDefType(DataHandle nodeDef) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return EMPTY_STRING;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return EMPTY_STRING;
+    return nd->getType();
+}
+
+size_t MxElementAdapter::getNodeDefInputCount(DataHandle nodeDef) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return 0;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return 0;
+    return nd->getActiveInputs().size();
+}
+
+DataHandle MxElementAdapter::getNodeDefInput(DataHandle nodeDef, size_t index) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return InvalidHandle;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return InvalidHandle;
+    vector<InputPtr> inputs = nd->getActiveInputs();
+    if (index >= inputs.size()) return InvalidHandle;
+    return toHandle(inputs[index].get());
+}
+
+DataHandle MxElementAdapter::getNodeDefInputByName(DataHandle nodeDef, const string& name) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return InvalidHandle;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return InvalidHandle;
+    return toHandle(nd->getInput(name).get());
+}
+
+size_t MxElementAdapter::getNodeDefOutputCount(DataHandle nodeDef) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return 0;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return 0;
+    return nd->getActiveOutputs().size();
+}
+
+DataHandle MxElementAdapter::getNodeDefOutput(DataHandle nodeDef, size_t index) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return InvalidHandle;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return InvalidHandle;
+    vector<OutputPtr> outputs = nd->getActiveOutputs();
+    if (index >= outputs.size()) return InvalidHandle;
+    return toHandle(outputs[index].get());
+}
+
+DataHandle MxElementAdapter::getNodeDefOutputByName(DataHandle nodeDef, const string& name) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return InvalidHandle;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return InvalidHandle;
+    return toHandle(nd->getOutput(name).get());
+}
+
+size_t MxElementAdapter::getNodeDefValueElementCount(DataHandle nodeDef) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return 0;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return 0;
+    return nd->getActiveValueElements().size();
+}
+
+DataHandle MxElementAdapter::getNodeDefValueElement(DataHandle nodeDef, size_t index) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return InvalidHandle;
+    ConstNodeDefPtr nd = e->asA<NodeDef>();
+    if (!nd) return InvalidHandle;
+    vector<ValueElementPtr> elems = nd->getActiveValueElements();
+    if (index >= elems.size()) return InvalidHandle;
+    return toHandle(elems[index].get());
+}
+
+bool MxElementAdapter::valueElementIsOutput(DataHandle valueElem) const
+{
+    const Element* e = toElement(valueElem);
+    return e && e->isA<Output>();
+}
+
+string MxElementAdapter::getNodeDefAttribute(DataHandle nodeDef, const string& attrName) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return EMPTY_STRING;
+    return e->getAttribute(attrName);
+}
+
+void MxElementAdapter::getNodeDefAttributeNames(DataHandle nodeDef, StringVec& names) const
+{
+    const Element* e = toElement(nodeDef);
+    if (!e) return;
+    names = e->getAttributeNames();
+}
+
+// ─── NodeGraph interface ──────────────────────────────────────────────────────
+
+DataHandle MxElementAdapter::getNodeGraphNodeDef(DataHandle nodeGraph) const
+{
+    const Element* e = toElement(nodeGraph);
+    if (!e) return InvalidHandle;
+    ConstNodeGraphPtr ng = e->asA<NodeGraph>();
+    if (!ng) return InvalidHandle;
+    return toHandle(ng->getNodeDef().get());
+}
+
+string MxElementAdapter::getNodeGraphName(DataHandle nodeGraph) const
+{
+    const Element* e = toElement(nodeGraph);
+    if (!e) return EMPTY_STRING;
+    ConstNodeGraphPtr ng = e->asA<NodeGraph>();
+    return ng ? ng->getName() : EMPTY_STRING;
+}
+
+size_t MxElementAdapter::getNodeGraphInputCount(DataHandle nodeGraph) const
+{
+    const Element* e = toElement(nodeGraph);
+    if (!e) return 0;
+    ConstNodeGraphPtr ng = e->asA<NodeGraph>();
+    if (!ng) return 0;
+    return ng->getActiveInputs().size();
+}
+
+DataHandle MxElementAdapter::getNodeGraphInput(DataHandle nodeGraph, size_t index) const
+{
+    const Element* e = toElement(nodeGraph);
+    if (!e) return InvalidHandle;
+    ConstNodeGraphPtr ng = e->asA<NodeGraph>();
+    if (!ng) return InvalidHandle;
+    vector<InputPtr> inputs = ng->getActiveInputs();
+    if (index >= inputs.size()) return InvalidHandle;
+    return toHandle(inputs[index].get());
+}
+
+DataHandle MxElementAdapter::getOutputParentNodeGraph(DataHandle output) const
+{
+    const Element* e = toElement(output);
+    if (!e) return InvalidHandle;
+    ConstElementPtr parent = e->getParent();
+    if (!parent || !parent->isA<NodeGraph>()) return InvalidHandle;
+    return toHandle(parent.get());
+}
+
+// ─── Port queries ─────────────────────────────────────────────────────────────
+
+string MxElementAdapter::getPortName(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    return e ? e->getName() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getPortType(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstValueElementPtr ve = e->asA<ValueElement>();
+    return ve ? ve->getType() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getPortPath(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    return e ? e->getNamePath() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getPortValueString(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstValueElementPtr ve = e->asA<ValueElement>();
+    if (!ve) return EMPTY_STRING;
+    ValuePtr val = ve->getResolvedValue();
+    return val ? val->getValueString() : EMPTY_STRING;
+}
+
+bool MxElementAdapter::portHasValue(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return false;
+    ConstValueElementPtr ve = e->asA<ValueElement>();
+    return ve && ve->hasValue();
+}
+
+string MxElementAdapter::getPortAttribute(DataHandle port, const string& attrName) const
+{
+    const Element* e = toElement(port);
+    return e ? e->getAttribute(attrName) : EMPTY_STRING;
+}
+
+void MxElementAdapter::getPortAttributeNames(DataHandle port, StringVec& names) const
+{
+    const Element* e = toElement(port);
+    if (!e) return;
+    names = e->getAttributeNames();
+}
+
+// ─── Interface binding ────────────────────────────────────────────────────────
+
+bool MxElementAdapter::portHasInterfaceName(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return false;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp && inp->hasInterfaceName();
+}
+
+string MxElementAdapter::getPortInterfaceName(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp ? inp->getInterfaceName() : EMPTY_STRING;
+}
+
+DataHandle MxElementAdapter::getPortInterfaceInput(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return InvalidHandle;
+    ConstInputPtr inp = e->asA<Input>();
+    if (!inp) return InvalidHandle;
+    return toHandle(inp->getInterfaceInput().get());
+}
+
+// ─── Geometric default property ───────────────────────────────────────────────
+
+bool MxElementAdapter::portHasDefaultGeomProp(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return false;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp && inp->hasDefaultGeomPropString();
+}
+
+DataHandle MxElementAdapter::getPortDefaultGeomProp(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return InvalidHandle;
+    ConstInputPtr inp = e->asA<Input>();
+    if (!inp) return InvalidHandle;
+    return toHandle(inp->getDefaultGeomProp().get());
+}
+
+// ─── Unit metadata ────────────────────────────────────────────────────────────
+
+string MxElementAdapter::getPortUnit(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp ? inp->getUnit() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getPortUnitType(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp ? inp->getUnitType() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getPortActiveUnit(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp ? inp->getActiveUnit() : EMPTY_STRING;
+}
+
+// ─── Color space metadata ─────────────────────────────────────────────────────
+
+string MxElementAdapter::getPortColorSpace(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp ? inp->getColorSpace() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getPortActiveColorSpace(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return EMPTY_STRING;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp ? inp->getActiveColorSpace() : EMPTY_STRING;
+}
+
+// ─── Uniformity ───────────────────────────────────────────────────────────────
+
+bool MxElementAdapter::portIsUniform(DataHandle port) const
+{
+    const Element* e = toElement(port);
+    if (!e) return false;
+    ConstInputPtr inp = e->asA<Input>();
+    return inp && inp->getIsUniform();
+}
+
+// ─── GeomPropDef queries ──────────────────────────────────────────────────────
+
+string MxElementAdapter::getGeomPropDefName(DataHandle geomPropDef) const
+{
+    const Element* e = toElement(geomPropDef);
+    return e ? e->getName() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getGeomPropDefProp(DataHandle geomPropDef) const
+{
+    const Element* e = toElement(geomPropDef);
+    if (!e) return EMPTY_STRING;
+    ConstGeomPropDefPtr gp = e->asA<GeomPropDef>();
+    return gp ? gp->getGeomProp() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getGeomPropDefPath(DataHandle geomPropDef) const
+{
+    const Element* e = toElement(geomPropDef);
+    return e ? e->getNamePath() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getGeomPropDefSpace(DataHandle geomPropDef) const
+{
+    const Element* e = toElement(geomPropDef);
+    if (!e) return EMPTY_STRING;
+    ConstGeomPropDefPtr gp = e->asA<GeomPropDef>();
+    return gp ? gp->getSpace() : EMPTY_STRING;
+}
+
+string MxElementAdapter::getGeomPropDefIndex(DataHandle geomPropDef) const
+{
+    const Element* e = toElement(geomPropDef);
+    if (!e) return EMPTY_STRING;
+    ConstGeomPropDefPtr gp = e->asA<GeomPropDef>();
+    return gp ? gp->getIndex() : EMPTY_STRING;
+}
+
+// ─── Document-level queries ───────────────────────────────────────────────────
+
+ConstNodeDefPtr MxElementAdapter::getMxNodeDef(DataHandle node) const
+{
+    const Element* e = toElement(node);
+    if (!e) return nullptr;
+    ConstNodePtr n = e->asA<Node>();
+    return n ? n->getNodeDef() : nullptr;
+}
+
+ConstNodeDefPtr MxElementAdapter::getMxNodeDefByHandle(DataHandle nodeDefHandle) const
+{
+    const Element* e = toElement(nodeDefHandle);
+    return e ? e->asA<NodeDef>() : nullptr;
+}
+
+ConstNodePtr MxElementAdapter::getMxNode(DataHandle node) const
+{
+    const Element* e = toElement(node);
+    return e ? e->asA<Node>() : nullptr;
+}
+
+string MxElementAdapter::getActiveColorSpace() const
+{
+    return _document ? _document->getActiveColorSpace() : EMPTY_STRING;
+}
+
+DataHandle MxElementAdapter::getUnitTypeDefByName(const string& unitTypeName) const
+{
+    if (!_document) return InvalidHandle;
+    return toHandle(_document->getUnitTypeDef(unitTypeName).get());
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader2/MxElementAdapter.h
+++ b/source/MaterialXGenShader2/MxElementAdapter.h
@@ -1,0 +1,159 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_MXELEMENTADAPTER_H
+#define MATERIALX_GENSHADER2_MXELEMENTADAPTER_H
+
+/// @file
+/// IShaderSource implementation backed by a MaterialX Document and root Element.
+///
+/// MxElementAdapter is the bridge between the existing MaterialX data model and
+/// the new IShaderSource abstraction.  It wraps a (ConstDocumentPtr, ConstElementPtr)
+/// pair and answers every IShaderSource query by delegating to the corresponding
+/// MaterialX API call.
+///
+/// Handles are raw MaterialX Element* pointers cast to uint64_t.  The document
+/// must remain alive for the lifetime of this adapter.
+
+#include <MaterialXGenShader2/IShaderSource.h>
+
+#include <MaterialXCore/Document.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+/// @class MxElementAdapter
+/// Implements IShaderSource over a live MaterialX document + root element.
+///
+/// Typical usage:
+/// @code
+///   auto adapter = std::make_unique<MxElementAdapter>(doc, outputElement);
+///   GenContextCreate ctx(glslGenerator, std::move(adapter));
+///   ShaderGraph2Ptr graph = ctx.buildGraph("myShader");
+/// @endcode
+class MX_GENSHADER2_API MxElementAdapter : public IShaderSource
+{
+  public:
+    /// Constructs an adapter for the given document and root output/node element.
+    /// @param document  The owning document; must outlive this adapter.
+    /// @param root      The root Output or Node element from which to build the graph.
+    MxElementAdapter(ConstDocumentPtr document, ConstElementPtr root);
+
+    ~MxElementAdapter() override = default;
+
+    // ─── Root ─────────────────────────────────────────────────────────────────
+    DataHandle getRootElement() const override;
+
+    // ─── Element classification ───────────────────────────────────────────────
+    bool isNode(DataHandle elem) const override;
+    bool isOutput(DataHandle elem) const override;
+    bool isNodeGraph(DataHandle elem) const override;
+
+    // ─── Element identity ─────────────────────────────────────────────────────
+    string getElementName(DataHandle elem) const override;
+    string getElementPath(DataHandle elem) const override;
+
+    // ─── Node topology ────────────────────────────────────────────────────────
+    size_t   getNodeInputCount(DataHandle node) const override;
+    DataHandle getNodeInput(DataHandle node, size_t index) const override;
+    DataHandle getNodeInputByName(DataHandle node, const string& name) const override;
+    DataHandle getInputConnectedNode(DataHandle input) const override;
+    string   getInputConnectedOutputName(DataHandle input) const override;
+    DataHandle getOutputConnectedNode(DataHandle output) const override;
+    DataHandle getNodeParentGraph(DataHandle node) const override;
+
+    // ─── Node definition lookup ───────────────────────────────────────────────
+    string   getNodeDefName(DataHandle node) const override;
+    DataHandle getNodeDef(DataHandle node) const override;
+    DataHandle getNodeDefByName(const string& nodeDefName) const override;
+
+    // ─── NodeDef interface ────────────────────────────────────────────────────
+    string   getNodeDefType(DataHandle nodeDef) const override;
+    size_t   getNodeDefInputCount(DataHandle nodeDef) const override;
+    DataHandle getNodeDefInput(DataHandle nodeDef, size_t index) const override;
+    DataHandle getNodeDefInputByName(DataHandle nodeDef, const string& name) const override;
+    size_t   getNodeDefOutputCount(DataHandle nodeDef) const override;
+    DataHandle getNodeDefOutput(DataHandle nodeDef, size_t index) const override;
+    DataHandle getNodeDefOutputByName(DataHandle nodeDef, const string& name) const override;
+    size_t   getNodeDefValueElementCount(DataHandle nodeDef) const override;
+    DataHandle getNodeDefValueElement(DataHandle nodeDef, size_t index) const override;
+    bool     valueElementIsOutput(DataHandle valueElem) const override;
+    string   getNodeDefAttribute(DataHandle nodeDef, const string& attrName) const override;
+    void     getNodeDefAttributeNames(DataHandle nodeDef, StringVec& names) const override;
+
+    // ─── NodeGraph interface ──────────────────────────────────────────────────
+    DataHandle getNodeGraphNodeDef(DataHandle nodeGraph) const override;
+    string   getNodeGraphName(DataHandle nodeGraph) const override;
+    size_t   getNodeGraphInputCount(DataHandle nodeGraph) const override;
+    DataHandle getNodeGraphInput(DataHandle nodeGraph, size_t index) const override;
+    DataHandle getOutputParentNodeGraph(DataHandle output) const override;
+
+    // ─── Port queries ─────────────────────────────────────────────────────────
+    string   getPortName(DataHandle port) const override;
+    string   getPortType(DataHandle port) const override;
+    string   getPortPath(DataHandle port) const override;
+    string   getPortValueString(DataHandle port) const override;
+    bool     portHasValue(DataHandle port) const override;
+    string   getPortAttribute(DataHandle port, const string& attrName) const override;
+    void     getPortAttributeNames(DataHandle port, StringVec& names) const override;
+
+    // ─── Interface binding ────────────────────────────────────────────────────
+    bool     portHasInterfaceName(DataHandle port) const override;
+    string   getPortInterfaceName(DataHandle port) const override;
+    DataHandle getPortInterfaceInput(DataHandle port) const override;
+
+    // ─── Geometric default property ───────────────────────────────────────────
+    bool     portHasDefaultGeomProp(DataHandle port) const override;
+    DataHandle getPortDefaultGeomProp(DataHandle port) const override;
+
+    // ─── Unit metadata ────────────────────────────────────────────────────────
+    string   getPortUnit(DataHandle port) const override;
+    string   getPortUnitType(DataHandle port) const override;
+    string   getPortActiveUnit(DataHandle port) const override;
+
+    // ─── Color space metadata ─────────────────────────────────────────────────
+    string   getPortColorSpace(DataHandle port) const override;
+    string   getPortActiveColorSpace(DataHandle port) const override;
+
+    // ─── Uniformity ───────────────────────────────────────────────────────────
+    bool portIsUniform(DataHandle port) const override;
+
+    // ─── GeomPropDef queries ──────────────────────────────────────────────────
+    string getGeomPropDefName(DataHandle geomPropDef) const override;
+    string getGeomPropDefProp(DataHandle geomPropDef) const override;
+    string getGeomPropDefPath(DataHandle geomPropDef) const override;
+    string getGeomPropDefSpace(DataHandle geomPropDef) const override;
+    string getGeomPropDefIndex(DataHandle geomPropDef) const override;
+
+    // ─── Document-level queries ───────────────────────────────────────────────
+    string   getActiveColorSpace() const override;
+    DataHandle getUnitTypeDefByName(const string& unitTypeName) const override;
+
+    // ─── Phase 2 MX bridge ────────────────────────────────────────────────────
+    ConstDocumentPtr getMxDocument() const override { return _document; }
+    ConstNodeDefPtr  getMxNodeDef(DataHandle node) const override;
+    ConstNodeDefPtr  getMxNodeDefByHandle(DataHandle nodeDefHandle) const override;
+    ConstNodePtr     getMxNode(DataHandle node) const override;
+
+  private:
+    /// Converts a DataHandle back to a const Element pointer.
+    /// All handles issued by this adapter are Element* cast to uint64_t.
+    static const Element* toElement(DataHandle h)
+    {
+        return reinterpret_cast<const Element*>(static_cast<uintptr_t>(h));
+    }
+
+    /// Wraps a non-null Element pointer as a handle; null becomes InvalidHandle.
+    static DataHandle toHandle(const Element* e)
+    {
+        return e ? static_cast<DataHandle>(reinterpret_cast<uintptr_t>(e)) : InvalidHandle;
+    }
+
+    ConstDocumentPtr _document;
+    ConstElementPtr  _root;
+};
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_MXELEMENTADAPTER_H

--- a/source/MaterialXGenShader2/ShaderGraph2.cpp
+++ b/source/MaterialXGenShader2/ShaderGraph2.cpp
@@ -1,0 +1,455 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXGenShader2/ShaderGraph2.h>
+#include <MaterialXGenShader2/IShaderSource.h>
+
+#include <MaterialXGenShader/ColorManagementSystem.h>
+#include <MaterialXGenShader/GenContext.h>
+#include <MaterialXGenShader/ShaderNode.h>
+#include <MaterialXGenShader/Syntax.h>
+#include <MaterialXGenShader/UnitSystem.h>
+
+#include <MaterialXCore/Geom.h>
+#include <MaterialXCore/Types.h>
+#include <MaterialXCore/Value.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+// ─── populateUnitTransformMap2 ───────────────────────────────────────────────
+
+void ShaderGraph2::populateUnitTransformMap2(UnitSystemPtr unitSystem,
+                                              ShaderPort* shaderPort,
+                                              DataHandle portHandle,
+                                              const IShaderSource& source,
+                                              const string& globalTargetUnitSpace,
+                                              bool asInput)
+{
+    if (!unitSystem || globalTargetUnitSpace.empty())
+    {
+        return;
+    }
+
+    const string sourceUnitSpace = source.getPortUnit(portHandle);
+    if (!shaderPort || sourceUnitSpace.empty())
+    {
+        return;
+    }
+
+    const string unitType = source.getPortUnitType(portHandle);
+    if (!isValidHandle(source.getUnitTypeDefByName(unitType)))
+    {
+        return;
+    }
+
+    string targetUnitSpace = source.getPortActiveUnit(portHandle);
+    if (targetUnitSpace.empty())
+    {
+        targetUnitSpace = globalTargetUnitSpace;
+    }
+
+    const bool supportedType = (shaderPort->getType() == Type::FLOAT   ||
+                                shaderPort->getType() == Type::VECTOR2 ||
+                                shaderPort->getType() == Type::VECTOR3 ||
+                                shaderPort->getType() == Type::VECTOR4);
+    if (supportedType)
+    {
+        UnitTransform transform(sourceUnitSpace, targetUnitSpace, shaderPort->getType(), unitType);
+        if (unitSystem->supportsTransform(transform))
+        {
+            shaderPort->setUnit(sourceUnitSpace);
+            if (asInput)
+            {
+                _inputUnitTransformMap.emplace_back(static_cast<ShaderInput*>(shaderPort), transform);
+            }
+            else
+            {
+                _outputUnitTransformMap.emplace_back(static_cast<ShaderOutput*>(shaderPort), transform);
+            }
+        }
+    }
+}
+
+// ─── applyInputTransforms2 ───────────────────────────────────────────────────
+
+void ShaderGraph2::applyInputTransforms2(DataHandle nodeHandle,
+                                          ShaderNode* shaderNode,
+                                          const IShaderSource& source,
+                                          GenContext& context)
+{
+    ColorManagementSystemPtr cms = context.getShaderGenerator().getColorManagementSystem();
+    UnitSystemPtr unitSystem     = context.getShaderGenerator().getUnitSystem();
+
+    const string targetColorSpace = context.getOptions().targetColorSpaceOverride.empty()
+                                  ? source.getActiveColorSpace()
+                                  : context.getOptions().targetColorSpaceOverride;
+    const string& targetDistanceUnit = context.getOptions().targetDistanceUnit;
+
+    // Determine node-level color/multioutput classification from the NodeDef.
+    DataHandle ndH = source.getNodeDef(nodeHandle);
+    const string nodeDefType       = isValidHandle(ndH) ? source.getNodeDefType(ndH) : EMPTY_STRING;
+    const bool nodeIsColorType     = (nodeDefType == "color3" || nodeDefType == "color4");
+    const bool nodeIsMultiOutputType = (nodeDefType == "multioutput");
+
+    const size_t inputCount = source.getNodeInputCount(nodeHandle);
+    for (size_t i = 0; i < inputCount; ++i)
+    {
+        DataHandle inp = source.getNodeInput(nodeHandle, i);
+        if (!isValidHandle(inp))
+        {
+            continue;
+        }
+
+        if (source.portHasValue(inp) || source.portHasInterfaceName(inp))
+        {
+            const string sourceColorSpace = source.getPortActiveColorSpace(inp);
+            const string inputType        = source.getPortType(inp);
+
+            if (inputType == FILENAME_TYPE_STRING && (nodeIsColorType || nodeIsMultiOutputType))
+            {
+                // Filename input on a color or multi-output node: transforms apply
+                // to the outputs rather than the input itself.
+                //
+                // NOTE: The parent-chain interface color-space adjustment that
+                // ShaderGraph::applyInputTransforms performs via
+                // context.getParentNodes() requires a ConstNodePtr and is not
+                // replicated here.  This is a known limitation for non-MX backends.
+                for (ShaderOutput* shaderOutput : shaderNode->getOutputs())
+                {
+                    populateColorTransformMap(cms, shaderOutput,
+                                             sourceColorSpace, targetColorSpace, false);
+                    populateUnitTransformMap2(unitSystem, shaderOutput, inp,
+                                              source, targetDistanceUnit, false);
+                }
+            }
+            else
+            {
+                const string inputName     = source.getPortName(inp);
+                ShaderInput*  shaderInput  = shaderNode->getInput(inputName);
+                populateColorTransformMap(cms, shaderInput,
+                                         sourceColorSpace, targetColorSpace, true);
+                populateUnitTransformMap2(unitSystem, shaderInput, inp,
+                                          source, targetDistanceUnit, true);
+            }
+        }
+    }
+}
+
+// ─── initializeNode2 ─────────────────────────────────────────────────────────
+
+void ShaderGraph2::initializeNode2(DataHandle nodeHandle,
+                                    ShaderNode* shaderNode,
+                                    ConstNodeDefPtr nodeDef,
+                                    const IShaderSource& source,
+                                    GenContext& context)
+{
+    // 1. Copy input values, paths, units, and color spaces from node-instance
+    //    inputs — replicates the core of ShaderNode::initialize().
+    //
+    //    _impl->setValues(const Node&, ...) is intentionally NOT called here
+    //    because it requires a ConstNodePtr.  The only known override is
+    //    HwImageNode::setValues (UDIM UV normalization).  If that code path is
+    //    needed, the caller must fall back to createNode(ConstNodePtr) via the
+    //    getMxNode() bridge.
+    const size_t inputCount = source.getNodeInputCount(nodeHandle);
+    for (size_t i = 0; i < inputCount; ++i)
+    {
+        DataHandle inp = source.getNodeInput(nodeHandle, i);
+        if (!isValidHandle(inp))
+        {
+            continue;
+        }
+
+        const string inputName = source.getPortName(inp);
+        ShaderInput* shaderInput = shaderNode->getInput(inputName);
+        InputPtr nodedefInput    = nodeDef->getInput(inputName);
+        if (!shaderInput || !nodedefInput)
+        {
+            continue;
+        }
+
+        // Reconstruct the resolved value from its string representation.
+        const string valueStr = source.getPortValueString(inp);
+        if (!valueStr.empty())
+        {
+            const TypeDesc type = context.getTypeDesc(nodedefInput->getType());
+            const string& enumNames = nodedefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+            std::pair<TypeDesc, ValuePtr> enumResult;
+            if (context.getShaderGenerator().getSyntax().remapEnumeration(
+                    valueStr, type, enumNames, enumResult))
+            {
+                shaderInput->setValue(enumResult.second);
+            }
+            else
+            {
+                ValuePtr value = Value::createValueFromStrings(valueStr, nodedefInput->getType());
+                shaderInput->setValue(value);
+            }
+        }
+
+        // Set the element path; prefer the interface input's path when bound.
+        string path = source.getPortPath(inp);
+        DataHandle ifaceInp = source.getPortInterfaceInput(inp);
+        if (isValidHandle(ifaceInp))
+        {
+            const string ifacePath = source.getPortPath(ifaceInp);
+            if (!ifacePath.empty())
+            {
+                path = ifacePath;
+            }
+        }
+        if (!path.empty())
+        {
+            shaderInput->setPath(path);
+        }
+    }
+
+    // 2. Fallback paths for inputs that have no node-instance entry.
+    //    Replicates the second loop in ShaderNode::initialize().
+    const string nodePath = source.getElementPath(nodeHandle);
+    for (const InputPtr& ndInput : nodeDef->getActiveInputs())
+    {
+        ShaderInput* shaderInput = shaderNode->getInput(ndInput->getName());
+        if (shaderInput && shaderInput->getPath().empty())
+        {
+            shaderInput->setPath(nodePath + NAME_PATH_SEPARATOR + ndInput->getName());
+        }
+    }
+
+    // 3. Connect inputs that are bound to a named graph interface input socket.
+    //    Replicates the interface-name loop in ShaderGraph::createNode(ConstNodePtr).
+    for (size_t i = 0; i < inputCount; ++i)
+    {
+        DataHandle inp = source.getNodeInput(nodeHandle, i);
+        if (!isValidHandle(inp) || !source.portHasInterfaceName(inp))
+        {
+            continue;
+        }
+
+        const string ifaceName = source.getPortInterfaceName(inp);
+        if (ifaceName.empty())
+        {
+            continue;
+        }
+
+        ShaderGraphInputSocket* inputSocket = getInputSocket(ifaceName);
+        if (inputSocket)
+        {
+            ShaderInput* shaderInput = shaderNode->getInput(source.getPortName(inp));
+            if (shaderInput)
+            {
+                shaderInput->makeConnection(inputSocket);
+            }
+        }
+    }
+
+    // 4. DefaultGeomProp: create and connect geomprop nodes for unconnected inputs.
+    //    Replicates the geomprop loop in ShaderGraph::createNode(ConstNodePtr).
+    //    Uses the NodeDef (a library object always present for any backend) to find
+    //    the GeomPropDef — addDefaultGeomNode() looks up node defs via _document,
+    //    which must be set for this to succeed.
+    for (const InputPtr& ndInput : nodeDef->getActiveInputs())
+    {
+        ShaderInput* shaderInput = shaderNode->getInput(ndInput->getName());
+        if (!shaderInput)
+        {
+            continue;
+        }
+
+        // Skip if the node instance has an explicit connection to this input.
+        DataHandle nodeInpH = source.getNodeInputByName(nodeHandle, ndInput->getName());
+        const bool hasNodeConnection = isValidHandle(nodeInpH) &&
+                                       isValidHandle(source.getInputConnectedNode(nodeInpH));
+        if (hasNodeConnection || shaderInput->getConnection())
+        {
+            continue;
+        }
+
+        GeomPropDefPtr geomProp = ndInput->getDefaultGeomProp();
+        if (geomProp)
+        {
+            addDefaultGeomNode2(shaderInput, *geomProp, source, context);
+        }
+    }
+
+    // 5. Apply color-space and unit transform nodes.
+    applyInputTransforms2(nodeHandle, shaderNode, source, context);
+}
+
+// ─── addInputSocketFromPort3 (shared helper) ─────────────────────────────────
+
+void ShaderGraph2::addInputSocketFromPort3(DataHandle portHandle,
+                                            const IShaderSource& source,
+                                            GenContext& context)
+{
+    const string portName  = source.getPortName(portHandle);
+    const string portType  = source.getPortType(portHandle);
+    const string valueStr  = source.getPortValueString(portHandle);
+    const string enumNames = source.getPortAttribute(portHandle, ValueElement::ENUM_ATTRIBUTE);
+    const TypeDesc typeDesc = context.getTypeDesc(portType);
+
+    ShaderGraphInputSocket* inputSocket = nullptr;
+    std::pair<TypeDesc, ValuePtr> enumResult;
+    if (context.getShaderGenerator().getSyntax().remapEnumeration(
+            valueStr, typeDesc, enumNames, enumResult))
+    {
+        inputSocket = addInputSocket(portName, enumResult.first);
+        inputSocket->setValue(enumResult.second);
+    }
+    else
+    {
+        inputSocket = addInputSocket(portName, typeDesc);
+        if (!valueStr.empty())
+        {
+            ValuePtr value = Value::createValueFromStrings(valueStr, portType);
+            inputSocket->setValue(value);
+        }
+    }
+
+    if (source.portIsUniform(portHandle))
+    {
+        inputSocket->setUniform();
+    }
+
+    if (source.portHasDefaultGeomProp(portHandle))
+    {
+        DataHandle geomPropH = source.getPortDefaultGeomProp(portHandle);
+        if (isValidHandle(geomPropH))
+        {
+            inputSocket->setGeomProp(source.getGeomPropDefName(geomPropH));
+        }
+    }
+}
+
+// ─── addInputSocketsFrom*3 ────────────────────────────────────────────────────
+
+void ShaderGraph2::addInputSocketsFromNodeDef3(DataHandle nodeDefHandle,
+                                                const IShaderSource& source,
+                                                GenContext& context)
+{
+    const size_t n = source.getNodeDefInputCount(nodeDefHandle);
+    for (size_t i = 0; i < n; ++i)
+    {
+        DataHandle portH = source.getNodeDefInput(nodeDefHandle, i);
+        if (isValidHandle(portH))
+        {
+            addInputSocketFromPort3(portH, source, context);
+        }
+    }
+}
+
+void ShaderGraph2::addInputSocketsFromNodeGraph3(DataHandle nodeGraphHandle,
+                                                   const IShaderSource& source,
+                                                   GenContext& context)
+{
+    const size_t n = source.getNodeGraphInputCount(nodeGraphHandle);
+    for (size_t i = 0; i < n; ++i)
+    {
+        DataHandle portH = source.getNodeGraphInput(nodeGraphHandle, i);
+        if (isValidHandle(portH))
+        {
+            addInputSocketFromPort3(portH, source, context);
+        }
+    }
+}
+
+void ShaderGraph2::addInputSocketsFromNode3(DataHandle nodeHandle,
+                                              const IShaderSource& source,
+                                              GenContext& context)
+{
+    const size_t n = source.getNodeInputCount(nodeHandle);
+    for (size_t i = 0; i < n; ++i)
+    {
+        DataHandle portH = source.getNodeInput(nodeHandle, i);
+        if (isValidHandle(portH))
+        {
+            addInputSocketFromPort3(portH, source, context);
+        }
+    }
+}
+
+// ─── addDefaultGeomNode2 ─────────────────────────────────────────────────────
+
+void ShaderGraph2::addDefaultGeomNode2(ShaderInput* input, const GeomPropDef& geomprop,
+                                        const IShaderSource& source, GenContext& context)
+{
+    const string geomNodeName = "geomprop_" + geomprop.getName();
+    ShaderNode* node = getNode(geomNodeName);
+
+    if (!node)
+    {
+        // Find the NodeDef for the geometric node referenced by the geomprop.
+        // Replicates ShaderGraph::addDefaultGeomNode but uses IShaderSource
+        // instead of _document->getNodeDef() so no document pointer is needed.
+        const string geomNodeDefName = "ND_" + geomprop.getGeomProp() + "_" + input->getType().getName();
+        DataHandle ndH = source.getNodeDefByName(geomNodeDefName);
+        ConstNodeDefPtr geomNodeDef = source.getMxNodeDefByHandle(ndH);
+        if (!geomNodeDef)
+        {
+            throw ExceptionShaderGenError("Could not find a nodedef named '" + geomNodeDefName +
+                                          "' for defaultgeomprop on input '" + input->getFullName() + "'");
+        }
+
+        ShaderNodePtr geomNode = ShaderNode::create(this, geomNodeName, *geomNodeDef, context);
+        addNode(geomNode);
+
+        // Set node inputs if given.
+        const string& namePath = geomprop.getNamePath();
+        const string& space = geomprop.getSpace();
+        if (!space.empty())
+        {
+            ShaderInput* spaceInput = geomNode->getInput(GeomPropDef::SPACE_ATTRIBUTE);
+            ValueElementPtr nodeDefSpaceInput = geomNodeDef->getActiveValueElement(GeomPropDef::SPACE_ATTRIBUTE);
+            if (spaceInput && nodeDefSpaceInput)
+            {
+                std::pair<TypeDesc, ValuePtr> enumResult;
+                const string& enumNames = nodeDefSpaceInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+                const TypeDesc portType = context.getTypeDesc(nodeDefSpaceInput->getType());
+                if (context.getShaderGenerator().getSyntax().remapEnumeration(space, portType, enumNames, enumResult))
+                {
+                    spaceInput->setValue(enumResult.second);
+                }
+                else
+                {
+                    spaceInput->setValue(Value::createValue<string>(space));
+                }
+                spaceInput->setPath(namePath);
+            }
+        }
+        const string& index = geomprop.getIndex();
+        if (!index.empty())
+        {
+            ShaderInput* indexInput = geomNode->getInput("index");
+            if (indexInput)
+            {
+                indexInput->setValue(Value::createValue<string>(index));
+                indexInput->setPath(namePath);
+            }
+        }
+        const string& geomProp = geomprop.getGeomProp();
+        if (!geomProp.empty())
+        {
+            ShaderInput* geomPropInput = geomNode->getInput(GeomPropDef::GEOM_PROP_ATTRIBUTE);
+            if (geomPropInput)
+            {
+                geomPropInput->setValue(Value::createValue<string>(geomProp));
+                geomPropInput->setPath(namePath);
+            }
+        }
+
+        node = geomNode.get();
+
+        // Assign a unique variable name for the node output.
+        const Syntax& syntax = context.getShaderGenerator().getSyntax();
+        ShaderOutput* output = node->getOutput();
+        string variable = output->getFullName();
+        variable = syntax.getVariableName(variable, output->getType(), _identifiers);
+        output->setVariable(variable);
+    }
+
+    input->makeConnection(node->getOutput());
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader2/ShaderGraph2.h
+++ b/source/MaterialXGenShader2/ShaderGraph2.h
@@ -1,0 +1,133 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_SHADERGRAPH2_H
+#define MATERIALX_GENSHADER2_SHADERGRAPH2_H
+
+/// @file
+/// Thin subclass of ShaderGraph that elevates protected methods needed by
+/// ShaderGraphBuilder without touching the existing ShaderGraph API.
+///
+/// Several ShaderGraph methods required for graph construction
+/// (finalize, addInputSockets, addOutputSockets) are protected in the base
+/// class.  ShaderGraph2 exposes them via public forwarding methods so that
+/// ShaderGraphBuilder — living in a different module — can call them.
+///
+/// ShaderGraph2 IS-A ShaderGraph: it can be stored in a ShaderGraphPtr and
+/// used anywhere a ShaderGraph* is expected.
+
+#include <MaterialXGenShader2/DataHandle.h>
+#include <MaterialXGenShader2/Export.h>
+
+#include <MaterialXGenShader/ShaderGraph.h>
+
+MATERIALX_NAMESPACE_BEGIN
+
+/// Forward declaration — full type only needed in ShaderGraph2.cpp.
+class IShaderSource;
+
+/// @class ShaderGraph2
+/// ShaderGraph subclass that exposes the protected construction methods
+/// needed by ShaderGraphBuilder.
+class MX_GENSHADER2_API ShaderGraph2 : public ShaderGraph
+{
+  public:
+    using ShaderGraph::ShaderGraph;
+
+    /// Calls the protected ShaderGraph::finalize().
+    void finalize2(GenContext& context) { finalize(context); }
+
+    /// Calls the protected ShaderGraph::addInputSockets().
+    void addInputSockets2(const InterfaceElement& elem, GenContext& context)
+    {
+        addInputSockets(elem, context);
+    }
+
+    /// Calls the protected ShaderGraph::addOutputSockets().
+    void addOutputSockets2(const InterfaceElement& elem, GenContext& context)
+    {
+        addOutputSockets(elem, context);
+    }
+
+    /// Exposes the protected _classification field for ShaderGraphBuilder.
+    void setClassification2(uint32_t classification) { _classification = classification; }
+
+    /// Exposes the protected simple createNode overload that creates a ShaderNode
+    /// without adding defaultgeomprop nodes or running applyInputTransforms.
+    /// This mirrors the call used in ShaderGraph::create() for the root node.
+    ShaderNode* createNode2(const string& name, const string& uniqueId,
+                            ConstNodeDefPtr nodeDef, GenContext& context)
+    {
+        return createNode(name, uniqueId, nodeDef, context);
+    }
+
+    /// Initializes an upstream ShaderNode from IShaderSource queries, replacing
+    /// the ShaderGraph::createNode(ConstNodePtr) path for non-MX backends.
+    ///
+    /// Replicates:
+    ///   1. ShaderNode::initialize() — value/path/unit/colorspace copying
+    ///   2. Interface-name connections to graph input sockets
+    ///   3. defaultgeomprop node creation (still uses ConstNodeDefPtr, which is
+    ///      always available even for non-MX backends)
+    ///   4. applyInputTransforms2()
+    ///
+    /// @note ShaderNodeImpl::setValues(const Node&, ...) is NOT called here
+    ///       because it requires a ConstNodePtr.  The only known override is
+    ///       HwImageNode::setValues (UDIM UV normalization), which needs the
+    ///       MxNode bridge.  That code path must still go through createNode(ConstNodePtr).
+    void initializeNode2(DataHandle nodeHandle, ShaderNode* shaderNode,
+                         ConstNodeDefPtr nodeDef, const IShaderSource& source,
+                         GenContext& context);
+
+    /// Applies color and unit transform nodes to the inputs of a ShaderNode,
+    /// driven entirely by IShaderSource queries (replaces the
+    /// ShaderGraph::applyInputTransforms(ConstNodePtr, ...) overload).
+    ///
+    /// @note The parent-node chain adjustment for filename inputs with an
+    ///       interfaceName (context.getParentNodes()) requires ConstNodePtr and
+    ///       is therefore skipped here.  This is a known limitation for non-MX
+    ///       backends.
+    void applyInputTransforms2(DataHandle nodeHandle, ShaderNode* shaderNode,
+                               const IShaderSource& source, GenContext& context);
+
+    /// Creates graph input sockets from a NodeDef's declared inputs.
+    /// Replicates addInputSockets(InterfaceElement&) for the NodeDef case.
+    void addInputSocketsFromNodeDef3(DataHandle nodeDefHandle,
+                                     const IShaderSource& source, GenContext& context);
+
+    /// Creates graph input sockets from a NodeGraph's declared inputs.
+    /// Used when the NodeGraph has no associated NodeDef (free-standing graph).
+    void addInputSocketsFromNodeGraph3(DataHandle nodeGraphHandle,
+                                       const IShaderSource& source, GenContext& context);
+
+    /// Creates graph input sockets from a Node's active inputs.
+    /// Used when a Document-level Output's connected node acts as the interface.
+    void addInputSocketsFromNode3(DataHandle nodeHandle,
+                                  const IShaderSource& source, GenContext& context);
+
+  private:
+    /// Replicates ShaderGraph::populateUnitTransformMap() using IShaderSource
+    /// port queries instead of a ValueElementPtr.
+    void populateUnitTransformMap2(UnitSystemPtr unitSystem, ShaderPort* shaderPort,
+                                   DataHandle portHandle, const IShaderSource& source,
+                                   const string& globalTargetUnitSpace, bool asInput);
+
+    /// Creates one input socket from a port DataHandle.
+    /// Shared implementation used by all addInputSocketsFrom*3 variants.
+    void addInputSocketFromPort3(DataHandle portHandle,
+                                  const IShaderSource& source, GenContext& context);
+
+    /// Replicates ShaderGraph::addDefaultGeomNode() using IShaderSource queries
+    /// instead of _document->getNodeDef().
+    /// @note Requires source.getMxNodeDefByHandle() to return a valid NodeDef.
+    void addDefaultGeomNode2(ShaderInput* input, const GeomPropDef& geomprop,
+                              const IShaderSource& source, GenContext& context);
+};
+
+using ShaderGraph2Ptr = shared_ptr<ShaderGraph2>;
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_SHADERGRAPH2_H

--- a/source/MaterialXGenShader2/ShaderGraphBuilder.cpp
+++ b/source/MaterialXGenShader2/ShaderGraphBuilder.cpp
@@ -1,0 +1,410 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXGenShader2/ShaderGraphBuilder.h>
+
+#include <MaterialXGenShader/Exception.h>
+#include <MaterialXGenShader/ShaderNode.h>
+
+#include <MaterialXCore/Interface.h>
+#include <MaterialXCore/Node.h>
+#include <MaterialXCore/Value.h>
+
+#include <memory>
+#include <queue>
+
+MATERIALX_NAMESPACE_BEGIN
+
+ShaderGraphBuilder::ShaderGraphBuilder(const IShaderSource& source, GenContext& context)
+    : _source(source)
+    , _context(context)
+{
+}
+
+// ─── Public entry point ───────────────────────────────────────────────────────
+
+ShaderGraph2Ptr ShaderGraphBuilder::build(const string& name)
+{
+    DataHandle root = _source.getRootElement();
+    if (!isValidHandle(root))
+    {
+        throw ExceptionShaderGenError("ShaderGraphBuilder: IShaderSource returned an invalid root handle");
+    }
+
+    if (_source.isNode(root))
+    {
+        // Resolve the NodeDef via the MX compatibility bridge.
+        // TODO: express this through pure IShaderSource queries for non-MX backends.
+        ConstNodeDefPtr nodeDef = _source.getMxNodeDef(root);
+        if (!nodeDef)
+        {
+            throw ExceptionShaderGenError("ShaderGraphBuilder: could not resolve NodeDef for root node '" +
+                                          _source.getElementName(root) + "'. Non-MX backends must override getMxNodeDef().");
+        }
+
+        // Pass nullptr for the document — ShaderGraph2 no longer needs _document
+        // for GLSL/MDL generation.  addDefaultGeomNode2 uses IShaderSource queries
+        // instead of _document->getNodeDef(), so no document pointer is required.
+        ShaderGraph2Ptr graph = std::make_shared<ShaderGraph2>(nullptr, name, nullptr, _context);
+        graph->setClassification2(0);
+
+        buildNodeRoot(*graph, root, nodeDef);
+
+        if (_context.getOptions().addUpstreamDependencies)
+        {
+            addUpstreamDependencies(*graph, root);
+        }
+
+        graph->finalize2(_context);
+        return graph;
+    }
+
+    if (_source.isOutput(root))
+    {
+        ShaderGraph2Ptr graph = std::make_shared<ShaderGraph2>(nullptr, name, nullptr, _context);
+        graph->setClassification2(0);
+
+        buildOutputRoot(*graph, root);
+
+        if (_context.getOptions().addUpstreamDependencies)
+        {
+            addUpstreamDependencies(*graph, root);
+        }
+
+        graph->finalize2(_context);
+        return graph;
+    }
+
+    throw ExceptionShaderGenError("ShaderGraphBuilder: root element '" + _source.getElementName(root) +
+                                  "' is neither a Node nor an Output");
+}
+
+// ─── Root setup ───────────────────────────────────────────────────────────────
+
+void ShaderGraphBuilder::buildNodeRoot(ShaderGraph2& graph, DataHandle rootNode,
+                                        ConstNodeDefPtr nodeDef)
+{
+    graph.addInputSockets2(*nodeDef, _context);
+    graph.addOutputSockets2(*nodeDef, _context);
+
+    // Use the simple createNode2 (name, id, nodeDef) overload so that
+    // defaultgeomprop nodes and applyInputTransforms are NOT applied inside
+    // createNode — replicate the root-node setup from ShaderGraph::create() exactly:
+    // manual value wiring first, then a single explicit applyInputTransforms at the end.
+    const string rootName = _source.getElementName(rootNode);
+    const string uniqueId = _source.getElementPath(rootNode);
+    ShaderNode* shaderNode = graph.createNode2(rootName, uniqueId, nodeDef, _context);
+    if (!shaderNode)
+    {
+        throw ExceptionShaderGenError("ShaderGraphBuilder: createNode failed for '" +
+                                      rootName + "'");
+    }
+
+    // Share metadata with the graph.
+    graph.setMetadata(shaderNode->getMetadata());
+
+    // Wire root node outputs to graph output sockets.
+    for (size_t i = 0; i < shaderNode->numOutputs(); ++i)
+    {
+        ShaderGraphOutputSocket* outputSocket = graph.getOutputSocket(i);
+        if (outputSocket)
+        {
+            outputSocket->makeConnection(shaderNode->getOutput(i));
+            outputSocket->setPath(uniqueId);
+        }
+    }
+
+    // Wire graph input sockets to the root node's inputs, copying values/metadata.
+    // This replicates the nodeInput loop in ShaderGraph::create() for the Node case.
+    // Uses IShaderSource queries instead of a ConstNodePtr to be MX-independent.
+    for (InputPtr nodedefInput : nodeDef->getActiveInputs())
+    {
+        ShaderGraphInputSocket* inputSocket = graph.getInputSocket(nodedefInput->getName());
+        ShaderInput* input = shaderNode->getInput(nodedefInput->getName());
+        if (!inputSocket || !input)
+        {
+            continue;
+        }
+
+        DataHandle inp = _source.getNodeInputByName(rootNode, nodedefInput->getName());
+        if (isValidHandle(inp))
+        {
+            const string valueStr = _source.getPortValueString(inp);
+            if (!valueStr.empty())
+            {
+                std::pair<TypeDesc, ValuePtr> enumResult;
+                const TypeDesc type = _context.getTypeDesc(nodedefInput->getType());
+                const string& enumNames = nodedefInput->getAttribute(ValueElement::ENUM_ATTRIBUTE);
+                if (_context.getShaderGenerator().getSyntax().remapEnumeration(
+                        valueStr, type, enumNames, enumResult))
+                {
+                    inputSocket->setValue(enumResult.second);
+                }
+                else
+                {
+                    ValuePtr value = Value::createValueFromStrings(valueStr, nodedefInput->getType());
+                    inputSocket->setValue(value);
+                }
+            }
+
+            input->setBindInput();
+
+            const string path = _source.getPortPath(inp);
+            if (!path.empty())
+            {
+                inputSocket->setPath(path);
+                input->setPath(path);
+            }
+            const string unit = _source.getPortUnit(inp);
+            if (!unit.empty())
+            {
+                inputSocket->setUnit(unit);
+                input->setUnit(unit);
+            }
+            const string colorSpace = _source.getPortColorSpace(inp);
+            if (!colorSpace.empty())
+            {
+                inputSocket->setColorSpace(colorSpace);
+                input->setColorSpace(colorSpace);
+            }
+        }
+
+        inputSocket->makeConnection(input);
+        inputSocket->setMetadata(input->getMetadata());
+    }
+
+    // Apply color and unit transforms to the root node's inputs via IShaderSource.
+    graph.applyInputTransforms2(rootNode, shaderNode, _source, _context);
+}
+
+void ShaderGraphBuilder::buildOutputRoot(ShaderGraph2& graph, DataHandle rootOutput)
+{
+    const string outputName = _source.getElementName(rootOutput);
+    const string outputType = _source.getPortType(rootOutput);
+
+    // Determine the interface for input socket creation using IShaderSource queries.
+    // The parent of a root Output is either a NodeGraph or the root Document.
+    DataHandle parentGraph = _source.getOutputParentNodeGraph(rootOutput);
+    if (isValidHandle(parentGraph))
+    {
+        // Output lives inside a NodeGraph.
+        // Prefer the NodeDef interface; fall back to the NodeGraph's own inputs
+        // when no NodeDef is associated (free-standing NodeGraph).
+        DataHandle ndH = _source.getNodeGraphNodeDef(parentGraph);
+        if (isValidHandle(ndH))
+        {
+            graph.addInputSocketsFromNodeDef3(ndH, _source, _context);
+        }
+        else
+        {
+            graph.addInputSocketsFromNodeGraph3(parentGraph, _source, _context);
+        }
+    }
+    else
+    {
+        // Output lives directly in the Document.
+        // The connected node's inputs become the graph interface.
+        DataHandle connNode = _source.getOutputConnectedNode(rootOutput);
+        if (!isValidHandle(connNode))
+        {
+            throw ExceptionShaderGenError(
+                "ShaderGraphBuilder: document-level output '" + outputName +
+                "' is not connected to any node");
+        }
+        graph.addInputSocketsFromNode3(connNode, _source, _context);
+    }
+
+    // Create the output socket.
+    const TypeDesc outTypeDesc = _context.getTypeDesc(outputType);
+    ShaderGraphOutputSocket* outputSocket = graph.addOutputSocket(outputName, outTypeDesc);
+    outputSocket->setPath(_source.getPortPath(rootOutput));
+
+    const string unit = _source.getPortUnit(rootOutput);
+    if (!unit.empty()) outputSocket->setUnit(unit);
+    const string cs = _source.getPortColorSpace(rootOutput);
+    if (!cs.empty()) outputSocket->setColorSpace(cs);
+}
+
+// ─── BFS traversal (replaces ShaderGraph::addUpstreamDependencies) ───────────
+
+void ShaderGraphBuilder::addUpstreamDependencies(ShaderGraph2& graph, DataHandle rootElem)
+{
+    // Worklist entry: (downstreamElem, upstreamNode, connectingInput).
+    struct WorkItem
+    {
+        DataHandle downstream;     // node or output socket downstream of the edge
+        DataHandle upstream;       // upstream node handle
+        DataHandle connectingInput; // input on the downstream node (InvalidHandle if downstream is Output)
+    };
+
+    std::queue<WorkItem> worklist;
+    std::set<string> processedOutputPaths; // avoid re-processing graph Output elements
+
+    // ── Lambda: seed worklist from a node's connected inputs ─────────────────
+    auto seedFromNode = [&](DataHandle nodeHandle)
+    {
+        size_t n = _source.getNodeInputCount(nodeHandle);
+        for (size_t i = 0; i < n; ++i)
+        {
+            DataHandle inp   = _source.getNodeInput(nodeHandle, i);
+            DataHandle conn  = _source.getInputConnectedNode(inp);
+            if (isValidHandle(conn))
+            {
+                worklist.push({ nodeHandle, conn, inp });
+            }
+        }
+    };
+
+    // Seed the worklist from the root.
+    if (_source.isOutput(rootElem))
+    {
+        DataHandle conn = _source.getOutputConnectedNode(rootElem);
+        if (isValidHandle(conn))
+        {
+            worklist.push({ rootElem, conn, InvalidHandle });
+        }
+    }
+    else if (_source.isNode(rootElem))
+    {
+        seedFromNode(rootElem);
+    }
+
+    // ── BFS ──────────────────────────────────────────────────────────────────
+    while (!worklist.empty())
+    {
+        WorkItem item = worklist.front();
+        worklist.pop();
+
+        // If the downstream is an Output we have already processed, skip.
+        if (_source.isOutput(item.downstream))
+        {
+            string path = _source.getElementPath(item.downstream);
+            if (!processedOutputPaths.insert(path).second)
+            {
+                continue; // already processed
+            }
+            // Jump over the Output to the node it's connected to.
+            DataHandle actualNode = _source.getOutputConnectedNode(item.downstream);
+            if (!isValidHandle(actualNode))
+            {
+                continue;
+            }
+            item.upstream = actualNode;
+        }
+
+        // If the upstream itself is an Output element, jump through it.
+        if (_source.isOutput(item.upstream))
+        {
+            string path = _source.getElementPath(item.upstream);
+            processedOutputPaths.insert(path);
+            DataHandle actualNode = _source.getOutputConnectedNode(item.upstream);
+            if (!isValidHandle(actualNode))
+            {
+                continue;
+            }
+            item.upstream = actualNode;
+        }
+
+        createConnectedNodes(graph, item.downstream, item.upstream, item.connectingInput);
+
+        // Continue BFS into the upstream node's inputs.
+        seedFromNode(item.upstream);
+    }
+}
+
+// ─── Single-edge node creation and connection ─────────────────────────────────
+
+void ShaderGraphBuilder::createConnectedNodes(ShaderGraph2& graph,
+                                               DataHandle downstreamElem,
+                                               DataHandle upstreamNode,
+                                               DataHandle connectingInput)
+{
+    // ── Create upstream ShaderNode if it doesn't exist ────────────────────────
+    const string upstreamPath = _source.getElementPath(upstreamNode);
+    ShaderNode* newNode = graph.getNode(upstreamPath);
+    if (!newNode)
+    {
+        // Resolve the NodeDef via the MX compatibility bridge.
+        // getMxNodeDef() is still required: NodeDefs live in the library and any
+        // backend that can drive generation will have them loaded.
+        ConstNodeDefPtr nodeDef = _source.getMxNodeDef(upstreamNode);
+        if (!nodeDef)
+        {
+            throw ExceptionShaderGenError(
+                "ShaderGraphBuilder: could not resolve NodeDef for upstream node '" +
+                _source.getElementName(upstreamNode) +
+                "'. Non-MX backends must override getMxNodeDef().");
+        }
+
+        const string nodeName = _source.getElementName(upstreamNode);
+        newNode = graph.createNode2(nodeName, upstreamPath, nodeDef, _context);
+        if (!newNode)
+        {
+            throw ExceptionShaderGenError(
+                "ShaderGraphBuilder: createNode failed for '" + nodeName + "'");
+        }
+
+        // Initialize values, paths, interface connections, defaultgeomprops,
+        // and transform nodes — all driven through IShaderSource queries.
+        graph.initializeNode2(upstreamNode, newNode, nodeDef, _source, _context);
+    }
+
+    // ── Identify which output of the upstream node to connect from ────────────
+    ShaderOutput* upstreamOutput = nullptr;
+    if (isValidHandle(connectingInput))
+    {
+        const string outputName = _source.getInputConnectedOutputName(connectingInput);
+        upstreamOutput = outputName.empty() ? newNode->getOutput()
+                                            : newNode->getOutput(outputName);
+    }
+    if (!upstreamOutput)
+    {
+        upstreamOutput = newNode->getOutput(); // default first output
+    }
+    if (!upstreamOutput)
+    {
+        throw ExceptionShaderGenError(
+            "ShaderGraphBuilder: no output found on upstream node '" +
+            _source.getElementName(upstreamNode) + "'");
+    }
+
+    // ── Wire connection to downstream node input or graph output socket ────────
+    if (_source.isNode(downstreamElem))
+    {
+        const string downstreamPath = _source.getElementPath(downstreamElem);
+        ShaderNode* downstream = graph.getNode(downstreamPath);
+        if (!downstream)
+        {
+            return; // downstream not yet created; will be connected when processed
+        }
+        if (downstream == newNode)
+        {
+            throw ExceptionShaderGenError(
+                "ShaderGraphBuilder: node '" + downstream->getName() +
+                "' has itself as upstream — cycle detected");
+        }
+        if (isValidHandle(connectingInput))
+        {
+            const string inputName = _source.getPortName(connectingInput);
+            ShaderInput* input = downstream->getInput(inputName);
+            if (input)
+            {
+                input->makeConnection(upstreamOutput);
+            }
+        }
+    }
+    else
+    {
+        // Downstream is an Output socket on the graph.
+        const string socketName = _source.getElementName(downstreamElem);
+        ShaderGraphOutputSocket* outputSocket = graph.getOutputSocket(socketName);
+        if (outputSocket)
+        {
+            outputSocket->makeConnection(upstreamOutput);
+        }
+    }
+}
+
+MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader2/ShaderGraphBuilder.h
+++ b/source/MaterialXGenShader2/ShaderGraphBuilder.h
@@ -1,0 +1,101 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#ifndef MATERIALX_GENSHADER2_SHADERGRAPHBUILDER_H
+#define MATERIALX_GENSHADER2_SHADERGRAPHBUILDER_H
+
+/// @file
+/// Constructs a ShaderGraph from an IShaderSource.
+///
+/// ShaderGraphBuilder replaces the internal ShaderGraph::addUpstreamDependencies()
+/// / traverseGraph() traversal with an explicit BFS driven entirely by
+/// IShaderSource queries.
+///
+/// ## Current bridge dependencies
+///
+/// Most of the graph construction is now driven through pure IShaderSource
+/// queries.  Two bridge methods on IShaderSource are still required:
+///
+///   • getMxNodeDef() — needed to obtain a ConstNodeDefPtr for every node
+///     (both root and upstream).  NodeDefs live in the loaded shader library;
+///     any backend that can drive generation will have them available.
+///
+///   • getMxDocument() — no longer required by ShaderGraphBuilder.  The graph
+///     is built entirely through IShaderSource queries (Phase 4b/4c).
+///     Retained in IShaderSource for compatibility with buildShader().
+///
+/// getMxNode() is NO LONGER required; upstream node initialization and
+/// transform application now go through ShaderGraph2::initializeNode2() and
+/// ShaderGraph2::applyInputTransforms2() respectively.
+///
+/// Known limitation: ShaderNodeImpl::setValues(const Node&, ...) is not
+/// called for upstream nodes because it requires a ConstNodePtr.  The only
+/// known override is HwImageNode::setValues (UDIM UV normalization).  That
+/// path is not exercised by any standard MaterialX shader.
+
+#include <MaterialXGenShader2/Export.h>
+#include <MaterialXGenShader2/IShaderSource.h>
+#include <MaterialXGenShader2/ShaderGraph2.h>
+
+#include <MaterialXGenShader/GenContext.h>
+
+#include <set>
+#include <string>
+
+MATERIALX_NAMESPACE_BEGIN
+
+/// @class ShaderGraphBuilder
+/// Builds a ShaderGraph (specifically a ShaderGraph2) from an IShaderSource.
+///
+/// Usage:
+/// @code
+///   MxElementAdapter adapter(doc, element);
+///   GenContext context(GlslShaderGenerator::create());
+///   context.registerSourceCodeSearchPath(searchPath);
+///
+///   ShaderGraphBuilder builder(adapter, context);
+///   ShaderGraph2Ptr graph = builder.build("myShader");
+/// @endcode
+class MX_GENSHADER2_API ShaderGraphBuilder
+{
+  public:
+    ShaderGraphBuilder(const IShaderSource& source, GenContext& context);
+
+    /// Build a ShaderGraph from the root element provided by IShaderSource.
+    /// Returns a finalized ShaderGraph2 equivalent to what
+    /// ShaderGraph::create(nullptr, name, element, context) would produce.
+    ShaderGraph2Ptr build(const string& name);
+
+  private:
+    // ── Graph traversal (replaces ShaderGraph::addUpstreamDependencies) ───────
+
+    /// BFS upstream from rootElem, calling createConnectedNodes for every edge.
+    void addUpstreamDependencies(ShaderGraph2& graph, DataHandle rootElem);
+
+    /// Replicates ShaderGraph::createConnectedNodes for a single (downstream,
+    /// upstream, connectingInput) triple discovered during BFS.
+    void createConnectedNodes(ShaderGraph2& graph,
+                              DataHandle downstreamElem,
+                              DataHandle upstreamNode,
+                              DataHandle connectingInput);
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Build the root-node case: root is a Node element (the common case for
+    /// surface/material shaders).  Populates sockets, creates the root
+    /// ShaderNode, and wires everything to graph I/O.
+    void buildNodeRoot(ShaderGraph2& graph, DataHandle rootNode, ConstNodeDefPtr nodeDef);
+
+    /// Build the output-socket case: root is an Output element inside a
+    /// NodeGraph or floating in the Document.
+    void buildOutputRoot(ShaderGraph2& graph, DataHandle rootOutput);
+
+    const IShaderSource& _source;
+    GenContext&          _context;
+};
+
+MATERIALX_NAMESPACE_END
+
+#endif // MATERIALX_GENSHADER2_SHADERGRAPHBUILDER_H

--- a/source/MaterialXTest/CMakeLists.txt
+++ b/source/MaterialXTest/CMakeLists.txt
@@ -46,6 +46,8 @@ endif()
 
 add_subdirectory(MaterialXGenShader)
 target_link_libraries(MaterialXTest MaterialXGenShader)
+add_subdirectory(MaterialXGenShader2)
+target_link_libraries(MaterialXTest MaterialXGenShader2)
 if(MATERIALX_BUILD_GEN_GLSL OR MATERIALX_BUILD_GEN_OSL OR MATERIALX_BUILD_GEN_MDL OR MATERIALX_BUILD_GEN_MSL OR MATERIALX_BUILD_GEN_SLANG)
   if(MATERIALX_BUILD_GEN_GLSL)
     add_subdirectory(MaterialXGenGlsl)

--- a/source/MaterialXTest/MaterialXGenShader2/CMakeLists.txt
+++ b/source/MaterialXTest/MaterialXGenShader2/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB_RECURSE source "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+file(GLOB_RECURSE headers "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+target_sources(MaterialXTest PUBLIC ${source} ${headers})
+add_tests("${source}")
+
+assign_source_group("Source Files" ${source})
+assign_source_group("Header Files" ${headers})

--- a/source/MaterialXTest/MaterialXGenShader2/GenShader2Parity.cpp
+++ b/source/MaterialXTest/MaterialXGenShader2/GenShader2Parity.cpp
@@ -1,0 +1,709 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// @file
+/// Tests for MaterialXGenShader2.
+///
+/// Adapter unit tests: verify MxElementAdapter faithfully reflects the
+///   MaterialX data model through the IShaderSource interface.
+///
+/// Graph parity tests: build a ShaderGraph via GenContextCreate /
+///   ShaderGraphBuilder and assert it is structurally identical to the graph
+///   produced by the existing ShaderGraph::create() path.
+///
+/// Shader emit parity tests: drive full code emission through GenContextCreate
+///   and assert the generated source is byte-for-byte identical to the output
+///   of the existing ShaderGenerator::generate() path, for both GLSL and MDL.
+///
+/// Phase 4 bridge tests: re-run graph parity via NoMxNodeAdapter, which
+///   overrides getMxNode() to FAIL() if called.  A passing test proves that
+///   ShaderGraphBuilder no longer calls getMxNode() for any upstream node.
+///
+/// Phase 4b bridge tests: re-run graph parity (including Output-root cases)
+///   via NoMxDocumentAdapter, which overrides getMxDocument() to FAIL() if
+///   called.  A passing test proves that buildOutputRoot() no longer calls
+///   getMxDocument().
+
+#include <MaterialXTest/External/Catch/catch.hpp>
+#include <MaterialXTest/MaterialXGenShader/GenShaderUtil.h>
+
+#include <MaterialXGenShader2/GenContextCreate.h>
+#include <MaterialXGenShader2/MxElementAdapter.h>
+
+#include <MaterialXGenShader/GenContext.h>
+#include <MaterialXGenShader/ShaderGraph.h>
+#include <MaterialXGenShader/ShaderGenerator.h>
+
+#include <MaterialXGenGlsl/GlslShaderGenerator.h>
+
+#ifdef MATERIALX_BUILD_GEN_MDL
+#include <MaterialXGenMdl/MdlShaderGenerator.h>
+#endif
+
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/Util.h>
+
+#include <MaterialXCore/Document.h>
+
+namespace mx = MaterialX;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+static mx::DocumentPtr loadLibraries()
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, doc);
+    return doc;
+}
+
+static mx::DocumentPtr loadMaterial(const mx::FilePath& mtlxFile)
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr doc = loadLibraries();
+    mx::readFromXmlFile(doc, mtlxFile, searchPath);
+    std::string errors;
+    REQUIRE(doc->validate(&errors));
+    return doc;
+}
+
+static mx::GenContext makeGlslContext()
+{
+    return mx::GenContext(mx::GlslShaderGenerator::create());
+}
+
+// ─── Phase 1: MxElementAdapter unit tests ────────────────────────────────────
+
+TEST_CASE("GenShader2: MxElementAdapter - root element", "[genshader2][adapter]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    if (!mtlxFile.exists())
+    {
+        WARN("Test material not found, skipping: " + mtlxFile.asString());
+        return;
+    }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+
+    mx::ElementPtr renderableElem;
+    for (mx::ElementPtr elem : doc->traverseTree())
+    {
+        if (elem->isA<mx::Output>() || elem->isA<mx::Node>())
+        {
+            renderableElem = elem;
+            break;
+        }
+    }
+    REQUIRE(renderableElem);
+
+    mx::MxElementAdapter adapter(doc, renderableElem);
+    mx::DataHandle root = adapter.getRootElement();
+    REQUIRE(mx::isValidHandle(root));
+    CHECK(adapter.getElementName(root) == renderableElem->getName());
+    CHECK(adapter.getElementPath(root) == renderableElem->getNamePath());
+}
+
+TEST_CASE("GenShader2: MxElementAdapter - node queries", "[genshader2][adapter]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    if (!mtlxFile.exists())
+    {
+        WARN("Test material not found, skipping: " + mtlxFile.asString());
+        return;
+    }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+
+    mx::NodePtr ssNode;
+    for (mx::NodePtr node : doc->getNodes())
+    {
+        if (node->getCategory() == "standard_surface")
+        {
+            ssNode = node;
+            break;
+        }
+    }
+    REQUIRE(ssNode);
+
+    mx::MxElementAdapter adapter(doc, ssNode);
+    mx::DataHandle nodeH = adapter.getRootElement();
+    REQUIRE(mx::isValidHandle(nodeH));
+    REQUIRE(adapter.isNode(nodeH));
+
+    mx::DataHandle ndH = adapter.getNodeDef(nodeH);
+    REQUIRE(mx::isValidHandle(ndH));
+    CHECK(!adapter.getNodeDefType(ndH).empty());
+
+    size_t inputCount = adapter.getNodeInputCount(nodeH);
+    CHECK(inputCount > 0);
+    for (size_t i = 0; i < inputCount; ++i)
+    {
+        mx::DataHandle inputH = adapter.getNodeInput(nodeH, i);
+        REQUIRE(mx::isValidHandle(inputH));
+        CHECK(!adapter.getPortName(inputH).empty());
+        CHECK(!adapter.getPortType(inputH).empty());
+    }
+
+    size_t outputCount = adapter.getNodeDefOutputCount(ndH);
+    CHECK(outputCount > 0);
+    for (size_t i = 0; i < outputCount; ++i)
+    {
+        mx::DataHandle outH = adapter.getNodeDefOutput(ndH, i);
+        REQUIRE(mx::isValidHandle(outH));
+        CHECK(!adapter.getPortName(outH).empty());
+    }
+}
+
+TEST_CASE("GenShader2: MxElementAdapter - document queries", "[genshader2][adapter]")
+{
+    mx::DocumentPtr doc = loadLibraries();
+    mx::MxElementAdapter adapter(doc, doc->getChildren().front());
+
+    std::string colorSpace = adapter.getActiveColorSpace();
+    CHECK(true);
+
+    mx::DataHandle ndH = adapter.getNodeDefByName("ND_standard_surface_surfaceshader");
+    if (mx::isValidHandle(ndH))
+    {
+        CHECK(!adapter.getNodeDefType(ndH).empty());
+    }
+}
+
+// ─── Graph parity tests ───────────────────────────────────────────────────────
+
+/// Compare two ShaderGraphs and verify structural equivalence:
+///   - same node count
+///   - every node present in the old graph also exists in the new graph
+///   - every node has the same number of inputs and outputs
+static void checkGraphParity(const mx::ShaderGraph& oldGraph, const mx::ShaderGraph& newGraph,
+                              const std::string& materialName)
+{
+    INFO("Material: " << materialName);
+
+    const auto& oldNodes = oldGraph.getNodes();
+    const auto& newNodes = newGraph.getNodes();
+
+    CHECK(newNodes.size() == oldNodes.size());
+
+    for (const mx::ShaderNode* oldNode : oldNodes)
+    {
+        const mx::ShaderNode* newNode = newGraph.getNode(oldNode->getUniqueId());
+        INFO("  Node: " << oldNode->getName() << "  uniqueId: " << oldNode->getUniqueId());
+        REQUIRE(newNode != nullptr);
+        CHECK(newNode->numInputs()  == oldNode->numInputs());
+        CHECK(newNode->numOutputs() == oldNode->numOutputs());
+    }
+}
+
+/// Build both old and new ShaderGraphs from a Node element and assert parity.
+static void runNodeParityTest(mx::DocumentPtr doc, mx::NodePtr rootNode,
+                              const std::string& shaderName)
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+
+    mx::GenContext oldContext = makeGlslContext();
+    oldContext.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderGraphPtr oldGraph = mx::ShaderGraph::create(nullptr, shaderName, rootNode, oldContext);
+    REQUIRE(oldGraph);
+
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderGraph2Ptr newGraph = ctx.buildGraph(shaderName);
+    REQUIRE(newGraph);
+
+    checkGraphParity(*oldGraph, *newGraph, shaderName);
+}
+
+/// Build both old and new ShaderGraphs from an Output element and assert parity.
+static void runOutputParityTest(mx::DocumentPtr doc, mx::OutputPtr rootOutput,
+                                const std::string& shaderName)
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+
+    mx::GenContext oldContext = makeGlslContext();
+    oldContext.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderGraphPtr oldGraph = mx::ShaderGraph::create(nullptr, shaderName, rootOutput, oldContext);
+    REQUIRE(oldGraph);
+
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootOutput);
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderGraph2Ptr newGraph = ctx.buildGraph(shaderName);
+    REQUIRE(newGraph);
+
+    checkGraphParity(*oldGraph, *newGraph, shaderName);
+}
+
+// ─── Phase 4 bridge: NoMxNodeAdapter ─────────────────────────────────────────
+
+/// MxElementAdapter subclass that FAIL()s the test if getMxNode() is called.
+///
+/// Use this in place of MxElementAdapter to prove that ShaderGraphBuilder
+/// no longer requires the getMxNode() bridge (Phase 4 invariant).
+/// getMxDocument() and getMxNodeDef() are still delegated to the base class
+/// because those bridges remain required.
+class NoMxNodeAdapter : public mx::MxElementAdapter
+{
+  public:
+    using mx::MxElementAdapter::MxElementAdapter;
+
+    mx::ConstNodePtr getMxNode(mx::DataHandle /*node*/) const override
+    {
+        FAIL("ShaderGraphBuilder called getMxNode() — Phase 4 invariant violated");
+        return nullptr;
+    }
+};
+
+/// Run a graph parity test using NoMxNodeAdapter (getMxNode() must not fire).
+static void runNodeParityTestNoMxNode(mx::DocumentPtr doc, mx::NodePtr rootNode,
+                                       const std::string& shaderName)
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+
+    // Reference graph via the standard path.
+    mx::GenContext oldContext = makeGlslContext();
+    oldContext.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderGraphPtr oldGraph = mx::ShaderGraph::create(nullptr, shaderName, rootNode, oldContext);
+    REQUIRE(oldGraph);
+
+    // New path: NoMxNodeAdapter will FAIL() if getMxNode() is ever called.
+    auto adapter = std::make_unique<NoMxNodeAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderGraph2Ptr newGraph = ctx.buildGraph(shaderName);
+    REQUIRE(newGraph);
+
+    checkGraphParity(*oldGraph, *newGraph, shaderName);
+}
+
+TEST_CASE("GenShader2: Phase 4 - getMxNode not called - standard_surface_default",
+          "[genshader2][phase4]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTestNoMxNode(doc, rootNode, "phase4_standard_surface_default");
+}
+
+TEST_CASE("GenShader2: Phase 4 - getMxNode not called - standard_surface_marble_solid",
+          "[genshader2][phase4]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTestNoMxNode(doc, rootNode, "phase4_standard_surface_marble_solid");
+}
+
+TEST_CASE("GenShader2: Phase 4 - getMxNode not called - open_pbr_carpaint",
+          "[genshader2][phase4]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/OpenPbr/open_pbr_carpaint.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "open_pbr_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTestNoMxNode(doc, rootNode, "phase4_open_pbr_carpaint");
+}
+
+// ─── Phase 4b bridge: CountingDocumentAdapter ────────────────────────────────
+
+/// MxElementAdapter subclass that counts calls to getMxDocument().
+///
+/// After Phase 4c, ShaderGraphBuilder passes nullptr to the ShaderGraph2
+/// constructor and addDefaultGeomNode2 uses IShaderSource queries instead of
+/// _document->getNodeDef().  getMxDocument() should therefore never be called
+/// during graph construction.
+///
+/// The invariant proven by these tests:
+///   • For a node-root graph, getMxDocument() is called ZERO times.
+///   • For an output-root graph, getMxDocument() is called ZERO times.
+///
+/// Any count > 0 means a new getMxDocument() dependency was introduced.
+class CountingDocumentAdapter : public mx::MxElementAdapter
+{
+  public:
+    using mx::MxElementAdapter::MxElementAdapter;
+
+    mx::ConstDocumentPtr getMxDocument() const override
+    {
+        ++callCount;
+        return mx::MxElementAdapter::getMxDocument();
+    }
+
+    mutable int callCount = 0;
+};
+
+TEST_CASE("GenShader2: Phase 4c - getMxDocument called zero times (node-root) - marble_solid",
+          "[genshader2][phase4b][phase4c]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+
+    mx::FileSearchPath sp = mx::getDefaultDataSearchPath();
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(),
+                             std::make_unique<CountingDocumentAdapter>(doc, rootNode));
+    ctx.getGenContext().registerSourceCodeSearchPath(sp);
+    mx::ShaderGraph2Ptr newGraph = ctx.buildGraph("phase4b_marble");
+    REQUIRE(newGraph);
+
+    // Phase 4c: getMxDocument() must not be called at all — the graph is built
+    // entirely through IShaderSource queries.
+    const auto& counter = static_cast<const CountingDocumentAdapter&>(ctx.getSource());
+    CHECK(counter.callCount == 0);
+}
+
+TEST_CASE("GenShader2: Phase 4c - getMxDocument called zero times (output-root) - brass nodegraph",
+          "[genshader2][phase4b][phase4c]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodeGraphPtr ng = doc->getNodeGraph("NG_brass1");
+    REQUIRE(ng);
+
+    for (mx::OutputPtr output : ng->getOutputs())
+    {
+        mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(),
+                                 std::make_unique<CountingDocumentAdapter>(doc, output));
+        ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+        mx::ShaderGraph2Ptr newGraph = ctx.buildGraph("phase4b_brass_" + output->getName());
+        REQUIRE(newGraph);
+
+        // Phase 4c: getMxDocument() must not be called at all — the graph is built
+        // entirely through IShaderSource queries.
+        const auto& counter = static_cast<const CountingDocumentAdapter&>(ctx.getSource());
+        CHECK(counter.callCount == 0);
+    }
+}
+
+// ─── StandardSurface ─────────────────────────────────────────────────────────
+
+TEST_CASE("GenShader2: graph parity - standard_surface_default", "[genshader2][parity]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTest(doc, rootNode, "test_standard_surface_default");
+}
+
+TEST_CASE("GenShader2: graph parity - standard_surface_marble_solid", "[genshader2][parity]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTest(doc, rootNode, "test_standard_surface_marble_solid");
+}
+
+TEST_CASE("GenShader2: graph parity - standard_surface_glass", "[genshader2][parity]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_glass.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTest(doc, rootNode, "test_standard_surface_glass");
+}
+
+// ─── OpenPBR ─────────────────────────────────────────────────────────────────
+
+TEST_CASE("GenShader2: graph parity - open_pbr_default", "[genshader2][parity]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "open_pbr_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTest(doc, rootNode, "test_open_pbr_default");
+}
+
+TEST_CASE("GenShader2: graph parity - open_pbr_carpaint", "[genshader2][parity]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/OpenPbr/open_pbr_carpaint.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "open_pbr_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTest(doc, rootNode, "test_open_pbr_carpaint");
+}
+
+// ─── GltfPbr ─────────────────────────────────────────────────────────────────
+
+TEST_CASE("GenShader2: graph parity - gltf_pbr_default", "[genshader2][parity]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/GltfPbr/gltf_pbr_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "gltf_pbr") { rootNode = node; break; }
+    REQUIRE(rootNode);
+    runNodeParityTest(doc, rootNode, "test_gltf_pbr_default");
+}
+
+// ─── Output-rooted (NodeGraph output) ────────────────────────────────────────
+
+TEST_CASE("GenShader2: graph parity - nodegraph output root", "[genshader2][parity]")
+{
+    // standard_surface_brass_tiled.mtlx contains NG_brass1 with outputs
+    // out_color and out_roughness — exercise the buildOutputRoot path.
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_brass_tiled.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+
+    mx::NodeGraphPtr ng = doc->getNodeGraph("NG_brass1");
+    REQUIRE(ng);
+
+    for (mx::OutputPtr output : ng->getOutputs())
+    {
+        runOutputParityTest(doc, output, "test_brass_ng_" + output->getName());
+    }
+}
+
+// ─── Shader emit parity helpers ───────────────────────────────────────────────
+
+/// Compare generated shader source stage-by-stage.
+static void checkShaderParity(const mx::Shader& oldShader, const mx::Shader& newShader,
+                               const std::string& label)
+{
+    INFO("Shader: " << label);
+    REQUIRE(newShader.numStages() == oldShader.numStages());
+    for (size_t i = 0; i < oldShader.numStages(); ++i)
+    {
+        const mx::ShaderStage& oldStage = oldShader.getStage(i);
+        const mx::ShaderStage& newStage = newShader.getStage(i);
+        INFO("  Stage: " << oldStage.getName());
+        CHECK(newStage.getSourceCode() == oldStage.getSourceCode());
+    }
+}
+
+// ─── GLSL emit parity ─────────────────────────────────────────────────────────
+
+TEST_CASE("GenShader2: emit parity GLSL - standard_surface_default", "[genshader2][emit]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+
+    const std::string shaderName = "emit_test_ss_default";
+
+    // Old path
+    mx::GenContext oldCtx = makeGlslContext();
+    oldCtx.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr oldShader = oldCtx.getShaderGenerator().generate(shaderName, rootNode, oldCtx);
+    REQUIRE(oldShader);
+
+    // New path
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr newShader = ctx.buildShader(shaderName);
+    REQUIRE(newShader);
+
+    checkShaderParity(*oldShader, *newShader, "GLSL standard_surface_default");
+}
+
+TEST_CASE("GenShader2: emit parity GLSL - standard_surface_marble_solid", "[genshader2][emit]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_marble_solid.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+
+    const std::string shaderName = "emit_test_ss_marble";
+
+    mx::GenContext oldCtx = makeGlslContext();
+    oldCtx.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr oldShader = oldCtx.getShaderGenerator().generate(shaderName, rootNode, oldCtx);
+    REQUIRE(oldShader);
+
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr newShader = ctx.buildShader(shaderName);
+    REQUIRE(newShader);
+
+    checkShaderParity(*oldShader, *newShader, "GLSL standard_surface_marble_solid");
+}
+
+TEST_CASE("GenShader2: emit parity GLSL - open_pbr_default", "[genshader2][emit]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "open_pbr_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+
+    const std::string shaderName = "emit_test_openpbr";
+
+    mx::GenContext oldCtx = makeGlslContext();
+    oldCtx.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr oldShader = oldCtx.getShaderGenerator().generate(shaderName, rootNode, oldCtx);
+    REQUIRE(oldShader);
+
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::GlslShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr newShader = ctx.buildShader(shaderName);
+    REQUIRE(newShader);
+
+    checkShaderParity(*oldShader, *newShader, "GLSL open_pbr_default");
+}
+
+// ─── MDL emit parity ──────────────────────────────────────────────────────────
+
+#ifdef MATERIALX_BUILD_GEN_MDL
+
+static mx::GenContext makeMdlContext()
+{
+    return mx::GenContext(mx::MdlShaderGenerator::create());
+}
+
+TEST_CASE("GenShader2: emit parity MDL - standard_surface_default", "[genshader2][emit]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/StandardSurface/standard_surface_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "standard_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+
+    const std::string shaderName = "emit_test_mdl_ss_default";
+
+    mx::GenContext oldCtx = makeMdlContext();
+    oldCtx.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr oldShader = oldCtx.getShaderGenerator().generate(shaderName, rootNode, oldCtx);
+    REQUIRE(oldShader);
+
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::MdlShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr newShader = ctx.buildShader(shaderName);
+    REQUIRE(newShader);
+
+    checkShaderParity(*oldShader, *newShader, "MDL standard_surface_default");
+}
+
+TEST_CASE("GenShader2: emit parity MDL - open_pbr_default", "[genshader2][emit]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::FilePath mtlxFile = searchPath.find(
+        "resources/Materials/Examples/OpenPbr/open_pbr_default.mtlx");
+    if (!mtlxFile.exists()) { WARN("Test material not found, skipping: " + mtlxFile.asString()); return; }
+
+    mx::DocumentPtr doc = loadMaterial(mtlxFile);
+    mx::NodePtr rootNode;
+    for (mx::NodePtr node : doc->getNodes())
+        if (node->getCategory() == "open_pbr_surface") { rootNode = node; break; }
+    REQUIRE(rootNode);
+
+    const std::string shaderName = "emit_test_mdl_openpbr";
+
+    mx::GenContext oldCtx = makeMdlContext();
+    oldCtx.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr oldShader = oldCtx.getShaderGenerator().generate(shaderName, rootNode, oldCtx);
+    REQUIRE(oldShader);
+
+    auto adapter = std::make_unique<mx::MxElementAdapter>(doc, rootNode);
+    mx::GenContextCreate ctx(mx::MdlShaderGenerator::create(), std::move(adapter));
+    ctx.getGenContext().registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr newShader = ctx.buildShader(shaderName);
+    REQUIRE(newShader);
+
+    checkShaderParity(*oldShader, *newShader, "MDL open_pbr_default");
+}
+
+#endif // MATERIALX_BUILD_GEN_MDL


### PR DESCRIPTION
…construction

Introduces a new MaterialXGenShader2 library that decouples shader graph construction from the MaterialX Element hierarchy (issue #2566). Any system that can answer graph-topology queries — a MaterialX Document, a USD/Hydra HdMaterialNetwork, a runtime node graph — can drive shader generation via opaque DataHandle tokens without constructing MaterialX Elements.

Core additions:
- IShaderSource: pure-virtual, read-only interface (~43 methods) covering node topology, NodeDef/NodeGraph queries, port metadata (value, unit, color space, geomprops), and an optional MX compatibility bridge.
- DataHandle: opaque uint64_t token; 0 == InvalidHandle.
- MxElementAdapter: IShaderSource implementation over a live (ConstDocumentPtr, ConstElementPtr) pair — the reference MX backend.
- ShaderGraph2: ShaderGraph subclass exposing protected methods and adding IShaderSource-driven variants (initializeNode2, applyInputTransforms2, addDefaultGeomNode2, addInputSocketsFromNodeDef3, etc.).
- ShaderGraphBuilder: BFS traversal driven entirely by IShaderSource; replaces ShaderGraph::addUpstreamDependencies. Passes nullptr as document to ShaderGraph2 — no ConstDocumentPtr required for GLSL/MDL generation.
- GenContextCreate: thin entry point (generator + IShaderSource -> buildGraph).

Test coverage (source/MaterialXTest/MaterialXGenShader2/GenShader2Parity.cpp):
- 341 assertions in 20 test cases, all passing.
- Graph structure parity vs original ShaderGraph across 6 materials.
- Full GLSL and MDL emit parity.
- NoMxNodeAdapter: asserts getMxNode() is never called.
- CountingDocumentAdapter: asserts getMxDocument() call count == 0.

Known limitations documented in IShaderSource.h and GenContextCreate.h:
- ShaderNodeImpl::setValues is not called (HwImageNode UDIM).
- buildShader() still requires getMxDocument() for the emit step.
- getMxNodeDef() still required via MX bridge for NodeDef resolution.