### PR TITLE
Bug fix: guard asin/acos inputs outside [-1, 1] in osl

### DIFF
--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -387,8 +387,8 @@
   <implementation name="IM_sin_float_genosl" nodedef="ND_sin_float" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_float_genosl" nodedef="ND_cos_float" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_float_genosl" nodedef="ND_tan_float" target="genosl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" target="genosl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" target="genosl" sourcecode="acos({{in}})" />
+  <implementation name="IM_asin_float_genosl" nodedef="ND_asin_float" target="genosl" sourcecode="mx_ternary(abs({{in}}) <= 1.0, asin({{in}}), 0.0)" />
+  <implementation name="IM_acos_float_genosl" nodedef="ND_acos_float" target="genosl" sourcecode="mx_ternary(abs({{in}}) <= 1.0, acos({{in}}), 0.0)" />
   <implementation name="IM_atan2_float_genosl" nodedef="ND_atan2_float" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
   <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" target="genosl" sourcecode="cos({{in}})" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -393,20 +393,20 @@
   <implementation name="IM_sin_vector2_genosl" nodedef="ND_sin_vector2" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector2_genosl" nodedef="ND_cos_vector2" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector2_genosl" nodedef="ND_tan_vector2" target="genosl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" target="genosl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" target="genosl" sourcecode="acos({{in}})" />
+  <implementation name="IM_asin_vector2_genosl" nodedef="ND_asin_vector2" target="genosl" sourcecode="vector2(mx_ternary(abs({{in}}.x) &lt;= 1.0, asin({{in}}.x), 0.0), mx_ternary(abs({{in}}.y) &lt;= 1.0, asin({{in}}.y), 0.0))" />
+  <implementation name="IM_acos_vector2_genosl" nodedef="ND_acos_vector2" target="genosl" sourcecode="vector2(mx_ternary(abs({{in}}.x) &lt;= 1.0, acos({{in}}.x), 0.0), mx_ternary(abs({{in}}.y) &lt;= 1.0, acos({{in}}.y), 0.0))" />
   <implementation name="IM_atan2_vector2_genosl" nodedef="ND_atan2_vector2" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
   <implementation name="IM_sin_vector3_genosl" nodedef="ND_sin_vector3" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector3_genosl" nodedef="ND_cos_vector3" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector3_genosl" nodedef="ND_tan_vector3" target="genosl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" target="genosl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" target="genosl" sourcecode="acos({{in}})" />
+  <implementation name="IM_asin_vector3_genosl" nodedef="ND_asin_vector3" target="genosl" sourcecode="vector(mx_ternary(abs({{in}}.x) &lt;= 1.0, asin({{in}}.x), 0.0), mx_ternary(abs({{in}}.y) &lt;= 1.0, asin({{in}}.y), 0.0), mx_ternary(abs({{in}}.z) &lt;= 1.0, asin({{in}}.z), 0.0))" />
+  <implementation name="IM_acos_vector3_genosl" nodedef="ND_acos_vector3" target="genosl" sourcecode="vector(mx_ternary(abs({{in}}.x) &lt;= 1.0, acos({{in}}.x), 0.0), mx_ternary(abs({{in}}.y) &lt;= 1.0, acos({{in}}.y), 0.0), mx_ternary(abs({{in}}.z) &lt;= 1.0, acos({{in}}.z), 0.0))" />
   <implementation name="IM_atan2_vector3_genosl" nodedef="ND_atan2_vector3" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
   <implementation name="IM_sin_vector4_genosl" nodedef="ND_sin_vector4" target="genosl" sourcecode="sin({{in}})" />
   <implementation name="IM_cos_vector4_genosl" nodedef="ND_cos_vector4" target="genosl" sourcecode="cos({{in}})" />
   <implementation name="IM_tan_vector4_genosl" nodedef="ND_tan_vector4" target="genosl" sourcecode="tan({{in}})" />
-  <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" target="genosl" sourcecode="asin({{in}})" />
-  <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" target="genosl" sourcecode="acos({{in}})" />
+  <implementation name="IM_asin_vector4_genosl" nodedef="ND_asin_vector4" target="genosl" sourcecode="vector4(mx_ternary(abs({{in}}.x) &lt;= 1.0, asin({{in}}.x), 0.0), mx_ternary(abs({{in}}.y) &lt;= 1.0, asin({{in}}.y), 0.0), mx_ternary(abs({{in}}.z) &lt;= 1.0, asin({{in}}.z), 0.0), mx_ternary(abs({{in}}.w) &lt;= 1.0, asin({{in}}.w), 0.0))" />
+  <implementation name="IM_acos_vector4_genosl" nodedef="ND_acos_vector4" target="genosl" sourcecode="vector4(mx_ternary(abs({{in}}.x) &lt;= 1.0, acos({{in}}.x), 0.0), mx_ternary(abs({{in}}.y) &lt;= 1.0, acos({{in}}.y), 0.0), mx_ternary(abs({{in}}.z) &lt;= 1.0, acos({{in}}.z), 0.0), mx_ternary(abs({{in}}.w) &lt;= 1.0, acos({{in}}.w), 0.0))" />
   <implementation name="IM_atan2_vector4_genosl" nodedef="ND_atan2_vector4" target="genosl" sourcecode="atan2({{iny}},{{inx}})" />
 
   <!-- <sqrt> -->


### PR DESCRIPTION
I noticed via the https://material-fidelity.ben3d.ca test suite that out of range asin/acos values render different in MaterialX OSL as compared to the GLSL / Metal versions.

Before fix render comparisons:
<img width="1213" height="663" alt="Screenshot 2026-05-11 at 12 17 56 PM" src="https://github.com/user-attachments/assets/25660445-81ff-4c5b-9316-28764f8d08fc" />


This updates the `genosl` stdlib implementations for `asin` and `acos` to explicitly guard out-of-domain inputs so that the resulting value matches that produced by materialx glsl.

- `ND_asin_float`: `asin(in)` -> `mx_ternary(abs(in) <= 1.0, asin(in), 0.0)`
- `ND_acos_float`: `acos(in)` -> `mx_ternary(abs(in) <= 1.0, acos(in), 0.0)`

## Why

In degenerate-but-valid authoring cases, some graphs intentionally feed values outside `[-1, 1]` into inverse trig nodes. Backend behavior for out-of-domain inputs can differ (NaN propagation, clamping, or undefined results), which causes renderer divergence.

This change makes `genosl` behavior explicit and deterministic for those edge cases, improving cross-backend consistency.


## Validation

After fix render (I also fixed the blender-materialx-importer as well) comparisons:
<img width="1207" height="667" alt="Screenshot 2026-05-11 at 12 18 36 PM" src="https://github.com/user-attachments/assets/48697983-e1e3-4f82-ba8b-a405cdaf7710" />

## Notes

This PR is intentionally minimal and only changes `genosl` source expressions for float `asin`/`acos`.