### PR TITLE
Improve test logging in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
       run: cmake --build build --target install --config Release --parallel 2
 
     - name: CMake Unit Tests
-      run: ctest -VV --output-on-failure --build-config Release
+      run: ctest --output-on-failure --build-config Release
       working-directory: build
 
     - name: Python Tests
@@ -373,12 +373,13 @@ jobs:
         path: build/**/*.perfetto-trace
         if-no-files-found: ignore
 
-    - name: Upload Log Files
+    - name: Upload Test Logs
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       if: always()
       with:
-        name: Log_files_${{ matrix.name }}
+        name: TestLog_${{ matrix.name }}
         path: build/bin/**/*.txt
+        if-no-files-found: ignore
 
   javascript:
     name: JavaScript


### PR DESCRIPTION
This changelist reduces console noise and simplifies test logging artifacts in GitHub CI, including the following specific changes:

- Drop the `-VV` flag from the CTest invocation, so that verbose output is printed only for failing tests.
- Rename test log results to `TestLog_${{ matrix.name }}` for alignment across artifact names.
- Add `if-no-files-found: ignore` to the test log upload step, so that jobs without a test step don't generate warnings.