### PR TITLE
Migrate JavaScript unit tests to Playwright

### DIFF
--- a/javascript/.gitignore
+++ b/javascript/.gitignore
@@ -2,3 +2,4 @@ build
 **/_build
 **/dist
 **/node_modules
+**/playwright-report

--- a/javascript/MaterialXTest/codeExamples.spec.js
+++ b/javascript/MaterialXTest/codeExamples.spec.js
@@ -122,13 +122,13 @@ test.describe('Code Examples', () =>
         // For each material node, locate its surface shader and traverse the
         // dataflow graph upstream, gathering the nodes that contribute to the
         // shading result.  The marble surface is driven by a procedural noise
-        // network, so the traversal crosses into the bound nodegraph and
-        // reaches a fractal3d noise node.
+        // network bound through a nodegraph, so the traversal crosses from the
+        // top-level document into that nodegraph.
         const materialNodes = doc.getMaterialNodes();
         expect(materialNodes.length).toBe(1);
 
         let nodeCount = 0;
-        let foundNoise = false;
+        let crossedIntoNodeGraph = false;
         for (const materialNode of materialNodes)
         {
             const shaderNodes = mx.getShaderNodes(materialNode);
@@ -140,10 +140,16 @@ test.describe('Code Examples', () =>
                     if (upstreamElem instanceof mx.Node)
                     {
                         nodeCount++;
-                        if (upstreamElem.getCategory() === 'fractal3d')
+
+                        // An upstream node whose parent is a nodegraph rather
+                        // than the document confirms that the traversal has
+                        // descended into the bound nodegraph.
+                        const parent = upstreamElem.getParent();
+                        if (parent instanceof mx.NodeGraph)
                         {
-                            foundNoise = true;
+                            crossedIntoNodeGraph = true;
                         }
+                        if (parent) parent.delete();
                     }
                     if (upstreamElem) upstreamElem.delete();
                     if (edge) edge.delete();
@@ -152,7 +158,7 @@ test.describe('Code Examples', () =>
             shaderNodes.forEach(s => s.delete());
         }
         expect(nodeCount).toBeGreaterThan(0);
-        expect(foundNoise).toBe(true);
+        expect(crossedIntoNodeGraph).toBe(true);
 
         // Cleanup wrappers
         materialNodes.forEach(n => n.delete());

--- a/javascript/MaterialXTest/codeExamples.spec.js
+++ b/javascript/MaterialXTest/codeExamples.spec.js
@@ -1,10 +1,10 @@
-import { expect } from 'chai';
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 import { getMtlxStrings } from './testHelpers.js';
 
-describe('Code Examples', () =>
+test.describe('Code Examples', () =>
 {
-    it('Building a MaterialX Document', async () =>
+    test('Building a MaterialX Document', async () =>
     {
         const mx = await Module();
         // Create a document.
@@ -12,79 +12,79 @@ describe('Code Examples', () =>
 
         // Create a node graph with a single image node and output.
         const nodeGraph = doc.addNodeGraph();
-        expect(doc.getNodeGraphs().length).to.equal(1);
+        expect(doc.getNodeGraphs().length).toBe(1);
         const image = nodeGraph.addNode('image');
         const nodes = nodeGraph.getNodes();
-        expect(nodes.length).to.equal(1);
-        expect(nodes[0]).to.eql(image);
+        expect(nodes.length).toBe(1);
+        expect(nodes[0].equals(image)).toBe(true);
 
         image.setInputValueString('file', 'image1.tif', 'filename');
         const input = image.getInput('file');
-        expect(input).to.not.be.null;
-        expect(input.getValue().getData()).to.equal('image1.tif');
+        expect(input).not.toBeNull();
+        expect(input.getValue().getData()).toBe('image1.tif');
 
         const output = nodeGraph.addOutput();
         const outputs = nodeGraph.getOutputs();
-        expect(outputs.length).to.equal(1);
-        expect(outputs[0]).to.eql(output);
+        expect(outputs.length).toBe(1);
+        expect(outputs[0].equals(output)).toBe(true);
 
         output.setConnectedNode(image);
         const connectedNode = output.getConnectedNode();
-        expect(connectedNode).to.not.be.null;
-        expect(connectedNode instanceof mx.Node).to.be.true;
+        expect(connectedNode).not.toBeNull();
+        expect(connectedNode instanceof mx.Node).toBe(true);
 
         // Create a simple shader interface.
         const simpleSrf = doc.addNodeDef('ND_simpleSrf', 'surfaceshader', 'simpleSrf');
         const nodeDefs = doc.getNodeDefs();
-        expect(nodeDefs.length).to.equal(1);
-        expect(nodeDefs[0]).to.eql(simpleSrf);
+        expect(nodeDefs.length).toBe(1);
+        expect(nodeDefs[0].equals(simpleSrf)).toBe(true);
 
         simpleSrf.setInputValueColor3('diffColor', new mx.Color3(1.0, 1.0, 1.0));
         let inputValue = simpleSrf.getInputValue('diffColor');
-        expect(inputValue).to.not.be.null;
-        expect(inputValue.getData()).to.eql(new mx.Color3(1.0, 1.0, 1.0));
+        expect(inputValue).not.toBeNull();
+        expect(inputValue.getData().equals(new mx.Color3(1.0, 1.0, 1.0))).toBe(true);
 
         simpleSrf.setInputValueColor3('specColor', new mx.Color3(0.0, 0.0, 0.0));
         inputValue = simpleSrf.getInputValue('specColor');
-        expect(inputValue).to.not.be.null;
-        expect(inputValue.getData()).to.eql(new mx.Color3(0.0, 0.0, 0.0));
+        expect(inputValue).not.toBeNull();
+        expect(inputValue.getData().equals(new mx.Color3(0.0, 0.0, 0.0))).toBe(true);
 
         const roughness = simpleSrf.setInputValueFloat('roughness', 0.25);
         inputValue = simpleSrf.getInputValue('roughness');
-        expect(inputValue).to.not.be.null;
-        expect(inputValue.getData()).to.equal(0.25);
+        expect(inputValue).not.toBeNull();
+        expect(inputValue.getData()).toBe(0.25);
 
-        // // Create a material that instantiates the shader.
-        // const material = doc.addMaterial();
-        // const materials = doc.getMaterials();
-        // expect(materials.length).to.equal(1);
-        // expect(materials[0]).to.eql(material);
-        // const refSimpleSrf = material.addShaderRef('SR_simpleSrf', 'simpleSrf');
-        // const shaderRefs = material.getShaderRefs();
-        // expect(shaderRefs.length).to.equal(1);
-        // expect(shaderRefs[0]).to.eql(refSimpleSrf);
-        // expect(shaderRefs[0].getName()).to.equal('SR_simpleSrf');
+        // Instantiate the shader and create a material node that references it.
+        const shaderNode = doc.addNodeInstance(simpleSrf);
+        const materialNode = doc.addMaterialNode('', shaderNode);
+        expect(doc.getMaterialNodes().length).toBe(1);
 
-        // // Bind roughness to a new value within this material.
-        // const bindInput = refSimpleSrf.addBindInput('roughness');
-        // const bindInputs = refSimpleSrf.getBindInputs();
-        // expect(bindInputs.length).to.equal(1);
-        // expect(bindInputs[0]).to.eql(bindInput);
-        // bindInput.setValuefloat(0.5);
-        // expect(bindInput.getValue()).to.not.be.null;
-        // expect(bindInput.getValue().getData()).to.equal(0.5);
+        // Connect the diffuse color of the shader to the image output, and
+        // confirm that the upstream image node is reachable from the shader.
+        shaderNode.setConnectedOutput('diffColor', output);
+        const upstreamNode = shaderNode.getUpstreamElement();
+        expect(upstreamNode).not.toBeNull();
+        expect(upstreamNode.getName()).toBe(image.getName());
 
-        // // Validate the value of roughness in the context of this material.
-        // expect(roughness.getBoundValue(material).getValueString()).to.equal('0.5');
+        // Override roughness on this shader instance; its default value is
+        // inherited from the shader's nodedef.
+        const instanceRoughness = shaderNode.setInputValueFloat('roughness', 0.5);
+        expect(instanceRoughness.getValue().getData()).toBe(0.5);
+        expect(instanceRoughness.getDefaultValue().getData()).toBe(roughness.getValue().getData());
+
         // Cleanup wrappers
         nodeDefs.forEach(nd => nd.delete());
+        upstreamNode.delete();
+        instanceRoughness.delete();
+        materialNode.delete();
+        shaderNode.delete();
         output.delete();
         image.delete();
         nodeGraph.delete();
         doc.delete();
     });
 
-    it('Traversing a Document Tree', async () =>
+    test('Traversing a Document Tree', async () =>
     {
         const xmlStr = getMtlxStrings(
             ['standard_surface_greysphere_calibration.mtlx'],
@@ -106,11 +106,11 @@ describe('Code Examples', () =>
                 imageCount++;
             }
         }
-        expect(imageCount).to.greaterThan(0);
+        expect(imageCount).toBeGreaterThan(0);
         doc.delete();
     });
 
-    it('Building a MaterialX Document', async () =>
+    test('Traversing a Dataflow Graph', async () =>
     {
         const xmlStr = getMtlxStrings(['standard_surface_marble_solid.mtlx'], '../../resources/Materials/Examples/StandardSurface')[0];
         const mx = await Module();
@@ -119,27 +119,43 @@ describe('Code Examples', () =>
         const doc = mx.createDocument();
         await mx.readFromXmlString(doc, xmlStr);
 
-        // let materialCount = 0;
-        // let shaderInputCount = 0;
-        // // Iterate through 1.37 materials for which there should be none
-        // const materials = doc.getMaterials();
-        // materials.forEach((material) => {
-        //     materialCount++;
+        // For each material node, locate its surface shader and traverse the
+        // dataflow graph upstream, gathering the nodes that contribute to the
+        // shading result.  The marble surface is driven by a procedural noise
+        // network, so the traversal crosses into the bound nodegraph and
+        // reaches a fractal3d noise node.
+        const materialNodes = doc.getMaterialNodes();
+        expect(materialNodes.length).toBe(1);
 
-        //     // For each shader input, find all upstream images in the dataflow graph.
-        //     const primaryShaderInputs = material.getPrimaryShaderInputs();
-        //     primaryShaderInputs.forEach((input) => {
-        //         const graphIter = input.traverseGraph(material);
-        //         let edge = graphIter.next();
-        //         while (edge) {
-        //             shaderInputCount++;
-        //             edge = graphIter.next();
-        //         }
-        //     });
-        // });
+        let nodeCount = 0;
+        let foundNoise = false;
+        for (const materialNode of materialNodes)
+        {
+            const shaderNodes = mx.getShaderNodes(materialNode);
+            for (const shaderNode of shaderNodes)
+            {
+                for (const edge of shaderNode.traverseGraph())
+                {
+                    const upstreamElem = edge.getUpstreamElement();
+                    if (upstreamElem instanceof mx.Node)
+                    {
+                        nodeCount++;
+                        if (upstreamElem.getCategory() === 'fractal3d')
+                        {
+                            foundNoise = true;
+                        }
+                    }
+                    if (upstreamElem) upstreamElem.delete();
+                    if (edge) edge.delete();
+                }
+            }
+            shaderNodes.forEach(s => s.delete());
+        }
+        expect(nodeCount).toBeGreaterThan(0);
+        expect(foundNoise).toBe(true);
 
-        // expect(materialCount).to.equal(0);
-        // expect(shaderInputCount).to.equal(0);
+        // Cleanup wrappers
+        materialNodes.forEach(n => n.delete());
         doc.delete();
     });
 });

--- a/javascript/MaterialXTest/customBindings.spec.js
+++ b/javascript/MaterialXTest/customBindings.spec.js
@@ -1,35 +1,35 @@
-import { expect } from 'chai';
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 import { getMtlxStrings } from './testHelpers.js';
 
-describe('Custom Bindings', () =>
+test.describe('Custom Bindings', () =>
 {
     const examplesPath = '../../resources/Materials/Examples/StandardSurface';
 
     let mx;
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
     });
 
-    it('Optional parameters work as expected', () =>
+    test('Optional parameters work as expected', () =>
     {
         const doc = mx.createDocument();
         // Call a method without optional argument
         const nodeGraph = doc.addNodeGraph();
-        expect(nodeGraph).to.be.instanceof(mx.NodeGraph);
-        expect(nodeGraph.getName()).to.equal('nodegraph1'); // Auto-constructed default value
+        expect(nodeGraph).toBeInstanceOf(mx.NodeGraph);
+        expect(nodeGraph.getName()).toBe('nodegraph1'); // Auto-constructed default value
         // Call a method with optional argument
         const nodeGraph2 = doc.addNodeGraph('myGraph');
-        expect(nodeGraph2).to.be.instanceof(mx.NodeGraph);
-        expect(nodeGraph2.getName()).to.equal('myGraph');
+        expect(nodeGraph2).toBeInstanceOf(mx.NodeGraph);
+        expect(nodeGraph2.getName()).toBe('myGraph');
 
         // Call a method that requires at least one parameter
         const node = nodeGraph.addNode('node');
-        expect(node).to.be.instanceof(mx.Node);
+        expect(node).toBeInstanceOf(mx.Node);
 
         // Omitting non-optional parameter should throw
-        expect(() => { nodeGraph.addNode(); }).to.throw;
+        expect(() => { nodeGraph.addNode(); }).toThrow();
 
         // Cleanup
         node.delete();
@@ -38,15 +38,15 @@ describe('Custom Bindings', () =>
         doc.delete();
     });
 
-    it('Vector <-> Array conversion', () =>
+    test('Vector <-> Array conversion', () =>
     {
         // Functions that return vectors in C++ should return an array in JS
         const doc = mx.createDocument();
         const nodeGraph = doc.addNodeGraph();
         const nodeGraphB = doc.addNodeGraph();
         const nodeGraphs = doc.getNodeGraphs();
-        expect(nodeGraphs).to.be.an.instanceof(Array);
-        expect(nodeGraphs.length).to.equal(2);
+        expect(nodeGraphs).toBeInstanceOf(Array);
+        expect(nodeGraphs.length).toBe(2);
 
         // Elements fetched through the vector -> array conversion should be editable and changes should be reflected
         // in the original objects.
@@ -54,15 +54,15 @@ describe('Custom Bindings', () =>
         // to the same object.
         const backdrop = nodeGraph.addBackdrop();
         const backDrops = nodeGraphs[0].getBackdrops();
-        expect(backDrops.length).to.equal(1);
+        expect(backDrops.length).toBe(1);
         nodeGraphs[0].addBackdrop();
-        expect(nodeGraph.getBackdrops().length).to.equal(2);
+        expect(nodeGraph.getBackdrops().length).toBe(2);
 
         // Functions that expect vectors as parameters in C++ should accept arrays in JS
         // Built-in types (strings)
         const pathSegments = ['path', 'to', 'something'];
         const namePath = mx.createNamePath(pathSegments);
-        expect(namePath).to.equal(pathSegments.join(mx.NAME_PATH_SEPARATOR));
+        expect(namePath).toBe(pathSegments.join(mx.NAME_PATH_SEPARATOR));
 
         // Complex (smart pointer) types
         const node1 = nodeGraph.addNode('node');
@@ -70,10 +70,10 @@ describe('Custom Bindings', () =>
         const node3 = nodeGraph.addNode('node', 'anotherNode');
         backdrop.setContainsElements([node1, node2, node3]);
         const nodes = backdrop.getContainsElements();
-        expect(nodes.length).to.equal(3);
-        expect(nodes[0].getName()).to.equal('node1'); // Name auto-constructed from category
-        expect(nodes[1].getName()).to.equal('node2'); // Name auto-constructed from category
-        expect(nodes[2].getName()).to.equal('anotherNode'); // Name set explicitly at creation time
+        expect(nodes.length).toBe(3);
+        expect(nodes[0].getName()).toBe('node1'); // Name auto-constructed from category
+        expect(nodes[1].getName()).toBe('node2'); // Name auto-constructed from category
+        expect(nodes[2].getName()).toBe('anotherNode'); // Name set explicitly at creation time
 
         // Cleanup created wrappers
         nodes.forEach(n => n.delete());
@@ -86,7 +86,7 @@ describe('Custom Bindings', () =>
         doc.delete();
     });
 
-    it('C++ exception handling', () =>
+    test('C++ exception handling', () =>
     {
         // Exceptions that are thrown and caught in C++ shouldn't bubble up to JS
         const doc = mx.createDocument();
@@ -94,18 +94,18 @@ describe('Custom Bindings', () =>
         const nodeGraph2 = doc.addNodeGraph();
         nodeGraph1.setInheritsFrom(nodeGraph2);
         nodeGraph2.setInheritsFrom(nodeGraph1);
-        expect(nodeGraph1.hasInheritanceCycle()).to.not.throw;
-        expect(nodeGraph1.hasInheritanceCycle()).to.be.true;
+        expect(() => nodeGraph1.hasInheritanceCycle()).not.toThrow();
+        expect(nodeGraph1.hasInheritanceCycle()).toBe(true);
 
         // Exceptions that are not caught in C++ should throw
         nodeGraph1.addNode('node', 'node1');
-        expect(() => { nodeGraph1.addNode('node', 'node1'); }).to.throw;
+        expect(() => { nodeGraph1.addNode('node', 'node1'); }).toThrow();
         try
         {
             nodeGraph1.addNode('node', 'node1');
         } catch (err)
         {
-            expect(mx.getExceptionMessage(err)).to.be.a('string');
+            expect(typeof mx.getExceptionMessage(err)).toBe('string');
         }
         // Cleanup
         nodeGraph2.delete();
@@ -113,20 +113,20 @@ describe('Custom Bindings', () =>
         doc.delete();
     });
 
-    it('getReferencedSourceUris', async () =>
+    test('getReferencedSourceUris', async () =>
     {
         const doc = mx.createDocument();
         const filename = 'standard_surface_look_brass_tiled.mtlx';
         await mx.readFromXmlFile(doc, filename, examplesPath);
         const sourceUris = doc.getReferencedSourceUris();
-        expect(sourceUris).to.be.instanceof(Array);
-        expect(sourceUris.length).to.equal(3);
-        expect(sourceUris[0]).to.be.a('string');
-        expect(sourceUris.includes('standard_surface_brass_tiled.mtlx')).to.be.true;
+        expect(sourceUris).toBeInstanceOf(Array);
+        expect(sourceUris.length).toBe(3);
+        expect(typeof sourceUris[0]).toBe('string');
+        expect(sourceUris.includes('standard_surface_brass_tiled.mtlx')).toBe(true);
         doc.delete();
     });
 
-    it('Should invoke correct instance of \'validate\'', () =>
+    test('Should invoke correct instance of \'validate\'', () =>
     {
         // We check whether the correct function is called by provoking an error message that is specific to the
         // function that we expect to be called.
@@ -134,25 +134,25 @@ describe('Custom Bindings', () =>
 
         // Should invoke Document::validate.
         const doc = mx.createDocument();
-        expect(doc.validate()).to.be.true;
+        expect(doc.validate()).toBe(true);
         doc.removeAttribute(mx.InterfaceElement.VERSION_ATTRIBUTE);
-        expect(doc.validate()).to.be.true;
+        expect(doc.validate()).toBe(true);
 
         // Should invoke Node::validate
         const node = doc.addNode('node');
-        expect(node.validate()).to.be.true;
+        expect(node.validate()).toBe(true);
         node.setCategory('');
-        expect(node.validate()).to.be.false;
-        expect(node.validate(message)).to.be.false;
-        expect(message.message).to.include('Node element is missing a category');
+        expect(node.validate()).toBe(false);
+        expect(node.validate(message)).toBe(false);
+        expect(message.message).toContain('Node element is missing a category');
 
         // Should invoke inherited ValueElement::validate
         const token = new mx.Token(node, 'token');
-        expect(token.validate()).to.be.true;
+        expect(token.validate()).toBe(true);
         token.setUnitType('bogus');
-        expect(token.validate()).to.be.false;
-        expect(token.validate(message)).to.be.false;
-        expect(message.message).to.include('Unit type definition does not exist in document')
+        expect(token.validate()).toBe(false);
+        expect(token.validate(message)).toBe(false);
+        expect(message.message).toContain('Unit type definition does not exist in document')
 
         // Cleanup
         token.delete();
@@ -160,7 +160,7 @@ describe('Custom Bindings', () =>
         doc.delete();
     });
 
-    it('StringResolver name substitution getters', () =>
+    test('StringResolver name substitution getters', () =>
     {
         const fnTestData = {
             fnKey: 'fnValue',
@@ -179,37 +179,37 @@ describe('Custom Bindings', () =>
         resolver.setFilenameSubstitution(fnTestKeys[0], fnTestData[fnTestKeys[0]]);
         resolver.setFilenameSubstitution(fnTestKeys[1], fnTestData[fnTestKeys[1]]);
         const fnSubs = resolver.getFilenameSubstitutions();
-        expect(fnSubs).to.be.instanceof(Object);
-        expect(Object.keys(fnSubs).length).to.equal(2);
-        expect(fnSubs).to.deep.equal(fnTestData);
+        expect(fnSubs).toBeInstanceOf(Object);
+        expect(Object.keys(fnSubs).length).toBe(2);
+        expect(fnSubs).toEqual(fnTestData);
 
         resolver.setGeomNameSubstitution(gnTestKeys[0], gnTestData[gnTestKeys[0]]);
         resolver.setGeomNameSubstitution(gnTestKeys[1], gnTestData[gnTestKeys[1]]);
         const gnSubs = resolver.getGeomNameSubstitutions();
-        expect(gnSubs).to.be.instanceof(Object);
-        expect(Object.keys(gnSubs).length).to.equal(2);
-        expect(gnSubs).to.deep.equal(gnTestData);
+        expect(gnSubs).toBeInstanceOf(Object);
+        expect(Object.keys(gnSubs).length).toBe(2);
+        expect(gnSubs).toEqual(gnTestData);
         resolver.delete();
     });
 
-    it('getShaderNodes', async () =>
+    test('getShaderNodes', async () =>
     {
         const doc = mx.createDocument();
         const fileNames = ['standard_surface_marble_solid.mtlx'];
         const mtlxStrs = getMtlxStrings(fileNames, examplesPath);
         await mx.readFromXmlString(doc, mtlxStrs[0]);
         let matNodes = doc.getMaterialNodes();
-        expect(matNodes.length).to.equal(1);
+        expect(matNodes.length).toBe(1);
         const matNode = matNodes[0];
 
         // Should return a surface shader node but no displacement shader node
         let shaderNodes = mx.getShaderNodes(matNode);
-        expect(shaderNodes).to.be.instanceof(Array);
-        expect(shaderNodes.length).to.equal(1);
-        expect(shaderNodes[0].getType()).to.equal(mx.SURFACE_SHADER_TYPE_STRING);
+        expect(shaderNodes).toBeInstanceOf(Array);
+        expect(shaderNodes.length).toBe(1);
+        expect(shaderNodes[0].getType()).toBe(mx.SURFACE_SHADER_TYPE_STRING);
         shaderNodes = mx.getShaderNodes(matNode, mx.DISPLACEMENT_SHADER_TYPE_STRING);
-        expect(shaderNodes).to.be.instanceof(Array);
-        expect(shaderNodes.length).to.equal(0);
+        expect(shaderNodes).toBeInstanceOf(Array);
+        expect(shaderNodes.length).toBe(0);
 
         // Cleanup wrappers
         shaderNodes.forEach(s => s.delete());
@@ -217,34 +217,42 @@ describe('Custom Bindings', () =>
         doc.delete();
     });
 
-    it('createValidName', () =>
+    test('createValidName', () =>
     {
         const testString = '_Note_:Please,turn.this+-into*1#valid\nname for_me';
         const replaceRegex = /[^a-zA-Z0-9_:]/g
-        expect(mx.createValidName(testString)).to.equal(testString.replace(replaceRegex, '_'));
-        expect(mx.createValidName(testString, '-')).to.equal(testString.replace(replaceRegex, '-'));
+        expect(mx.createValidName(testString)).toBe(testString.replace(replaceRegex, '_'));
+        expect(mx.createValidName(testString, '-')).toBe(testString.replace(replaceRegex, '-'));
     });
 
-    it('getVersionIntegers', () =>
+    test('getVersionIntegers', () =>
     {
         const versionStringArr = mx.getVersionString().split('.').map((value) => parseInt(value, 10));
 
         // Global getVersionIntegers
         const globalVersion = mx.getVersionIntegers();
-        expect(globalVersion).to.be.instanceof(Array);
-        expect(globalVersion.length).to.equal(3);
-        expect(globalVersion).to.deep.equal(versionStringArr);
+        expect(globalVersion).toBeInstanceOf(Array);
+        expect(globalVersion.length).toBe(3);
+        expect(globalVersion).toEqual(versionStringArr);
 
         // Document.getVersionIntegers
         versionStringArr.pop();
         const doc = mx.createDocument();
         const docVersion = doc.getVersionIntegers();
-        expect(docVersion).to.be.instanceof(Array);
-        expect(docVersion.length).to.equal(2);
-        expect(docVersion).to.deep.equal(versionStringArr);
+        expect(docVersion).toBeInstanceOf(Array);
+        expect(docVersion.length).toBe(2);
+        expect(docVersion).toEqual(versionStringArr);
         doc.delete();
 
         // InterfaceElement.getVersionIntegers (via NodeDef)
-        // TODO: This function can currently not be called, since we have a linker issue that messes up this function.
+        const versionDoc = mx.createDocument();
+        const nodeDef = versionDoc.addNodeDef('ND_test', 'float', 'test');
+        nodeDef.setVersionString('2.5');
+        const nodeDefVersion = nodeDef.getVersionIntegers();
+        expect(nodeDefVersion).toBeInstanceOf(Array);
+        expect(nodeDefVersion.length).toBe(2);
+        expect(nodeDefVersion).toEqual([2, 5]);
+        nodeDef.delete();
+        versionDoc.delete();
     });
 });

--- a/javascript/MaterialXTest/document.spec.js
+++ b/javascript/MaterialXTest/document.spec.js
@@ -1,10 +1,10 @@
-import { expect } from 'chai';
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 
-describe('Document', () =>
+test.describe('Document', () =>
 {
     let mx, doc;
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
         // Create a document.
@@ -20,16 +20,16 @@ describe('Document', () =>
         } catch (exceptionPtr)
         {
             const message = mx.getExceptionMessage(exceptionPtr);
-            expect(message.indexOf(type) !== -1).to.be.true;
+            expect(message.indexOf(type) !== -1).toBe(true);
         }
     }
 
     let nodeGraph;
-    it('Build document', () =>
+    test('Build document', () =>
     {
         // Create a node graph with constant and image sources.
         nodeGraph = doc.addNodeGraph();
-        expect(nodeGraph).to.exist;
+        expect(nodeGraph).toBeTruthy();
         expectError('Child name is not unique: nodegraph1', () =>
         {
             doc.addNodeGraph(nodeGraph.getName());
@@ -42,20 +42,20 @@ describe('Document', () =>
         const output2 = nodeGraph.addOutput();
         output1.setConnectedNode(constant);
         output2.setConnectedNode(image);
-        expect(output1.getConnectedNode()).to.eql(constant);
-        expect(output2.getConnectedNode()).to.eql(image);
-        expect(output1.getUpstreamElement()).to.eql(constant);
-        expect(output2.getUpstreamElement()).to.eql(image);
+        expect(output1.getConnectedNode().equals(constant)).toBe(true);
+        expect(output2.getConnectedNode().equals(image)).toBe(true);
+        expect(output1.getUpstreamElement().equals(constant)).toBe(true);
+        expect(output2.getUpstreamElement().equals(image)).toBe(true);
 
         // Set constant node color
         const color = new mx.Color3(0.1, 0.2, 0.3);
         constant.setInputValueColor3('value', color);
-        expect(constant.getInputValue('value').getData()).to.eql(color);
+        expect(constant.getInputValue('value').getData().equals(color)).toBe(true);
 
         // Set image node file
         const file = 'image1.tif';
         image.setInputValueString('file', file, 'filename');
-        expect(image.getInputValue('file').getData()).to.eql(file);
+        expect(image.getInputValue('file').getData()).toBe(file);
 
         // Create a custom nodedef
         const nodeDef = doc.addNodeDef('nodeDef1', 'float', 'turbulence3d');
@@ -65,103 +65,103 @@ describe('Document', () =>
 
         // Reference the custom nodedef
         const custom = nodeGraph.addNode('turbulence3d', 'turbulence1', 'float');
-        expect(custom.getInputValue('octaves').getData()).to.equal(3);
+        expect(custom.getInputValue('octaves').getData()).toBe(3);
         custom.setInputValueInteger('octaves', 5);
-        expect(custom.getInputValue('octaves').getData()).to.equal(5);
+        expect(custom.getInputValue('octaves').getData()).toBe(5);
 
         // Test scoped attributes
         nodeGraph.setFilePrefix('folder/');
         nodeGraph.setColorSpace('lin_rec709');
-        expect(image.getInput('file').getResolvedValueString()).to.equal('folder/image1.tif');
-        expect(constant.getActiveColorSpace()).to.equal('lin_rec709');
+        expect(image.getInput('file').getResolvedValueString()).toBe('folder/image1.tif');
+        expect(constant.getActiveColorSpace()).toBe('lin_rec709');
 
         // Create a simple shader interface
         const simpleSrf = doc.addNodeDef('', 'surfaceshader', 'simpleSrf');
         simpleSrf.setInputValueColor3('diffColor', new mx.Color3(1.0, 1.0, 1.0));
         simpleSrf.setInputValueColor3('specColor', new mx.Color3(0.0, 0.0, 0.0));
         const roughness = simpleSrf.setInputValueFloat('roughness', 0.25);
-        expect(roughness.getIsUniform()).to.be.false;
+        expect(roughness.getIsUniform()).toBe(false);
         roughness.setIsUniform(true);
-        expect(roughness.getIsUniform()).to.be.true;
+        expect(roughness.getIsUniform()).toBe(true);
 
         // Instantiate shader and material nodes
         const shaderNode = doc.addNodeInstance(simpleSrf);
         const materialNode = doc.addMaterialNode('', shaderNode);
-        expect(materialNode.getUpstreamElement().equals(shaderNode)).to.be.true;
+        expect(materialNode.getUpstreamElement().equals(shaderNode)).toBe(true);
 
         // Bind the diffuse color input to the constant color output
         shaderNode.setConnectedOutput('diffColor', output1);
-        expect(shaderNode.getUpstreamElement().equals(constant)).to.be.true;
+        expect(shaderNode.getUpstreamElement().equals(constant)).toBe(true);
 
         // Bind the roughness input to a value
         const instanceRoughness = shaderNode.setInputValueFloat('roughness', 0.5);
-        expect(instanceRoughness.getValue().getData()).to.equal(0.5);
-        expect(instanceRoughness.getDefaultValue().getData()).to.equal(0.25);
+        expect(instanceRoughness.getValue().getData()).toBe(0.5);
+        expect(instanceRoughness.getDefaultValue().getData()).toBe(0.25);
 
         // Create a look for the material
         const look = doc.addLook();
-        expect(doc.getLooks().length).to.equal(1);
+        expect(doc.getLooks().length).toBe(1);
 
         // Bind the material to a geometry string
         let matAssign1 = look.addMaterialAssign('matAssign1', materialNode.getName());
         matAssign1 = look.getMaterialAssign('matAssign1');
-        expect(matAssign1);
+        expect(matAssign1).toBeTruthy();
         matAssign1.setGeom('/robot1');
-        expect(matAssign1.getReferencedMaterial().equals(materialNode)).to.be.true;
-        expect(mx.getGeometryBindings(materialNode, '/robot1').length).to.equal(1);
-        expect(mx.getGeometryBindings(materialNode, '/robot2').length).to.equal(0);
+        expect(matAssign1.getReferencedMaterial().equals(materialNode)).toBe(true);
+        expect(mx.getGeometryBindings(materialNode, '/robot1').length).toBe(1);
+        expect(mx.getGeometryBindings(materialNode, '/robot2').length).toBe(0);
 
         // Bind the material to a collection
         let matAssign2 = look.addMaterialAssign('matAssign2', materialNode.getName());
-        matAssign2 = look.getMaterialAssign('matAssign1');
-        expect(matAssign2);
+        matAssign2 = look.getMaterialAssign('matAssign2');
+        expect(matAssign2).toBeTruthy();
         const collection = doc.addCollection();
         collection.setIncludeGeom('/robot2');
         collection.setExcludeGeom('/robot2/left_arm');
         matAssign2.setCollection(collection);
-        expect(matAssign2.getReferencedMaterial().equals(materialNode)).to.be.true;
-        expect(mx.getGeometryBindings(materialNode, '/robot2').length).to.equal(1);
-        expect(mx.getGeometryBindings(materialNode, '/robot2/right_arm').length).to.equal(1);
-        expect(mx.getGeometryBindings(materialNode, '/robot2/left_arm').length).to.equal(0);
+        expect(matAssign2.getReferencedMaterial().equals(materialNode)).toBe(true);
+        expect(mx.getGeometryBindings(materialNode, '/robot2').length).toBe(1);
+        expect(mx.getGeometryBindings(materialNode, '/robot2/right_arm').length).toBe(1);
+        expect(mx.getGeometryBindings(materialNode, '/robot2/left_arm').length).toBe(0);
 
         const materialAssigns = look.getMaterialAssigns();
-        expect(materialAssigns.length).to.equal(2);
+        expect(materialAssigns.length).toBe(2);
 
         // Create a property assignment
         const propertyAssign = look.addPropertyAssign();
         propertyAssign.setProperty('twosided');
         propertyAssign.setGeom('/robot1');
         propertyAssign.setValueBoolean(true);
-        expect(propertyAssign.getProperty()).to.equal('twosided');
-        expect(propertyAssign.getGeom()).to.equal('/robot1');
-        expect(propertyAssign.getValue().getData()).to.equal(true);
+        expect(propertyAssign.getProperty()).toBe('twosided');
+        expect(propertyAssign.getGeom()).toBe('/robot1');
+        expect(propertyAssign.getValue().getData()).toBe(true);
         let propertyAssigns = look.getPropertyAssigns();
-        expect(propertyAssigns.length).to.equal(1);
+        expect(propertyAssigns.length).toBe(1);
 
         // Create a property set assignment
         const propertySet = doc.addPropertySet();
         propertySet.setPropertyValueBoolean('matte', false);
-        expect(propertySet.getPropertyValue('matte').getData()).to.equal(false);
+        expect(propertySet.getPropertyValue('matte').getData()).toBe(false);
         const propertySetAssign = look.addPropertySetAssign();
         propertySetAssign.setPropertySet(propertySet);
         propertySetAssign.setGeom('/robot1');
-        expect(propertySetAssign.getPropertySet().equals(propertySet)).to.be.true;
-        expect(propertySetAssign.getGeom()).to.equal('/robot1');
+        expect(propertySetAssign.getPropertySet().equals(propertySet)).toBe(true);
+        expect(propertySetAssign.getGeom()).toBe('/robot1');
 
         // Create a variant set
         const variantSet = doc.addVariantSet();
         variantSet.addVariant('original');
         variantSet.addVariant('damaged');
-        expect(variantSet.getVariants().length).to.equal(2);
+        expect(variantSet.getVariants().length).toBe(2);
 
         // Validate the document
-        expect(doc.validate()).to.be.true;
+        expect(doc.validate()).toBe(true);
 
         // Disconnect output from sources
         output1.setConnectedNode(null);
         output2.setConnectedNode(null);
-        expect(output1.getConnectedNode()).to.equal(null);
-        expect(output2.getConnectedNode()).to.equal(null);
+        expect(output1.getConnectedNode()).toBeNull();
+        expect(output2.getConnectedNode()).toBeNull();
         // Cleanup created wrappers
         propertySetAssign.delete();
         propertySet.delete();

--- a/javascript/MaterialXTest/element.spec.js
+++ b/javascript/MaterialXTest/element.spec.js
@@ -1,7 +1,7 @@
-import { expect } from 'chai';
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 
-describe('Element', () =>
+test.describe('Element', () =>
 {
     let mx, doc, valueTypes;
 
@@ -16,7 +16,7 @@ describe('Element', () =>
         BooleanArray: [true, true, false],
     }
 
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
         doc = mx.createDocument();
@@ -31,14 +31,14 @@ describe('Element', () =>
         };
     });
 
-    after(() =>
+    test.afterAll(() =>
     {
         // Cleanup typed helper objects and document
         Object.values(valueTypes).forEach(v => v.delete());
         doc.delete();
     });
 
-    describe('value setters', () =>
+    test.describe('value setters', () =>
     {
         const checkValue = (types, assertionCallback) =>
         {
@@ -52,31 +52,31 @@ describe('Element', () =>
             elem.delete();
         };
 
-        it('should work with expected type', () =>
+        test('should work with expected type', () =>
         {
             checkValue(valueTypes, (returnedValue, typeName) =>
             {
-                expect(returnedValue).to.be.an.instanceof(mx[`${typeName}`]);
-                expect(returnedValue.equals(valueTypes[typeName])).to.equal(true);
+                expect(returnedValue).toBeInstanceOf(mx[`${typeName}`]);
+                expect(returnedValue.equals(valueTypes[typeName])).toBe(true);
             });
         });
 
-        it('should work with expected primitive type', () =>
+        test('should work with expected primitive type', () =>
         {
             checkValue(primitiveValueTypes, (returnedValue, typeName) =>
             {
-                expect(returnedValue).to.eql(primitiveValueTypes[typeName]);
+                expect(returnedValue).toEqual(primitiveValueTypes[typeName]);
             });
         });
 
-        it('should fail for incorrect type', () =>
+        test('should fail for incorrect type', () =>
         {
             const elem = doc.addChildOfCategory('geomprop');
-            expect(() => elem.Matrix33(true)).to.throw();
+            expect(() => elem.Matrix33(true)).toThrow();
         });
     });
 
-    describe('typed value setters', () =>
+    test.describe('typed value setters', () =>
     {
         const checkTypes = (types, assertionCallback) =>
         {
@@ -91,30 +91,30 @@ describe('Element', () =>
             elem.delete();
         };
 
-        it('should work with expected custom type', () =>
+        test('should work with expected custom type', () =>
         {
             checkTypes(valueTypes, (returnedValue, originalValue) =>
             {
-                expect(returnedValue.equals(originalValue)).to.equal(true);
+                expect(returnedValue.equals(originalValue)).toBe(true);
             });
         });
 
-        it('should work with expected primitive type', () =>
+        test('should work with expected primitive type', () =>
         {
             checkTypes(primitiveValueTypes, (returnedValue, originalValue) =>
             {
-                expect(returnedValue).to.eql(originalValue);
+                expect(returnedValue).toEqual(originalValue);
             });
         });
 
-        it('should fail for incorrect type', () =>
+        test('should fail for incorrect type', () =>
         {
             const elem = doc.addChildOfCategory('geomprop');
-            expect(() => elem.setTypedAttributeColor3('wrongType', true)).to.throw();
+            expect(() => elem.setTypedAttributeColor3('wrongType', true)).toThrow();
         });
     });
 
-    it('factory invocation should match specialized functions', () =>
+    test('factory invocation should match specialized functions', () =>
     {
         // List based in source/MaterialXCore/Element.cpp
         const elemtypeArr = [
@@ -154,8 +154,8 @@ describe('Element', () =>
             const specializedFn = `addChild${typeName}`;
             const factoryName = typeName.toLowerCase();
             const type = mx[typeName];
-            expect(doc[specializedFn]()).to.be.an.instanceof(type);
-            expect(doc.addChildOfCategory(factoryName)).to.be.an.instanceof(type);
+            expect(doc[specializedFn]()).toBeInstanceOf(type);
+            expect(doc.addChildOfCategory(factoryName)).toBeInstanceOf(type);
         });
 
         const specialElemType = {
@@ -168,18 +168,18 @@ describe('Element', () =>
         {
             const specializedFn = `addChild${typeName}`;
             const factoryName = typeName.toLowerCase();
-            expect(doc[specializedFn]()).to.be.an.instanceof(specialElemType[typeName]);
-            expect(doc.addChildOfCategory(factoryName)).to.be.an.instanceof(specialElemType[typeName]);
+            expect(doc[specializedFn]()).toBeInstanceOf(specialElemType[typeName]);
+            expect(doc.addChildOfCategory(factoryName)).toBeInstanceOf(specialElemType[typeName]);
         });
-        // No doc.delete() here; cleaned up in after()
+        // No doc.delete() here; cleaned up in afterAll()
     });
 });
 
-describe('Equivalence', () =>
+test.describe('Equivalence', () =>
 {
     let mx, doc, doc2
 
-    before(async () => {
+    test.beforeAll(async () => {
         mx = await Module();
         doc = mx.createDocument();
         doc.addNodeGraph("graph");
@@ -187,15 +187,15 @@ describe('Equivalence', () =>
         doc2.addNodeGraph("graph1");
     });
 
-    it('Compare document equivalency', () =>
+    test('Compare document equivalency', () =>
     {
         let options = new mx.ElementEquivalenceOptions();
         let differences = {};
         options.performValueComparisons = false;
         let result = doc.isEquivalent(doc2, options, differences);
-        expect(result).to.be.false;
-        expect(differences.message).to.not.be.empty;
+        expect(result).toBe(false);
+        expect(differences.message).toBeTruthy();
         result = doc.isEquivalent(doc2, options, undefined);
-        expect(result).to.be.false;
+        expect(result).toBe(false);
     });
 });

--- a/javascript/MaterialXTest/environ.spec.js
+++ b/javascript/MaterialXTest/environ.spec.js
@@ -1,20 +1,20 @@
-import { expect } from 'chai';;
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 
-describe('Environ', () =>
+test.describe('Environ', () =>
 {
     let mx;
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
     });
 
-    it('Environment variables', () =>
+    test('Environment variables', () =>
     {
-        expect(mx.getEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR)).to.equal('');
+        expect(mx.getEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR)).toBe('');
         mx.setEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR, 'test');
-        expect(mx.getEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR)).to.equal('test');
+        expect(mx.getEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR)).toBe('test');
         mx.removeEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR);
-        expect(mx.getEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR)).to.equal('');
+        expect(mx.getEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR)).toBe('');
     });
 });

--- a/javascript/MaterialXTest/package.json
+++ b/javascript/MaterialXTest/package.json
@@ -4,18 +4,13 @@
   "description": "",
   "type": "module",
   "scripts": {
-    "pretest": "node scripts/buildSetup.js",
-    "test": "npm run mocha",
-    "pretest:browser": "node scripts/buildSetup.js",
-    "test:browser": "playwright test",
-    "mocha": "mocha *.spec.js --timeout 5000"
+    "test": "playwright test --project=unit",
+    "test:browser": "playwright test --project=browser"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "chai": "^5.3.3",
-    "mocha": "^11.7.5",
     "@playwright/test": "^1.58.2"
   }
 }

--- a/javascript/MaterialXTest/playwright.config.js
+++ b/javascript/MaterialXTest/playwright.config.js
@@ -1,12 +1,31 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-    testDir: './browser',
+    // Stage the WASM build artifacts into _build before any project runs.
+    globalSetup: './scripts/buildSetup.js',
+    // Write test artifacts (and .last-run.json) under _build, which is already
+    // gitignored and removed by clean_javascript_win.bat.
+    outputDir: './_build/test-results',
     timeout: 120_000,
-    use: {
-        browserName: 'chromium',
-        launchOptions: {
-            args: ['--enable-gpu', '--enable-webgl']
+    projects: [
+        {
+            // Node-side unit tests for the JsMaterialXCore bindings. These run in
+            // the Playwright worker process (Node) and never launch a browser.
+            name: 'unit',
+            testDir: '.',
+            testIgnore: ['browser/**'],
+        },
+        {
+            // Browser-based shader generation tests, which exercise the WebGL/WASM
+            // build inside a real Chromium page.
+            name: 'browser',
+            testDir: './browser',
+            use: {
+                browserName: 'chromium',
+                launchOptions: {
+                    args: ['--enable-gpu', '--enable-webgl']
+                }
+            }
         }
-    }
+    ]
 });

--- a/javascript/MaterialXTest/scripts/buildSetup.js
+++ b/javascript/MaterialXTest/scripts/buildSetup.js
@@ -1,4 +1,5 @@
-// Cross-platform clean and copy of build artifacts for testing.
+// Cross-platform clean and copy of build artifacts for testing, used as
+// Playwright's globalSetup.
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -8,13 +9,16 @@ const testRoot = path.resolve(__dirname, '..');
 const buildDir = path.join(testRoot, '_build');
 const srcDir = path.resolve(testRoot, '..', 'build', 'bin');
 
-fs.rmSync(buildDir, { recursive: true, force: true });
-fs.mkdirSync(buildDir, { recursive: true });
-
-for (const file of fs.readdirSync(srcDir))
+export default function buildSetup()
 {
-    if (file.startsWith('JsMaterialX'))
+    fs.rmSync(buildDir, { recursive: true, force: true });
+    fs.mkdirSync(buildDir, { recursive: true });
+
+    for (const file of fs.readdirSync(srcDir))
     {
-        fs.copyFileSync(path.join(srcDir, file), path.join(buildDir, file));
+        if (file.startsWith('JsMaterialX'))
+        {
+            fs.copyFileSync(path.join(srcDir, file), path.join(buildDir, file));
+        }
     }
 }

--- a/javascript/MaterialXTest/traversal.spec.js
+++ b/javascript/MaterialXTest/traversal.spec.js
@@ -1,15 +1,15 @@
-import { expect } from 'chai';
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 
-describe('Traversal', () =>
+test.describe('Traversal', () =>
 {
     let mx;
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
     });
 
-    it('Traverse Graph', () =>
+    test('Traverse Graph', () =>
     {
         // Create a document.
         const doc = mx.createDocument();
@@ -40,7 +40,7 @@ describe('Traversal', () =>
         mix.setConnectedNode('mask', noise3d);
         output.setConnectedNode(mix);
 
-        expect(doc.validate()).to.be.true;
+        expect(doc.validate()).toBe(true);
 
         // Traverse the document tree (implicit iterator).
         let nodeCount = 0;
@@ -52,7 +52,7 @@ describe('Traversal', () =>
             }
             elem.delete();
         }
-        expect(nodeCount).to.equal(7);
+        expect(nodeCount).toBe(7);
 
         // Traverse the document tree (explicit iterator)
         let treeIter = doc.traverseTree();
@@ -67,8 +67,8 @@ describe('Traversal', () =>
             maxElementDepth = Math.max(maxElementDepth, treeIter.getElementDepth());
             elem.delete();
         }
-        expect(nodeCount).to.equal(7);
-        expect(maxElementDepth).to.equal(3);
+        expect(nodeCount).toBe(7);
+        expect(maxElementDepth).toBe(3);
 
         // Traverse the document tree (prune subtree).
         nodeCount = 0;
@@ -85,7 +85,7 @@ describe('Traversal', () =>
             }
             elem.delete();
         }
-        expect(nodeCount).to.equal(0);
+        expect(nodeCount).toBe(0);
 
         // Traverse upstream from the graph output (implicit iterator)
         nodeCount = 0;
@@ -99,7 +99,7 @@ describe('Traversal', () =>
                 nodeCount++;
                 if (downstreamElem instanceof mx.Node)
                 {
-                    expect(connectingElem instanceof mx.Input).to.be.true;
+                    expect(connectingElem instanceof mx.Input).toBe(true);
                 }
             }
             if (upstreamElem) upstreamElem.delete();
@@ -107,7 +107,7 @@ describe('Traversal', () =>
             if (downstreamElem) downstreamElem.delete();
             if (edge) edge.delete();
         }
-        expect(nodeCount).to.equal(7);
+        expect(nodeCount).toBe(7);
 
         // Traverse upstream from the graph output (explicit iterator)
         nodeCount = 0;
@@ -126,9 +126,9 @@ describe('Traversal', () =>
             if (upstreamElem) upstreamElem.delete();
             if (edge) edge.delete();
         }
-        expect(nodeCount).to.equal(7);
-        expect(maxElementDepth).to.equal(3);
-        expect(maxNodeDepth).to.equal(3);
+        expect(nodeCount).toBe(7);
+        expect(maxElementDepth).toBe(3);
+        expect(maxNodeDepth).toBe(3);
 
         // Traverse upstream from the graph output (prune subgraph)
         nodeCount = 0;
@@ -136,7 +136,7 @@ describe('Traversal', () =>
         for (let edge of graphIter)
         {
             const upstreamElem = edge.getUpstreamElement();
-            expect(upstreamElem.getSelf()).to.be.an.instanceof(mx.Element);
+            expect(upstreamElem.getSelf()).toBeInstanceOf(mx.Element);
             if (upstreamElem instanceof mx.Node)
             {
                 nodeCount++;
@@ -148,23 +148,23 @@ describe('Traversal', () =>
             if (upstreamElem) upstreamElem.delete();
             if (edge) edge.delete();
         }
-        expect(nodeCount).to.equal(5);
+        expect(nodeCount).toBe(5);
 
         // Create and detect a cycle
         multiply.setConnectedNode('in2', mix);
-        expect(output.hasUpstreamCycle()).to.be.true;
-        expect(doc.validate()).to.be.false;
+        expect(output.hasUpstreamCycle()).toBe(true);
+        expect(doc.validate()).toBe(false);
         multiply.setConnectedNode('in2', constant);
-        expect(output.hasUpstreamCycle()).to.be.false;
-        expect(doc.validate()).to.be.true;
+        expect(output.hasUpstreamCycle()).toBe(false);
+        expect(doc.validate()).toBe(true);
 
         // Create and detect a loop
         contrast.setConnectedNode('in', contrast);
-        expect(output.hasUpstreamCycle()).to.be.true;
-        expect(doc.validate()).to.be.false;
+        expect(output.hasUpstreamCycle()).toBe(true);
+        expect(doc.validate()).toBe(false);
         contrast.setConnectedNode('in', image2);
-        expect(output.hasUpstreamCycle()).to.be.false;
-        expect(doc.validate()).to.be.true;
+        expect(output.hasUpstreamCycle()).toBe(false);
+        expect(doc.validate()).toBe(true);
 
         // Cleanup wrappers
         output.delete();
@@ -179,11 +179,11 @@ describe('Traversal', () =>
         doc.delete();
     });
 
-    describe("Traverse inheritance", () =>
+    test.describe("Traverse inheritance", () =>
     {
         let nodeDefInheritanceLevel2, nodeDefInheritanceLevel1, nodeDefParent;
         let doc;
-        beforeEach(() =>
+        test.beforeEach(() =>
         {
             doc = mx.createDocument();
             nodeDefParent = doc.addNodeDef();
@@ -195,7 +195,7 @@ describe('Traversal', () =>
             nodeDefInheritanceLevel2.setInheritsFrom(nodeDefInheritanceLevel1);
             nodeDefInheritanceLevel1.setInheritsFrom(nodeDefParent);
         });
-        afterEach(() =>
+        test.afterEach(() =>
         {
             nodeDefInheritanceLevel2.delete();
             nodeDefInheritanceLevel1.delete();
@@ -203,7 +203,7 @@ describe('Traversal', () =>
             doc.delete();
         });
 
-        it('for of loop', () =>
+        test('for of loop', () =>
         {
             const inheritanceIterator = nodeDefInheritanceLevel2.traverseInheritance();
             let inheritanceChainLength = 0;
@@ -214,10 +214,10 @@ describe('Traversal', () =>
                     inheritanceChainLength++;
                 }
             }
-            expect(inheritanceChainLength).to.equal(2);;
+            expect(inheritanceChainLength).toBe(2);
         });
 
-        it('while loop', () =>
+        test('while loop', () =>
         {
             const inheritanceIterator = nodeDefInheritanceLevel2.traverseInheritance();
             let inheritanceChainLength = 0;
@@ -230,7 +230,7 @@ describe('Traversal', () =>
                 }
                 elem = inheritanceIterator.next();
             }
-            expect(inheritanceChainLength).to.equal(2);;
+            expect(inheritanceChainLength).toBe(2);
         });
     });
 });

--- a/javascript/MaterialXTest/types.spec.js
+++ b/javascript/MaterialXTest/types.spec.js
@@ -1,65 +1,65 @@
-import { expect } from 'chai';;
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 
-describe('Types', () =>
+test.describe('Types', () =>
 {
     let mx;
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
     });
 
-    it('Vectors', () =>
+    test('Vectors', () =>
     {
         const v1 = new mx.Vector3(1, 2, 3);
         let v2 = new mx.Vector3(2, 4, 6);
 
         // Indexing operators
-        expect(v1.getItem(2)).to.equal(3);
+        expect(v1.getItem(2)).toBe(3);
 
         v1.setItem(2, 4);
-        expect(v1.getItem(2)).to.equal(4);
+        expect(v1.getItem(2)).toBe(4);
         v1.setItem(2, 3);
         // Component-wise operators
         let res = v2.add(v1);
-        expect(res.equals(new mx.Vector3(3, 6, 9))).to.be.true;
+        expect(res.equals(new mx.Vector3(3, 6, 9))).toBe(true);
 
         res = v2.sub(v1);
-        expect(res.equals(new mx.Vector3(1, 2, 3))).to.be.true;
+        expect(res.equals(new mx.Vector3(1, 2, 3))).toBe(true);
 
         res = v2.multiply(v1);
-        expect(res.equals(new mx.Vector3(2, 8, 18))).to.be.true;
+        expect(res.equals(new mx.Vector3(2, 8, 18))).toBe(true);
 
         res = v2.divide(v1);
-        expect(res.equals(new mx.Vector3(2, 2, 2))).to.be.true;
+        expect(res.equals(new mx.Vector3(2, 2, 2))).toBe(true);
 
         v2 = v2.add(v1);
-        expect(v2.equals(new mx.Vector3(3, 6, 9))).to.be.true;
+        expect(v2.equals(new mx.Vector3(3, 6, 9))).toBe(true);
 
         v2 = v2.sub(v1);
-        expect(v2.equals(new mx.Vector3(2, 4, 6))).to.be.true;
+        expect(v2.equals(new mx.Vector3(2, 4, 6))).toBe(true);
 
         v2 = v2.multiply(v1);
-        expect(v2.equals(new mx.Vector3(2, 8, 18))).to.be.true;
+        expect(v2.equals(new mx.Vector3(2, 8, 18))).toBe(true);
 
         v2 = v2.divide(v1);
-        expect(v2.equals(new mx.Vector3(2, 4, 6))).to.be.true;
+        expect(v2.equals(new mx.Vector3(2, 4, 6))).toBe(true);
 
-        expect(v1.multiply(new mx.Vector3(2, 2, 2)).equals(v2)).to.be.true;
-        expect(v2.divide(new mx.Vector3(2, 2, 2)).equals(v1)).to.be.true;
+        expect(v1.multiply(new mx.Vector3(2, 2, 2)).equals(v2)).toBe(true);
+        expect(v2.divide(new mx.Vector3(2, 2, 2)).equals(v1)).toBe(true);
 
         // Geometric methods
         let v3 = new mx.Vector4(4, 4, 4, 4);
-        expect(v3.getMagnitude()).to.equal(8);
-        expect(v3.getNormalized().getMagnitude()).to.equal(1);
-        expect(v1.dot(v2)).to.equal(28);
-        expect(v1.cross(v2).equals(new mx.Vector3())).to.be.true;
+        expect(v3.getMagnitude()).toBe(8);
+        expect(v3.getNormalized().getMagnitude()).toBe(1);
+        expect(v1.dot(v2)).toBe(28);
+        expect(v1.cross(v2).equals(new mx.Vector3())).toBe(true);
 
         // Vector copy
         const v4 = v2.copy();
-        expect(v4.equals(v2)).to.be.true;
+        expect(v4.equals(v2)).toBe(true);
         v4.setItem(0, v4.getItem(0) + 1);
-        expect(v4.notEquals(v2)).to.be.true;
+        expect(v4.notEquals(v2)).toBe(true);
     });
 
     function multiplyMatrix(matrix, val)
@@ -90,7 +90,7 @@ describe('Types', () =>
         return clonedMatrix;
     }
 
-    it('Matrices', () =>
+    test('Matrices', () =>
     {
         // Translation and scale
         const trans = mx.Matrix44.createTranslation(new mx.Vector3(1, 2, 3));
@@ -98,16 +98,16 @@ describe('Types', () =>
         expect(trans.equals(new mx.Matrix44(1, 0, 0, 0,
             0, 1, 0, 0,
             0, 0, 1, 0,
-            1, 2, 3, 1)));
+            1, 2, 3, 1))).toBe(true);
         expect(scale.equals(new mx.Matrix44(2, 0, 0, 0,
             0, 2, 0, 0,
             0, 0, 2, 0,
-            0, 0, 0, 1)));
+            0, 0, 0, 1))).toBe(true);
 
         // Indexing operators
-        expect(trans.getItem(3, 2)).to.equal(3);
+        expect(trans.getItem(3, 2)).toBe(3);
         trans.setItem(3, 2, 4);
-        expect(trans.getItem(3, 2)).to.equal(4);
+        expect(trans.getItem(3, 2)).toBe(4);
         trans.setItem(3, 2, 3);
 
         // Matrix methods
@@ -116,12 +116,12 @@ describe('Types', () =>
                 0, 1, 0, 2,
                 0, 0, 1, 3,
                 0, 0, 0, 1)
-        )).to.be.true;
-        expect(scale.getTranspose().equals(scale)).to.be.true;
-        expect(trans.getDeterminant()).to.equal(1);
-        expect(scale.getDeterminant()).to.equal(8);
+        )).toBe(true);
+        expect(scale.getTranspose().equals(scale)).toBe(true);
+        expect(trans.getDeterminant()).toBe(1);
+        expect(scale.getDeterminant()).toBe(8);
         expect(trans.getInverse().equals(
-            mx.Matrix44.createTranslation(new mx.Vector3(-1, -2, -3)))).to.be.true;
+            mx.Matrix44.createTranslation(new mx.Vector3(-1, -2, -3)))).toBe(true);
 
         // Matrix product
         const prod1 = trans.multiply(scale);
@@ -132,16 +132,16 @@ describe('Types', () =>
         expect(prod1.equals(new mx.Matrix44(2, 0, 0, 0,
             0, 2, 0, 0,
             0, 0, 2, 0,
-            2, 4, 6, 1)));
+            2, 4, 6, 1))).toBe(true);
         expect(prod2.equals(new mx.Matrix44(2, 0, 0, 0,
             0, 2, 0, 0,
             0, 0, 2, 0,
-            1, 2, 3, 1)));
+            1, 2, 3, 1))).toBe(true);
         expect(prod3.equals(new mx.Matrix44(2, 0, 0, 0,
             0, 2, 0, 0,
             0, 0, 2, 0,
-            2, 4, 6, 2)));
-        expect(prod4.equals(prod1));
+            2, 4, 6, 2))).toBe(true);
+        expect(prod4.equals(prod1)).toBe(true);
 
         // Matrix division
         const quot1 = prod1.divide(scale);
@@ -149,30 +149,30 @@ describe('Types', () =>
         const quot3 = divideMatrix(prod3, 2);
         let quot4 = quot1;
         quot4 = quot4.divide(trans);
-        expect(quot1.equals(trans)).to.be.true;
-        expect(quot2.equals(scale)).to.be.true;
-        expect(quot3.equals(trans)).to.be.true;
+        expect(quot1.equals(trans)).toBe(true);
+        expect(quot2.equals(scale)).toBe(true);
+        expect(quot3.equals(trans)).toBe(true);
 
         // 2D rotation
         const _epsilon = 1e-4;
         const rot1 = mx.Matrix33.createRotation(Math.PI / 2);
         const rot2 = mx.Matrix33.createRotation(Math.PI);
-        expect(rot1.multiply(rot1).isEquivalent(rot2, _epsilon));
-        expect(rot2.isEquivalent(mx.Matrix33.createScale(new mx.Vector2(-1, -1)), _epsilon));
-        expect(rot2.multiply(rot2).isEquivalent(mx.Matrix33.IDENTITY, _epsilon));
+        expect(rot1.multiply(rot1).isEquivalent(rot2, _epsilon)).toBe(true);
+        expect(rot2.isEquivalent(mx.Matrix33.createScale(new mx.Vector2(-1, -1)), _epsilon)).toBe(true);
+        expect(rot2.multiply(rot2).isEquivalent(mx.Matrix33.IDENTITY, _epsilon)).toBe(true);
 
         // 3D rotation
         const rotX = mx.Matrix44.createRotationX(Math.PI);
         const rotY = mx.Matrix44.createRotationY(Math.PI);
         const rotZ = mx.Matrix44.createRotationZ(Math.PI);
-        expect(rotX.multiply(rotY).isEquivalent(mx.Matrix44.createScale(new mx.Vector3(-1, -1, 1)), _epsilon));
-        expect(rotX.multiply(rotZ).isEquivalent(mx.Matrix44.createScale(new mx.Vector3(-1, 1, -1)), _epsilon));
-        expect(rotY.multiply(rotZ).isEquivalent(mx.Matrix44.createScale(new mx.Vector3(1, -1, -1)), _epsilon));
+        expect(rotX.multiply(rotY).isEquivalent(mx.Matrix44.createScale(new mx.Vector3(-1, -1, 1)), _epsilon)).toBe(true);
+        expect(rotX.multiply(rotZ).isEquivalent(mx.Matrix44.createScale(new mx.Vector3(-1, 1, -1)), _epsilon)).toBe(true);
+        expect(rotY.multiply(rotZ).isEquivalent(mx.Matrix44.createScale(new mx.Vector3(1, -1, -1)), _epsilon)).toBe(true);
 
         // Matrix copy
         const trans2 = trans.copy();
-        expect(trans2.equals(trans)).to.be.true;
+        expect(trans2.equals(trans)).toBe(true);
         trans2.setItem(0, 0, trans2.getItem(0, 0) + 1);
-        expect(trans2.notEquals(trans)).to.be.true;
+        expect(trans2.notEquals(trans)).toBe(true);
     });
 });

--- a/javascript/MaterialXTest/value.spec.js
+++ b/javascript/MaterialXTest/value.spec.js
@@ -1,15 +1,15 @@
-import { expect } from 'chai';;
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
 
-describe('Value', () =>
+test.describe('Value', () =>
 {
     let mx;
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
     });
 
-    it('Create values of different types', () =>
+    test('Create values of different types', () =>
     {
         const testValues = {
             integer: '1',
@@ -35,8 +35,8 @@ describe('Value', () =>
             const newValue = mx.Value.createValueFromStrings(value, type);
             const typeString = newValue.getTypeString();
             const valueString = newValue.getValueString();
-            expect(typeString).to.equal(type);
-            expect(valueString).to.equal(value);
+            expect(typeString).toBe(type);
+            expect(valueString).toBe(value);
         }
     });
 });

--- a/javascript/MaterialXTest/xmlIo.spec.js
+++ b/javascript/MaterialXTest/xmlIo.spec.js
@@ -1,11 +1,9 @@
 import path from 'path';
+import { test, expect } from '@playwright/test';
 import Module from './_build/JsMaterialXCore.js';
-import { expect } from 'chai';
 import { getMtlxStrings } from './testHelpers.js';
 
-const TIMEOUT = 60000;
-
-describe('XmlIo', () =>
+test.describe('XmlIo', () =>
 {
     let mx;
 
@@ -61,7 +59,7 @@ describe('XmlIo', () =>
             {
                 doc.importLibrary(lib);
             }
-            expect(doc.validate()).to.be.true;
+            expect(doc.validate()).toBe(true);
 
             // Make sure the document does actually contain something.
             let valueElementCount = 0;
@@ -75,17 +73,17 @@ describe('XmlIo', () =>
                 // Release wrapper created by iterator
                 elem.delete();
             }
-            expect(valueElementCount).to.be.greaterThan(0);
+            expect(valueElementCount).toBeGreaterThan(0);
             doc.delete();
         };
     }
 
-    before(async () =>
+    test.beforeAll(async () =>
     {
         mx = await Module();
     });
 
-    it('Read XML from file', async () =>
+    test('Read XML from file', async () =>
     {
         // Read the standard library
         const libs = await readStdLibrary(false);
@@ -104,14 +102,14 @@ describe('XmlIo', () =>
         await mx.readFromXmlFile(doc, filename, examplesPath);
         const copy = doc.copy();
         await mx.readFromXmlFile(doc, filename, examplesPath);
-        expect(doc.validate()).to.be.true;
-        expect(copy.equals(doc)).to.be.true;
+        expect(doc.validate()).toBe(true);
+        expect(copy.equals(doc)).toBe(true);
         copy.delete();
         doc.delete();
         libs.forEach(l => l.delete());
-    }).timeout(TIMEOUT);
+    });
 
-    it('Read XML from string', async () =>
+    test('Read XML from string', async () =>
     {
         // Read the standard library
         const libs = await readStdLibrary(true);
@@ -131,70 +129,72 @@ describe('XmlIo', () =>
         await mx.readFromXmlString(doc, file);
         const copy = doc.copy();
         await mx.readFromXmlString(doc, file);
-        expect(doc.validate()).to.be.true;
-        expect(copy.equals(doc)).to.be.true;
+        expect(doc.validate()).toBe(true);
+        expect(copy.equals(doc)).toBe(true);
         copy.delete();
         doc.delete();
         libs.forEach(l => l.delete());
-    }).timeout(TIMEOUT);
+    });
 
-    it('Read XML with recursive includes', async () =>
+    test('Read XML with recursive includes', async () =>
     {
         const doc = mx.createDocument();
         await mx.readFromXmlFile(doc, includeTestPath + '/root.mtlx');
-        expect(doc.getChild('paint_semigloss')).to.exist;
-        expect(doc.validate()).to.be.true;
+        expect(doc.getChild('paint_semigloss')).toBeTruthy();
+        expect(doc.validate()).toBe(true);
         doc.delete();
     });
 
-    it('Locate XML includes via search path', async () =>
+    test('Locate XML includes via search path', async () =>
     {
         const searchPath = includeTestPath + ';' + includeTestPath + '/folder';
         const filename = 'non_relative_includes.mtlx';
         const doc = mx.createDocument();
-        expect(async () => await mx.readFromXmlFile(doc, filename, includeTestPath)).to.throw;
+        // Includes cannot be resolved without 'folder' on the search path.
+        await expect(mx.readFromXmlFile(doc, filename, includeTestPath)).rejects.toThrow();
         await mx.readFromXmlFile(doc, filename, searchPath);
-        expect(doc.getChild('paint_semigloss')).to.exist;
-        expect(doc.validate()).to.be.true;
+        expect(doc.getChild('paint_semigloss')).toBeTruthy();
+        expect(doc.validate()).toBe(true);
 
         const doc2 = mx.createDocument();
         const mtlxString = getMtlxStrings([filename], includeTestPath);
-        expect(async () => await mx.readFromXmlString(doc2, mtlxString[0])).to.throw;
+        await expect(mx.readFromXmlString(doc2, mtlxString[0])).rejects.toThrow();
         await mx.readFromXmlString(doc2, mtlxString[0], searchPath);
-        expect(doc2.getChild('paint_semigloss')).to.exist;
-        expect(doc2.validate()).to.be.true;
-        expect(doc2.equals(doc)).to.be.true;
+        expect(doc2.getChild('paint_semigloss')).toBeTruthy();
+        expect(doc2.validate()).toBe(true);
+        expect(doc2.equals(doc)).toBe(true);
         doc2.delete();
         doc.delete();
     });
 
-    it('Locate XML includes via environment variable', async () =>
+    test('Locate XML includes via environment variable', async () =>
     {
         const searchPath = includeTestPath + ';' + includeTestPath + '/folder';
         const filename = 'non_relative_includes.mtlx';
 
         const doc = mx.createDocument();
-        expect(async () => await mx.readFromXmlFile(doc, includeTestPath + '/' + filename)).to.throw;
+        // Includes cannot be resolved with no search path configured.
+        await expect(mx.readFromXmlFile(doc, includeTestPath + '/' + filename)).rejects.toThrow();
         mx.setEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR, searchPath);
         await mx.readFromXmlFile(doc, filename);
         mx.removeEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR);
-        expect(doc.getChild('paint_semigloss')).to.exist;
-        expect(doc.validate()).to.be.true;
+        expect(doc.getChild('paint_semigloss')).toBeTruthy();
+        expect(doc.validate()).toBe(true);
 
         const doc2 = mx.createDocument();
         const mtlxString = getMtlxStrings([filename], includeTestPath);
-        expect(async () => await mx.readFromXmlString(doc2, mtlxString[0])).to.throw;
+        await expect(mx.readFromXmlString(doc2, mtlxString[0])).rejects.toThrow();
         mx.setEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR, searchPath);
         await mx.readFromXmlString(doc2, mtlxString[0]);
         mx.removeEnviron(mx.MATERIALX_SEARCH_PATH_ENV_VAR);
-        expect(doc2.getChild('paint_semigloss')).to.exist;
-        expect(doc2.validate()).to.be.true;
-        expect(doc2.equals(doc)).to.be.true;
+        expect(doc2.getChild('paint_semigloss')).toBeTruthy();
+        expect(doc2.validate()).toBe(true);
+        expect(doc2.equals(doc)).toBe(true);
         doc2.delete();
         doc.delete();
     });
 
-    it('Locate XML includes via absolute search paths', async () =>
+    test('Locate XML includes via absolute search paths', async () =>
     {
         let absolutePath;
         if (typeof window === 'object')
@@ -212,23 +212,25 @@ describe('XmlIo', () =>
         doc.delete();
     });
 
-    it('Detect XML include cycles', async () =>
+    test('Detect XML include cycles', async () =>
     {
         const doc = mx.createDocument();
-        expect(async () => await mx.readFromXmlFile(doc, includeTestPath + '/cycle.mtlx')).to.throw;
+        // A self-referential include chain must be rejected.
+        await expect(mx.readFromXmlFile(doc, includeTestPath + '/cycle.mtlx')).rejects.toThrow();
         doc.delete();
     });
 
-    it('Disabling XML includes', async () =>
+    test('Disabling XML includes', async () =>
     {
         const doc = mx.createDocument();
         const readOptions = new mx.XmlReadOptions();
         readOptions.readXIncludes = false;
-        expect(async () => await mx.readFromXmlFile(doc, includeTestPath + '/cycle.mtlx', readOptions)).to.not.throw;
+        // With includes disabled, the cycle is never followed (readOptions is the 4th arg).
+        await expect(mx.readFromXmlFile(doc, includeTestPath + '/cycle.mtlx', '', readOptions)).resolves.toBeUndefined();
         doc.delete();
     });
 
-    it('Write to XML string', async () =>
+    test('Write to XML string', async () =>
     {
         // Read all example documents and write them to an XML string
         const searchPath = libraryPath + ';' + examplesPath;
@@ -246,26 +248,26 @@ describe('XmlIo', () =>
             // Verify that the serialized document is identical.
             const writtenDoc = mx.createDocument();
             await mx.readFromXmlString(writtenDoc, xmlString);
-            expect(writtenDoc).to.eql(doc);
+            expect(writtenDoc.equals(doc)).toBe(true);
             writtenDoc.delete();
             doc.delete();
         };
     });
 
-    it('Prepend include tag', () =>
+    test('Prepend include tag', () =>
     {
         const doc = mx.createDocument();
         const includePath = "SomePath";
         const writeOptions = new mx.XmlWriteOptions();
         mx.prependXInclude(doc, includePath);
         const xmlString = mx.writeToXmlString(doc, writeOptions);
-        expect(xmlString).to.include(includePath);
+        expect(xmlString).toContain(includePath);
         writeOptions.delete();
         doc.delete();
     });
 
     // Node only, because we cannot read from a downloaded file in the browser
-    it('Write XML to file', async () =>
+    test('Write XML to file', async () =>
     {
         const filename = '_build/testFile.mtlx';
         const includeRegex = /<xi:include href="(.*)"\s*\/>/g;
@@ -277,11 +279,11 @@ describe('XmlIo', () =>
         // Read written document and compare with the original
         const doc2 = mx.createDocument();
         await mx.readFromXmlFile(doc2, filename, includeTestPath);
-        expect(doc2.equals(doc));
+        expect(doc2.equals(doc)).toBe(true);
         // Read written file content and verify that includes are preserved
         let fileString = getMtlxStrings([filename], '')[0];
         let matches = Array.from(fileString.matchAll(includeRegex));
-        expect(matches.length).to.be.greaterThan(0);
+        expect(matches.length).toBeGreaterThan(0);
 
         // Write inlining included content
         const writeOptions = new mx.XmlWriteOptions();
@@ -290,12 +292,12 @@ describe('XmlIo', () =>
         // Read written document and compare with the original
         const doc3 = mx.createDocument();
         await mx.readFromXmlFile(doc3, filename);
-        expect(doc3.equals(doc));
-        expect(doc.getChild('paint_semigloss')).to.exist;
+        expect(doc3.equals(doc)).toBe(true);
+        expect(doc.getChild('paint_semigloss')).toBeTruthy();
         // Read written file content and verify that includes are inlined
         fileString = getMtlxStrings([filename], '')[0];
         matches = Array.from(fileString.matchAll(includeRegex));
-        expect(matches.length).to.equal(0);
+        expect(matches.length).toBe(0);
         doc3.delete();
         doc2.delete();
         doc.delete();

--- a/javascript/clean_javascript_win.bat
+++ b/javascript/clean_javascript_win.bat
@@ -1,4 +1,6 @@
 rmdir build /s /q
 rmdir node_modules /s /q
 rmdir MaterialXTest\_build /s /q
+rmdir MaterialXTest\playwright-report /s /q
+rmdir MaterialXView\node_modules /s /q
 rmdir MaterialXView\dist /s /q

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -17,9 +17,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.58.2",
-        "chai": "^5.3.3",
-        "mocha": "^11.7.5"
+        "@playwright/test": "^1.58.2"
       }
     },
     "MaterialXView": {
@@ -28,7 +26,7 @@
       "dependencies": {
         "fflate": "^0.8.2",
         "lil-gui": "^0.19.2",
-        "three": "^0.183.0"
+        "three": "^0.183.2"
       },
       "devDependencies": {
         "copy-webpack-plugin": "^14.0.0",
@@ -40,8 +38,6 @@
     },
     "MaterialXView/node_modules/three": {
       "version": "0.183.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
-      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
       "license": "MIT"
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -52,24 +48,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -174,14 +152,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-core": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.1.tgz",
-      "integrity": "sha512-YrEi/ZPmgc+GfdO0esBF04qv8boK9Dg9WpRQw/+vM8Qt3nnVIJWIa8HwZ/LXVZ0DB11XUROM8El/7yYTJX+WtA==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.57.2.tgz",
+      "integrity": "sha512-SVjwklkpIV5wrynpYtuYnfYH1QF4/nDuLBX7VXdb+3miglcAgBVZb/5y0cOsehRV/9Vb+3UqhkMq3/NR3ztdkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -196,15 +174,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-fsa": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.1.tgz",
-      "integrity": "sha512-ooEPvSW/HQDivPDPZMibHGKZf/QS4WRir1czGZmXmp3MsQqLECZEpN0JobrD8iV9BzsuwdIv+PxtWX9WpPLsIA==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.57.2.tgz",
+      "integrity": "sha512-fhO8+iR2I+OCw668ISDJdn1aArc9zx033sWejIyzQ8RBeXa9bDSaUeA3ix0poYOfrj1KdOzytmYNv2/uLDfV6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "thingies": "^2.5.0"
       },
       "engines": {
@@ -219,17 +197,17 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.1.tgz",
-      "integrity": "sha512-3YaKhP8gXEKN+2O49GLNfNb5l2gbnCFHyAaybbA2JkkbQP3dpdef7WcUaHAulg/c5Dg4VncHsA3NWAUSZMR5KQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.57.2.tgz",
+      "integrity": "sha512-nX2AdL6cOFwLdju9G4/nbRnYevmCJbh7N7hvR3gGm97Cs60uEjyd0rpR+YBS7cTg175zzl22pGKXR5USaQMvKg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "glob-to-regex.js": "^1.0.0",
         "thingies": "^2.5.0"
       },
@@ -245,9 +223,9 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-builtins": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.1.tgz",
-      "integrity": "sha512-XHkFKQ5GSH3uxm8c3ZYXVrexGdscpWKIcMWKFQpMpMJc8gA3AwOMBJXJlgpdJqmrhPyQXxaY9nbkNeYpacC0Og==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
+      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -262,15 +240,15 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-to-fsa": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.1.tgz",
-      "integrity": "sha512-pqGHyWWzNck4jRfaGV39hkqpY5QjRUQ/nRbNT7FYbBa0xf4bDG+TE1Gt2KWZrSkrkZZDE3qZUjYMbjwSliX6pg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.57.2.tgz",
+      "integrity": "sha512-18LmWTSONhoAPW+IWRuf8w/+zRolPFGPeGwMxlAhhfY11EKzX+5XHDBPAw67dBF5dxDErHJbl40U+3IXSDRXSQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1"
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -284,13 +262,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-node-utils": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.1.tgz",
-      "integrity": "sha512-vp+7ZzIB8v43G+GLXTS4oDUSQmhAsRz532QmmWBbdYA20s465JvwhkSFvX9cVTqRRAQg+vZ7zWDaIEh0lFe2gw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.57.2.tgz",
+      "integrity": "sha512-rsPSJgekz43IlNbLyAM/Ab+ouYLWGp5DDBfYBNNEqDaSpsbXfthBn29Q4muFA9L0F+Z3mKo+CWlgSCXrf+mOyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-builtins": "4.57.1"
+        "@jsonjoy.com/fs-node-builtins": "4.57.2"
       },
       "engines": {
         "node": ">=10.0"
@@ -304,13 +282,13 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-print": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.1.tgz",
-      "integrity": "sha512-Ynct7ZJmfk6qoXDOKfpovNA36ITUx8rChLmRQtW08J73VOiuNsU8PB6d/Xs7fxJC2ohWR3a5AqyjmLojfrw5yw==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.57.2.tgz",
+      "integrity": "sha512-wK9NSow48i4DbDl9F1CQE5TqnyZOJ04elU3WFG5aJ76p+YxO/ulyBBQvKsessPxdo381Bc2pcEoyPujMOhcRqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "tree-dump": "^1.1.0"
       },
       "engines": {
@@ -325,14 +303,14 @@
       }
     },
     "node_modules/@jsonjoy.com/fs-snapshot": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.1.tgz",
-      "integrity": "sha512-/oG8xBNFMbDXTq9J7vepSA1kerS5vpgd3p5QZSPd+nX59uwodGJftI51gDYyHRpP57P3WCQf7LHtBYPqwUg2Bg==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.57.2.tgz",
+      "integrity": "sha512-GdduDZuoP5V/QCgJkx9+BZ6SC0EZ/smXAdTS7PfMqgMTGXLlt/bH/FqMYaqB9JmLf05sJPtO0XRbAwwkEEPbVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jsonjoy.com/buffers": "^17.65.0",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
         "@jsonjoy.com/json-pack": "^17.65.0",
         "@jsonjoy.com/util": "^17.65.0"
       },
@@ -573,138 +551,148 @@
       }
     },
     "node_modules/@peculiar/asn1-cms": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
-      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
-        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-csr": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
-      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-ecc": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
-      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pfx": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
-      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.1",
-        "@peculiar/asn1-pkcs8": "^2.6.1",
-        "@peculiar/asn1-rsa": "^2.6.1",
-        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs8": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
-      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-pkcs9": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
-      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-cms": "^2.6.1",
-        "@peculiar/asn1-pfx": "^2.6.1",
-        "@peculiar/asn1-pkcs8": "^2.6.1",
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
-        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-rsa": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
-      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
-      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
-      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.6",
-        "pvtsutils": "^1.3.6",
         "tslib": "^2.8.1"
       }
     },
     "node_modules/@peculiar/asn1-x509-attr": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
-      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.6.0",
-        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
         "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tslib": "^2.8.1"
       }
     },
@@ -731,25 +719,14 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -800,32 +777,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -894,19 +849,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1260,9 +1215,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1321,32 +1276,13 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -1376,13 +1312,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1391,41 +1320,24 @@
       "license": "MIT"
     },
     "node_modules/asn1js": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
-      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
-        "pvutils": "^1.1.3",
+        "pvutils": "^1.1.5",
         "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1456,9 +1368,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1470,7 +1382,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -1480,27 +1392,10 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/bonjour-service": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
-      "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.4.0.tgz",
+      "integrity": "sha512-fGQtj1qdR9vIKjFiWPQd52qIqwjaYqhcI40JEiDuvlZ86E7ZBPBwY9fPgHy9r2rYGIjiRfctNPYz6OQU73ww2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1515,16 +1410,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1538,17 +1423,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1566,11 +1444,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1664,23 +1542,10 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -1698,77 +1563,42 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 8.10.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -1794,84 +1624,6 @@
         "node": ">= 10.0"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/clone-deep": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -1886,26 +1638,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -1955,23 +1687,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/compression/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/compression/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/connect-history-api-fallback": {
       "version": "2.0.0",
@@ -2100,44 +1815,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "ms": "2.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -2210,16 +1894,6 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/dns-packet": {
       "version": "5.6.1",
@@ -2329,13 +2003,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2344,18 +2011,11 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.325",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
-      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2368,14 +2028,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.0.tgz",
+      "integrity": "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -2425,16 +2085,16 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2460,19 +2120,6 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -2549,15 +2196,15 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -2576,7 +2223,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -2595,23 +2242,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/express/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2620,9 +2250,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -2678,9 +2308,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -2715,38 +2345,18 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/finalhandler/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/finalhandler/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^6.0.0",
+        "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/flat": {
@@ -2760,9 +2370,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -2778,23 +2388,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forwarded": {
@@ -2842,16 +2435,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2889,28 +2472,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3001,9 +2562,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3092,9 +2653,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.6",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
-      "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3280,9 +2841,9 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
-      "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3303,13 +2864,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3342,16 +2903,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3387,9 +2938,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.2.tgz",
+      "integrity": "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3407,16 +2958,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -3443,19 +2984,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-wsl": {
@@ -3498,22 +3026,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jest-worker": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
@@ -3528,26 +3040,6 @@
       "engines": {
         "node": ">= 10.13.0"
       }
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -3584,9 +3076,9 @@
       "license": "MIT"
     },
     "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3598,49 +3090,22 @@
       }
     },
     "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-locate": "^5.0.0"
+        "p-locate": "^4.1.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3653,13 +3118,6 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/MaterialXTest": {
       "resolved": "MaterialXTest",
@@ -3690,20 +3148,20 @@
       }
     },
     "node_modules/memfs": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.1.tgz",
-      "integrity": "sha512-WvzrWPwMQT+PtbX2Et64R4qXKK0fj/8pO85MrUCzymX3twwCiJCdvntW3HdhG1teLJcHDDLIKx5+c3HckWYZtQ==",
+      "version": "4.57.2",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
+      "integrity": "sha512-2nWzSsJzrukurSDna4Z0WywuScK4Id3tSKejgu74u8KCdW4uNrseKRSIDg75C6Yw5ZRqBe0F0EtMNlTbUq8bAQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@jsonjoy.com/fs-core": "4.57.1",
-        "@jsonjoy.com/fs-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node": "4.57.1",
-        "@jsonjoy.com/fs-node-builtins": "4.57.1",
-        "@jsonjoy.com/fs-node-to-fsa": "4.57.1",
-        "@jsonjoy.com/fs-node-utils": "4.57.1",
-        "@jsonjoy.com/fs-print": "4.57.1",
-        "@jsonjoy.com/fs-snapshot": "4.57.1",
+        "@jsonjoy.com/fs-core": "4.57.2",
+        "@jsonjoy.com/fs-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node": "4.57.2",
+        "@jsonjoy.com/fs-node-builtins": "4.57.2",
+        "@jsonjoy.com/fs-node-to-fsa": "4.57.2",
+        "@jsonjoy.com/fs-node-utils": "4.57.2",
+        "@jsonjoy.com/fs-print": "4.57.2",
+        "@jsonjoy.com/fs-snapshot": "4.57.2",
         "@jsonjoy.com/json-pack": "^1.11.0",
         "@jsonjoy.com/util": "^1.9.0",
         "glob-to-regex.js": "^1.0.1",
@@ -3787,9 +3245,9 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3809,6 +3267,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -3816,73 +3284,10 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mocha": {
-      "version": "11.7.5",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
-      "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browser-stdout": "^1.3.1",
-        "chokidar": "^4.0.1",
-        "debug": "^4.3.5",
-        "diff": "^7.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "find-up": "^5.0.0",
-        "glob": "^10.4.5",
-        "he": "^1.2.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
-        "ms": "^2.1.3",
-        "picocolors": "^1.1.1",
-        "serialize-javascript": "^6.0.2",
-        "strip-json-comments": "^3.1.1",
-        "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
-        "yargs-unparser": "^2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3929,11 +3334,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4021,35 +3429,32 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "yocto-queue": "^0.1.0"
+        "p-try": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^3.0.2"
+        "p-limit": "^2.2.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/p-retry": {
@@ -4079,13 +3484,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -4146,39 +3544,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4213,62 +3584,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pkijs": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
@@ -4288,13 +3603,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4307,9 +3622,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4382,9 +3697,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4439,17 +3754,29 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">=8.6"
       },
       "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rechoir": {
@@ -4496,39 +3823,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "node_modules/renderkid/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/renderkid/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -4547,12 +3841,13 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -4707,20 +4002,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4757,16 +4042,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/serve-index/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/serve-index/node_modules/depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4793,13 +4068,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/serve-index/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/serve-index/node_modules/statuses": {
       "version": "1.5.0",
@@ -4871,9 +4139,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4904,14 +4172,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4957,19 +4225,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/sockjs": {
@@ -5037,6 +4292,56 @@
         "wbuf": "^1.7.3"
       }
     },
+    "node_modules/spdy-transport/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/spdy-transport/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/spdy/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/spdy/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5057,88 +4362,7 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5149,29 +4373,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -5204,9 +4405,9 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5218,9 +4419,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
-      "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5237,9 +4438,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
-      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
+      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5259,10 +4460,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -5302,14 +4530,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5400,9 +4628,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5516,13 +4744,12 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
+      "version": "5.107.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.1.tgz",
+      "integrity": "sha512-mvdIWxj/H6QsfgDdH9djne3a5dYcmEmtsXGESkypaGN5jXjF/b+9KDlmTDQ2TKlFUeA2fI9Y65kihD30JOdB+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
@@ -5532,21 +4759,20 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.21.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
+        "terser-webpack-plugin": "^5.5.0",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "webpack-sources": "^3.4.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -5647,16 +4873,6 @@
         }
       }
     },
-    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/webpack-dev-middleware/node_modules/mime-types": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
@@ -5675,9 +4891,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5732,70 +4948,6 @@
         }
       }
     },
-    "node_modules/webpack-dev-server/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/webpack-merge": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
@@ -5812,9 +4964,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.0.tgz",
+      "integrity": "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5869,112 +5021,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/workerpool": {
-      "version": "9.3.4",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
-      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6004,129 +5054,6 @@
       },
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -7,9 +7,5 @@
   ],
   "engines": {
     "node": ">=18"
-  },
-  "overrides": {
-    "diff": "8.0.4",
-    "serialize-javascript": "7.0.5"
   }
 }

--- a/source/JsMaterialX/JsMaterialXFormat/JsXmlIo.cpp
+++ b/source/JsMaterialX/JsMaterialXFormat/JsXmlIo.cpp
@@ -19,7 +19,9 @@ EMSCRIPTEN_BINDINGS(xmlio)
         .constructor<>()
         .property<bool>("readXIncludes",
             [](const mx::XmlReadOptions &self) {
-                return self.readXIncludeFunction == nullptr;
+                // XIncludes are enabled when a read function is installed; the
+                // default-constructed value is mx::readFromXmlFile.
+                return self.readXIncludeFunction != nullptr;
             },
             [](mx::XmlReadOptions &self, bool useIncludes) {
                 if (useIncludes) {


### PR DESCRIPTION
This changelist migrates the JavaScript unit tests from Mocha and Chai to Playwright, harmonizing on a single JavaScript test framework for both browser and unit tests.  The following specific changes are included:

- Convert the unit tests from Mocha and Chai to Playwright, removing the `mocha` and `chai` dependencies.
- Run the Node and browser tests as separate Playwright projects from a single configuration.
- Stage the WASM build artifacts through a Playwright `globalSetup` rather than npm `pretest` hooks.
- Restore assertions that had silently become no-ops, so each `expect` again verifies its condition.
- Fix an inverted `readXIncludes` getter on `XmlReadOptions`, uncovered by the restored assertions.