### PR TITLE
Omit `specular_weight` from metal edge tint in OpenPBR

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -424,14 +424,10 @@
       <input name="in1" type="color3" interfacename="base_color" />
       <input name="in2" type="float" interfacename="base_weight" />
     </multiply>
-    <multiply name="metal_edgecolor" type="color3">
-      <input name="in1" type="color3" interfacename="specular_color" />
-      <input name="in2" type="float" interfacename="specular_weight" />
-    </multiply>
     <generalized_schlick_bsdf name="metal_bsdf" type="BSDF">
       <input name="weight" type="float" interfacename="specular_weight" />
       <input name="color0" type="color3" nodename="metal_reflectivity" />
-      <input name="color82" type="color3" nodename="metal_edgecolor" />
+      <input name="color82" type="color3" interfacename="specular_color" />
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
       <input name="tangent" type="vector3" interfacename="geometry_tangent" />
@@ -439,7 +435,7 @@
     <generalized_schlick_bsdf name="metal_bsdf_tf" type="BSDF">
       <input name="weight" type="float" interfacename="specular_weight" />
       <input name="color0" type="color3" nodename="metal_reflectivity" />
-      <input name="color82" type="color3" nodename="metal_edgecolor" />
+      <input name="color82" type="color3" interfacename="specular_color" />
       <input name="roughness" type="vector2" nodename="main_roughness" />
       <input name="normal" type="vector3" interfacename="geometry_normal" />
       <input name="tangent" type="vector3" interfacename="geometry_tangent" />


### PR DESCRIPTION
This changelist removes `specular_weight` from the computation of metal edge tint in OpenPBR Surface, aligning the behavior of this shading model with a [proposed fix](https://github.com/AcademySoftwareFoundation/OpenPBR/pull/240) for OpenPBR 1.2.

As described in the proposed fix, the edge-tint color for the `generalized_schlick_bsdf` should not be multiplied by `specular_weight`, as the whole lobe is multiplied by `specular_weight` as well.