### PR TITLE
Bug fix: downsample HiDPI framebuffers to the requested size when saving images

### DIFF
--- a/source/MaterialXView/RenderPipelineGL.cpp
+++ b/source/MaterialXView/RenderPipelineGL.cpp
@@ -532,7 +532,7 @@ void GLRenderPipeline::bakeTextures()
 mx::ImagePtr GLRenderPipeline::getFrameImage()
 {
     glFlush();
-    
+
     const auto& size = _viewer->m_size;
     const auto& pixel_ratio = _viewer->m_pixel_ratio;
 
@@ -543,6 +543,15 @@ mx::ImagePtr GLRenderPipeline::getFrameImage()
 
     // Read pixels into the image buffer.
     glReadPixels(0, 0, image->getWidth(), image->getHeight(), GL_RGB, GL_UNSIGNED_BYTE, image->getResourceBuffer());
+
+    // Downsample HiDPI framebuffers to the requested logical viewer size.
+    unsigned int downsampleFactor = (unsigned int) std::round(pixel_ratio);
+    if (downsampleFactor > 1 &&
+        image->getWidth() == (unsigned int) size.x() * downsampleFactor &&
+        image->getHeight() == (unsigned int) size.y() * downsampleFactor)
+    {
+        image = image->applyBoxDownsample(downsampleFactor);
+    }
 
     return image;
 }

--- a/source/MaterialXView/RenderPipelineMetal.mm
+++ b/source/MaterialXView/RenderPipelineMetal.mm
@@ -753,6 +753,20 @@ mx::ImagePtr MetalRenderPipeline::getFrameImage()
         memcpy(&resourceBuffer[(height - i - 1) * frame->getRowStride()],
                tmp.data(), frame->getRowStride());
     }
+
+    const unsigned int targetWidth = (unsigned int) _viewer->m_size.x();
+    const unsigned int targetHeight = (unsigned int) _viewer->m_size.y();
+    if (targetWidth > 0 && targetHeight > 0 &&
+        frame->getWidth() != targetWidth && frame->getHeight() != targetHeight &&
+        frame->getWidth() % targetWidth == 0 && frame->getHeight() % targetHeight == 0)
+    {
+        const unsigned int widthFactor = frame->getWidth() / targetWidth;
+        const unsigned int heightFactor = frame->getHeight() / targetHeight;
+        if (widthFactor == heightFactor && widthFactor > 1)
+        {
+            frame = frame->applyBoxDownsample(widthFactor);
+        }
+    }
     
     framebuffer = nullptr;
     unsigned int downsampleFactor = (unsigned int) std::round(_viewer->m_pixel_ratio);

--- a/source/MaterialXView/RenderPipelineMetal.mm
+++ b/source/MaterialXView/RenderPipelineMetal.mm
@@ -755,5 +755,12 @@ mx::ImagePtr MetalRenderPipeline::getFrameImage()
     }
     
     framebuffer = nullptr;
+    unsigned int downsampleFactor = (unsigned int) std::round(_viewer->m_pixel_ratio);
+    if (downsampleFactor > 1 &&
+        frame->getWidth() == (unsigned int) _viewer->m_size.x() * downsampleFactor &&
+        frame->getHeight() == (unsigned int) _viewer->m_size.y() * downsampleFactor)
+    {
+        frame = frame->applyBoxDownsample(downsampleFactor);
+    }
     return frame;
 }


### PR DESCRIPTION
While generating images for my MaterialX Fidelity Suite via the materialxview command line, I noticed that on high DPI devices, such as MacBooks, when you request an image at say 512x512 as an output, you'll get an image of size 1024x1024.  This is because currently the screen capture is an exact copy of what is in the screen buffer and the screen buffer, even thought it was requested to be 512x512, is actually because of HiDPI, 1024x1024 or some other resolution.  Thus I added this downsampling to get the correct size.

This fixes both GLSL and Metal backends.
