### PR TITLE
Bug fix: align osl range with glsl range via clamp-> max/min

### DIFF
--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -436,17 +436,17 @@
   <implementation name="IM_sign_vector4_genosl" nodedef="ND_sign_vector4" target="genosl" sourcecode="sign({{in}})" />
 
   <!-- <clamp> -->
-  <implementation name="IM_clamp_float_genosl" nodedef="ND_clamp_float" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color3_genosl" nodedef="ND_clamp_color3" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color3FA_genosl" nodedef="ND_clamp_color3FA" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color4_genosl" nodedef="ND_clamp_color4" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_color4FA_genosl" nodedef="ND_clamp_color4FA" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector2_genosl" nodedef="ND_clamp_vector2" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector2FA_genosl" nodedef="ND_clamp_vector2FA" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector3_genosl" nodedef="ND_clamp_vector3" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector3FA_genosl" nodedef="ND_clamp_vector3FA" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector4_genosl" nodedef="ND_clamp_vector4" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
-  <implementation name="IM_clamp_vector4FA_genosl" nodedef="ND_clamp_vector4FA" target="genosl" sourcecode="clamp({{in}}, {{low}}, {{high}})" />
+  <implementation name="IM_clamp_float_genosl" nodedef="ND_clamp_float" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_color3_genosl" nodedef="ND_clamp_color3" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_color3FA_genosl" nodedef="ND_clamp_color3FA" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_color4_genosl" nodedef="ND_clamp_color4" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_color4FA_genosl" nodedef="ND_clamp_color4FA" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_vector2_genosl" nodedef="ND_clamp_vector2" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_vector2FA_genosl" nodedef="ND_clamp_vector2FA" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_vector3_genosl" nodedef="ND_clamp_vector3" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_vector3FA_genosl" nodedef="ND_clamp_vector3FA" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_vector4_genosl" nodedef="ND_clamp_vector4" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
+  <implementation name="IM_clamp_vector4FA_genosl" nodedef="ND_clamp_vector4FA" target="genosl" sourcecode="min(max({{in}}, {{low}}), {{high}})" />
 
   <!-- <min> -->
   <implementation name="IM_min_float_genosl" nodedef="ND_min_float" target="genosl" sourcecode="min({{in1}}, {{in2}})" />


### PR DESCRIPTION
I noticed via the Fidelity Suite (https://materials-fidelity.ben3d.ca) that the range renders did not align between GLSL and OSL.  I have narrowed down the issue to that OSL uses a Clamp operation, where as GLSL uses nested Min/Max.  These can, when the range is inverted, produce different results.

For the parameters:
* in = 0.50
* low = 0.80
* high = 0.20 (note low > high)

Nested min/max produces: 0.20

```
min(max(in, low), high)
= min(max(0.50, 0.80), 0.20)
= min(0.80, 0.20)
= 0.20
```

Where as OSL's clamp produces: 0.8

```
if (in < low) return low;
else if (in > high) return high;
else return in;

0.50 < 0.80 is true
result = 0.80
```

Thus PR thus replaces OSL's native clamp with the equivalent to GLSL's nested min/max so that it produces identical results across the parameter range.

An alternative solution, would be to replace GLSL and other renderer's code with OSL equivalents.  I can see the argument for either solution.