### PR TITLE
Move dynamic analysis to MacOS 15 in GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,9 +97,9 @@ jobs:
           cmake_config: -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
         - name: MacOS_Xcode_DynamicAnalysis
-          os: macos-26
+          os: macos-15
           compiler: xcode
-          compiler_version: "26.0"
+          compiler_version: "16.4"
           python: None
           dynamic_analysis: ON
           cmake_config: -DMATERIALX_DYNAMIC_ANALYSIS=ON


### PR DESCRIPTION
This changelist moves our dynamic analysis test from MacOS 26 to MacOS 15 in GitHub CI, as the former environment is encountering a deadlock in multi-threaded CTest runs with dynamic analysis enabled.