### PR TITLE
Support concurrent node definition in the same document

### DIFF
--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -1,9 +1,868 @@
 <?xml version="1.0"?>
 <materialx version="1.39">
   <!--
-    OpenPBR Surface node definition
+    OpenPBR Surface node definitions (v1.2 default, v1.1.1)
   -->
-  <nodedef name="ND_open_pbr_surface_surfaceshader" node="open_pbr_surface" nodegroup="pbr" version="1.1.1" isdefaultversion="true"
+
+  <!-- ============================================================ -->
+  <!--  OpenPBR Surface v1.2 (default)                              -->
+  <!-- ============================================================ -->
+
+  <nodedef name="ND_open_pbr_surface_surfaceshader" node="open_pbr_surface" nodegroup="pbr" version="1.2" isdefaultversion="true"
+           doc="OpenPBR Surface Shading Model" uiname="OpenPBR Surface">
+    <input name="base_weight" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base Weight" uifolder="Base"
+           doc="Multiplier on the intensity of the reflection from the diffuse and metallic base." />
+    <input name="base_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Base Color" uifolder="Base"
+           doc="Color of the reflection from the diffuse and metallic base." />
+    <input name="base_diffuse_roughness" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Base Diffuse Roughness" uifolder="Base" uiadvanced="true"
+           doc="Roughness of the diffuse reflection. Higher values cause the surface to appear flatter." />
+    <input name="base_metalness" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Base Metalness" uifolder="Base"
+           doc="Specifies how metallic the base material appears (dials the base from pure dielectric to pure metal)." />
+    <input name="specular_weight" type="float" value="1.0" uimin="0.0" uisoftmax="1.0" uiname="Specular Weight" uifolder="Specular"
+           doc="Multiplies the specular reflectivity." />
+    <input name="specular_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Specular Color" uifolder="Specular"
+           doc="Color of the specular reflection (controls the physical edge-tint for metals, and a non-physical overall tint for dielectrics)." />
+    <input name="specular_roughness" type="float" value="0.3" uimin="0.0" uimax="1.0" uiname="Specular Roughness" uifolder="Specular"
+           doc="The roughness of the specular reflection. Lower numbers produce sharper reflections, higher numbers produce blurrier reflections." />
+    <input name="specular_ior" type="float" value="1.5" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Specular Index of Refraction" uifolder="Specular"
+           doc="Index of refraction of the dielectric base." />
+    <input name="specular_roughness_anisotropy" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Specular Anisotropy" uifolder="Specular" uiadvanced="true"
+           doc="The directional bias of the roughness of the metal/dielectric base, resulting in increasingly stretched highlights along the tangent direction." />
+    <input name="specular_haze" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Specular Haze" uifolder="Specular" uiadvanced="true"
+           doc="Mix weight of a secondary specular lobe for a hazy gloss appearance." />
+    <input name="specular_haze_spread" type="float" value="0.3" uimin="0.0" uimax="1.0" uiname="Specular Haze Spread" uifolder="Specular" uiadvanced="true"
+           doc="Extra roughness of the secondary haze lobe, interpolating between core roughness and 1." />
+    <input name="transmission_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Transmission Weight" uifolder="Transmission" uiadvanced="true" hint="transparency"
+           doc="Mixture weight between the transparent and opaque dielectric base. The greater the value the more transparent the material." />
+    <input name="transmission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Color" uifolder="Transmission" uiadvanced="true"
+           doc="Controls color of the transparent base due to Beer's law volumetric absorption under the surface (reverts to a non-physical tint when transmission_depth is zero)." />
+    <input name="transmission_depth" type="float" value="0.0" uimin="0.0" uisoftmax="1.0" uiname="Transmission Depth" uifolder="Transmission" uiadvanced="true"
+           doc="Specifies the distance light travels inside the transparent base before it becomes exactly the transmission_color according to Beer's law." />
+    <input name="transmission_scatter" type="color3" value="0, 0, 0" uimin="0,0,0" uimax="1,1,1" uiname="Transmission Scatter" uifolder="Transmission" uiadvanced="true"
+           doc="Controls the color of light volumetrically scattered inside the transparent base. Suitable for materials with visually significant scattering such as honey, fruit juice, murky water, opalescent glass, or milky glass." />
+    <input name="transmission_scatter_anisotropy" type="float" value="0.0" uimin="-1.0" uimax="1.0" uiname="Transmission Anisotropy" uifolder="Transmission" uiadvanced="true"
+           doc="The amount of directional bias, or anisotropy, of the volumetric scattering in the transparent base." />
+    <input name="transmission_dispersion_scale" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Transmission Dispersion Scale" uifolder="Transmission" uiadvanced="true"
+           doc="Linearly scales the amount of dispersion." />
+    <input name="transmission_dispersion_abbe_number" type="float" value="20.0" uimin="0.0" uisoftmin="9.0" uisoftmax="91.0" uiname="Transmission Dispersion Abbe Number" uifolder="Transmission" uiadvanced="true"
+           doc="Physical Abbe number of the dielectric medium, describing how much the dielectric index of refraction varies across wavelengths." />
+    <input name="subsurface_weight" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Subsurface Weight" uifolder="Subsurface" uiadvanced="true"
+           doc="Mixture weight which dials the opaque dielectric base between diffuse reflection and subsurface scattering. A value of 1.0 indicates full subsurface scattering and a value 0 for diffuse reflection only." />
+    <input name="subsurface_color" type="color3" value="0.8, 0.8, 0.8" uimin="0,0,0" uimax="1,1,1" uiname="Subsurface Color" uifolder="Subsurface" uiadvanced="true"
+           doc="The observed reflection color of the subsurface scattering medium." />
+    <input name="subsurface_radius" type="float" value="1.0" uimin="0.0" uisoftmax="1.0" uiname="Subsurface Radius" uifolder="Subsurface" uiadvanced="true"
+           doc="Length scale of the subsurface scattering mean free path." />
+    <input name="subsurface_radius_scale" type="color3" value="1.0, 0.5, 0.25" uimin="0,0,0" uimax="1,1,1" uiname="Subsurface Radius Scale" uifolder="Subsurface" uiadvanced="true"
+           doc="RGB multiplier to subsurface_radius, giving the per-channel scattering mean-free-paths." />
+    <input name="subsurface_scatter_anisotropy" type="float" value="0.0" uimin="-1.0" uimax="1.0" uiname="Subsurface Anisotropy" uifolder="Subsurface" uiadvanced="true"
+           doc="Controls the phase-function of subsurface scattering, where zero scatters light evenly, positive values scatter forwards, and negative values scatter backwards." />
+    <input name="fuzz_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Fuzz Weight" uifolder="Fuzz" uiadvanced="true"
+           doc="The presence weight of a fuzz layer that can be used to approximate microfibers, for fabrics such as velvet and satin as well as dust grains." />
+    <input name="fuzz_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Fuzz Color" uifolder="Fuzz" uiadvanced="true"
+           doc="The color of the fuzz layer." />
+    <input name="fuzz_roughness" type="float" value="0.5" uimin="0.0" uimax="1.0" uiname="Fuzz Roughness" uifolder="Fuzz" uiadvanced="true"
+           doc="The roughness of the fuzz layer." />
+    <input name="coat_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Weight" uifolder="Coat"
+           doc="The presence weight of a reflective clear-coat layer on top of the material. Use for materials such as car paint or an oily layer." />
+    <input name="coat_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Coat Color" uifolder="Coat"
+           doc="The color of the clear-coat layer's transparency, due to absorption in the coat." />
+    <input name="coat_roughness" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Roughness" uifolder="Coat"
+           doc="The roughness of the clear-coat reflections. The lower the value, the sharper the reflection." />
+    <input name="coat_roughness_anisotropy" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Coat Anisotropy" uifolder="Coat" uiadvanced="true"
+           doc="The directional bias of the roughness of the clear-coat layer, resulting in increasingly stretched highlights along the coat tangent direction." />
+    <input name="coat_ior" type="float" value="1.6" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Coat Index of Refraction" uifolder="Coat"
+           doc="The index of refraction of the clear-coat layer." />
+    <input name="coat_darkening" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Coat Darkening" uifolder="Coat"
+           doc="Modulates the physical coat darkening effect." />
+    <input name="thin_film_weight" type="float" value="0" uimin="0.0" uimax="1.0" uiname="Thin Film Weight" uifolder="Thin Film" uiadvanced="true"
+           doc="Coverage weight of the thin-film. Use for materials such as multi-tone car paint or soap bubbles." />
+    <input name="thin_film_thickness" type="float" value="0.5" uimin="0.0" uisoftmax="1.0" uiname="Thin Film Thickness" uifolder="Thin Film" uiadvanced="true"
+           doc="The thickness of the thin-film layer on the base (in micrometers)." />
+    <input name="thin_film_ior" type="float" value="1.4" uimin="0.0" uisoftmin="1.0" uisoftmax="3.0" uiname="Thin Film Index of Refraction" uifolder="Thin Film" uiadvanced="true"
+           doc="The index of refraction of the thin-film." />
+    <input name="emission_weight" type="float" value="0.0" uimin="0.0" uimax="1.0" uiname="Emission Weight" uifolder="Emission"
+           doc="Emission weight luminance multiplier." />
+    <input name="emission_luminance" type="float" value="0.0" uimin="0.0" uisoftmax="1000.0" uiname="Emission Luminance" uifolder="Emission"
+           doc="The amount of emitted light, as a luminance in nits." />
+    <input name="emission_color" type="color3" value="1, 1, 1" uimin="0,0,0" uimax="1,1,1" uiname="Emission Color" uifolder="Emission"
+           doc="The color of the emitted light." />
+    <input name="geometry_opacity" type="float" value="1" uimin="0" uimax="1" uiname="Opacity" uifolder="Geometry" hint="opacity"
+           doc="The opacity of the entire material." />
+    <input name="geometry_thin_walled" type="boolean" value="false" uniform="true" uiname="Thin Walled" uifolder="Geometry" uiadvanced="true"
+           doc="If true the surface is double-sided and represents an infinitesimally thin shell. Suitable for extremely geometrically thin objects such as leaves or paper." />
+    <input name="geometry_normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" uifolder="Geometry"
+           doc="Input geometric normal" />
+    <input name="geometry_coat_normal" type="vector3" defaultgeomprop="Nworld" uiname="Coat Normal" uifolder="Geometry"
+           doc="Input normal for coat layer" />
+    <input name="geometry_tangent" type="vector3" defaultgeomprop="Tworld" uiname="Tangent" uifolder="Geometry"
+           doc="Input geometric tangent" />
+    <input name="geometry_coat_tangent" type="vector3" defaultgeomprop="Tworld" uiname="Coat Tangent" uifolder="Geometry"
+           doc="Input geometric tangent for coat layer" />
+    <output name="out" type="surfaceshader" />
+  </nodedef>
+
+  <!--
+    OpenPBR Surface v1.2 graph definition
+  -->
+  <nodegraph name="NG_open_pbr_surface_surfaceshader" nodedef="ND_open_pbr_surface_surfaceshader">
+
+    <!-- Sanitize inputs according to OpenPBR Surface parameter reference (Section 4 of the spec)-->
+    <clamp name="base_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="base_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="base_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="base_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="base_diffuse_roughness_clamped" type="float">
+      <input name="in" type="float" interfacename="base_diffuse_roughness" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="base_metalness_clamped" type="float">
+      <input name="in" type="float" interfacename="base_metalness" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="specular_weight_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="specular_weight" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="specular_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="specular_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="specular_roughness_clamped" type="float">
+      <input name="in" type="float" interfacename="specular_roughness" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="specular_ior_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="specular_ior" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="specular_roughness_anisotropy_clamped" type="float">
+      <input name="in" type="float" interfacename="specular_roughness_anisotropy" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="specular_haze_clamped" type="float">
+      <input name="in" type="float" interfacename="specular_haze" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="specular_haze_spread_clamped" type="float">
+      <input name="in" type="float" interfacename="specular_haze_spread" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="transmission_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="transmission_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="transmission_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="transmission_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="transmission_depth_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="transmission_depth" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="transmission_scatter_clamped" type="color3">
+      <input name="in" type="color3" interfacename="transmission_scatter" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="transmission_scatter_anisotropy_clamped" type="float">
+      <input name="in" type="float" interfacename="transmission_scatter_anisotropy" />
+      <input name="low" type="float" value="-1.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="subsurface_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="subsurface_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="subsurface_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="subsurface_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="subsurface_radius_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="subsurface_radius" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="subsurface_radius_scale_clamped" type="color3">
+      <input name="in" type="color3" interfacename="subsurface_radius_scale" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="subsurface_scatter_anisotropy_clamped" type="float">
+      <input name="in" type="float" interfacename="subsurface_scatter_anisotropy" />
+      <input name="low" type="float" value="-1.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="fuzz_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="fuzz_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="fuzz_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="fuzz_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="fuzz_roughness_clamped" type="float">
+      <input name="in" type="float" interfacename="fuzz_roughness" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="coat_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="coat_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="coat_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="coat_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="coat_roughness_clamped" type="float">
+      <input name="in" type="float" interfacename="coat_roughness" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="coat_roughness_anisotropy_clamped" type="float">
+      <input name="in" type="float" interfacename="coat_roughness_anisotropy" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="coat_ior_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="coat_ior" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="coat_darkening_clamped" type="float">
+      <input name="in" type="float" interfacename="coat_darkening" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="thin_film_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="thin_film_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="thin_film_thickness_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="thin_film_thickness" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <max name="thin_film_ior_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="thin_film_ior" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="emission_weight_clamped" type="float">
+      <input name="in" type="float" interfacename="emission_weight" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <max name="emission_luminance_nonnegative" type="float">
+      <input name="in1" type="float" interfacename="emission_luminance" />
+      <input name="in2" type="float" value="0.0" />
+    </max>
+    <clamp name="emission_color_clamped" type="color3">
+      <input name="in" type="color3" interfacename="emission_color" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+    <clamp name="geometry_opacity_clamped" type="float">
+      <input name="in" type="float" interfacename="geometry_opacity" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="1.0" />
+    </clamp>
+
+    <!-- Roughening due to coat-->
+    <power name="coat_roughness_to_power_4" type="float">
+      <input name="in1" type="float" nodename="coat_roughness_clamped" />
+      <input name="in2" type="float" value="4.0" />
+    </power>
+    <multiply name="two_times_coat_roughness_to_power_4" type="float">
+      <input name="in1" type="float" nodename="coat_roughness_to_power_4" />
+      <input name="in2" type="float" value="2.0" />
+    </multiply>
+    <power name="specular_roughness_to_power_4" type="float">
+      <input name="in1" type="float" nodename="specular_roughness_clamped" />
+      <input name="in2" type="float" value="4.0" />
+    </power>
+    <add name="add_coat_and_spec_roughnesses_to_power_4" type="float">
+      <input name="in1" type="float" nodename="two_times_coat_roughness_to_power_4" />
+      <input name="in2" type="float" nodename="specular_roughness_to_power_4" />
+    </add>
+    <min name="min_1_add_coat_and_spec_roughnesses_to_power_4" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="add_coat_and_spec_roughnesses_to_power_4" />
+    </min>
+    <power name="coat_affected_specular_roughness" type="float">
+      <input name="in1" type="float" nodename="min_1_add_coat_and_spec_roughnesses_to_power_4" />
+      <input name="in2" type="float" value="0.25" />
+    </power>
+    <mix name="effective_specular_roughness" type="float">
+      <input name="fg" type="float" nodename="coat_affected_specular_roughness" />
+      <input name="bg" type="float" nodename="specular_roughness_clamped" />
+      <input name="mix" type="float" nodename="coat_weight_clamped" />
+    </mix>
+
+    <!-- Calculate main specular roughness -->
+    <open_pbr_anisotropy name="main_roughness" type="vector2">
+      <input name="roughness" type="float" nodename="effective_specular_roughness" />
+      <input name="anisotropy" type="float" nodename="specular_roughness_anisotropy_clamped" />
+    </open_pbr_anisotropy>
+
+    <!-- Calculate haze specular roughness -->
+    <!-- r_haze = lerp(specular_roughness, 1.0, specular_haze_spread) -->
+    <mix name="haze_roughness_base" type="float">
+      <input name="fg" type="float" value="1.0" />
+      <input name="bg" type="float" nodename="specular_roughness_clamped" />
+      <input name="mix" type="float" nodename="specular_haze_spread_clamped" />
+    </mix>
+    <!-- Apply coat roughening to haze roughness -->
+    <power name="haze_roughness_to_power_4" type="float">
+      <input name="in1" type="float" nodename="haze_roughness_base" />
+      <input name="in2" type="float" value="4.0" />
+    </power>
+    <add name="add_coat_and_haze_roughnesses_to_power_4" type="float">
+      <input name="in1" type="float" nodename="two_times_coat_roughness_to_power_4" />
+      <input name="in2" type="float" nodename="haze_roughness_to_power_4" />
+    </add>
+    <min name="min_1_add_coat_and_haze_roughnesses_to_power_4" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="add_coat_and_haze_roughnesses_to_power_4" />
+    </min>
+    <power name="coat_affected_haze_roughness" type="float">
+      <input name="in1" type="float" nodename="min_1_add_coat_and_haze_roughnesses_to_power_4" />
+      <input name="in2" type="float" value="0.25" />
+    </power>
+    <mix name="effective_haze_roughness" type="float">
+      <input name="fg" type="float" nodename="coat_affected_haze_roughness" />
+      <input name="bg" type="float" nodename="haze_roughness_base" />
+      <input name="mix" type="float" nodename="coat_weight_clamped" />
+    </mix>
+    <open_pbr_anisotropy name="haze_roughness" type="vector2">
+      <input name="roughness" type="float" nodename="effective_haze_roughness" />
+      <input name="anisotropy" type="float" nodename="specular_roughness_anisotropy_clamped" />
+    </open_pbr_anisotropy>
+
+    <!-- Subsurface (thin-walled) -->
+    <oren_nayar_diffuse_bsdf name="subsurface_thin_walled_reflection_bsdf" type="BSDF">
+      <input name="color" type="color3" nodename="subsurface_color_clamped" />
+      <input name="roughness" type="float" nodename="base_diffuse_roughness_clamped" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+    </oren_nayar_diffuse_bsdf>
+    <translucent_bsdf name="subsurface_thin_walled_transmission_bsdf" type="BSDF">
+      <input name="color" type="color3" nodename="subsurface_color_clamped" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+    </translucent_bsdf>
+    <subtract name="one_minus_subsurface_scatter_anisotropy" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="subsurface_scatter_anisotropy_clamped" />
+    </subtract>
+    <multiply name="subsurface_thin_walled_brdf_mix_factor" type="float">
+      <input name="in1" type="float" value="0.5" />
+      <input name="in2" type="float" nodename="one_minus_subsurface_scatter_anisotropy" />
+    </multiply>
+    <mix name="subsurface_thin_walled" type="BSDF">
+      <input name="fg" type="BSDF" nodename="subsurface_thin_walled_reflection_bsdf" />
+      <input name="bg" type="BSDF" nodename="subsurface_thin_walled_transmission_bsdf" />
+      <input name="mix" type="float" nodename="subsurface_thin_walled_brdf_mix_factor" />
+    </mix>
+
+    <!-- Subsurface (non-thin-walled) -->
+    <multiply name="subsurface_radius_scaled" type="color3">
+      <input name="in1" type="color3" nodename="subsurface_radius_scale_clamped" />
+      <input name="in2" type="float" nodename="subsurface_radius_nonnegative" />
+    </multiply>
+    <subsurface_bsdf name="subsurface_bsdf" type="BSDF">
+      <input name="color" type="color3" nodename="subsurface_color_clamped" />
+      <input name="radius" type="color3" nodename="subsurface_radius_scaled" />
+      <input name="anisotropy" type="float" nodename="subsurface_scatter_anisotropy_clamped" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+    </subsurface_bsdf>
+
+    <!-- Opaque Dielectric Base -->
+    <oren_nayar_diffuse_bsdf name="diffuse_bsdf" type="BSDF">
+      <input name="weight" type="float" nodename="base_weight_clamped" />
+      <input name="color" type="color3" nodename="base_color_clamped" />
+      <input name="roughness" type="float" nodename="base_diffuse_roughness_clamped" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="energy_compensation" type="boolean" value="true" />
+    </oren_nayar_diffuse_bsdf>
+    <convert name="subsurface_selector" type="float">
+      <input name="in" type="boolean" interfacename="geometry_thin_walled" />
+    </convert>
+    <mix name="selected_subsurface" type="BSDF">
+      <input name="fg" type="BSDF" nodename="subsurface_thin_walled" />
+      <input name="bg" type="BSDF" nodename="subsurface_bsdf" />
+      <input name="mix" type="float" nodename="subsurface_selector" />
+    </mix>
+    <mix name="opaque_base" type="BSDF">
+      <input name="fg" type="BSDF" nodename="selected_subsurface" />
+      <input name="bg" type="BSDF" nodename="diffuse_bsdf" />
+      <input name="mix" type="float" nodename="subsurface_weight_clamped" />
+    </mix>
+
+    <!-- Dielectric Base VDF -->
+    <convert name="transmission_color_vector" type="vector3">
+      <input name="in" type="color3" nodename="transmission_color_clamped" />
+    </convert>
+    <ln name="transmission_color_ln" type="vector3">
+      <input name="in" type="vector3" nodename="transmission_color_vector" />
+    </ln>
+    <multiply name="extinction_coeff_denom" type="vector3">
+      <input name="in1" type="vector3" nodename="transmission_color_ln" />
+      <input name="in2" type="float" value="-1.0" />
+    </multiply>
+    <convert name="transmission_depth_vector" type="vector3">
+      <input name="in" type="float" nodename="transmission_depth_nonnegative" />
+    </convert>
+    <divide name="extinction_coeff" type="vector3">
+      <input name="in1" type="vector3" nodename="extinction_coeff_denom" />
+      <input name="in2" type="vector3" nodename="transmission_depth_vector" />
+    </divide>
+    <convert name="transmission_scatter_albedo_vector" type="vector3">
+      <input name="in" type="color3" nodename="transmission_scatter_clamped" />
+    </convert>
+    <multiply name="scattering_coeff" type="vector3">
+      <input name="in1" type="vector3" nodename="transmission_scatter_albedo_vector" />
+      <input name="in2" type="vector3" nodename="extinction_coeff" />
+    </multiply>
+    <subtract name="absorption_coeff" type="vector3">
+      <input name="in1" type="vector3" nodename="extinction_coeff" />
+      <input name="in2" type="vector3" nodename="scattering_coeff" />
+    </subtract>
+    <ifgreater name="if_volume_absorption" type="vector3">
+      <input name="value1" type="float" nodename="transmission_depth_nonnegative" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="vector3" nodename="absorption_coeff" />
+      <input name="in2" type="vector3" value="0.0,0.0,0.0" />
+    </ifgreater>
+    <ifgreater name="if_volume_scattering" type="vector3">
+      <input name="value1" type="float" nodename="transmission_depth_nonnegative" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="vector3" nodename="scattering_coeff" />
+      <input name="in2" type="vector3" value="0.0,0.0,0.0" />
+    </ifgreater>
+    <anisotropic_vdf name="dielectric_volume" type="VDF">
+      <input name="absorption" type="vector3" nodename="if_volume_absorption" />
+      <input name="scattering" type="vector3" nodename="if_volume_scattering" />
+      <input name="anisotropy" type="float" nodename="transmission_scatter_anisotropy_clamped" />
+    </anisotropic_vdf>
+
+    <!-- Thin-film Thickness -->
+    <multiply name="thin_film_thickness_nm" type="float">
+      <input name="in1" type="float" nodename="thin_film_thickness_nonnegative" />
+      <input name="in2" type="float" value="1000.0" />
+    </multiply>
+
+    <!-- Dielectric Base -->
+    <!-- apply IOR ratio inversion method to avoid TIR artifact (as in Coat TIR section of spec) -->
+    <divide name="specular_to_coat_ior_ratio" type="float">
+      <input name="in1" type="float" nodename="specular_ior_nonnegative" />
+      <input name="in2" type="float" nodename="coat_ior_nonnegative" />
+    </divide>
+    <divide name="coat_to_specular_ior_ratio" type="float">
+      <input name="in1" type="float" nodename="coat_ior_nonnegative" />
+      <input name="in2" type="float" nodename="specular_ior_nonnegative" />
+    </divide>
+    <ifgreater name="specular_to_coat_ior_ratio_tir_fix" type="float">
+      <input name="value1" type="float" nodename="specular_to_coat_ior_ratio" />
+      <input name="value2" type="float" value="1.0" />
+      <input name="in1" type="float" nodename="specular_to_coat_ior_ratio" />
+      <input name="in2" type="float" nodename="coat_to_specular_ior_ratio" />
+    </ifgreater>
+    <mix name="eta_s" type="float">
+      <input name="fg" type="float" nodename="specular_to_coat_ior_ratio_tir_fix" />
+      <input name="bg" type="float" nodename="specular_ior_nonnegative" />
+      <input name="mix" type="float" nodename="coat_weight_clamped" />
+    </mix>
+    <subtract name="eta_s_minus_one" type="float">
+      <input name="in1" type="float" nodename="eta_s" />
+      <input name="in2" type="float" value="1.0" />
+    </subtract>
+    <add name="eta_s_plus_one" type="float">
+      <input name="in1" type="float" nodename="eta_s" />
+      <input name="in2" type="float" value="1.0" />
+    </add>
+    <divide name="specular_F0_sqrt" type="float">
+      <input name="in1" type="float" nodename="eta_s_minus_one" />
+      <input name="in2" type="float" nodename="eta_s_plus_one" />
+    </divide>
+    <multiply name="specular_F0" type="float">
+      <input name="in1" type="float" nodename="specular_F0_sqrt" />
+      <input name="in2" type="float" nodename="specular_F0_sqrt" />
+    </multiply>
+    <multiply name="scaled_specular_F0" type="float">
+      <input name="in1" type="float" nodename="specular_weight_nonnegative" />
+      <input name="in2" type="float" nodename="specular_F0" />
+    </multiply>
+    <clamp name="scaled_specular_F0_clamped" type="float">
+      <input name="in" type="float" nodename="scaled_specular_F0" />
+      <input name="low" type="float" value="0.0" />
+      <input name="high" type="float" value="0.99999" />
+    </clamp>
+    <sqrt name="sqrt_scaled_specular_F0" type="float">
+      <input name="in" type="float" nodename="scaled_specular_F0_clamped" />
+    </sqrt>
+    <sign name="sign_eta_s_minus_one" type="float">
+      <input name="in" type="float" nodename="eta_s_minus_one" />
+    </sign>
+    <multiply name="modulated_eta_s_epsilon" type="float">
+      <input name="in1" type="float" nodename="sign_eta_s_minus_one" />
+      <input name="in2" type="float" nodename="sqrt_scaled_specular_F0" />
+    </multiply>
+    <subtract name="one_minus_modulated_eta_s_epsilon" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="modulated_eta_s_epsilon" />
+    </subtract>
+    <add name="one_plus_modulated_eta_s_epsilon" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="modulated_eta_s_epsilon" />
+    </add>
+    <divide name="modulated_eta_s" type="float">
+      <input name="in1" type="float" nodename="one_plus_modulated_eta_s_epsilon" />
+      <input name="in2" type="float" nodename="one_minus_modulated_eta_s_epsilon" />
+    </divide>
+    <ifgreater name="if_transmission_tint" type="color3">
+      <input name="value1" type="float" nodename="transmission_depth_nonnegative" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="in2" type="color3" nodename="transmission_color_clamped" />
+    </ifgreater>
+    <dielectric_bsdf name="dielectric_transmission" type="BSDF">
+      <input name="tint" type="color3" nodename="if_transmission_tint" />
+      <input name="ior" type="float" nodename="eta_s" />
+      <input name="roughness" type="vector2" nodename="main_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="scatter_mode" type="string" value="T" />
+    </dielectric_bsdf>
+    <layer name="dielectric_volume_transmission" type="BSDF">
+      <input name="top" type="BSDF" nodename="dielectric_transmission" />
+      <input name="base" type="VDF" nodename="dielectric_volume" />
+    </layer>
+    <mix name="dielectric_substrate" type="BSDF">
+      <input name="fg" type="BSDF" nodename="dielectric_volume_transmission" />
+      <input name="bg" type="BSDF" nodename="opaque_base" />
+      <input name="mix" type="float" nodename="transmission_weight_clamped" />
+    </mix>
+    <dielectric_bsdf name="dielectric_reflection" type="BSDF">
+      <input name="tint" type="color3" nodename="specular_color_clamped" />
+      <input name="ior" type="float" nodename="modulated_eta_s" />
+      <input name="roughness" type="vector2" nodename="main_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="scatter_mode" type="string" value="R" />
+    </dielectric_bsdf>
+    <dielectric_bsdf name="dielectric_reflection_tf" type="BSDF">
+      <input name="tint" type="color3" nodename="specular_color_clamped" />
+      <input name="ior" type="float" nodename="modulated_eta_s" />
+      <input name="roughness" type="vector2" nodename="main_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="scatter_mode" type="string" value="R" />
+      <input name="thinfilm_thickness" type="float" nodename="thin_film_thickness_nm" />
+      <input name="thinfilm_ior" type="float" nodename="thin_film_ior_nonnegative" />
+    </dielectric_bsdf>
+    <mix name="dielectric_reflection_tf_mix" type="BSDF">
+      <input name="fg" type="BSDF" nodename="dielectric_reflection_tf" />
+      <input name="bg" type="BSDF" nodename="dielectric_reflection" />
+      <input name="mix" type="float" nodename="thin_film_weight_clamped" />
+    </mix>
+
+    <!-- Dielectric Haze -->
+    <dielectric_bsdf name="dielectric_reflection_haze" type="BSDF">
+      <input name="tint" type="color3" nodename="specular_color_clamped" />
+      <input name="ior" type="float" nodename="modulated_eta_s" />
+      <input name="roughness" type="vector2" nodename="haze_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="scatter_mode" type="string" value="R" />
+    </dielectric_bsdf>
+    <dielectric_bsdf name="dielectric_reflection_haze_tf" type="BSDF">
+      <input name="tint" type="color3" nodename="specular_color_clamped" />
+      <input name="ior" type="float" nodename="modulated_eta_s" />
+      <input name="roughness" type="vector2" nodename="haze_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="scatter_mode" type="string" value="R" />
+      <input name="thinfilm_thickness" type="float" nodename="thin_film_thickness_nm" />
+      <input name="thinfilm_ior" type="float" nodename="thin_film_ior_nonnegative" />
+    </dielectric_bsdf>
+    <mix name="dielectric_reflection_haze_tf_mix" type="BSDF">
+      <input name="fg" type="BSDF" nodename="dielectric_reflection_haze_tf" />
+      <input name="bg" type="BSDF" nodename="dielectric_reflection_haze" />
+      <input name="mix" type="float" nodename="thin_film_weight_clamped" />
+    </mix>
+    <mix name="dielectric_reflection_with_haze" type="BSDF">
+      <input name="fg" type="BSDF" nodename="dielectric_reflection_haze_tf_mix" />
+      <input name="bg" type="BSDF" nodename="dielectric_reflection_tf_mix" />
+      <input name="mix" type="float" nodename="specular_haze_clamped" />
+    </mix>
+    <layer name="dielectric_base" type="BSDF">
+      <input name="top" type="BSDF" nodename="dielectric_reflection_with_haze" />
+      <input name="base" type="BSDF" nodename="dielectric_substrate" />
+    </layer>
+
+    <!-- Metal Layer -->
+    <multiply name="metal_reflectivity" type="color3">
+      <input name="in1" type="color3" nodename="base_color_clamped" />
+      <input name="in2" type="float" nodename="base_weight_clamped" />
+    </multiply>
+    <generalized_schlick_bsdf name="metal_bsdf" type="BSDF">
+      <input name="weight" type="float" nodename="specular_weight_nonnegative" />
+      <input name="color0" type="color3" nodename="metal_reflectivity" />
+      <input name="color82" type="color3" nodename="specular_color_clamped" />
+      <input name="roughness" type="vector2" nodename="main_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+    </generalized_schlick_bsdf>
+    <generalized_schlick_bsdf name="metal_bsdf_tf" type="BSDF">
+      <input name="weight" type="float" nodename="specular_weight_nonnegative" />
+      <input name="color0" type="color3" nodename="metal_reflectivity" />
+      <input name="color82" type="color3" nodename="specular_color_clamped" />
+      <input name="roughness" type="vector2" nodename="main_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="thinfilm_thickness" type="float" nodename="thin_film_thickness_nm" />
+      <input name="thinfilm_ior" type="float" nodename="thin_film_ior_nonnegative" />
+    </generalized_schlick_bsdf>
+    <mix name="metal_bsdf_tf_mix" type="BSDF">
+      <input name="fg" type="BSDF" nodename="metal_bsdf_tf" />
+      <input name="bg" type="BSDF" nodename="metal_bsdf" />
+      <input name="mix" type="float" nodename="thin_film_weight_clamped" />
+    </mix>
+
+    <!-- Metal Haze -->
+    <generalized_schlick_bsdf name="metal_bsdf_haze" type="BSDF">
+      <input name="weight" type="float" nodename="specular_weight_nonnegative" />
+      <input name="color0" type="color3" nodename="metal_reflectivity" />
+      <input name="color82" type="color3" nodename="specular_color_clamped" />
+      <input name="roughness" type="vector2" nodename="haze_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+    </generalized_schlick_bsdf>
+    <generalized_schlick_bsdf name="metal_bsdf_haze_tf" type="BSDF">
+      <input name="weight" type="float" nodename="specular_weight_nonnegative" />
+      <input name="color0" type="color3" nodename="metal_reflectivity" />
+      <input name="color82" type="color3" nodename="specular_color_clamped" />
+      <input name="roughness" type="vector2" nodename="haze_roughness" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_tangent" />
+      <input name="thinfilm_thickness" type="float" nodename="thin_film_thickness_nm" />
+      <input name="thinfilm_ior" type="float" nodename="thin_film_ior_nonnegative" />
+    </generalized_schlick_bsdf>
+    <mix name="metal_bsdf_haze_tf_mix" type="BSDF">
+      <input name="fg" type="BSDF" nodename="metal_bsdf_haze_tf" />
+      <input name="bg" type="BSDF" nodename="metal_bsdf_haze" />
+      <input name="mix" type="float" nodename="thin_film_weight_clamped" />
+    </mix>
+    <mix name="metal_bsdf_with_haze" type="BSDF">
+      <input name="fg" type="BSDF" nodename="metal_bsdf_haze_tf_mix" />
+      <input name="bg" type="BSDF" nodename="metal_bsdf_tf_mix" />
+      <input name="mix" type="float" nodename="specular_haze_clamped" />
+    </mix>
+
+    <mix name="base_substrate" type="BSDF">
+      <input name="fg" type="BSDF" nodename="metal_bsdf_with_haze" />
+      <input name="bg" type="BSDF" nodename="dielectric_base" />
+      <input name="mix" type="float" nodename="base_metalness_clamped" />
+    </mix>
+
+    <!-- Coat Layer -->
+
+    <!-- Inter-reflection darkening calculation -->
+    <!-- approximate Kcoat, "internal diffuse reflection coefficient" of coat  -->
+    <subtract name="one_minus_coat_F0" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="coat_ior_to_F0" />
+    </subtract>
+    <multiply name="coat_ior_sqr" type="float">
+      <input name="in1" type="float" nodename="coat_ior_nonnegative" />
+      <input name="in2" type="float" nodename="coat_ior_nonnegative" />
+    </multiply>
+    <divide name="one_minus_coat_F0_over_eta2" type="float">
+      <input name="in1" type="float" nodename="one_minus_coat_F0" />
+      <input name="in2" type="float" nodename="coat_ior_sqr" />
+    </divide>
+    <subtract name="Kcoat" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="one_minus_coat_F0_over_eta2" />
+    </subtract>
+    <!-- Approximate base metal albedo estimate, Emetal  -->
+    <multiply name="Emetal" type="color3">
+      <input name="in1" type="color3" nodename="base_color_clamped" />
+      <input name="in2" type="float" nodename="specular_weight_nonnegative" />
+    </multiply>
+    <!-- Approximate base dielectric albedo estimate, Edielectric  -->
+    <mix name="Edielectric" type="color3">
+      <input name="fg" type="color3" nodename="subsurface_color_clamped" />
+      <input name="bg" type="color3" nodename="base_color_clamped" />
+      <input name="mix" type="float" nodename="subsurface_weight_clamped" />
+    </mix>
+    <!-- Thus calculate overall base albedo estimate approximation, Ebase  -->
+    <mix name="Ebase" type="color3">
+      <input name="fg" type="color3" nodename="Emetal" />
+      <input name="bg" type="color3" nodename="Edielectric" />
+      <input name="mix" type="float" nodename="base_metalness_clamped" />
+    </mix>
+    <!-- Final base inter-reflection darkening factor due to coat,
+         where Tcoat2 = coat_color:
+              base_darkening = (1 - Kcoat) / (1 - Ebase*Kcoat*Tcoat2) -->
+    <multiply name="Ebase_Kcoat" type="color3">
+      <input name="in1" type="color3" nodename="Ebase" />
+      <input name="in2" type="float" nodename="Kcoat" />
+    </multiply>
+    <multiply name="Ebase_Kcoat_Tcoat2" type="color3">
+      <input name="in1" type="color3" nodename="Ebase_Kcoat" />
+      <input name="in2" type="color3" interfacename="coat_color" />
+    </multiply>
+    <subtract name="one_minus_Kcoat" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="Kcoat" />
+    </subtract>
+    <subtract name="one_minus_Ebase_Kcoat_Tcoat2" type="color3">
+      <input name="in1" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="in2" type="color3" nodename="Ebase_Kcoat_Tcoat2" />
+    </subtract>
+    <convert name="one_minus_Kcoat_color" type="color3">
+      <input name="in" type="float" nodename="one_minus_Kcoat" />
+    </convert>
+    <divide name="base_darkening" type="color3">
+      <input name="in1" type="color3" nodename="one_minus_Kcoat_color" />
+      <input name="in2" type="color3" nodename="one_minus_Ebase_Kcoat_Tcoat2" />
+    </divide>
+
+    <!-- Inter-reflection darkening, modulated by coat_darkening -->
+    <mix name="modulated_base_darkening" type="color3">
+      <input name="fg" type="color3" nodename="base_darkening" />
+      <input name="bg" type="color3" value="1.0, 1.0, 1.0" />
+      <input name="mix" type="float" interfacename="coat_darkening" />
+    </mix>
+    <multiply name="darkened_base_substrate" type="BSDF">
+      <input name="in1" type="BSDF" nodename="base_substrate" />
+      <input name="in2" type="color3" nodename="modulated_base_darkening" />
+    </multiply>
+    <!-- Base substrate, attenuated due to absorption color, and (optional) inter-reflection darkening  -->
+    <multiply name="base_substrate_attenuated" type="BSDF">
+      <input name="in1" type="BSDF" nodename="darkened_base_substrate" />
+      <input name="in2" type="color3" nodename="coat_color_clamped" />
+    </multiply>
+    <!-- Coat BSDF  -->
+    <open_pbr_anisotropy name="coat_roughness_vector" type="vector2">
+      <input name="roughness" type="float" nodename="coat_roughness_clamped" />
+      <input name="anisotropy" type="float" nodename="coat_roughness_anisotropy_clamped" />
+    </open_pbr_anisotropy>
+    <dielectric_bsdf name="coat_bsdf" type="BSDF">
+      <input name="weight" type="float" value="1.0" />
+      <input name="ior" type="float" interfacename="coat_ior" />
+      <input name="roughness" type="vector2" nodename="coat_roughness_vector" />
+      <input name="normal" type="vector3" interfacename="geometry_coat_normal" />
+      <input name="tangent" type="vector3" interfacename="geometry_coat_tangent" />
+      <input name="scatter_mode" type="string" value="R" />
+    </dielectric_bsdf>
+    <!-- Coated base  -->
+    <layer name="coated_base_substrate" type="BSDF">
+      <input name="top" type="BSDF" nodename="coat_bsdf" />
+      <input name="base" type="BSDF" nodename="base_substrate_attenuated" />
+    </layer>
+    <!-- Statistical mix of coated and uncoated base  -->
+    <mix name="partially_coated_base" type="BSDF">
+      <input name="fg" type="BSDF" nodename="coated_base_substrate" />
+      <input name="bg" type="BSDF" nodename="base_substrate" />
+      <input name="mix" type="float" interfacename="coat_weight" />
+    </mix>
+
+    <!-- Fuzz Layer -->
+    <sheen_bsdf name="fuzz_bsdf" type="BSDF">
+      <input name="weight" type="float" nodename="fuzz_weight_clamped" />
+      <input name="color" type="color3" nodename="fuzz_color_clamped" />
+      <input name="roughness" type="float" nodename="fuzz_roughness_clamped" />
+      <input name="normal" type="vector3" interfacename="geometry_normal" />
+      <input name="mode" type="string" value="zeltner" />
+    </sheen_bsdf>
+    <layer name="fuzz_layer" type="BSDF">
+      <input name="top" type="BSDF" nodename="fuzz_bsdf" />
+      <input name="base" type="BSDF" nodename="partially_coated_base" />
+    </layer>
+
+    <!-- Emission Layer -->
+    <subtract name="coat_ior_minus_one" type="float">
+      <input name="in1" type="float" nodename="coat_ior_nonnegative" />
+      <input name="in2" type="float" value="1.0" />
+    </subtract>
+    <add name="coat_ior_plus_one" type="float">
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" nodename="coat_ior_nonnegative" />
+    </add>
+    <divide name="coat_ior_to_F0_sqrt" type="float">
+      <input name="in1" type="float" nodename="coat_ior_minus_one" />
+      <input name="in2" type="float" nodename="coat_ior_plus_one" />
+    </divide>
+    <multiply name="coat_ior_to_F0" type="float">
+      <input name="in1" type="float" nodename="coat_ior_to_F0_sqrt" />
+      <input name="in2" type="float" nodename="coat_ior_to_F0_sqrt" />
+    </multiply>
+    <multiply name="weighted_emission_luminance" type="float">
+      <input name="in1" type="float" nodename="emission_weight_clamped" />
+      <input name="in2" type="float" nodename="emission_luminance_nonnegative" />
+    </multiply>
+    <multiply name="emission_color_weight" type="color3">
+      <input name="in1" type="color3" nodename="emission_color_clamped" />
+      <input name="in2" type="float" nodename="weighted_emission_luminance" />
+    </multiply>
+    <uniform_edf name="uncoated_emission_edf" type="EDF">
+      <input name="color" type="color3" nodename="emission_color_weight" />
+    </uniform_edf>
+    <multiply name="coat_tinted_emission_edf" type="EDF">
+      <input name="in1" type="EDF" nodename="uncoated_emission_edf" />
+      <input name="in2" type="color3" nodename="coat_color_clamped" />
+    </multiply>
+    <convert name="one_minus_coat_F0_color" type="color3">
+      <input name="in" type="float" nodename="one_minus_coat_F0" />
+    </convert>
+    <generalized_schlick_edf name="coated_emission_edf" type="EDF">
+      <input name="color0" type="color3" nodename="one_minus_coat_F0_color" />
+      <input name="color90" type="color3" value="0.0, 0.0, 0.0" />
+      <input name="exponent" type="float" value="5.0" />
+      <input name="base" type="EDF" nodename="coat_tinted_emission_edf" />
+    </generalized_schlick_edf>
+    <mix name="emission_edf" type="EDF">
+      <input name="fg" type="EDF" nodename="coated_emission_edf" />
+      <input name="bg" type="EDF" nodename="uncoated_emission_edf" />
+      <input name="mix" type="float" nodename="coat_weight_clamped" />
+    </mix>
+
+    <!-- Surface Construction -->
+    <surface name="shader_constructor" type="surfaceshader">
+      <input name="bsdf" type="BSDF" nodename="fuzz_layer" />
+      <input name="edf" type="EDF" nodename="emission_edf" />
+      <input name="opacity" type="float" nodename="geometry_opacity_clamped" />
+      <input name="thin_walled" type="boolean" interfacename="geometry_thin_walled" />
+    </surface>
+
+    <!-- Output -->
+    <output name="out" type="surfaceshader" nodename="shader_constructor" />
+
+  </nodegraph>
+
+  <!-- ============================================================ -->
+  <!--  OpenPBR Surface v1.1.1                                      -->
+  <!-- ============================================================ -->
+
+  <nodedef name="ND_open_pbr_surface_surfaceshader" node="open_pbr_surface" nodegroup="pbr" version="1.1.1" isdefaultversion="false"
            doc="OpenPBR Surface Shading Model" uiname="OpenPBR Surface">
     <input name="base_weight" type="float" value="1.0" uimin="0.0" uimax="1.0" uiname="Base Weight" uifolder="Base"
            doc="Multiplier on the intensity of the reflection from the diffuse and metallic base." />
@@ -90,9 +949,6 @@
     <output name="out" type="surfaceshader" />
   </nodedef>
 
-  <!--
-    OpenPBR Surface graph definition
-  -->
   <nodegraph name="NG_open_pbr_surface_surfaceshader" nodedef="ND_open_pbr_surface_surfaceshader">
 
     <!-- Roughening due to coat-->
@@ -619,9 +1475,10 @@
 
   </nodegraph>
 
-  <!--
-    OpenPBR Anisotropy node definition
-  -->
+  <!-- ============================================================ -->
+  <!--  OpenPBR Anisotropy (shared utility, version-independent)    -->
+  <!-- ============================================================ -->
+
   <nodedef name="ND_open_pbr_anisotropy" node="open_pbr_anisotropy" nodegroup="pbr"
            doc="Computes anisotropic surface roughness as defined in the OpenPBR specification.">
     <input name="roughness" type="float" value="0.0" />
@@ -629,9 +1486,6 @@
     <output name="out" type="vector2" />
   </nodedef>
 
-  <!--
-    OpenPBR Anisotropy graph definition
-  -->
   <nodegraph name="NG_open_pbr_anisotropy" nodedef="ND_open_pbr_anisotropy">
     <invert name="aniso_invert" type="float">
       <input name="in" type="float" interfacename="anisotropy" />

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/open_pbr_specular_haze.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/open_pbr_specular_haze.mtlx
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <surfacematerial name="dielectric_haze" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="dielectric_haze_shader" />
+  </surfacematerial>
+  <open_pbr_surface name="dielectric_haze_shader" type="surfaceshader">
+    <input name="specular_roughness" type="float" value="0.1" />
+    <input name="specular_haze" type="float" value="0.5" />
+    <input name="specular_haze_spread" type="float" value="0.5" />
+  </open_pbr_surface>
+  <surfacematerial name="metallic_haze" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="metallic_haze_shader" />
+  </surfacematerial>
+  <open_pbr_surface name="metallic_haze_shader" type="surfaceshader">
+    <input name="base_metalness" type="float" value="1.0" />
+    <input name="base_color" type="color3" value="0.9, 0.7, 0.4" />
+    <input name="specular_roughness" type="float" value="0.15" />
+    <input name="specular_haze" type="float" value="0.5" />
+    <input name="specular_haze_spread" type="float" value="0.3" />
+  </open_pbr_surface>
+</materialx>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/open_pbr_v1_1_1.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/open_pbr_v1_1_1.mtlx
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <surfacematerial name="open_pbr_v1_1_1_mat" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="open_pbr_v1_1_1_shader" />
+  </surfacematerial>
+  <open_pbr_surface name="open_pbr_v1_1_1_shader" type="surfaceshader" version="1.1.1">
+    <input name="base_color" type="color3" value="0.2, 0.5, 0.8" />
+    <input name="specular_roughness" type="float" value="0.2" />
+    <input name="coat_weight" type="float" value="0.5" />
+    <input name="coat_color" type="color3" value="1, 1, 1" />
+    <input name="coat_roughness" type="float" value="0.1" />
+  </open_pbr_surface>
+</materialx>

--- a/resources/Materials/TestSuite/pbrlib/surfaceshader/open_pbr_version_test.mtlx
+++ b/resources/Materials/TestSuite/pbrlib/surfaceshader/open_pbr_version_test.mtlx
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<materialx version="1.39" colorspace="lin_rec709">
+  <!-- Explicit v1.2 with specular haze -->
+  <surfacematerial name="open_pbr_v1_2_explicit" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="v1_2_shader" />
+  </surfacematerial>
+  <open_pbr_surface name="v1_2_shader" type="surfaceshader" version="1.2">
+    <input name="base_color" type="color3" value="0.9, 0.1, 0.1" />
+    <input name="specular_roughness" type="float" value="0.1" />
+    <input name="specular_haze" type="float" value="0.3" />
+    <input name="specular_haze_spread" type="float" value="0.4" />
+  </open_pbr_surface>
+
+  <!-- Explicit v1.1.1 without haze params -->
+  <surfacematerial name="open_pbr_v1_1_1_explicit" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="v1_1_1_shader" />
+  </surfacematerial>
+  <open_pbr_surface name="v1_1_1_shader" type="surfaceshader" version="1.1.1">
+    <input name="base_color" type="color3" value="0.1, 0.9, 0.1" />
+    <input name="specular_roughness" type="float" value="0.25" />
+    <input name="coat_weight" type="float" value="0.3" />
+  </open_pbr_surface>
+
+  <!-- Implicit default (should resolve to v1.2) with haze params -->
+  <surfacematerial name="open_pbr_default_version" type="material">
+    <input name="surfaceshader" type="surfaceshader" nodename="default_shader" />
+  </surfacematerial>
+  <open_pbr_surface name="default_shader" type="surfaceshader">
+    <input name="base_color" type="color3" value="0.1, 0.1, 0.9" />
+    <input name="specular_roughness" type="float" value="0.05" />
+    <input name="specular_haze" type="float" value="0.6" />
+    <input name="specular_haze_spread" type="float" value="0.2" />
+  </open_pbr_surface>
+</materialx>

--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -5,6 +5,8 @@
 
 #include <MaterialXCore/Document.h>
 
+#include <algorithm>
+#include <map>
 #include <mutex>
 #include <shared_mutex>
 
@@ -265,6 +267,52 @@ void Document::importLibrary(const ConstDocumentPtr& library)
         return;
     }
 
+    // Phase 1: Build a rename map for versioned nodedef conflicts.
+    // When an incoming nodedef has the same name as an existing one but a
+    // different version, auto-rename it to <name>_<version> (dots→underscores)
+    // so both can coexist in the merged document.
+    std::map<string, string> renames;
+    for (const auto& child : library->getChildren())
+    {
+        ConstNodeDefPtr newNodeDef = child->asA<NodeDef>();
+        if (!newNodeDef || newNodeDef->getVersionString().empty())
+            continue;
+        const string childName = child->getQualifiedName(child->getName());
+        ConstElementPtr previous = getChild(childName);
+        if (!previous)
+            continue;
+        ConstNodeDefPtr prevNodeDef = previous->asA<NodeDef>();
+        if (!prevNodeDef)
+            continue;
+        if (newNodeDef->getVersionString() != prevNodeDef->getVersionString())
+        {
+            string vSuffix = newNodeDef->getVersionString();
+            std::replace(vSuffix.begin(), vSuffix.end(), '.', '_');
+            renames[childName] = childName + "_" + vSuffix;
+        }
+    }
+
+    // Phase 2: Extend renames to nodegraphs that implement a renamed nodedef.
+    if (!renames.empty())
+    {
+        for (const auto& child : library->getChildren())
+        {
+            if (!child->asA<NodeGraph>())
+                continue;
+            const string ndAttr = child->getAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+            if (ndAttr.empty())
+                continue;
+            const string qualNd = child->getQualifiedName(ndAttr);
+            auto it = renames.find(qualNd);
+            if (it == renames.end())
+                continue;
+            const string ngName = child->getQualifiedName(child->getName());
+            const string suffix = it->second.substr(it->first.size());
+            renames[ngName] = ngName + suffix;
+        }
+    }
+
+    // Phase 3: Import all children, applying renames and updating references.
     for (auto child : library->getChildren())
     {
         if (child->getCategory().empty())
@@ -272,9 +320,11 @@ void Document::importLibrary(const ConstDocumentPtr& library)
             throw Exception("Trying to import child without a category: " + child->getName());
         }
 
-        const string childName = child->getQualifiedName(child->getName());
+        const string originalName = child->getQualifiedName(child->getName());
+        auto renameIt = renames.find(originalName);
+        const string childName = (renameIt != renames.end()) ? renameIt->second : originalName;
 
-        // Check for duplicate elements.
+        // Check for duplicate elements (after applying any rename).
         ConstElementPtr previous = getChild(childName);
         if (previous)
         {
@@ -284,6 +334,21 @@ void Document::importLibrary(const ConstDocumentPtr& library)
         // Create the imported element.
         ElementPtr childCopy = addChildOfCategory(child->getCategory(), childName);
         childCopy->copyContentFrom(child);
+
+        // If this nodegraph's nodedef reference was renamed, update it.
+        if (!renames.empty() && child->asA<NodeGraph>())
+        {
+            const string ndAttr = childCopy->getAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+            if (!ndAttr.empty())
+            {
+                const string qualNd = child->getQualifiedName(ndAttr);
+                auto ndRename = renames.find(qualNd);
+                if (ndRename != renames.end())
+                    childCopy->setAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE, ndRename->second);
+
+            }
+        }
+
         if (!childCopy->hasFilePrefix() && library->hasFilePrefix())
         {
             childCopy->setFilePrefix(library->getFilePrefix());

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -9,8 +9,10 @@
 
 #include <MaterialXCore/Types.h>
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
+#include <map>
 #include <sstream>
 
 using namespace pugi;
@@ -123,6 +125,9 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         }
     }
 
+    // Track auto-renames for versioned nodedef conflicts within this element's children.
+    std::map<string, string> versionedRenames;
+
     // Create child elements and recurse.
     for (const xml_node& xmlChild : xmlNode.children())
     {
@@ -133,12 +138,47 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
             continue;
         }
 
-        // Get child name and skip duplicates.
+        // Get child name and handle duplicates.
         string name = xmlChild.attribute(Element::NAME_ATTRIBUTE.c_str()).value();
         ConstElementPtr previous = elem->getChild(name);
         if (previous)
         {
-            continue;
+            // Auto-rename versioned nodedef conflicts instead of skipping.
+            if (category == NodeDef::CATEGORY)
+            {
+                string newVersion = xmlChild.attribute(InterfaceElement::VERSION_ATTRIBUTE.c_str()).value();
+                ConstNodeDefPtr prevNodeDef = previous->asA<NodeDef>();
+                if (prevNodeDef && !newVersion.empty() && newVersion != prevNodeDef->getVersionString())
+                {
+                    string vSuffix = newVersion;
+                    std::replace(vSuffix.begin(), vSuffix.end(), '.', '_');
+                    name = name + "_" + vSuffix;
+                    versionedRenames[xmlChild.attribute(Element::NAME_ATTRIBUTE.c_str()).value()] = name;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            else if (category == NodeGraph::CATEGORY && !versionedRenames.empty())
+            {
+                // Auto-rename nodegraphs that implement a renamed nodedef.
+                string ndAttr = xmlChild.attribute(InterfaceElement::NODE_DEF_ATTRIBUTE.c_str()).value();
+                auto it = versionedRenames.find(ndAttr);
+                if (it != versionedRenames.end())
+                {
+                    string suffix = it->second.substr(it->first.size());
+                    name = name + suffix;
+                }
+                else
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                continue;
+            }
         }
 
         // Enforce maximum tree depth.
@@ -150,6 +190,17 @@ void elementFromXml(const xml_node& xmlNode, ElementPtr elem, const XmlReadOptio
         // Create the child element.
         ElementPtr child = elem->addChildOfCategory(category, name);
         elementFromXml(xmlChild, child, readOptions, depth + 1);
+
+        // Update nodedef reference on auto-renamed nodegraphs.
+        if (category == NodeGraph::CATEGORY && !versionedRenames.empty())
+        {
+            string ndAttr = child->getAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE);
+            auto it = versionedRenames.find(ndAttr);
+            if (it != versionedRenames.end())
+            {
+                child->setAttribute(InterfaceElement::NODE_DEF_ATTRIBUTE, it->second);
+            }
+        }
 
         // Handle the interpretation of XML comments and newlines.
         if (readOptions && category.empty())

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -12,8 +12,10 @@
 #include <imgui_node_editor_internal.h>
 #include <widgets.h>
 
+#include <algorithm>
 #include <cctype>
 #include <iostream>
+#include <set>
 
 namespace
 {
@@ -138,6 +140,7 @@ Graph::Graph(const std::string& materialFilename,
     _popup(false),
     _shaderPopup(false),
     _searchNodeId(-1),
+    _contextMenuNodeId(-1),
     _addNewNode(false),
     _ctrlClick(false),
     _isCut(false),
@@ -1129,6 +1132,11 @@ void Graph::createNodeUIList(mx::DocumentPtr doc)
 
     for (const auto& nodeDef : nodeDefs)
     {
+        // Skip non-default versions from the add-node menu.
+        // Users create the default version, then switch via right-click context menu.
+        if (!nodeDef->getVersionString().empty() && !nodeDef->getDefaultVersion())
+            continue;
+
         std::string group = nodeDef->getNodeGroup();
         if (group.empty())
         {
@@ -3975,6 +3983,144 @@ void Graph::readOnlyPopup()
     }
 }
 
+void Graph::nodeVersionPopup()
+{
+    if (ImGui::BeginPopup("node version"))
+    {
+        int pos = findNode(_contextMenuNodeId);
+        if (pos >= 0)
+        {
+            UiNodePtr uiNode = _state.nodes[pos];
+            mx::NodePtr mxNode = uiNode->getNode();
+            if (mxNode)
+            {
+                std::string category = mxNode->getCategory();
+                std::vector<mx::NodeDefPtr> matchingNodeDefs = _graphDoc->getMatchingNodeDefs(category);
+
+                if (matchingNodeDefs.size() > 1)
+                {
+                    ImGui::Text("Switch Version: %s", category.c_str());
+                    ImGui::Separator();
+                    mx::NodeDefPtr currentNodeDef = mxNode->getNodeDef();
+                    for (mx::NodeDefPtr nodeDef : matchingNodeDefs)
+                    {
+                        std::string version = nodeDef->getVersionString();
+                        std::string label = version.empty() ? getUserNodeDefName(nodeDef->getName()) : "v" + version;
+                        bool isCurrent = currentNodeDef && (currentNodeDef->getName() == nodeDef->getName());
+                        if (isCurrent)
+                        {
+                            ImGui::Text("[current] %s", label.c_str());
+                        }
+                        else if (!readOnly() && ImGui::MenuItem(label.c_str()))
+                        {
+                            switchNodeVersion(uiNode, nodeDef);
+                            ImGui::CloseCurrentPopup();
+                        }
+                    }
+                }
+                else
+                {
+                    ImGui::Text("No other versions available");
+                }
+            }
+        }
+        ImGui::EndPopup();
+    }
+}
+
+void Graph::switchNodeVersion(UiNodePtr uiNode, mx::NodeDefPtr newNodeDef)
+{
+    mx::NodePtr mxNode = uiNode->getNode();
+    if (!mxNode || !newNodeDef)
+        return;
+
+    // Bind the node to the new version using the version attribute (spec-compliant).
+    // This keeps saved files clean — no internal auto-renamed nodedef strings are written out.
+    mxNode->removeAttribute(mx::InterfaceElement::NODE_DEF_ATTRIBUTE);
+    if (!newNodeDef->getVersionString().empty() && !newNodeDef->getDefaultVersion())
+        mxNode->setVersionString(newNodeDef->getVersionString());
+    else
+        mxNode->removeAttribute(mx::InterfaceElement::VERSION_ATTRIBUTE);
+
+    // Collect input names defined by the new nodedef
+    std::set<std::string> newInputNames;
+    for (mx::InputPtr input : newNodeDef->getActiveInputs())
+        newInputNames.insert(input->getName());
+
+    // Remove inputs from the MX node that are not in the new nodedef
+    std::vector<std::string> inputsToRemove;
+    for (mx::InputPtr input : mxNode->getInputs())
+    {
+        if (newInputNames.find(input->getName()) == newInputNames.end())
+            inputsToRemove.push_back(input->getName());
+    }
+    for (const std::string& name : inputsToRemove)
+        mxNode->removeInput(name);
+
+    // Disconnect UI edges for input pins that are being removed
+    for (UiPinPtr pin : uiNode->getInputPins())
+    {
+        if (newInputNames.find(pin->getName()) == newInputNames.end())
+        {
+            UiNodePtr upNode = uiNode->getConnectedNode(pin->getName());
+            if (upNode)
+            {
+                upNode->removeOutputConnection(uiNode->getName());
+                uiNode->eraseEdge(upNode->getId(), pin);
+            }
+        }
+    }
+
+    // Remove obsolete edges from the global edge list
+    for (size_t i = _state.edges.size(); i > 0; --i)
+    {
+        const UiEdge& edge = _state.edges[i - 1];
+        if (edge.getDown()->getId() == uiNode->getId())
+        {
+            mx::InputPtr edgeInput = edge.getInput();
+            if (edgeInput && newInputNames.find(edgeInput->getName()) == newInputNames.end())
+                _state.edges.erase(_state.edges.begin() + (i - 1));
+        }
+    }
+
+    // Remove all existing pins for this node from the global pin list
+    for (UiPinPtr pin : uiNode->getInputPins())
+        _state.pins.erase(std::remove(_state.pins.begin(), _state.pins.end(), pin), _state.pins.end());
+    for (UiPinPtr pin : uiNode->getOutputPins())
+        _state.pins.erase(std::remove(_state.pins.begin(), _state.pins.end(), pin), _state.pins.end());
+
+    // Clear pin collections on the UiNode
+    uiNode->getInputPins().clear();
+    uiNode->getOutputPins().clear();
+
+    // Rebuild input pins from the new nodedef
+    for (mx::InputPtr input : newNodeDef->getActiveInputs())
+    {
+        // Use the node's actual input element if it exists (preserves connected/valued inputs)
+        if (mxNode->getInput(input->getName()))
+            input = mxNode->getInput(input->getName());
+        UiPinPtr inPin = std::make_shared<UiPin>(_state.nextUiId, uiNode, ax::NodeEditor::PinKind::Input, input);
+        uiNode->getInputPins().push_back(inPin);
+        _state.pins.push_back(inPin);
+        ++_state.nextUiId;
+    }
+
+    // Rebuild output pins from the new nodedef
+    for (mx::OutputPtr output : newNodeDef->getActiveOutputs())
+    {
+        if (mxNode->getOutput(output->getName()))
+            output = mxNode->getOutput(output->getName());
+        UiPinPtr outPin = std::make_shared<UiPin>(_state.nextUiId, uiNode, ax::NodeEditor::PinKind::Output, output);
+        uiNode->getOutputPins().push_back(outPin);
+        _state.pins.push_back(outPin);
+        ++_state.nextUiId;
+    }
+
+    // Rebuild UI links and trigger material recompilation
+    linkGraph();
+    updateMaterials();
+}
+
 void Graph::shaderPopup()
 {
     if (_renderer->getMaterialCompilation())
@@ -4115,6 +4261,16 @@ void Graph::drawGraph(ImVec2 mousePos)
     {
         ed::Suspend();
 
+        // Detect right-click on node for version switch context menu
+        {
+            ed::NodeId contextNodeId;
+            if (ed::ShowNodeContextMenu(&contextNodeId))
+            {
+                _contextMenuNodeId = (int)contextNodeId.Get();
+                ImGui::OpenPopup("node version");
+            }
+        }
+
         // Set up popups for adding a node when tab is pressed
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(8.f, 8.f));
         ImGui::SetNextWindowSizeConstraints(ImVec2(250.0f, 300.0f), ImVec2(-1.0f, 500.0f));
@@ -4122,6 +4278,7 @@ void Graph::drawGraph(ImVec2 mousePos)
         searchNodePopup(TextCursor);
         addPinPopup();
         readOnlyPopup();
+        nodeVersionPopup();
         ImGui::PopStyleVar();
 
         ed::Resume();

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -250,6 +250,8 @@ class Graph
     void addPinPopup();
     bool readOnly();
     void readOnlyPopup();
+    void nodeVersionPopup();
+    void switchNodeVersion(UiNodePtr node, mx::NodeDefPtr newNodeDef);
 
     // Compiling shaders message
     void shaderPopup();
@@ -329,6 +331,7 @@ class Graph
     bool _popup;
     bool _shaderPopup;
     int _searchNodeId;
+    int _contextMenuNodeId;
     bool _addNewNode;
     bool _ctrlClick;
     bool _isCut;


### PR DESCRIPTION
This PR adds support for having nodes pointing at multiple versions of the same node definition using different node graphs in the same document. This also adds the draft version of OpenPBR 1.2 as a practical example.