### PR TITLE
Fix alpha handling in HSV/RGB conversion in GLSL/OSL

### DIFF
--- a/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl
@@ -2,5 +2,5 @@
 
 void mx_hsvtorgb_color4(vec4 _in, out vec4 result)
 {
-    result = vec4(mx_hsvtorgb(_in.rgb), 1.0);
+    result = vec4(mx_hsvtorgb(_in.rgb), _in.a);
 }

--- a/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
+++ b/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl
@@ -2,5 +2,5 @@
 
 void mx_rgbtohsv_color4(vec4 _in, out vec4 result)
 {
-    result = vec4(mx_rgbtohsv(_in.rgb), 1.0);
+    result = vec4(mx_rgbtohsv(_in.rgb), _in.a);
 }

--- a/libraries/stdlib/genosl/mx_hsvtorgb_color4.osl
+++ b/libraries/stdlib/genosl/mx_hsvtorgb_color4.osl
@@ -1,4 +1,4 @@
 void mx_hsvtorgb_color4(color4 _in, output color4 result)
 {
-    result = color4(transformc("hsv","rgb", _in.rgb), 1.0);
+    result = color4(transformc("hsv","rgb", _in.rgb), _in.a);
 }

--- a/libraries/stdlib/genosl/mx_rgbtohsv_color4.osl
+++ b/libraries/stdlib/genosl/mx_rgbtohsv_color4.osl
@@ -1,4 +1,4 @@
 void mx_rgbtohsv_color4(color4 _in, output color4 result)
 {
-    result = color4(transformc("rgb","hsv", _in.rgb), 1.0);
+    result = color4(transformc("rgb","hsv", _in.rgb), _in.a);
 }


### PR DESCRIPTION
`mx_rgbtohsv` and `xm_hsvtorgb` had hardcoded output alpha set to `1.0`. The alpha channel should forward the preexisting alpha value `_in.a` unchanged.

Changes made in
- `/libraries/stdlib/genglsl/mx_hsvtorgb_color4.glsl`
- `/libraries/stdlib/genglsl/mx_rgbtohsv_color4.glsl`
- `/libraries/stdlib/genosl/mx_hsvtorgb_color4.osl`
- `/libraries/stdlib/genosl/mx_rgbtohsv_color4.osl`

This fixes #2765 