### PR TITLE
Update OpenPBR to v1.1.1

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -3,7 +3,7 @@
   <!--
     OpenPBR Surface node definition
   -->
-  <nodedef name="ND_open_pbr_surface_surfaceshader" node="open_pbr_surface" nodegroup="pbr" version="1.1" isdefaultversion="true"
+  <nodedef name="ND_open_pbr_surface_surfaceshader" node="open_pbr_surface" nodegroup="pbr" version="1.1.1" isdefaultversion="true"
            doc="OpenPBR Surface Shading Model" uiname="OpenPBR Surface">
     <input name="base_weight" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base Weight" uifolder="Base"
            doc="Multiplier on the intensity of the reflection from the diffuse and metallic base." />


### PR DESCRIPTION
This changelist updates the version string of OpenPBR Surface to `1.1.1`, aligning the MaterialX project with the latest release of OpenPBR at https://github.com/AcademySoftwareFoundation/OpenPBR/releases/tag/v1.1.1.