### PR TITLE
Use `windows-2022` for VS2022 in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
           cmake_config: -G "Visual Studio 17 2022" -A "Win32"
 
         - name: Windows_VS2022_x64_Python313
-          os: windows-2025
+          os: windows-2022
           architecture: x64
           python: 3.13
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
@@ -124,7 +124,7 @@ jobs:
           extended_cmake_config: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-release -DMATERIALX_MDL_SDK_DIR=C:/vcpkg/installed/x64-windows-release
 
         - name: Windows_VS2022_x64_Python314
-          os: windows-2025
+          os: windows-2022
           architecture: x64
           python: 3.14
           cmake_config: -G "Visual Studio 17 2022" -A "x64"
@@ -133,7 +133,7 @@ jobs:
           extended_cmake_config: -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows -DMATERIALX_BUILD_OIIO=ON
 
         - name: Windows_VS2022_x64_SharedLibs
-          os: windows-2025
+          os: windows-2022
           architecture: x64
           python: None
           cmake_config: -G "Visual Studio 17 2022" -A "x64" -DMATERIALX_BUILD_SHARED_LIBS=ON


### PR DESCRIPTION
This changelist updates GitHub CI to use `windows-2022` consistently for VS2022 builds, as an upcoming change to GitHub Actions will replace `windows-2025` with a VS2026-focused environment.