### PR TITLE
Remove multiple flips of the V texcoord in MaterialXView (upon glTF load and when accessing textures)

### DIFF
--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -160,7 +160,6 @@ RenderView::RenderView(mx::DocumentPtr doc,
 
     // Set default Glsl generator options.
     _genContext.getOptions().targetColorSpaceOverride = "lin_rec709";
-    _genContext.getOptions().fileTextureVerticalFlip = true;
     _genContext.getOptions().hwShadowMap = true;
     // Make sure all uniforms are added so value updates can
     // find the corresponding uniform.

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -128,7 +128,7 @@ void decodeVec4Tangents(MeshStreamPtr vec4TangentStream, MeshStreamPtr normalStr
 
 } // anonymous namespace
 
-bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool /*texcoordVerticalFlip*/)
+bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList)
 {
     const string input_filename = filePath.asString();
     const string ext = stringToLower(filePath.getExtension());

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -128,7 +128,7 @@ void decodeVec4Tangents(MeshStreamPtr vec4TangentStream, MeshStreamPtr normalStr
 
 } // anonymous namespace
 
-bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip)
+bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool /*texcoordVerticalFlip*/)
 {
     const string input_filename = filePath.asString();
     const string ext = stringToLower(filePath.getExtension());
@@ -396,14 +396,6 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                                 for (cgltf_size v = 0; v < desiredVectorSize; v++)
                                 {
                                     float floatValue = (v < vectorSize) ? input[v] : 0.0f;
-                                    // Perform v-flip
-                                    if (isTexCoordStream && v == 1)
-                                    {
-                                        if (!texcoordVerticalFlip)
-                                        {
-                                            floatValue = 1.0f - floatValue;
-                                        }
-                                    }
                                     buffer.push_back(floatValue);
                                 }
                             }

--- a/source/MaterialXRender/CgltfLoader.h
+++ b/source/MaterialXRender/CgltfLoader.h
@@ -32,7 +32,7 @@ class MX_RENDER_API CgltfLoader : public GeometryLoader
     static CgltfLoaderPtr create() { return std::make_shared<CgltfLoader>(); }
 
     /// Load geometry from file path
-    bool load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip = false) override;
+    bool load(const FilePath& filePath, MeshList& meshList) override;
 
   private:
     unsigned int _debugLevel;

--- a/source/MaterialXRender/GeometryHandler.cpp
+++ b/source/MaterialXRender/GeometryHandler.cpp
@@ -85,7 +85,7 @@ void GeometryHandler::computeBounds()
     }
 }
 
-bool GeometryHandler::loadGeometry(const FilePath& filePath, bool texcoordVerticalFlip)
+bool GeometryHandler::loadGeometry(const FilePath& filePath)
 {
     // Early return if already loaded
     if (hasGeometry(filePath))
@@ -102,7 +102,7 @@ bool GeometryHandler::loadGeometry(const FilePath& filePath, bool texcoordVertic
     GeometryLoaderMap::iterator last = --range.first;
     for (auto it = first; it != last; --it)
     {
-        loaded = it->second->load(filePath, _meshes, texcoordVerticalFlip);
+        loaded = it->second->load(filePath, _meshes);
         if (loaded)
         {
             break;

--- a/source/MaterialXRender/GeometryHandler.h
+++ b/source/MaterialXRender/GeometryHandler.h
@@ -42,9 +42,8 @@ class MX_RENDER_API GeometryLoader
     /// Load geometry from disk. Must be implemented by derived classes.
     /// @param filePath Path to file to load
     /// @param meshList List of meshes to update
-    /// @param texcoordVerticalFlip Flip texture coordinates in V when loading
     /// @return True if load was successful
-    virtual bool load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip = false) = 0;
+    virtual bool load(const FilePath& filePath, MeshList& meshList) = 0;
 
   protected:
     // List of supported string extensions
@@ -92,8 +91,7 @@ class MX_RENDER_API GeometryHandler
 
     /// Load geometry from a given location
     /// @param filePath Path to geometry
-    /// @param texcoordVerticalFlip Flip texture coordinates in V. Default is to not flip.
-    bool loadGeometry(const FilePath& filePath, bool texcoordVerticalFlip = false);
+    bool loadGeometry(const FilePath& filePath);
 
     /// Get list of meshes
     const MeshList& getMeshes() const

--- a/source/MaterialXRender/TinyObjLoader.cpp
+++ b/source/MaterialXRender/TinyObjLoader.cpp
@@ -48,7 +48,7 @@ using VertexIndexMap = std::unordered_map<VertexVector, uint32_t, VertexVector::
 // TinyObjLoader methods
 //
 
-bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip)
+bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList)
 {
     tinyobj::attrib_t attrib;
     vector<tinyobj::shape_t> shapes;
@@ -116,10 +116,6 @@ bool TinyObjLoader::load(const FilePath& filePath, MeshList& meshList, bool texc
                 if (indexObj.texcoord_index >= 0 && k < MeshStream::STRIDE_2D)
                 {
                     texcoord[k] = attrib.texcoords[indexObj.texcoord_index * MeshStream::STRIDE_2D + k];
-                }
-                if (texcoordVerticalFlip && k == 1)
-                {
-                    texcoord[k] = 1.0f - texcoord[k];
                 }
             }
 

--- a/source/MaterialXRender/TinyObjLoader.h
+++ b/source/MaterialXRender/TinyObjLoader.h
@@ -31,7 +31,7 @@ class MX_RENDER_API TinyObjLoader : public GeometryLoader
     static TinyObjLoaderPtr create() { return std::make_shared<TinyObjLoader>(); }
 
     /// Load geometry from disk
-    bool load(const FilePath& filePath, MeshList& meshList, bool texcoordVerticalFlip = false) override;
+    bool load(const FilePath& filePath, MeshList& meshList) override;
 };
 
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderGlsl/RenderGlsl.cpp
@@ -265,11 +265,8 @@ RenderUtil::RenderProfileResult GlslShaderRenderTester::runRenderer(
 
                 if (!geomHandler->hasGeometry(geomPath))
                 {
-                    // For test sphere and plane geometry perform a V-flip of texture coordinates.
-                    const std::string baseName = geomPath.getBaseName();
-                    bool texcoordVerticalFlip = baseName == "sphere.obj" || baseName == "plane.obj";
                     geomHandler->clearGeometry();
-                    geomHandler->loadGeometry(geomPath, texcoordVerticalFlip);
+                    geomHandler->loadGeometry(geomPath);
                     for (mx::MeshPtr mesh : geomHandler->getMeshes())
                     {
                         addAdditionalTestStreams(mesh);

--- a/source/MaterialXTest/MaterialXRenderMsl/RenderMsl.mm
+++ b/source/MaterialXTest/MaterialXRenderMsl/RenderMsl.mm
@@ -267,11 +267,8 @@ RenderUtil::RenderProfileResult MslShaderRenderTester::runRenderer(
 
                 if (!geomHandler->hasGeometry(geomPath))
                 {
-                    // For test sphere and plane geometry perform a V-flip of texture coordinates.
-                    const std::string baseName = geomPath.getBaseName();
-                    bool texcoordVerticalFlip = baseName == "sphere.obj" || baseName == "plane.obj";
                     geomHandler->clearGeometry();
-                    geomHandler->loadGeometry(geomPath, texcoordVerticalFlip);
+                    geomHandler->loadGeometry(geomPath);
                     for (mx::MeshPtr mesh : geomHandler->getMeshes())
                     {
                         addAdditionalTestStreams(mesh);

--- a/source/MaterialXTest/MaterialXRenderSlang/RenderSlang.cpp
+++ b/source/MaterialXTest/MaterialXRenderSlang/RenderSlang.cpp
@@ -260,11 +260,8 @@ RenderUtil::RenderProfileResult SlangShaderRenderTester::runRenderer(
 
                 if (!geomHandler->hasGeometry(geomPath))
                 {
-                    // For test sphere and plane geometry perform a V-flip of texture coordinates.
-                    const std::string baseName = geomPath.getBaseName();
-                    bool texcoordVerticalFlip = baseName == "sphere.obj" || baseName == "plane.obj";
                     geomHandler->clearGeometry();
-                    geomHandler->loadGeometry(geomPath, texcoordVerticalFlip);
+                    geomHandler->loadGeometry(geomPath);
                     for (mx::MeshPtr mesh : geomHandler->getMeshes())
                     {
                         addAdditionalTestStreams(mesh);

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -252,7 +252,6 @@ Viewer::Viewer(const std::string& materialFilename,
 
     // Set default Glsl generator options.
     _genContext.getOptions().targetColorSpaceOverride = "lin_rec709";
-    _genContext.getOptions().fileTextureVerticalFlip = true;
     _genContext.getOptions().hwShadowMap = true;
     _genContext.getOptions().hwImplicitBitangents = false;
 

--- a/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
+++ b/source/PyMaterialX/PyMaterialXRender/PyGeometryHandler.cpp
@@ -18,15 +18,14 @@ class PyGeometryLoader : public mx::GeometryLoader
     {
     }
 
-    bool load(const mx::FilePath& filePath, mx::MeshList& meshList, bool texcoordVerticalFlip = false) override
+    bool load(const mx::FilePath& filePath, mx::MeshList& meshList) override
     {
         PYBIND11_OVERLOAD_PURE(
             bool,
             mx::GeometryLoader,
             load,
             filePath,
-            meshList,
-            texcoordVerticalFlip
+            meshList
         );
     }
 };


### PR DESCRIPTION
Fixes the issue identified here: https://github.com/AcademySoftwareFoundation/MaterialX/issues/2881

The MaterialXViewer flips V texture coordinates of obis and glTF files upon load.  It also flips the V texture coordinate when accessing textures.  I believe both of these flips are incorrect.  Neither should exist.  This PR removes both of them.

It leads to simpler code but also now the UV space of a mesh does not have to be modified in order to render it.

Lastly, math operations in a flip UV space are not the same as in a non-flipped UV space.  Thus this flipped UV space leads to incorrect math results:

```
prefliped V with math != post-flipped V with math

flipV(V) + 0.1 != flipV( V + 0.1 )
( 1 - V ) + 0.1 != 1 - ( V + 0.1 )
1.1 - V != 0.9 - V
```

And also pre flipped + post-flipped V doesn't equal no flipping:
```
flipV( flipV(V) + 0.1 ) !== V + 0.1
1 - ( 1 - V + 0.1 ) != V + 0.1
1 - 1 + V - 0.1 != V + 0.1
V - 0.1 != V + 0.1
```