### PR TITLE
Support multiple glTF UV sets

### DIFF
--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -85,20 +85,6 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
         }
     }
 
-    // Remap unsupported texture coordinate indices.
-    for (mx::ElementPtr elem : doc->traverseTree())
-    {
-        mx::NodePtr node = elem->asA<mx::Node>();
-        if (node && node->getCategory() == "texcoord")
-        {
-            mx::InputPtr index = node->getInput("index");
-            mx::ValuePtr value = index ? index->getValue() : nullptr;
-            if (value && value->isA<int>() && value->asA<int>() != 0)
-            {
-                index->setValue(0);
-            }
-        }
-    }
 }
 
 void RenderView::setDocument(mx::DocumentPtr document)

--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -270,9 +270,16 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                     {
                         continue;
                     }
-                    // Only load one stream of each type for now.
                     cgltf_int streamIndex = attribute->index;
-                    if (streamIndex != 0)
+
+                    bool isPositionStream = (attribute->type == cgltf_attribute_type_position);
+                    bool isNormalStream = (attribute->type == cgltf_attribute_type_normal);
+                    bool isTangentStream = (attribute->type == cgltf_attribute_type_tangent);
+                    bool isColorStream = (attribute->type == cgltf_attribute_type_color);
+                    bool isTexCoordStream = (attribute->type == cgltf_attribute_type_texcoord);
+
+                    // Only positions, normals, and tangents use the primary glTF stream.
+                    if ((isPositionStream || isNormalStream || isTangentStream) && streamIndex != 0)
                     {
                         continue;
                     }
@@ -287,12 +294,6 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                     size_t desiredVectorSize = 3;
 
                     MeshStreamPtr geomStream = nullptr;
-
-                    bool isPositionStream = (attribute->type == cgltf_attribute_type_position);
-                    bool isNormalStream = (attribute->type == cgltf_attribute_type_normal);
-                    bool isTangentStream = (attribute->type == cgltf_attribute_type_tangent);
-                    bool isColorStream = (attribute->type == cgltf_attribute_type_color);
-                    bool isTexCoordStream = (attribute->type == cgltf_attribute_type_texcoord);
 
                     if (isPositionStream)
                     {
@@ -328,14 +329,18 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                     }
                     else if (isTexCoordStream)
                     {
-                        texcoordStream = MeshStream::create("i_" + MeshStream::TEXCOORD_ATTRIBUTE + "_0", MeshStream::TEXCOORD_ATTRIBUTE, 0);
-                        mesh->addStream(texcoordStream);
+                        auto tcStream = MeshStream::create("i_" + MeshStream::TEXCOORD_ATTRIBUTE + "_" + std::to_string(streamIndex), MeshStream::TEXCOORD_ATTRIBUTE, streamIndex);
+                        mesh->addStream(tcStream);
                         if (vectorSize == 2)
                         {
-                            texcoordStream->setStride(MeshStream::STRIDE_2D);
+                            tcStream->setStride(MeshStream::STRIDE_2D);
                             desiredVectorSize = 2;
                         }
-                        geomStream = texcoordStream;
+                        geomStream = tcStream;
+                        if (streamIndex == 0)
+                        {
+                            texcoordStream = tcStream;
+                        }
                     }
                     else
                     {

--- a/source/MaterialXRenderGlsl/GlslProgram.cpp
+++ b/source/MaterialXRenderGlsl/GlslProgram.cpp
@@ -261,7 +261,15 @@ void GlslProgram::bindAttribute(const GlslProgram::InputMap& inputs, MeshPtr mes
         MeshStreamPtr stream = mesh->getStream(input.first);
         if (!stream)
         {
-            throw ExceptionRenderError("Geometry buffer could not be retrieved for binding: " + input.first + ". Index: " + std::to_string(index));
+            // Fall back to the first texcoord stream when the mesh has fewer UV sets than the material.
+            if (input.first.find("i_texcoord_") != std::string::npos)
+            {
+                stream = mesh->getStream(MeshStream::TEXCOORD_ATTRIBUTE, 0);
+            }
+            if (!stream)
+            {
+                throw ExceptionRenderError("Geometry buffer could not be retrieved for binding: " + input.first + ". Index: " + std::to_string(index));
+            }
         }
         MeshFloatBuffer& attributeData = stream->getData();
         stride = stream->getStride();

--- a/source/MaterialXRenderMsl/MslPipelineStateObject.mm
+++ b/source/MaterialXRenderMsl/MslPipelineStateObject.mm
@@ -369,6 +369,11 @@ void MslProgram::bindAttribute(id<MTLRenderCommandEncoder> renderCmdEncoder, con
 
         unsigned int stride = 0;
         MeshStreamPtr stream = mesh->getStream(input.first);
+        // Fall back to the first texcoord stream when the mesh has fewer UV sets than the material.
+        if (!stream && input.first.find("i_texcoord_") != std::string::npos)
+        {
+            stream = mesh->getStream(MeshStream::TEXCOORD_ATTRIBUTE, 0);
+        }
         if (!stream)
         {
             errors.push_back("Geometry buffer could not be retrieved for binding: " + input.first + ". Index: " + std::to_string(index));

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -135,20 +135,6 @@ void applyModifiers(mx::DocumentPtr doc, const DocumentModifiers& modifiers)
         }
     }
 
-    // Remap unsupported texture coordinate indices.
-    for (mx::ElementPtr elem : doc->traverseTree())
-    {
-        mx::NodePtr node = elem->asA<mx::Node>();
-        if (node && node->getCategory() == "texcoord")
-        {
-            mx::InputPtr index = node->getInput("index");
-            mx::ValuePtr value = index ? index->getValue() : nullptr;
-            if (value && value->isA<int>() && value->asA<int>() != 0)
-            {
-                index->setValue(0);
-            }
-        }
-    }
 }
 
 } // anonymous namespace


### PR DESCRIPTION
This PR adds support for multiple UV sets throughout the apps in this repository. So MaterialXView, MaterialXGraphEditor and so on can now work with materials and objects that have multiple UV sets.