### PR TITLE
Bug fix: OSL transformmatrix for matrix44 to match GLSL/Metal

### DIFF
--- a/libraries/stdlib/genosl/mx_transformmatrix_vector3M4.osl
+++ b/libraries/stdlib/genosl/mx_transformmatrix_vector3M4.osl
@@ -1,0 +1,5 @@
+void mx_transformmatrix_vector3M4(vector val, matrix m, output vector result)
+{
+    vector4 res = transform(m, vector4(val[0], val[1], val[2], 1.0));
+    result = vector(res.x, res.y, res.z);
+}

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -504,7 +504,7 @@
   <!-- <transformmatrix> -->
   <implementation name="IM_transformmatrix_vector2M3_genosl" nodedef="ND_transformmatrix_vector2M3" function="mx_transformmatrix_vector2M3" file="mx_transformmatrix_vector2M3.osl" target="genosl" />
   <implementation name="IM_transformmatrix_vector3_genosl" nodedef="ND_transformmatrix_vector3" target="genosl" sourcecode="transform({{mat}}, {{in}})" />
-  <implementation name="IM_transformmatrix_vector3M4_genosl" nodedef="ND_transformmatrix_vector3M4" target="genosl" sourcecode="transform({{mat}}, {{in}})" />
+  <implementation name="IM_transformmatrix_vector3M4_genosl" nodedef="ND_transformmatrix_vector3M4" function="mx_transformmatrix_vector3M4" file="mx_transformmatrix_vector3M4.osl" target="genosl" />
   <implementation name="IM_transformmatrix_vector4_genosl" nodedef="ND_transformmatrix_vector4" target="genosl" sourcecode="transform({{mat}}, {{in}})" />
 
   <!-- <transpose> -->


### PR DESCRIPTION
This fixes issue #2887

The original issue was not row versus column, it was just that the vector-matrix multiply was not treated as a point being multiplied by a homogeneous matrix.  Thus its translation was lost.