### PR TITLE
Add GitHub CI artifact for log files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,6 +373,13 @@ jobs:
         path: build/**/*.perfetto-trace
         if-no-files-found: ignore
 
+    - name: Upload Log Files
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+      if: always()
+      with:
+        name: Log_files_${{ matrix.name }}
+        path: build/bin/**/*.txt
+
   javascript:
     name: JavaScript
     runs-on: ubuntu-latest


### PR DESCRIPTION
The output from the tools invoked by genmdl (and rendermdl) is redirected to separate log files. This output is not visible in the regular CTest output and/or job log and makes it difficult to debug failures. The new artifact includes all *.txt files in build/bin.