### PR TITLE
Bug fix: smoothstep should emulate glsl behavior in degenerate cases

### DIFF
--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -544,9 +544,9 @@
 
   <!-- <smoothstep> -->
   <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" target="genosl" sourcecode="mx_ternary({{high}} > {{low}}, smoothstep({{low}}, {{high}}, {{in}}), mx_ternary({{in}} < {{high}}, 0.0, 1.0))" />
-  <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />
-  <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />
-  <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />
+  <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" target="genosl" sourcecode="vector2(mx_ternary({{high}}.x &gt; {{low}}.x, smoothstep({{low}}.x, {{high}}.x, {{in}}.x), mx_ternary({{in}}.x &lt; {{high}}.x, 0.0, 1.0)), mx_ternary({{high}}.y &gt; {{low}}.y, smoothstep({{low}}.y, {{high}}.y, {{in}}.y), mx_ternary({{in}}.y &lt; {{high}}.y, 0.0, 1.0)))" />
+  <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" target="genosl" sourcecode="vector(mx_ternary({{high}}.x &gt; {{low}}.x, smoothstep({{low}}.x, {{high}}.x, {{in}}.x), mx_ternary({{in}}.x &lt; {{high}}.x, 0.0, 1.0)), mx_ternary({{high}}.y &gt; {{low}}.y, smoothstep({{low}}.y, {{high}}.y, {{in}}.y), mx_ternary({{in}}.y &lt; {{high}}.y, 0.0, 1.0)), mx_ternary({{high}}.z &gt; {{low}}.z, smoothstep({{low}}.z, {{high}}.z, {{in}}.z), mx_ternary({{in}}.z &lt; {{high}}.z, 0.0, 1.0)))" />
+  <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" target="genosl" sourcecode="vector4(mx_ternary({{high}}.x &gt; {{low}}.x, smoothstep({{low}}.x, {{high}}.x, {{in}}.x), mx_ternary({{in}}.x &lt; {{high}}.x, 0.0, 1.0)), mx_ternary({{high}}.y &gt; {{low}}.y, smoothstep({{low}}.y, {{high}}.y, {{in}}.y), mx_ternary({{in}}.y &lt; {{high}}.y, 0.0, 1.0)), mx_ternary({{high}}.z &gt; {{low}}.z, smoothstep({{low}}.z, {{high}}.z, {{in}}.z), mx_ternary({{in}}.z &lt; {{high}}.z, 0.0, 1.0)), mx_ternary({{high}}.w &gt; {{low}}.w, smoothstep({{low}}.w, {{high}}.w, {{in}}.w), mx_ternary({{in}}.w &lt; {{high}}.w, 0.0, 1.0)))" />
 
   <!-- <luminance> -->
   <implementation name="IM_luminance_color3_genosl" nodedef="ND_luminance_color3" file="mx_luminance_color3.osl" function="mx_luminance_color3" target="genosl" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -543,7 +543,7 @@
   <implementation name="IM_remap_vector4FA_genosl" nodedef="ND_remap_vector4FA" target="genosl" sourcecode="mx_remap({{in}}, {{inlow}}, {{inhigh}}, {{outlow}}, {{outhigh}}, 0)" />
 
   <!-- <smoothstep> -->
-  <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />
+  <implementation name="IM_smoothstep_float_genosl" nodedef="ND_smoothstep_float" target="genosl" sourcecode="mx_ternary({{high}} > {{low}}, smoothstep({{low}}, {{high}}, {{in}}), mx_ternary({{in}} < {{high}}, 0.0, 1.0))" />
   <implementation name="IM_smoothstep_vector2_genosl" nodedef="ND_smoothstep_vector2" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />
   <implementation name="IM_smoothstep_vector3_genosl" nodedef="ND_smoothstep_vector3" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />
   <implementation name="IM_smoothstep_vector4_genosl" nodedef="ND_smoothstep_vector4" target="genosl" sourcecode="smoothstep({{low}}, {{high}}, {{in}})" />


### PR DESCRIPTION
Like most of my PRs I noticed via https://material-fidelity.ben3d.ca that smooth step when the bounds are inverted does not replicate glsl behaviour.  This PR fixes that.

## Summary

Update the float `smoothstep` implementation in `genosl` to handle degenerate/inverted bounds explicitly.

- `ND_smoothstep_float` now uses:
  - normal `smoothstep(low, high, in)` when `high > low`
  - a deterministic fallback when `high <= low`: hard step at `high` (`in < high ? 0.0 : 1.0`)

## Why

For inverted bounds, `smoothstep` behavior can diverge across backends due to undefined/implementation-dependent handling. This caused visible mismatch in `materialx-osl` for degenerate node tests.

Making the fallback explicit in `genosl` improves determinism and cross-renderer consistency for these edge cases.

## Validation

Renders from OSL, Metal and GLSL now match:

<img width="1220" height="327" alt="Screenshot 2026-05-11 at 12 38 10 PM" src="https://github.com/user-attachments/assets/68101c84-14bc-4023-b209-747fd87db83c" />
