### PR TITLE
Fix material switching in the MaterialX Web Viewer

### DIFF
--- a/javascript/MaterialXView/source/viewer.js
+++ b/javascript/MaterialXView/source/viewer.js
@@ -1111,8 +1111,14 @@ export class Material
                     {
                         continue;
                     }
-                    
-                    // Skip non-input types and anything > 2 levels deep 
+
+                    // Skip elements from the referenced data library
+                    if (currentElem.getActiveSourceUri() !== elem.getDocument().getSourceUri())
+                    {
+                        continue;
+                    }
+
+                    // Skip non-input types and anything > 2 levels deep
                     if (!currentElem.asAInput() || currentElem.getNamePath().split('/').length > 2)
                     {
                         continue;


### PR DESCRIPTION
This changelist fixes a regression in the MaterialX Web Viewer, where switching to any example material other than Standard Surface Default would fail to update the rendered material.

Since the update to `Element::getChild` in #2923, calling `Element::getDescendant` on a Document with a referenced data library can resolve uniform paths _into_ the library, returning elements such as NodeDef inputs whose parent is not a Node.  The Web Viewer's property editor then throws a `TypeError` when calling `getNodeDef` on the NodeDef parent, preventing materials other than Standard Surface Default (which declares all inputs explicitly) from displaying.

The fix is to skip descendants whose active source URI differs from that of the working document, ensuring the property editor only processes elements from the content document.