### PR TITLE
Add iridescence support to Standard Surface to glTF PBR translation

### DIFF
--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -261,9 +261,12 @@
       <input name="in1" type="float" value="1.0" />
       <input name="in2" type="float" value="0.0" />
     </ifgreater>
-    <dot name="iridescence_ior" type="float">
-      <input name="in" type="float" interfacename="thin_film_IOR" />
-    </dot>
+    <ifgreater name="iridescence_ior" type="float">
+      <input name="value1" type="float" interfacename="thin_film_thickness" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="float" interfacename="thin_film_IOR" />
+      <input name="in2" type="float" value="1.3" />
+    </ifgreater>
     <dot name="iridescence_thickness" type="float">
       <input name="in" type="float" interfacename="thin_film_thickness" />
     </dot>

--- a/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
+++ b/libraries/bxdf/translation/standard_surface_to_gltf_pbr.mtlx
@@ -27,6 +27,8 @@
     <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
     <input name="opacity" type="color3" value="1, 1, 1" />
     <input name="thin_walled" type="boolean" value="false" />
+    <input name="thin_film_thickness" type="float" value="0.0" />
+    <input name="thin_film_IOR" type="float" value="1.5" />
 
     <output name="base_color_out" type="color3" />
     <output name="metallic_out" type="float" />
@@ -44,6 +46,9 @@
     <output name="sheen_roughness_out" type="float" />
     <output name="clearcoat_out" type="float" />
     <output name="clearcoat_roughness_out" type="float" />
+    <output name="iridescence_out" type="float" />
+    <output name="iridescence_ior_out" type="float" />
+    <output name="iridescence_thickness_out" type="float" />
     <output name="dispersion_out" type="float" />
     <output name="emissive_out" type="color3" />
     <output name="emissive_strength_out" type="float" />
@@ -249,6 +254,20 @@
       <input name="in2" type="float" nodename="dispersion_from_abbe" />
     </ifequal>
 
+    <!-- Iridescence -->
+    <ifgreater name="iridescence" type="float">
+      <input name="value1" type="float" interfacename="thin_film_thickness" />
+      <input name="value2" type="float" value="0.0" />
+      <input name="in1" type="float" value="1.0" />
+      <input name="in2" type="float" value="0.0" />
+    </ifgreater>
+    <dot name="iridescence_ior" type="float">
+      <input name="in" type="float" interfacename="thin_film_IOR" />
+    </dot>
+    <dot name="iridescence_thickness" type="float">
+      <input name="in" type="float" interfacename="thin_film_thickness" />
+    </dot>
+
     <!-- Geometry -->
     <dot name="normal" type="vector3">
       <input name="in" type="vector3" interfacename="normal" />
@@ -290,6 +309,9 @@
     <output name="sheen_roughness_out" type="float" nodename="sqrt_sheen_roughness" />
     <output name="clearcoat_out" type="float" nodename="clearcoat" />
     <output name="clearcoat_roughness_out" type="float" nodename="clearcoat_roughness" />
+    <output name="iridescence_out" type="float" nodename="iridescence" />
+    <output name="iridescence_ior_out" type="float" nodename="iridescence_ior" />
+    <output name="iridescence_thickness_out" type="float" nodename="iridescence_thickness" />
     <output name="dispersion_out" type="float" nodename="dispersion" />
     <output name="emissive_out" type="color3" nodename="emissive" />
     <output name="emissive_strength_out" type="float" nodename="emissive_strength" />


### PR DESCRIPTION
Hi all,

This PR maps the thin_film_thickness and thin_film_IOR to the glTF iridescence, iridescence_ior, and iridescence_thickness outputs. The iridescence weight is derived from the thickness being non-zero, as Standard Surface has no separate iridescence weight input.

I tested the output with:
```python
import MaterialX as mx                                                                                                                                                                                                                                                                    
from MaterialX import PyMaterialXGenShader as mxgs
                                                                                                                                                                                                                                                                                            
stdlib = mx.createDocument()                                                                                                                                                                                                                                                            
sp = mx.FileSearchPath('/home/ben/dev/MaterialX/build/Debug/bin')                                                                                                                                                                                                                         
mx.loadLibraries(mx.getDefaultDataLibraryFolders(), sp, stdlib)                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                            
doc = mx.createDocument()                                                                                                                                                                                                                                                                 
doc.setDataLibrary(stdlib)                                                                                                                                                                                                                                                                
mx.readFromXmlFile(doc,
                   'resources/Materials/Examples/StandardSurface/standard_surface_thin_film.mtlx', 
                   sp)
                                                                                                                                                                                                                                                                                            
translator = mxgs.ShaderTranslator.create()
translator.translateAllMaterials(doc, 'gltf_pbr')                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                            
mx.writeToXmlFile(doc, '/tmp/thin_film_as_gltf.mtlx')  
```

The output material:
```xml
<?xml version="1.0"?>
<materialx version="1.39" colorspace="lin_rec709">
  <gltf_pbr name="SR_thin_film" type="surfaceshader">
    <input name="base_color" type="color3" output="base_color_out" nodegraph="nodegraph1" />
    <input name="metallic" type="float" output="metallic_out" nodegraph="nodegraph1" />
    <input name="roughness" type="float" output="roughness_out" nodegraph="nodegraph1" />
    <input name="specular" type="float" output="specular_out" nodegraph="nodegraph1" />
    <input name="specular_color" type="color3" output="specular_color_out" nodegraph="nodegraph1" />
    <input name="ior" type="float" output="ior_out" nodegraph="nodegraph1" />
    <input name="anisotropy_strength" type="float" output="anisotropy_strength_out" nodegraph="nodegraph1" />
    <input name="anisotropy_rotation" type="float" output="anisotropy_rotation_out" nodegraph="nodegraph1" />
    <input name="transmission" type="float" output="transmission_out" nodegraph="nodegraph1" />
    <input name="thickness" type="float" output="thickness_out" nodegraph="nodegraph1" />
    <input name="attenuation_color" type="color3" output="attenuation_color_out" nodegraph="nodegraph1" />
    <input name="attenuation_distance" type="float" output="attenuation_distance_out" nodegraph="nodegraph1" />
    <input name="sheen_color" type="color3" output="sheen_color_out" nodegraph="nodegraph1" />
    <input name="sheen_roughness" type="float" output="sheen_roughness_out" nodegraph="nodegraph1" />
    <input name="clearcoat" type="float" output="clearcoat_out" nodegraph="nodegraph1" />
    <input name="clearcoat_roughness" type="float" output="clearcoat_roughness_out" nodegraph="nodegraph1" />
    <input name="iridescence" type="float" output="iridescence_out" nodegraph="nodegraph1" />
    <input name="iridescence_ior" type="float" output="iridescence_ior_out" nodegraph="nodegraph1" />
    <input name="iridescence_thickness" type="float" output="iridescence_thickness_out" nodegraph="nodegraph1" />
    <input name="dispersion" type="float" output="dispersion_out" nodegraph="nodegraph1" />
    <input name="emissive" type="color3" output="emissive_out" nodegraph="nodegraph1" />
    <input name="emissive_strength" type="float" output="emissive_strength_out" nodegraph="nodegraph1" />
    <input name="normal" type="vector3" output="normal_out" nodegraph="nodegraph1" />
    <input name="tangent" type="vector3" output="tangent_out" nodegraph="nodegraph1" />
    <input name="alpha" type="float" output="alpha_out" nodegraph="nodegraph1" />
    <input name="alpha_mode" type="integer" output="alpha_mode_out" nodegraph="nodegraph1" />
  </gltf_pbr>
  <surfacematerial name="ThinFilm" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="SR_thin_film" />
  </surfacematerial>
  <nodegraph name="nodegraph1">
    <standard_surface_to_gltf_pbr name="node1" type="multioutput" nodedef="ND_standard_surface_to_gltf_pbr">
      <input name="base" type="float" value="0.0" colorspace="lin_rec709" />
      <input name="base_color" type="color3" value="1, 1, 1" colorspace="lin_rec709" />
      <input name="specular" type="float" value="1" colorspace="lin_rec709" />
      <input name="specular_color" type="color3" value="1, 1, 1" colorspace="lin_rec709" />
      <input name="specular_roughness" type="float" value="0.02" colorspace="lin_rec709" />
      <input name="specular_IOR" type="float" value="2.5" colorspace="lin_rec709" />
      <input name="specular_anisotropy" type="float" value="0" colorspace="lin_rec709" />
      <input name="specular_rotation" type="float" value="0" colorspace="lin_rec709" />
      <input name="metalness" type="float" value="0" colorspace="lin_rec709" />
      <input name="thin_film_thickness" type="float" value="550" colorspace="lin_rec709" />
      <input name="thin_film_IOR" type="float" value="1.5" colorspace="lin_rec709" />
    </standard_surface_to_gltf_pbr>
    <output name="base_color_out" type="color3" nodename="node1" output="base_color_out" />
    <output name="metallic_out" type="float" nodename="node1" output="metallic_out" />
    <output name="roughness_out" type="float" nodename="node1" output="roughness_out" />
    <output name="specular_out" type="float" nodename="node1" output="specular_out" />
    <output name="specular_color_out" type="color3" nodename="node1" output="specular_color_out" />
    <output name="ior_out" type="float" nodename="node1" output="ior_out" />
    <output name="anisotropy_strength_out" type="float" nodename="node1" output="anisotropy_strength_out" />
    <output name="anisotropy_rotation_out" type="float" nodename="node1" output="anisotropy_rotation_out" />
    <output name="transmission_out" type="float" nodename="node1" output="transmission_out" />
    <output name="thickness_out" type="float" nodename="node1" output="thickness_out" />
    <output name="attenuation_color_out" type="color3" nodename="node1" output="attenuation_color_out" />
    <output name="attenuation_distance_out" type="float" nodename="node1" output="attenuation_distance_out" />
    <output name="sheen_color_out" type="color3" nodename="node1" output="sheen_color_out" />
    <output name="sheen_roughness_out" type="float" nodename="node1" output="sheen_roughness_out" />
    <output name="clearcoat_out" type="float" nodename="node1" output="clearcoat_out" />
    <output name="clearcoat_roughness_out" type="float" nodename="node1" output="clearcoat_roughness_out" />
    <output name="iridescence_out" type="float" nodename="node1" output="iridescence_out" />
    <output name="iridescence_ior_out" type="float" nodename="node1" output="iridescence_ior_out" />
    <output name="iridescence_thickness_out" type="float" nodename="node1" output="iridescence_thickness_out" />
    <output name="dispersion_out" type="float" nodename="node1" output="dispersion_out" />
    <output name="emissive_out" type="color3" nodename="node1" output="emissive_out" />
    <output name="emissive_strength_out" type="float" nodename="node1" output="emissive_strength_out" />
    <output name="normal_out" type="vector3" nodename="node1" output="normal_out" />
    <output name="tangent_out" type="vector3" nodename="node1" output="tangent_out" />
    <output name="alpha_out" type="float" nodename="node1" output="alpha_out" />
    <output name="alpha_mode_out" type="integer" nodename="node1" output="alpha_mode_out" />
  </nodegraph>
</materialx>
```

A few visual examples:
400 nm
<img width="940" height="828" alt="Screenshot_2026-05-08_08-49-44" src="https://github.com/user-attachments/assets/2d778bb2-f3fa-4a84-84c0-b6bfa6850b57" />

550 nm
<img width="940" height="828" alt="Screenshot_2026-05-08_08-49-33" src="https://github.com/user-attachments/assets/774b952e-c434-4c86-a088-f4ae0bdf4d4c" />

700 nm
<img width="940" height="828" alt="Screenshot_2026-05-08_08-49-55" src="https://github.com/user-attachments/assets/5760f131-f1a8-41c3-95b9-245d2dbdaff1" />

---
Closes #2583 