### PR TITLE
Fix uninitialized member variable in MetalState

### DIFF
--- a/source/MaterialXRenderMsl/MetalState.h
+++ b/source/MaterialXRenderMsl/MetalState.h
@@ -56,7 +56,7 @@ struct MX_RENDERMSL_API MetalState
     id<MTLRenderCommandEncoder> renderCmdEncoder = nil;
     std::stack<MaterialX::MetalFramebufferPtr> framebufferStack;
 
-    bool supportsTiledPipeline;
+    bool supportsTiledPipeline = false;
 
     id<MTLDepthStencilState> opaqueDepthStencilState = nil;
     id<MTLDepthStencilState> transparentDepthStencilState = nil;

--- a/source/MaterialXRenderMsl/MetalState.mm
+++ b/source/MaterialXRenderMsl/MetalState.mm
@@ -26,8 +26,6 @@ void MetalState::initialize(id<MTLDevice> mtlDevice, id<MTLCommandQueue> mtlCmdQ
     {
         supportsTiledPipeline = [device supportsFamily:MTLGPUFamilyApple4];
     }
-#else
-    supportsTiledPipeline = false;
 #endif
 
     MTLDepthStencilDescriptor* depthStencilDesc = [MTLDepthStencilDescriptor new];


### PR DESCRIPTION
This PR seeks to address issue #1518.

I believe the first part of this issue to be obsolete. The CMake targets have changed substantially since the issue was reported, and I was able to build with Xcode 12.4 on macOS Catalina 10.15.8 without errors.

The second part of the issue is still relevant. When compiled on a system with a macOS 11+ SDK but running on an OS version prior to macOS 11, the `supportsTiledPipeline` member variable is not initialized by the constructor or the `initialize()` method, and can hold an invalid value. This doesn't cause a crash because of further runtime checks in `initLinearToSRGBKernel()`, but it does raise a runtime issue when compiled with UBSAN.

These changes ensure that the `supportsTiledPipeline` variable is always initialized, regardless of SDK version or OS version.

Tested on macOS Catalina 10.15.8 with Xcode 12.4 and macOS Tahoe 26.4.1 with Xcode 26.4.1.