### PR TITLE
Bug fix: genmsl image node handling for MaterialX constant texture address

### DIFF
--- a/libraries/stdlib/genmsl/lib/mx_image_address.metal
+++ b/libraries/stdlib/genmsl/lib/mx_image_address.metal
@@ -1,0 +1,6 @@
+bool mx_image_coord_out_of_bounds(vec2 uv, int uaddressmode, int vaddressmode)
+{
+    // MaterialX address mode enum: constant=0, clamp=1, periodic=2, mirror=3.
+    return (uaddressmode == 0 && (uv.x < 0.0 || uv.x > 1.0)) ||
+           (vaddressmode == 0 && (uv.y < 0.0 || uv.y > 1.0));
+}

--- a/libraries/stdlib/genmsl/mx_image_color3.metal
+++ b/libraries/stdlib/genmsl/mx_image_color3.metal
@@ -1,0 +1,8 @@
+#include "../genglsl/lib/$fileTransformUv"
+#include "lib/mx_image_address.metal"
+
+void mx_image_color3($texSamplerSignature, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
+{
+    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
+    result = mx_image_coord_out_of_bounds(uv, uaddressmode, vaddressmode) ? defaultval : texture($texSamplerSampler2D, uv).rgb;
+}

--- a/libraries/stdlib/genmsl/mx_image_color4.metal
+++ b/libraries/stdlib/genmsl/mx_image_color4.metal
@@ -1,0 +1,8 @@
+#include "../genglsl/lib/$fileTransformUv"
+#include "lib/mx_image_address.metal"
+
+void mx_image_color4($texSamplerSignature, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
+{
+    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
+    result = mx_image_coord_out_of_bounds(uv, uaddressmode, vaddressmode) ? defaultval : texture($texSamplerSampler2D, uv);
+}

--- a/libraries/stdlib/genmsl/mx_image_float.metal
+++ b/libraries/stdlib/genmsl/mx_image_float.metal
@@ -1,0 +1,8 @@
+#include "../genglsl/lib/$fileTransformUv"
+#include "lib/mx_image_address.metal"
+
+void mx_image_float($texSamplerSignature, int layer, float defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out float result)
+{
+    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
+    result = mx_image_coord_out_of_bounds(uv, uaddressmode, vaddressmode) ? defaultval : texture($texSamplerSampler2D, uv).r;
+}

--- a/libraries/stdlib/genmsl/mx_image_vector2.metal
+++ b/libraries/stdlib/genmsl/mx_image_vector2.metal
@@ -1,0 +1,8 @@
+#include "../genglsl/lib/$fileTransformUv"
+#include "lib/mx_image_address.metal"
+
+void mx_image_vector2($texSamplerSignature, int layer, vec2 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec2 result)
+{
+    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
+    result = mx_image_coord_out_of_bounds(uv, uaddressmode, vaddressmode) ? defaultval : texture($texSamplerSampler2D, uv).rg;
+}

--- a/libraries/stdlib/genmsl/mx_image_vector3.metal
+++ b/libraries/stdlib/genmsl/mx_image_vector3.metal
@@ -1,0 +1,8 @@
+#include "../genglsl/lib/$fileTransformUv"
+#include "lib/mx_image_address.metal"
+
+void mx_image_vector3($texSamplerSignature, int layer, vec3 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec3 result)
+{
+    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
+    result = mx_image_coord_out_of_bounds(uv, uaddressmode, vaddressmode) ? defaultval : texture($texSamplerSampler2D, uv).rgb;
+}

--- a/libraries/stdlib/genmsl/mx_image_vector4.metal
+++ b/libraries/stdlib/genmsl/mx_image_vector4.metal
@@ -1,0 +1,8 @@
+#include "../genglsl/lib/$fileTransformUv"
+#include "lib/mx_image_address.metal"
+
+void mx_image_vector4($texSamplerSignature, int layer, vec4 defaultval, vec2 texcoord, int uaddressmode, int vaddressmode, int filtertype, int framerange, int frameoffset, int frameendaction, vec2 uv_scale, vec2 uv_offset, out vec4 result)
+{
+    vec2 uv = mx_transform_uv(texcoord, uv_scale, uv_offset);
+    result = mx_image_coord_out_of_bounds(uv, uaddressmode, vaddressmode) ? defaultval : texture($texSamplerSampler2D, uv);
+}

--- a/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
+++ b/libraries/stdlib/genmsl/stdlib_genmsl_impl.mtlx
@@ -19,22 +19,22 @@
   <!-- ======================================================================== -->
 
   <!-- <image> -->
-  <implementation name="IM_image_float_genmsl" nodedef="ND_image_float" file="../genglsl/mx_image_float.glsl" function="mx_image_float" target="genmsl">
+  <implementation name="IM_image_float_genmsl" nodedef="ND_image_float" file="mx_image_float.metal" function="mx_image_float" target="genmsl">
     <input name="default" type="float" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color3_genmsl" nodedef="ND_image_color3" file="../genglsl/mx_image_color3.glsl" function="mx_image_color3" target="genmsl">
+  <implementation name="IM_image_color3_genmsl" nodedef="ND_image_color3" file="mx_image_color3.metal" function="mx_image_color3" target="genmsl">
     <input name="default" type="color3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_color4_genmsl" nodedef="ND_image_color4" file="../genglsl/mx_image_color4.glsl" function="mx_image_color4" target="genmsl">
+  <implementation name="IM_image_color4_genmsl" nodedef="ND_image_color4" file="mx_image_color4.metal" function="mx_image_color4" target="genmsl">
     <input name="default" type="color4" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector2_genmsl" nodedef="ND_image_vector2" file="../genglsl/mx_image_vector2.glsl" function="mx_image_vector2" target="genmsl">
+  <implementation name="IM_image_vector2_genmsl" nodedef="ND_image_vector2" file="mx_image_vector2.metal" function="mx_image_vector2" target="genmsl">
     <input name="default" type="vector2" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector3_genmsl" nodedef="ND_image_vector3" file="../genglsl/mx_image_vector3.glsl" function="mx_image_vector3" target="genmsl">
+  <implementation name="IM_image_vector3_genmsl" nodedef="ND_image_vector3" file="mx_image_vector3.metal" function="mx_image_vector3" target="genmsl">
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
-  <implementation name="IM_image_vector4_genmsl" nodedef="ND_image_vector4" file="../genglsl/mx_image_vector4.glsl" function="mx_image_vector4" target="genmsl">
+  <implementation name="IM_image_vector4_genmsl" nodedef="ND_image_vector4" file="mx_image_vector4.metal" function="mx_image_vector4" target="genmsl">
     <input name="default" type="vector4" implname="default_value" />
   </implementation>
 


### PR DESCRIPTION
Metal previously relied on `MTLSamplerAddressModeClampToBorderColor` for `constant` addressing. Metal samplers only support opaque black/white border colors, so arbitrary MaterialX image `default` values, for example bright green-yellow, rendered incorrectly as white.

## Fix
- Added MSL-specific image implementations for all image output types: `float`, `color3`, `color4`, `vector2`, `vector3`, and `vector4`.
- Added a shared helper, `mx_image_coord_out_of_bounds`, that checks transformed UVs against `[0, 1]` only for axes using `constant` address mode.
- When out of bounds, the image node now returns its MaterialX `default` input; otherwise it samples the texture normally.
- Updated `stdlib_genmsl_impl.mtlx` to use these MSL image implementations instead of reusing the GLSL versions.

## How It Was Realized
This was found through fidelity samples that set `uaddressmode` and `vaddressmode` to `constant` with a non-white default color. GLSL, OSL, Three.js, and Blender produced the expected default color outside the valid UV range, while Metal showed white. Inspecting `MetalTextureHandler.mm` showed the Metal backend maps `constant` to sampler border color and chooses only black or white based on `defaultColor[0]`, which cannot represent arbitrary defaults (such as purple in this example.(

<img width="663" height="303" alt="Screenshot 2026-05-07 at 2 07 00 PM" src="https://github.com/user-attachments/assets/d312c88c-c711-4b91-941c-4732f1542890" />

## Validation
Rendered the focused address-mode samples through `materialx-metal`:

`pnpm cli render --materials "re:image_addressmode_(constant|clamp|periodic|mirror)$" --renderers materialx-metal`

All 4 renders succeeded, and the constant-mode sample now shows the expected magenta default region.

<img width="660" height="298" alt="Screenshot 2026-05-07 at 2 11 29 PM" src="https://github.com/user-attachments/assets/3d8063aa-4b92-48ca-9b0e-ee607b75f1c6" />

