### PR TITLE
Improve build configuration in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 4
+  CTEST_PARALLEL_LEVEL: 4
+
 jobs:
 
   build:
@@ -35,6 +39,7 @@ jobs:
           compiler_version: "14"
           python: 3.13
           extended_build_perfetto: ON
+          extended_cmake_config: -DMATERIALX_BUILD_PERFETTO_TRACING=ON
 
         - name: Linux_GCC_14_Python314
           os: ubuntu-24.04
@@ -69,7 +74,7 @@ jobs:
           os: macos-14
           compiler: xcode
           compiler_version: "15.4"
-          cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON
+          cmake_config: -DMATERIALX_BUILD_SHARED_LIBS=ON -DMATERIALX_BUILD_DATA_LIBRARY=ON
           python: 3.11
 
         - name: MacOS_Xcode_16_Python313
@@ -79,6 +84,7 @@ jobs:
           python: 3.13
           test_shaders: ON
           test_render: ON
+          cmake_config: -DMATERIALX_TEST_RENDER=ON -DMATERIALX_RENDER_MSL_ONLY=ON
 
         - name: MacOS_Xcode_26_Python314
           os: macos-26
@@ -86,7 +92,7 @@ jobs:
           compiler_version: "26.0"
           python: 3.14
           static_analysis: ON
-          cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DMATERIALX_BUILD_DATA_LIBRARY=ON
+          cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
         - name: MacOS_Xcode_DynamicAnalysis
           os: macos-26
@@ -115,6 +121,7 @@ jobs:
           python: 3.13
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           extended_build_mdl_sdk: ON
+          extended_cmake_config: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-release -DMATERIALX_MDL_SDK_DIR=C:/vcpkg/installed/x64-windows-release
 
         - name: Windows_VS2022_x64_Python314
           os: windows-2025
@@ -123,6 +130,7 @@ jobs:
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
           test_shaders: ON
           extended_build_oiio: ON
+          extended_cmake_config: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DMATERIALX_BUILD_OIIO=ON
 
         - name: Windows_VS2022_x64_SharedLibs
           os: windows-2025
@@ -164,10 +172,12 @@ jobs:
           fi
         fi
 
-    - name: Install Dependencies (Windows)
+    - name: Setup Build Environment (Windows)
       if: runner.os == 'Windows'
       run: |
         Add-Content $env:GITHUB_PATH "$PWD/build/installed/bin"
+        # MSVC /MP already parallelizes within each project, so build projects serially.
+        Add-Content $env:GITHUB_ENV "CMAKE_BUILD_PARALLEL_LEVEL=1"
 
     - name: Install OpenImageIO
       if: env.IS_EXTENDED_BUILD == 'true' && matrix.extended_build_oiio == 'ON' && runner.os == 'Windows'
@@ -199,32 +209,16 @@ jobs:
     - name: CMake Generate
       shell: bash
       run: |
-        EXTENDED_BUILD_CONFIG=""
-        if [ "${{ env.IS_EXTENDED_BUILD }}" == "true" ]; then
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            EXTENDED_BUILD_CONFIG="-DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
-          fi
-          if [ "${{ matrix.extended_build_oiio }}" == "ON" ]; then
-            EXTENDED_BUILD_CONFIG="$EXTENDED_BUILD_CONFIG -DVCPKG_TARGET_TRIPLET=x64-windows -DMATERIALX_BUILD_OIIO=ON"
-          fi
-          if [ "${{ matrix.extended_build_mdl_sdk }}" == "ON" -a "${{ runner.os }}" == "Windows" ]; then
-            EXTENDED_BUILD_CONFIG="$EXTENDED_BUILD_CONFIG -DVCPKG_TARGET_TRIPLET=x64-windows-release -DMATERIALX_MDL_SDK_DIR=C:/vcpkg/installed/x64-windows-release"
-          fi
-          if [ "${{ matrix.extended_build_perfetto }}" == "ON" ]; then
-            EXTENDED_BUILD_CONFIG="$EXTENDED_BUILD_CONFIG -DMATERIALX_BUILD_PERFETTO_TRACING=ON"
-          fi
-        fi
-        TEST_RENDER_CONFIG="-DMATERIALX_TEST_RENDER=OFF"
-        if [ "${{ matrix.test_render }}" == "ON" ]; then
-          if [ "${{ runner.os }}" == "macOS" ]; then
-            TEST_RENDER_CONFIG="-DMATERIALX_TEST_RENDER=ON -DMATERIALX_RENDER_MSL_ONLY=ON"
-          fi
-        fi
-        EXTENDED_BUILD_CONFIG="$EXTENDED_BUILD_CONFIG $TEST_RENDER_CONFIG" 
-        cmake -S . -B build -DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_BUILD_VIEWER=ON -DMATERIALX_BUILD_GRAPH_EDITOR=ON -DMATERIALX_BUILD_TESTS=ON -DMATERIALX_WARNINGS_AS_ERRORS=ON $EXTENDED_BUILD_CONFIG ${{matrix.cmake_config}}
+        cmake -S . -B build \
+          -DMATERIALX_BUILD_VIEWER=ON -DMATERIALX_BUILD_GRAPH_EDITOR=ON \
+          -DMATERIALX_BUILD_PYTHON=ON \
+          -DMATERIALX_BUILD_TESTS=ON -DMATERIALX_TEST_RENDER=OFF \
+          -DMATERIALX_WARNINGS_AS_ERRORS=ON \
+          ${{ env.IS_EXTENDED_BUILD == 'true' && matrix.extended_cmake_config || '' }} \
+          ${{ matrix.cmake_config }}
 
     - name: CMake Build
-      run: cmake --build build --target install --config Release --parallel 2
+      run: cmake --build build --target install --config Release
 
     - name: CMake Unit Tests
       run: ctest --output-on-failure --build-config Release
@@ -294,14 +288,9 @@ jobs:
         echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
 
     - name: Setup Rendering Environment (MacOS)
-      if: matrix.test_render == 'ON' && runner.os == 'macOS'
+      if: matrix.test_render == 'ON' && runner.os == 'macOS' && env.IS_EXTENDED_BUILD == 'true'
       run: |
-        # macOS can render headless with Metal backend without virtual display
-        # Force software rendering for Metal backend (more reliable in CI)
-        echo "MTL_HARDWARE_RENDERING=0" >> $GITHUB_ENV
-        # Enable Metal debug layer for better debugging in CI
         echo "MTL_DEBUG_LAYER=1" >> $GITHUB_ENV
-        echo "LIBGL_ALWAYS_SOFTWARE=1" >> $GITHUB_ENV
 
     - name: Render Script Tests
       if: matrix.test_render == 'ON'
@@ -409,7 +398,7 @@ jobs:
       run: cmake -S . -B javascript/build -DMATERIALX_BUILD_JS=ON -DMATERIALX_EMSDK_PATH=${{ env.EMSDK }}
 
     - name: JavaScript CMake Build
-      run: cmake --build javascript/build --target install --config Release --parallel 2
+      run: cmake --build javascript/build --target install --config Release
     
     - name: Install JavaScript Dependencies
       run: |


### PR DESCRIPTION
This changelist improves the build configuration in GitHub CI, reducing duplication across the build matrix and adjusting parallelism per platform.  The following specific changes are included:

- Consolidate extended build configuration as a local `extended_cmake_config` field on each matrix row, reducing the CMake Generate step to a single call.
- Adjust build parallelism per platform through the CMAKE_BUILD_PARALLEL_LEVEL environment variable, defaulting to 4 and reduced to 1 on Windows, as the MSVC `/MP` flag already handles file-level parallelism within each project.
- Simplify the MacOS rendering setup to setting a debug flag in extended builds, as the `MTL_HARDWARE_RENDERING` and `LIBGL_ALWAYS_SOFTWARE` overrides are not actually supported in Metal rendering.