### PR TITLE
Add specification proposal for maxcomponent and mincomponent nodes

### DIFF
--- a/documents/Specification/MaterialX.Proposals.md
+++ b/documents/Specification/MaterialX.Proposals.md
@@ -290,6 +290,25 @@ If adopted, the existing `triplanarprojection` node would be reimplemented as a 
 |`filtertype`|The type of texture filtering to use                                                           |string         |linear   |closest, linear, cubic|
 |`out`       |Output: the blended value                                                                      |Same as `inx`  |__zero__ |                      |
 
+<a id="node-maxcomponent"> </a>
+
+### `maxcomponent`
+Output the maximum of all components of the incoming vectorN or colorN stream as a float value.
+
+|Port |Description                          |Type            |Default  |
+|-----|-------------------------------------|----------------|---------|
+|`in` |The input value                      |vectorN, colorN |__zero__ |
+|`out`|Output: maximum component of `in`    |float           |0.0      |
+
+<a id="node-mincomponent"> </a>
+
+### `mincomponent`
+Output the minimum of all components of the incoming vectorN or colorN stream as a float value.
+
+|Port |Description                          |Type            |Default  |
+|-----|-------------------------------------|----------------|---------|
+|`in` |The input value                      |vectorN, colorN |__zero__ |
+|`out`|Output: minimum component of `in`    |float           |0.0      |
 
 
 ### Adjustment Nodes


### PR DESCRIPTION
## Summary

Add specification proposal for `maxcomponent` and `mincomponent` nodes to the Math Nodes section of the Specification Proposals document.

Closes #2802

## Description

Per the discussion in #2802 with @jstone-lucasfilm :

- These nodes support **all vectorN and colorN types** (`vector2`, `vector3`, `vector4`, `color3`,
`color4`)
- Output type is **float**

The proposal format follows existing nodes such as `magnitude` and `dotproduct` in the Standard Nodes document.

### Use Cases

As mentioned in the issue, two places in the MaterialX data libraries currently use verbose 5-node patterns (3 `extract` + 2 `max`/`min`) that these nodes would simplify to a single node:

1. **Sheen intensity for glTF PBR** (`libraries/bxdf/gltf_pbr.mtlx`) — uses `maxcomponent` pattern
2. **Absorption coefficient for OpenPBR Surface** (`libraries/bxdf/open_pbr_surface.mtlx`) — uses `mincomponent` pattern

### Scope

This PR addresses the specification proposal only.  I can work on the follow-up implementation via graph definitions as a
separate PR once the proposal is reviewed and merged.