### PR TITLE
Load extraLibraryPaths before standard libraries in test suite

### DIFF
--- a/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.cpp
@@ -101,7 +101,11 @@ void ShaderRenderTester::loadDependentLibraries(TestRunState& runState)
 {
     runState.dependLib = mx::createDocument();
 
-    mx::loadLibraries({ "libraries" }, runState.searchPath, runState.dependLib);
+    // Load extra libraries BEFORE standard libraries so that extra
+    // implementations take priority. NodeDef::getImplementation() returns
+    // the first matching target, using document insertion order.
+    // This matches the behavior of MaterialXView and MaterialXGraphEditor
+    // where --library paths take precedence over standard libraries.
     for (size_t i = 0; i < runState.options.extraLibraryPaths.size(); i++)
     {
         const mx::FilePath& libraryPath = runState.options.extraLibraryPaths[i];
@@ -111,6 +115,7 @@ void ShaderRenderTester::loadDependentLibraries(TestRunState& runState)
             mx::loadLibrary((libraryPath / libraryFile), runState.dependLib);
         }
     }
+    mx::loadLibraries({ "libraries" }, runState.searchPath, runState.dependLib);
 
     // Load any additional per-renderer libraries
     loadAdditionalLibraries(runState.dependLib, runState.options);
@@ -463,6 +468,17 @@ void ShaderRenderTester::initializeGeneratorContext(TestRunState& runState, Test
     runState.context = std::make_unique<mx::GenContext>(_shaderGenerator);
     runState.context->registerSourceCodeSearchPath(runState.searchPath);
     runState.context->registerSourceCodeSearchPath(runState.searchPath.find("libraries/stdlib/genosl/include"));
+
+    // Register extra library paths as source code search paths so that
+    // wrapper source files in extra libraries can resolve #include directives
+    // for standard library source files.
+    for (size_t i = 0; i < runState.options.extraLibraryPaths.size(); i++)
+    {
+        runState.context->registerSourceCodeSearchPath(runState.options.extraLibraryPaths[i]);
+    }
+    // Also register the standard pbrlib genglsl source directory so that
+    // extra library wrappers can #include standard pbrlib source files.
+    runState.context->registerSourceCodeSearchPath(runState.searchPath.find("libraries/pbrlib/genglsl"));
 
     // Set target unit space
     runState.context->getOptions().targetDistanceUnit = "meter";


### PR DESCRIPTION
## Summary

Change the library loading order in MaterialXTest to load extra libraries **before** standard libraries, matching the behavior of MaterialXView and MaterialXGraphEditor where `--library` paths take precedence.

This allows `extraLibraryPaths` to provide override implementations for standard MaterialX nodes. `NodeDef::getImplementation()` returns the first matching target based on document insertion order, so loading overrides first ensures they are selected.

### Changes

- **Override-first loading**: Load `extraLibraryPaths` before `mx::loadLibraries({ "libraries" }, ...)` in `loadDependentLibraries()`
- **Source code search paths**: Register `extraLibraryPaths` and `libraries/pbrlib/genglsl` as source code search paths so that override implementations can `#include` standard library source files

### Motivation

MaterialXView already loads user-specified libraries first:
```cpp
// Append the standard library folder, giving it a lower precedence than user-supplied libraries.
libraryFolders.push_back("libraries");
```

The test suite should have the same behavior to enable testing of custom node implementations that override standard nodes.

## Test plan

- [x] Existing MaterialXTest render tests pass
- [ ] CI passes