### PR TITLE
Fix createValidChildName for Documents with referenced data libraries

### DIFF
--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -78,6 +78,18 @@ class MX_CORE_API Document : public GraphElement
         return _dataLibrary;
     }
 
+    /// Using the input name as a starting point, modify it to create a valid,
+    /// unique name for a child element.
+    string createValidChildName(string name) const override
+    {
+        name = name.empty() ? "_" : createValidName(name);
+        while (_childMap.count(name) || (_dataLibrary && _dataLibrary->getChild(name)))
+        {
+            name = incrementName(name);
+        }
+        return name;
+    }
+
     /// Import the given data library into this document.
     /// The contents of the data library are copied into this one, and
     /// are assigned the source URI of the library.

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -78,18 +78,6 @@ class MX_CORE_API Document : public GraphElement
         return _dataLibrary;
     }
 
-    /// Using the input name as a starting point, modify it to create a valid,
-    /// unique name for a child element.
-    string createValidChildName(string name) const override
-    {
-        name = name.empty() ? "_" : createValidName(name);
-        while (_childMap.count(name) || (_dataLibrary && _dataLibrary->getChild(name)))
-        {
-            name = incrementName(name);
-        }
-        return name;
-    }
-
     /// Import the given data library into this document.
     /// The contents of the data library are copied into this one, and
     /// are assigned the source URI of the library.

--- a/source/MaterialXCore/Element.cpp
+++ b/source/MaterialXCore/Element.cpp
@@ -278,6 +278,21 @@ ElementPtr Element::changeChildCategory(ElementPtr child, const string& category
     return newChild;
 }
 
+ElementPtr Element::getChild(const string& name) const
+{
+    ElementMap::const_iterator it = _childMap.find(name);
+    if (it != _childMap.end())
+    {
+        return it->second;
+    }
+    ConstDocumentPtr doc = asA<Document>();
+    if (doc && doc->hasDataLibrary())
+    {
+        return doc->getDataLibrary()->getChild(name);
+    }
+    return ElementPtr();
+}
+
 template <class T> shared_ptr<T> Element::getChildOfType(const string& name) const
 {
     ElementPtr child;

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -771,7 +771,7 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
 
     /// Using the input name as a starting point, modify it to create a valid,
     /// unique name for a child element.
-    string createValidChildName(string name) const
+    virtual string createValidChildName(string name) const
     {
         name = name.empty() ? "_" : createValidName(name);
         while (_childMap.count(name))

--- a/source/MaterialXCore/Element.h
+++ b/source/MaterialXCore/Element.h
@@ -431,11 +431,10 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
     ElementPtr changeChildCategory(ElementPtr child, const string& category);
 
     /// Return the child element, if any, with the given name.
-    ElementPtr getChild(const string& name) const
-    {
-        ElementMap::const_iterator it = _childMap.find(name);
-        return (it != _childMap.end()) ? it->second : ElementPtr();
-    }
+    /// For a Document with an attached data library, this also searches
+    /// the data library when no local child is found, keeping behavior
+    /// consistent with getChildOfType and getChildrenOfType.
+    ElementPtr getChild(const string& name) const;
 
     /// Return the child element, if any, with the given name and subclass.
     /// If a child with the given name exists, but belongs to a different
@@ -771,10 +770,10 @@ class MX_CORE_API Element : public std::enable_shared_from_this<Element>
 
     /// Using the input name as a starting point, modify it to create a valid,
     /// unique name for a child element.
-    virtual string createValidChildName(string name) const
+    string createValidChildName(string name) const
     {
         name = name.empty() ? "_" : createValidName(name);
-        while (_childMap.count(name))
+        while (getChild(name))
         {
             name = incrementName(name);
         }

--- a/source/MaterialXTest/MaterialXCore/Document.cpp
+++ b/source/MaterialXTest/MaterialXCore/Document.cpp
@@ -271,3 +271,91 @@ TEST_CASE("Document equivalence", "[document]")
     equivalent = doc->isEquivalent(doc2, options, &message);
     REQUIRE(!equivalent);
 }
+
+TEST_CASE("Document createValidChildName", "[document]")
+{
+    // Create a custom library.
+    mx::DocumentPtr customLibrary = mx::createDocument();
+    mx::NodeDefPtr customNodeDef = customLibrary->addNodeDef("ND_simpleSrf", mx::SURFACE_SHADER_TYPE_STRING, "simpleSrf");
+    mx::ImplementationPtr customImpl = customLibrary->addImplementation("IM_custom");
+    customImpl->setNodeDef(customNodeDef);
+    REQUIRE(customLibrary->validate());
+
+    mx::DocumentPtr doc;
+
+    // Create a document and import the data library
+    doc = mx::createDocument();
+    doc->importLibrary(customLibrary);
+
+    // test createValidChildName with imported data library
+    {
+        // add a non-clashing name
+        std::string nodename_01_orig = "non_clashing_name";
+        std::string nodename_01 = doc->createValidChildName(nodename_01_orig);
+        REQUIRE(nodename_01_orig == nodename_01);
+
+        mx::NodePtr node_01 = doc->addNodeInstance(customNodeDef, nodename_01);
+        REQUIRE(doc->validate());
+        REQUIRE(node_01->getName() == nodename_01);
+
+        // add a clashing name - which needs to be uniquified.
+        std::string nodename_02_orig = "non_clashing_name";
+        std::string nodename_02 = doc->createValidChildName(nodename_02_orig);
+        REQUIRE(nodename_02_orig != nodename_02);
+
+        // add the same name this should be uniquified
+        mx::NodePtr node_02 = doc->addNodeInstance(customNodeDef, nodename_02);
+        REQUIRE(doc->validate());
+        REQUIRE(node_02->getName() == nodename_02);
+
+        // add a name that clashes with something that is in the data library
+        std::string nodename_03_orig = "ND_simpleSrf";
+        std::string nodename_03 = doc->createValidChildName(nodename_03_orig);
+        REQUIRE(nodename_03_orig != nodename_03);
+
+        mx::NodePtr node_03 = doc->addNodeInstance(customNodeDef, nodename_03);
+        REQUIRE(doc->validate());
+        REQUIRE(node_03->getName() == nodename_03);
+        
+        // an empty name should be replaced with a valid placeholder
+        REQUIRE(!doc->createValidChildName("").empty());
+    }
+
+    // Create a document and reference the data library
+    doc = mx::createDocument();
+    doc->setDataLibrary(customLibrary);
+
+    // test createValidChildName with referenced data library
+    {
+        // add a non-clashing name
+        std::string nodename_01_orig = "non_clashing_name";
+        std::string nodename_01 = doc->createValidChildName(nodename_01_orig);
+        REQUIRE(nodename_01_orig == nodename_01);
+
+        mx::NodePtr node_01 = doc->addNodeInstance(customNodeDef, nodename_01);
+        REQUIRE(doc->validate());
+        REQUIRE(node_01->getName() == nodename_01);
+
+        // add a clashing name - which needs to be uniquified.
+        std::string nodename_02_orig = "non_clashing_name";
+        std::string nodename_02 = doc->createValidChildName(nodename_02_orig);
+        REQUIRE(nodename_02_orig != nodename_02);
+
+        // add the same name this should be uniquified
+        mx::NodePtr node_02 = doc->addNodeInstance(customNodeDef, nodename_02);
+        REQUIRE(doc->validate());
+        REQUIRE(node_02->getName() == nodename_02);
+
+        // add a name that clashes with something that is in the data library
+        std::string nodename_03_orig = "ND_simpleSrf";
+        std::string nodename_03 = doc->createValidChildName(nodename_03_orig);
+        REQUIRE(nodename_03_orig != nodename_03);
+
+        mx::NodePtr node_03 = doc->addNodeInstance(customNodeDef, nodename_03);
+        REQUIRE(doc->validate());
+        REQUIRE(node_03->getName() == nodename_03);
+
+        // an empty name should be replaced with a valid placeholder
+        REQUIRE(!doc->createValidChildName("").empty());
+    }
+}


### PR DESCRIPTION
This should address #2922. 
