### PR TITLE
Align OSL implementation of `cellnoise3d` with GLSL

### DIFF
--- a/libraries/stdlib/genosl/mx_cellnoise3d_float.osl
+++ b/libraries/stdlib/genosl/mx_cellnoise3d_float.osl
@@ -1,4 +1,6 @@
 void mx_cellnoise3d_float(vector position, output float result)
 {
-    result = cellnoise(position);
+    // Use the explicit point overload for deterministic 3D cell lookup.
+    // Avoid relying on implicit vector conversion in the OSL builtin.
+    result = cellnoise(point(position));
 }


### PR DESCRIPTION
I will be honest, I am not sure why this fixes the issue but it does.

Prior to this fix cellnoise3d looked different for OSL as compared to Metal/GLSL:

<img width="663" height="663" alt="Screenshot 2026-05-08 at 4 56 37 PM" src="https://github.com/user-attachments/assets/1186302f-90f7-415f-8515-8d2e84b19cb6" />

After this fix they match:

<img width="656" height="659" alt="Screenshot 2026-05-08 at 4 57 53 PM" src="https://github.com/user-attachments/assets/42afe772-4a51-43bf-807c-039496526017" />
