### PR TITLE
Improving NodeGraph::getNodeDef performance

### DIFF
--- a/source/MaterialXCore/Document.cpp
+++ b/source/MaterialXCore/Document.cpp
@@ -69,6 +69,13 @@ class Document::Cache
         return (it != _implementationMap.end()) ? it->second : vector<InterfaceElementPtr>();
     }
 
+    ImplementationPtr getImplementationForNodeGraph(const string& nodeGraphName)
+    {
+        auto lock = refreshWithLock();
+        auto it = _nodeGraphImplMap.find(nodeGraphName);
+        return (it != _nodeGraphImplMap.end()) ? it->second : ImplementationPtr();
+    }
+
   private:
     std::shared_lock<std::shared_mutex> refreshWithLock()
     {
@@ -103,6 +110,7 @@ class Document::Cache
         _portElementMap.clear();
         _nodeDefMap.clear();
         _implementationMap.clear();
+        _nodeGraphImplMap.clear();
 
         // Traverse the document to build a new cache.
         for (ElementPtr elem : doc->traverseTree())
@@ -119,6 +127,14 @@ class Document::Cache
                 if (portElem)
                 {
                     _portElementMap[portElem->getQualifiedName(portKey)].push_back(portElem);
+                }
+            }
+            if (!nodeGraphName.empty())
+            {
+                ImplementationPtr impl = elem->asA<Implementation>();
+                if (impl)
+                {
+                    _nodeGraphImplMap[impl->getQualifiedName(nodeGraphName)] = impl;
                 }
             }
             if (!nodeString.empty())
@@ -152,6 +168,7 @@ class Document::Cache
     std::unordered_map<string, std::vector<PortElementPtr>> _portElementMap;
     std::unordered_map<string, std::vector<NodeDefPtr>> _nodeDefMap;
     std::unordered_map<string, std::vector<InterfaceElementPtr>> _implementationMap;
+    std::unordered_map<string, ImplementationPtr> _nodeGraphImplMap;
 };
 
 //
@@ -378,9 +395,7 @@ vector<OutputPtr> Document::getMaterialOutputs() const
 vector<NodeDefPtr> Document::getMatchingNodeDefs(const string& nodeName) const
 {
     // Recurse to data library if present.
-    vector<NodeDefPtr> matchingNodeDefs = hasDataLibrary() ?
-                                          getDataLibrary()->getMatchingNodeDefs(nodeName) :
-                                          vector<NodeDefPtr>();
+    vector<NodeDefPtr> matchingNodeDefs = hasDataLibrary() ? getDataLibrary()->getMatchingNodeDefs(nodeName) : vector<NodeDefPtr>();
 
     // Append all nodedefs matching the given node name.
     vector<NodeDefPtr> localNodeDefs = _cache->getMatchingNodeDefs(nodeName);
@@ -392,15 +407,26 @@ vector<NodeDefPtr> Document::getMatchingNodeDefs(const string& nodeName) const
 vector<InterfaceElementPtr> Document::getMatchingImplementations(const string& nodeDef) const
 {
     // Recurse to data library if present.
-    vector<InterfaceElementPtr> matchingImplementations = hasDataLibrary() ?
-                                                          getDataLibrary()->getMatchingImplementations(nodeDef) :
-                                                          vector<InterfaceElementPtr>();
+    vector<InterfaceElementPtr> matchingImplementations = hasDataLibrary() ? getDataLibrary()->getMatchingImplementations(nodeDef) : vector<InterfaceElementPtr>();
 
     // Append all implementations matching the given nodedef string.
     vector<InterfaceElementPtr> localImpls = _cache->getMatchingImplementations(nodeDef);
     matchingImplementations.insert(matchingImplementations.end(), localImpls.begin(), localImpls.end());
 
     return matchingImplementations;
+}
+
+ImplementationPtr Document::getImplementationForNodeGraph(const string& nodeGraphName) const
+{
+    if (hasDataLibrary())
+    {
+        ImplementationPtr impl = getDataLibrary()->getImplementationForNodeGraph(nodeGraphName);
+        if (impl)
+        {
+            return impl;
+        }
+    }
+    return _cache->getImplementationForNodeGraph(nodeGraphName);
 }
 
 bool Document::validate(string* message) const

--- a/source/MaterialXCore/Document.h
+++ b/source/MaterialXCore/Document.h
@@ -551,6 +551,10 @@ class MX_CORE_API Document : public GraphElement
     /// Implementation element or NodeGraph element.
     vector<InterfaceElementPtr> getMatchingImplementations(const string& nodeDef) const;
 
+    /// Return the Implementation, if any, whose nodegraph attribute matches
+    /// the given fully-qualified nodegraph name.
+    ImplementationPtr getImplementationForNodeGraph(const string& nodeGraphName) const;
+
     /// @}
     /// @name UnitDef Elements
     /// @{

--- a/source/MaterialXCore/Node.cpp
+++ b/source/MaterialXCore/Node.cpp
@@ -192,7 +192,7 @@ vector<PortElementPtr> Node::getDownstreamPorts() const
         }
     }
     std::sort(downstreamPorts.begin(), downstreamPorts.end(), [](const ConstElementPtr& a, const ConstElementPtr& b)
-    {
+              {
         return a->getName() > b->getName();
     });
     return downstreamPorts;
@@ -745,12 +745,10 @@ NodeDefPtr NodeGraph::getNodeDef() const
     // If not directly defined look for an implementation which has a nodedef association
     if (!nodedef)
     {
-        for (auto impl : getDocument()->getImplementations())
+        ImplementationPtr impl = getDocument()->getImplementationForNodeGraph(getQualifiedName(getName()));
+        if (impl)
         {
-            if (impl->getNodeGraph() == getQualifiedName(getName()))
-            {
-                nodedef = impl->getNodeDef();
-            }
+            nodedef = impl->getNodeDef();
         }
     }
     return nodedef;
@@ -775,7 +773,7 @@ vector<PortElementPtr> NodeGraph::getDownstreamPorts() const
         }
     }
     std::sort(downstreamPorts.begin(), downstreamPorts.end(), [](const ConstElementPtr& a, const ConstElementPtr& b)
-    {
+              {
         return a->getName() > b->getName();
     });
     return downstreamPorts;

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -153,7 +153,7 @@ void Syntax::makeValidName(string& name) const
 {
     std::replace_if(name.begin(), name.end(), isInvalidChar, '_');
     name = replaceSubstrings(name, _invalidTokens);
-    if (std::find(_reservedWords.begin(), _reservedWords.end(), name) != _reservedWords.end())
+    if (_reservedWords.find(name) != _reservedWords.end())
     {
         // We append "1" here because thats the prior behavior from makeIdentifier() below when
         // the reservedWords were added to the identifiers list.

--- a/source/MaterialXTest/MaterialXCore/Performance.cpp
+++ b/source/MaterialXTest/MaterialXCore/Performance.cpp
@@ -1,0 +1,73 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <MaterialXTest/External/Catch/catch.hpp>
+
+#ifdef CATCH_CONFIG_ENABLE_BENCHMARKING
+
+    #include <MaterialXCore/Definition.h>
+    #include <MaterialXCore/Document.h>
+    #include <MaterialXCore/Node.h>
+
+namespace mx = MaterialX;
+
+// Build a document that scales the two axes feeding NodeGraph::getNodeDef
+// from PortElement::validate:
+//   * numImplStubs     - document-root <implementation> elements; sizes the
+//                        Document::Cache nodegraph -> implementation map.
+//   * numNodegraphRefs - inputs that resolve through a nodegraph; each one
+//                        performs a cache lookup.
+static mx::DocumentPtr buildScalingDocument(size_t numImplStubs, size_t numNodegraphRefs)
+{
+    mx::DocumentPtr doc = mx::createDocument();
+
+    // A nodegraph with one internal node and one output, so that
+    // PortElement::getConnectedNode() resolves transitively through the
+    // output (see Input::getConnectedNode in Interface.cpp).
+    mx::NodeGraphPtr ng = doc->addNodeGraph("ng");
+    mx::NodePtr inner = ng->addNode("constant", "inner", "color3");
+    mx::OutputPtr out = ng->addOutput("out", "color3");
+    out->setNodeName(inner->getName());
+
+    // A host node parenting many inputs that reference the nodegraph.
+    mx::NodePtr host = doc->addNode("surface", "host", "surfaceshader");
+    for (size_t i = 0; i < numNodegraphRefs; ++i)
+    {
+        mx::InputPtr in = host->addInput("in" + std::to_string(i), "color3");
+        in->setNodeGraphString("ng");
+        in->setOutputString("out");
+    }
+
+    for (size_t i = 0; i < numImplStubs; ++i)
+    {
+        mx::ImplementationPtr impl = doc->addImplementation("i" + std::to_string(i));
+        impl->setNodeDefString("n" + std::to_string(i));
+    }
+
+    return doc;
+}
+
+TEST_CASE("NodeGraph getNodeDef performance", "[node][performance]")
+{
+    BENCHMARK("validate, stubs=200 refs=100")
+    {
+        mx::DocumentPtr doc = buildScalingDocument(200, 100);
+        return doc->validate();
+    };
+
+    BENCHMARK("validate, stubs=1000 refs=100")
+    {
+        mx::DocumentPtr doc = buildScalingDocument(1000, 100);
+        return doc->validate();
+    };
+
+    BENCHMARK("validate, stubs=10000 refs=100")
+    {
+        mx::DocumentPtr doc = buildScalingDocument(10000, 100);
+        return doc->validate();
+    };
+}
+
+#endif // CATCH_CONFIG_ENABLE_BENCHMARKING


### PR DESCRIPTION
Fuzz testing was consistently findings some very slow inputs. Looking at this inputs through `perf`.

I've added a performance regression case that builds example trees that have this issue.

```
test -R MaterialXTest_NodeGraph_getNodeDef_performance -VV
...
27: -------------------------------------------------------------------------------
27: NodeGraph getNodeDef performance
27: -------------------------------------------------------------------------------
27: /home/sean/MaterialX_Clean/source/MaterialXTest/MaterialXCore/Performance.cpp:53
27: ...............................................................................
27:
27: benchmark name                       samples       iterations    estimated
27:                                      mean          low mean      high mean
27:                                      std dev       low std dev   high std dev
27: -------------------------------------------------------------------------------
27: validate, stubs=200 refs=100                   100             1     2.91805 m
27:                                         4.20239 ms    4.00369 ms    4.54723 ms
27:                                         1.30152 ms    875.207 us    2.10073 ms
27:
27: validate, stubs=1000 refs=100                  100             1      1.5165 s
27:                                         13.4589 ms    12.2686 ms    15.7144 ms
27:                                          8.1092 ms    5.15263 ms      13.99 ms
27:
27: validate, stubs=10000 refs=100                 100             1     23.5368 s
27:                                         154.384 ms    141.568 ms    192.638 ms
27:                                         103.788 ms    40.5831 ms    224.837 ms
27:
27:
27: 29.193 s: NodeGraph getNodeDef performance
27: ===============================================================================
27: test cases: 1 | 1 passed
27: assertions: - none -
27:
1/1 Test #27: MaterialXTest_NodeGraph_getNodeDef_performance ...   Passed   30.73 sec
```

I think I've found a couple of issues that come together to cause the processing time for loading .mtlx files grow linearly.

- `Syntax::makeValidName` uses `std::find` on `_reservedWords`. This is a `std::set<string>` and supports a faster O(log N) `.find()`. Give's a minor improvement (5-6%)

https://github.com/AcademySoftwareFoundation/MaterialX/blob/9ebe5f119adde1562bddf0e107d521eb733fd9a0/source/MaterialXGenShader/Syntax.cpp#L152-L162

- `NodeGraph::getNodeDef` calls `Document::getImplementations()` on every invocation. This rebuilds a fresh vector by scanning every document-level child with a dynamic_pointer_cast on each, with no result reuse. `Document::Cache` already maintains hash-map lookups for ports, nodedefs, and nodedDefImplementation, but the reverse direction (nodegraph-name -> implementation) was missing. I've added a _nodeGraphImplMap to the cache, populated during rebuild() alongside the existing maps, and replaced the linear scan with an O(1) lookup.

https://github.com/AcademySoftwareFoundation/MaterialX/blob/b661a4bf653d4720c6eda678dd4676208ee53649/source/MaterialXCore/Node.cpp#L742-L756

If we look at benchmark time I get a significant improvement

|Baseline|Time(s)|
|----|----|
|Unmodified|44.8|
|Syntax::makeValidName, fix _reservedWords check|41.94|
|Use Document::Cache lookups|12.34|