### PR TITLE
Optimize GLSL/OSL `rotate3d` using Rodrigues' rotation formula

### DIFF
--- a/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
@@ -1,6 +1,9 @@
 void mx_rotate_vector3(vec3 _in, float amount, vec3 axis, out vec3 result)
 {
-    // https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+    // based on https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+    // but the code in the Wikipedia article is for v' = M * v, where as 
+    // MaterialX is v' = v * M, thus the order of parameters into the first cross are reversed
+
     axis = normalize(axis);
     float rotationRadians = mx_radians(amount);
     float s = mx_sin(rotationRadians);

--- a/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
@@ -1,8 +1,8 @@
 void mx_rotate_vector3(vec3 _in, float amount, vec3 axis, out vec3 result)
 {
-    // based on https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
-    // but the code in the Wikipedia article is for v' = M * v, where as 
-    // MaterialX is v' = v * M, thus the order of parameters into the first cross are reversed
+    // Based on https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula, where the
+    // Wikipedia formula follows v' = M * v and MaterialX follows v' = v * M, thus the
+    // order of parameters to cross are reversed.
 
     axis = normalize(axis);
     float rotationRadians = mx_radians(amount);

--- a/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
+++ b/libraries/stdlib/genglsl/mx_rotate_vector3.glsl
@@ -1,19 +1,10 @@
-mat4 mx_rotationMatrix(vec3 axis, float angle)
-{
-    axis = normalize(axis);
-    float s = mx_sin(angle);
-    float c = mx_cos(angle);
-    float oc = 1.0 - c;
-
-    return mat4(oc * axis.x * axis.x + c,           oc * axis.x * axis.y - axis.z * s,  oc * axis.z * axis.x + axis.y * s,  0.0,
-                oc * axis.x * axis.y + axis.z * s,  oc * axis.y * axis.y + c,           oc * axis.y * axis.z - axis.x * s,  0.0,
-                oc * axis.z * axis.x - axis.y * s,  oc * axis.y * axis.z + axis.x * s,  oc * axis.z * axis.z + c,           0.0,
-                0.0,                                0.0,                                0.0,                                1.0);
-}
-
 void mx_rotate_vector3(vec3 _in, float amount, vec3 axis, out vec3 result)
 {
+    // https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+    axis = normalize(axis);
     float rotationRadians = mx_radians(amount);
-    mat4 m = mx_rotationMatrix(axis, rotationRadians);
-    result = mx_matrix_mul(m, vec4(_in, 1.0)).xyz;
+    float s = mx_sin(rotationRadians);
+    float c = mx_cos(rotationRadians);
+    float oc = 1.0 - c;
+    result = _in * c + cross(_in, axis) * s + axis * dot(axis, _in) * oc;
 }

--- a/libraries/stdlib/genosl/mx_rotate_vector3.osl
+++ b/libraries/stdlib/genosl/mx_rotate_vector3.osl
@@ -1,6 +1,9 @@
 void mx_rotate_vector3(vector _in, float amount, vector axis, output vector result)
 {
-    // https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+    // based on https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+    // but the code in the Wikipedia article is for v' = M * v, where as 
+    // MaterialX is v' = v * M, thus the order of parameters into the first cross are reversed
+
     vector nAxis = normalize(axis);
     float rotationRadians = radians(amount);
     float s = sin(rotationRadians);

--- a/libraries/stdlib/genosl/mx_rotate_vector3.osl
+++ b/libraries/stdlib/genosl/mx_rotate_vector3.osl
@@ -1,20 +1,10 @@
-matrix rotationMatrix(vector axis, float angle)
-{
-    vector nAxis = normalize(axis);
-    float s = sin(angle);
-    float c = cos(angle);
-    float oc = 1.0 - c;
-
-    return matrix(oc * nAxis[0] * nAxis[0] + c,             oc * nAxis[0] * nAxis[1] - nAxis[2] * s,  oc * nAxis[2] * nAxis[0] + nAxis[1] * s,  0.0,
-                  oc * nAxis[0] * nAxis[1] + nAxis[2] * s,  oc * nAxis[1] * nAxis[1] + c,             oc * nAxis[1] * nAxis[2] - nAxis[0] * s,  0.0,
-                  oc * nAxis[2] * nAxis[0] - nAxis[1] * s,  oc * nAxis[1] * nAxis[2] + nAxis[0] * s,  oc * nAxis[2] * nAxis[2] + c,             0.0,
-                  0.0,                                      0.0,                                      0.0,                                      1.0);
-}
-
 void mx_rotate_vector3(vector _in, float amount, vector axis, output vector result)
 {
+    // https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+    vector nAxis = normalize(axis);
     float rotationRadians = radians(amount);
-    matrix m = rotationMatrix(axis, rotationRadians);
-    vector4 trans = transform(m, vector4(_in[0], _in[1], _in[2], 1.0));
-    result = vector(trans.x, trans.y, trans.z);
+    float s = sin(rotationRadians);
+    float c = cos(rotationRadians);
+    float oc = 1.0 - c;
+    result = _in * c + cross(_in, nAxis) * s + nAxis * dot(nAxis, _in) * oc;
 }

--- a/libraries/stdlib/genosl/mx_rotate_vector3.osl
+++ b/libraries/stdlib/genosl/mx_rotate_vector3.osl
@@ -1,8 +1,8 @@
 void mx_rotate_vector3(vector _in, float amount, vector axis, output vector result)
 {
-    // based on https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
-    // but the code in the Wikipedia article is for v' = M * v, where as 
-    // MaterialX is v' = v * M, thus the order of parameters into the first cross are reversed
+    // Based on https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula, where the
+    // Wikipedia formula follows v' = M * v and MaterialX follows v' = v * M, thus the
+    // order of parameters to cross are reversed.
 
     vector nAxis = normalize(axis);
     float rotationRadians = radians(amount);


### PR DESCRIPTION
While fixing some issues with the rotate3d for my blender importer, I noticed that we can replace the matrix44 construction for just rotating a vector with Rodrigues' formula:

https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula

This PR makes that change.  Fidelity test passes with successful results so there was no degradation.