### PR TITLE
Bug fix: guard ln against nonpositive inputs in OSL

### DIFF
--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -416,7 +416,7 @@
   <implementation name="IM_sqrt_vector4_genosl" nodedef="ND_sqrt_vector4" target="genosl" sourcecode="sqrt({{in}})" />
 
   <!-- <ln> -->
-  <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" target="genosl" sourcecode="log({{in}})" />
+  <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" target="genosl" sourcecode="mx_ternary({{in}} > 0.0, log({{in}}), 0.0)" />
   <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" target="genosl" sourcecode="log({{in}})" />
   <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" target="genosl" sourcecode="log({{in}})" />
   <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" target="genosl" sourcecode="log({{in}})" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -417,9 +417,9 @@
 
   <!-- <ln> -->
   <implementation name="IM_ln_float_genosl" nodedef="ND_ln_float" target="genosl" sourcecode="mx_ternary({{in}} > 0.0, log({{in}}), 0.0)" />
-  <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" target="genosl" sourcecode="log({{in}})" />
-  <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" target="genosl" sourcecode="log({{in}})" />
-  <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" target="genosl" sourcecode="log({{in}})" />
+  <implementation name="IM_ln_vector2_genosl" nodedef="ND_ln_vector2" target="genosl" sourcecode="vector2(mx_ternary({{in}}.x &gt; 0.0, log({{in}}.x), 0.0), mx_ternary({{in}}.y &gt; 0.0, log({{in}}.y), 0.0))" />
+  <implementation name="IM_ln_vector3_genosl" nodedef="ND_ln_vector3" target="genosl" sourcecode="vector(mx_ternary({{in}}.x &gt; 0.0, log({{in}}.x), 0.0), mx_ternary({{in}}.y &gt; 0.0, log({{in}}.y), 0.0), mx_ternary({{in}}.z &gt; 0.0, log({{in}}.z), 0.0))" />
+  <implementation name="IM_ln_vector4_genosl" nodedef="ND_ln_vector4" target="genosl" sourcecode="vector4(mx_ternary({{in}}.x &gt; 0.0, log({{in}}.x), 0.0), mx_ternary({{in}}.y &gt; 0.0, log({{in}}.y), 0.0), mx_ternary({{in}}.z &gt; 0.0, log({{in}}.z), 0.0), mx_ternary({{in}}.w &gt; 0.0, log({{in}}.w), 0.0))" />
 
   <!-- <exp> -->
   <implementation name="IM_exp_float_genosl" nodedef="ND_exp_float" target="genosl" sourcecode="exp({{in}})" />


### PR DESCRIPTION
I noticed OSL rendered negative ln node inputs different than GLSL and Metal.  It is because it lacks a guard against negative values.

The visual results were this:

<img width="1185" height="328" alt="Screenshot 2026-05-11 at 12 33 42 PM" src="https://github.com/user-attachments/assets/8f3fbb18-7b31-498f-b948-19f36951c776" />


So I upated the `genosl` float `ln` implementation to handle nonpositive inputs explicitly:

- `ND_ln_float`: `log(in)` -> `mx_ternary(in > 0.0, log(in), 0.0)`

## Why

Degenerate-but-valid MaterialX graphs may feed zero or negative values into `ln`. In those cases, backend behavior can diverge due to undefined/non-finite math handling. This produced visible mismatch in `materialx-osl` versus the reference renderer behavior.

Making the fallback explicit in `genosl` improves deterministic behavior and cross-renderer consistency for these edge cases.

## Validation

The visual results across the renderers now match after this fix:

<img width="1218" height="333" alt="Screenshot 2026-05-11 at 12 33 51 PM" src="https://github.com/user-attachments/assets/b10f6e34-706c-4a82-bd6f-99406d710895" />
