### PR TITLE
Fix crash on exit with a debug Python

### DIFF
--- a/source/PyMaterialX/PyMaterialXCore/PyException.cpp
+++ b/source/PyMaterialX/PyMaterialXCore/PyException.cpp
@@ -12,7 +12,7 @@ namespace mx = MaterialX;
 
 void bindPyException(py::module& mod)
 {
-    static py::exception<mx::Exception> pyException(mod, "Exception");
+    py::register_exception<mx::Exception>(mod, "Exception");
 
     py::register_exception_translator(
         [](std::exception_ptr errPtr)


### PR DESCRIPTION
Under the hood (in both before and after code), this statement is adding the Exception instance as an attribute to the module.

Other examples found using the pattern, suggesting the static variable scope was not needed:

- py::register_exception<mx::ExceptionOrphanedElement>(mod, "ExceptionOrphanedElement");
- py::register_exception<mx::ExceptionFoundCycle>(mod, "ExceptionFoundCycle");
- py::register_exception<mx::ExceptionParseError>(mod, "ExceptionParseError");
- py::register_exception<mx::ExceptionFileMissing>(mod, "ExceptionFileMissing");

Fixes https://github.com/AcademySoftwareFoundation/MaterialX/issues/2749