### PR TITLE
Bug fix: incorrect transpose in Metal inverse world matrices

### DIFF
--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -1172,12 +1172,12 @@ void MslProgram::bindUniformBuffers(id<MTLRenderCommandEncoder> renderCmdEncoder
         }
         if (uniformName == HW::WORLD_INVERSE_MATRIX)
         {
-            memcpy((void*) &data[offset], invWorld.getTranspose().data(), 4 * 4 * sizeof(float));
+            memcpy((void*) &data[offset], invWorld.data(), 4 * 4 * sizeof(float));
             return true;
         }
         if (uniformName == HW::WORLD_INVERSE_TRANSPOSE_MATRIX)
         {
-            memcpy((void*) &data[offset], invTransWorld.getTranspose().data(), 4 * 4 * sizeof(float));
+            memcpy((void*) &data[offset], invTransWorld.data(), 4 * 4 * sizeof(float));
             return true;
         }
         if (uniformName == HW::FRAME)


### PR DESCRIPTION
The world inverse matrix uniforms in metal are incorrectly transposed.  This removes this incorrect transposes

You can tell pretty clearly that this is incorrect because when it sets the WORLD_MATRIX just a few lines above, it doesn't transpose it, so why transpose the inverse?

https://github.com/bhouston/MaterialX/blob/fe92050e77f6f64984958abf0461747369c713b4/source/MaterialXRenderMsl/MslPipelineStateObject.mm#L1163

This was found via the fidelity test suite.

