### PR TITLE
Align OSL `normalmap` tangent frame with GLSL/MSL

### DIFF
--- a/libraries/stdlib/genosl/mx_normalmap.osl
+++ b/libraries/stdlib/genosl/mx_normalmap.osl
@@ -1,21 +1,7 @@
 void mx_normalmap_vector2(vector value, vector2 normal_scale, vector N, vector T, vector B, output vector result)
 {
-    if (value == vector(0.0))
-    {
-        result = N;
-    }
-    else
-    {
-        // The OSL backend uses dPdu and dPdv for tangents and bitangents, but these vectors are not
-        // guaranteed to be orthonormal.
-        //
-        // Orthogonalize the tangent frame using Gram-Schmidt, unlike in the other backends.
-        //
-        vector v = value * 2.0 - 1.0;
-        vector Tn = normalize(T - dot(T, N) * N);
-        vector Bn = normalize(B - dot(B, N) * N - dot(B, Tn) * Tn);
-        result = normalize(Tn * v[0] * normal_scale.x + Bn * v[1] * normal_scale.y + N * v[2]);
-    }
+    vector v = (dot(value, value) == 0.0) ? vector(0.0, 0.0, 1.0) : value * 2.0 - 1.0;
+    result = normalize(T * v[0] * normal_scale.x + B * v[1] * normal_scale.y + N * v[2]);
 }
 
 void mx_normalmap_float(vector value, float normal_scale, vector N, vector T, vector B, output vector result)

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -193,10 +193,10 @@
   <implementation name="IM_normal_vector3_genosl" nodedef="ND_normal_vector3" target="genosl" sourcecode="transform({{space}}, N)" />
 
   <!-- <tangent> -->
-  <implementation name="IM_tangent_vector3_genosl" nodedef="ND_tangent_vector3" target="genosl" sourcecode="transform({{space}}, normalize(dPdu))" />
+  <implementation name="IM_tangent_vector3_genosl" nodedef="ND_tangent_vector3" target="genosl" sourcecode="normalize(transform({{space}}, dPdu))" />
 
   <!-- <bitangent> -->
-  <implementation name="IM_bitangent_vector3_genosl" nodedef="ND_bitangent_vector3" target="genosl" sourcecode="transform({{space}}, normalize(dPdv))" />
+  <implementation name="IM_bitangent_vector3_genosl" nodedef="ND_bitangent_vector3" target="genosl" sourcecode="normalize(transform({{space}}, cross(N, normalize(dPdu))))" />
 
   <!-- <texcoord> -->
   <implementation name="IM_texcoord_vector2_genosl" nodedef="ND_texcoord_vector2" target="genosl" sourcecode="vector2(u,v)" />

--- a/source/MaterialXGenOsl/OslShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslShaderGenerator.cpp
@@ -318,10 +318,10 @@ void OslShaderGenerator::emitShaderInputs(const VariableBlock& inputs, ShaderSta
         { "Pworld", "P" },
         { "Nobject", "transform(\"object\", N)" },
         { "Nworld", "N" },
-        { "Tobject", "transform(\"object\", dPdu)" },
-        { "Tworld", "dPdu" },
-        { "Bobject", "transform(\"object\", dPdv)" },
-        { "Bworld", "dPdv" },
+        { "Tobject", "normalize(transform(\"object\", dPdu))" },
+        { "Tworld", "normalize(dPdu)" },
+        { "Bobject", "normalize(cross(transform(\"object\", N), transform(\"object\", dPdu)))" },
+        { "Bworld", "normalize(cross(N, dPdu))" },
         { "UV0", "{u,v}" },
         { "Vworld", "I" }
     };

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -44,7 +44,7 @@ class TangentOsl : public mx::ShaderNodeImpl
         {
             shadergen.emitLineBegin(stage);
             shadergen.emitOutput(node.getOutput(), true, false, context, stage);
-            shadergen.emitString(" = normalize(vector(N[2], 0, -N[0]))", stage);
+            shadergen.emitString(" = normalize(dPdu)", stage);
             shadergen.emitLineEnd(stage);
         }
     }
@@ -66,7 +66,7 @@ class BitangentOsl : public mx::ShaderNodeImpl
         {
             shadergen.emitLineBegin(stage);
             shadergen.emitOutput(node.getOutput(), true, false, context, stage);
-            shadergen.emitString(" = normalize(cross(N, vector(N[2], 0, -N[0])))", stage);
+            shadergen.emitString(" = normalize(cross(N, normalize(dPdu)))", stage);
             shadergen.emitLineEnd(stage);
         }
     }


### PR DESCRIPTION
## Problem
The `color3_vec3_cm` standard surface sample rendered incorrectly with `materialx-osl` compared with `materialx-glsl`, `materialx-metal`, and other renderers. Investigation showed the color-management and `color3 -> vector3` conversion path was correct: the generated shader applied `srgb_texture_to_lin_rec709`, then converted the resulting `color3` to `vector3` before feeding `normalmap`.

The mismatch came from the OSL normal-map implementation and tangent-frame setup. OSL used an OSL-specific Gram-Schmidt path and `dPdv`-based bitangents, while the hardware backends use a tangent plus `cross(N, T)` bitangent convention.

<img width="654" height="306" alt="Screenshot 2026-05-07 at 2 27 38 PM" src="https://github.com/user-attachments/assets/1e0abf1c-727b-4614-9ded-a97f5f9f4578" />


This also affected "tangent" and "binormal" nodes, oil results were a mismatch compared to glsl/metal:

<img width="663" height="960" alt="Screenshot 2026-05-07 at 2 26 16 PM" src="https://github.com/user-attachments/assets/f74e7866-552b-46d5-9f8b-e15f8c7e194d" />


## Solution
Align the OSL normal-map path with the GLSL/MSL convention:

- Update `mx_normalmap.osl` to use the same normal-map formula as the hardware implementations.
- Normalize OSL tangent geomprops and derive bitangents as `cross(N, T)`.
- Update the local `materialx-osl` and OSL render-test tangent/bitangent overrides to use the same convention.

## How It Was Realized
The generated OSL for the failing sample was inspected to confirm the color transform and `convert_color3_vector3` graph were emitted correctly. The divergence was isolated to the tangent-space normal-map path. Since OSL `testrender` does not currently expose mesh tangent attributes through the OBJ path, the fix uses the available OSL derivatives consistently and derives the bitangent from `N` and normalized `dPdu`, matching the hardware backend convention more closely.

<img width="647" height="308" alt="Screenshot 2026-05-07 at 2 27 47 PM" src="https://github.com/user-attachments/assets/ad769a1e-0c80-49c7-a5e7-89619819cfff" />

And tangent and binormal nodes in oil now match glsl/metal:

<img width="656" height="971" alt="Screenshot 2026-05-07 at 2 26 32 PM" src="https://github.com/user-attachments/assets/d6733add-ddff-4c27-a1d6-ecade024897b" />
