### PR TITLE
Bug fix: tiling/scaling order in OSL hextiling to match GLSL

### DIFF
--- a/libraries/stdlib/genosl/lib/mx_hextile.osl
+++ b/libraries/stdlib/genosl/lib/mx_hextile.osl
@@ -1,9 +1,11 @@
 // https://www.shadertoy.com/view/4djSRW
 vector2 mx_hextile_hash(vector2 p)
 {
-    vector pp3 = fmod(vector(p.x, p.y, p.x) * vector(0.1031, 0.1030, 0.0973), 1.0);
+    vector pp3 = vector(p.x, p.y, p.x) * vector(0.1031, 0.1030, 0.0973);
+    pp3 -= floor(pp3);
     pp3 += dot(pp3, vector(pp3[1], pp3[2], pp3[0]) + 33.33);
-    return fmod(vector2(pp3[0] + pp3[1], pp3[0] + pp3[2]) * vector2(pp3[2], pp3[1]), 1.0);
+    vector2 result = vector2(pp3[0] + pp3[1], pp3[0] + pp3[2]) * vector2(pp3[2], pp3[1]);
+    return result - floor(result);
 }
 
 // Christophe Schlick. "Fast Alternatives to Perlin's Bias and Gain Functions".

--- a/libraries/stdlib/genosl/mx_hextiledimage_color3.osl
+++ b/libraries/stdlib/genosl/mx_hextiledimage_color3.osl
@@ -26,7 +26,7 @@ void mx_hextiledimage_color3(
         return;
     }
 
-    vector2 coord = mx_transform_uv(texcoord) * tiling;
+    vector2 coord = mx_transform_uv(texcoord * tiling);
 
     HextileData tile_data = mx_hextile_coord(coord, rotation, rotationrange, scale, scalerange, offset, offsetrange);
 

--- a/libraries/stdlib/genosl/mx_hextiledimage_color4.osl
+++ b/libraries/stdlib/genosl/mx_hextiledimage_color4.osl
@@ -26,7 +26,7 @@ void mx_hextiledimage_color4(
         return;
     }
 
-    vector2 coord = mx_transform_uv(texcoord) * tiling;
+    vector2 coord = mx_transform_uv(texcoord * tiling);
 
     HextileData tile_data = mx_hextile_coord(coord, rotation, rotationrange, scale, scalerange, offset, offsetrange);
 

--- a/libraries/stdlib/genosl/mx_hextilednormalmap_vector3.osl
+++ b/libraries/stdlib/genosl/mx_hextilednormalmap_vector3.osl
@@ -29,7 +29,7 @@ void mx_hextilednormalmap_vector3(
         return;
     }
 
-    vector2 coord = mx_transform_uv(texcoord) * tiling;
+    vector2 coord = mx_transform_uv(texcoord * tiling);
 
     HextileData tile_data = mx_hextile_coord(coord, rotation, rotationrange, scale, scalerange, offset, offsetrange);
 


### PR DESCRIPTION
This fix addresses the bug outlined here: https://github.com/AcademySoftwareFoundation/MaterialX/issues/2885