### PR TITLE
Forward alpha channel in color4 RgbToHsv and HsvToRgb

### DIFF
--- a/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
@@ -2,5 +2,5 @@
 
 void mx_hsvtorgb_color4(vec4 _in, out vec4 result)
 {
-    result = vec4(mx_hsvtorgb(_in.rgb), 1.0);
+    result = vec4(mx_hsvtorgb(_in.rgb), _in.a);
 }

--- a/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
@@ -2,5 +2,5 @@
 
 void mx_rgbtohsv_color4(vec4 _in, out vec4 result)
 {
-    result = vec4(mx_rgbtohsv(_in.rgb), 1.0);
+    result = vec4(mx_rgbtohsv(_in.rgb), _in.a);
 }

--- a/libraries/stdlib/genosl/mx_hsvtorgb_color4.osl
+++ b/libraries/stdlib/genosl/mx_hsvtorgb_color4.osl
@@ -1,4 +1,4 @@
 void mx_hsvtorgb_color4(color4 _in, output color4 result)
 {
-    result = color4(transformc("hsv","rgb", _in.rgb), 1.0);
+    result = color4(transformc("hsv","rgb", _in.rgb), _in.a);
 }

--- a/libraries/stdlib/genosl/mx_rgbtohsv_color4.osl
+++ b/libraries/stdlib/genosl/mx_rgbtohsv_color4.osl
@@ -1,4 +1,4 @@
 void mx_rgbtohsv_color4(color4 _in, output color4 result)
 {
-    result = color4(transformc("rgb","hsv", _in.rgb), 1.0);
+    result = color4(transformc("rgb","hsv", _in.rgb), _in.a);
 }


### PR DESCRIPTION
The color4 variants of `mx_rgbtohsv` and `mx_hsvtorgb` hardcode the
output alpha to `1.0` instead of forwarding `_in.a`. Per the MaterialX
spec, the alpha channel should pass through unchanged during color space
conversion.

Fixed in both GLSL (`genglsl/`) and OSL (`genosl/`) implementations.
The color3 variants are unaffected (no alpha channel).

**Files changed:**
- `libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl`: `1.0` -> `_in.a`
- `libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl`: `1.0` -> `_in.a`
- `libraries/stdlib/genosl/mx_rgbtohsv_color4.osl`: `1.0` -> `_in.a`
- `libraries/stdlib/genosl/mx_hsvtorgb_color4.osl`: `1.0` -> `_in.a`

As noted in the issue, this also fixes the inherited bug in HsvAdjust
(which is a node graph using RgbToHsv and HsvToRgb).

Fixes #2765

This contribution was developed with AI assistance (Claude Code).