### PR TITLE
Fix index count for unindexed primitives in `CgltfLoader`

### DIFF
--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -426,7 +426,7 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
                 }
                 else
                 {
-                    indexCount = positionStream->getData().size();
+                    indexCount = positionStream->getData().size() / MeshStream::STRIDE_3D;
                 }
                 size_t faceCount = indexCount / FACE_VERTEX_COUNT;
                 part->setFaceCount(faceCount);


### PR DESCRIPTION
This changelist fixes an indexing bug in `CgltfLoader` for glTF primitives that omit an index buffer.

When no index buffer is present, the loader synthesizes a sequential index buffer covering the position stream.  The previous code assigned the raw size of the position float buffer to `indexCount`, which is three times the vertex count for 3D positions, producing an inflated face count and out-of-range indices in the MaterialX Viewer.

This fix divides by `MeshStream::STRIDE_3D` to obtain the actual vertex count, matching the convention already used a few lines below when computing `setVertexCount`.