### PR TITLE
Fix OSL definitions of matrix extract

### DIFF
--- a/libraries/stdlib/genosl/include/mx_funcs.h
+++ b/libraries/stdlib/genosl/include/mx_funcs.h
@@ -132,14 +132,14 @@ float mx_extract(vector4 in, int index)
     else return in.w;
 }
 
-vector mx_extract(matrix33 in, int index)
+vector mx_extract_matrix33(matrix in, int index)
 {
-    if (index == 0) return vector(in.m[0][0], in.m[0][1], in.m[0][2]);
-    else if (index == 1) return vector(in.m[1][0], in.m[1][1], in.m[1][2]);
-    else return vector(in.m[2][0], in.m[2][1], in.m[2][2]);
+    if (index == 0) return vector(in[0][0], in[0][1], in[0][2]);
+    else if (index == 1) return vector(in[1][0], in[1][1], in[1][2]);
+    else return vector(in[2][0], in[2][1], in[2][2]);
 }
 
-vector4 mx_extract(matrix in, int index)
+vector4 mx_extract_matrix44(matrix in, int index)
 {
     if (index == 0) return vector4(in[0][0], in[0][1], in[0][2], in[0][3]);
     else if (index == 1) return vector4(in[1][0], in[1][1], in[1][2], in[1][3]);

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -755,8 +755,8 @@
   <implementation name="IM_extract_vector2_genosl" nodedef="ND_extract_vector2" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
   <implementation name="IM_extract_vector3_genosl" nodedef="ND_extract_vector3" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
   <implementation name="IM_extract_vector4_genosl" nodedef="ND_extract_vector4" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
-  <implementation name="IM_extract_matrix33_genosl" nodedef="ND_extract_matrix33" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
-  <implementation name="IM_extract_matrix44_genosl" nodedef="ND_extract_matrix44" sourcecode="mx_extract({{in}}, {{index}})" target="genosl" />
+  <implementation name="IM_extract_matrix33_genosl" nodedef="ND_extract_matrix33" sourcecode="mx_extract_matrix33({{in}}, {{index}})" target="genosl" />
+  <implementation name="IM_extract_matrix44_genosl" nodedef="ND_extract_matrix44" sourcecode="mx_extract_matrix44({{in}}, {{index}})" target="genosl" />
 
   <!-- ======================================================================== -->
   <!-- Convolution nodes                                                        -->


### PR DESCRIPTION
This changelist fixes a function overload error in the OSL definitions of the matrix extract nodes.

Fixes https://github.com/AcademySoftwareFoundation/MaterialX/issues/2845.