### PR TITLE
Unrecognized colorspace should throw rather than warn to stderr

### DIFF
--- a/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
+++ b/resources/Materials/TestSuite/stdlib/color_management/color_management.mtlx
@@ -188,5 +188,15 @@
       <input name="base_color" type="color3" nodename="color_lin_displayp3_color3" />
     </standard_surface>
     <output name="color_lin_displayp3_out" type="surfaceshader" nodename="color_lin_displayp3_standard_surface5" />
+    <constant name="color_lin_rec709_scene" type="color4">
+      <input name="value" type="color4" value="0.5, 0.0, 0.0, 1.0" colorspace="lin_rec709_scene" />
+    </constant>
+    <convert name="color_lin_rec709_scene_color3" type="color3">
+      <input name="in" type="color4" nodename="color_lin_rec709_scene" />
+    </convert>
+    <standard_surface name="color_lin_rec709_scene_standard_surface" type="surfaceshader">
+      <input name="base_color" type="color3" nodename="color_lin_rec709_scene_color3" />
+    </standard_surface>
+    <output name="color_lin_rec709_scene_out" type="surfaceshader" nodename="color_lin_rec709_scene_standard_surface" />
   </nodegraph>
 </materialx>

--- a/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/DefaultColorManagementSystem.cpp
@@ -67,6 +67,13 @@ NodeDefPtr DefaultColorManagementSystem::getNodeDef(const ColorSpaceTransform& t
 
     string sourceSpace = COLOR_SPACE_REMAP.count(transform.sourceSpace) ? COLOR_SPACE_REMAP.at(transform.sourceSpace) : transform.sourceSpace;
     string targetSpace = COLOR_SPACE_REMAP.count(transform.targetSpace) ? COLOR_SPACE_REMAP.at(transform.targetSpace) : transform.targetSpace;
+
+    // After remapping, the transform may be a no-op (e.g. lin_rec709_scene -> lin_rec709).
+    if (sourceSpace == targetSpace)
+    {
+        return _document->getNodeDef("ND_dot_" + transform.type.getName());
+    }
+
     string nodeName = sourceSpace + "_to_" + targetSpace;
 
     for (NodeDefPtr nodeDef : _document->getMatchingNodeDefs(nodeName))

--- a/source/MaterialXGenShader/OcioColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/OcioColorManagementSystem.cpp
@@ -154,17 +154,35 @@ NodeDefPtr OcioColorManagementSystemImpl::getNodeDef(const ColorSpaceTransform& 
         return {};
     }
 
-     static const auto NODE_NAME = string{ "ocio_color_conversion" };
--    const auto functionName = NODE_NAME + "_" + processor->getCacheID();
-+    const auto functionName = createValidName(NODE_NAME + "_" + processor->getCacheID());
-     const auto implName = OcioColorManagementSystem::IMPL_PREFIX + functionName + "_" + transform.type.getName();
-     const auto nodeDefName = ND_PREFIX + functionName + "_" + transform.type.getName();
-     auto nodeDef = document->getNodeDef(nodeDefName);
-
-
+    // Build a function name from the source/target color space names and the first
+    // six characters of the cache ID.  Each name component is sanitized individually:
+    // invalid characters are replaced with underscores and consecutive underscores are
+    // collapsed to one so that OCIO's own identifier normalizer cannot produce a
+    // different name than the one we register on the node def.
+    auto sanitizeName = [](const string& s) -> string
+    {
+        string result = createValidName(s);
+        string collapsed;
+        bool prevUnderscore = false;
+        for (char c : result)
+        {
+            if (c == '_')
+            {
+                if (!prevUnderscore)
+                    collapsed += c;
+                prevUnderscore = true;
+            }
+            else
+            {
+                collapsed += c;
+                prevUnderscore = false;
+            }
+        }
+        return collapsed;
+    };
     static const auto NODE_NAME = string{ "ocio_color_conversion" };
-    const string cacheID = processor->getCacheID();                                                                                           
-    const auto functionName = createValidName(NODE_NAME + "_" + sourceColorSpace + "_to_" + targetColorSpace + "_" + cacheID.substr(0, 6));      
+    const string cacheID = processor->getCacheID();
+    const auto functionName = NODE_NAME + "_" + sanitizeName(sourceColorSpace) + "_to_" + sanitizeName(targetColorSpace) + "_" + cacheID.substr(0, 6);
     const auto implName = OcioColorManagementSystem::IMPL_PREFIX + functionName + "_" + transform.type.getName();
     const auto nodeDefName = ND_PREFIX + functionName + "_" + transform.type.getName();
     auto nodeDef = document->getNodeDef(nodeDefName);

--- a/source/MaterialXGenShader/OcioColorManagementSystem.cpp
+++ b/source/MaterialXGenShader/OcioColorManagementSystem.cpp
@@ -154,8 +154,17 @@ NodeDefPtr OcioColorManagementSystemImpl::getNodeDef(const ColorSpaceTransform& 
         return {};
     }
 
+     static const auto NODE_NAME = string{ "ocio_color_conversion" };
+-    const auto functionName = NODE_NAME + "_" + processor->getCacheID();
++    const auto functionName = createValidName(NODE_NAME + "_" + processor->getCacheID());
+     const auto implName = OcioColorManagementSystem::IMPL_PREFIX + functionName + "_" + transform.type.getName();
+     const auto nodeDefName = ND_PREFIX + functionName + "_" + transform.type.getName();
+     auto nodeDef = document->getNodeDef(nodeDefName);
+
+
     static const auto NODE_NAME = string{ "ocio_color_conversion" };
-    const auto functionName = NODE_NAME + "_" + processor->getCacheID();
+    const string cacheID = processor->getCacheID();                                                                                           
+    const auto functionName = createValidName(NODE_NAME + "_" + sourceColorSpace + "_to_" + targetColorSpace + "_" + cacheID.substr(0, 6));      
     const auto implName = OcioColorManagementSystem::IMPL_PREFIX + functionName + "_" + transform.type.getName();
     const auto nodeDefName = ND_PREFIX + functionName + "_" + transform.type.getName();
     auto nodeDef = document->getNodeDef(nodeDefName);

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -12,7 +12,6 @@
 
 #include <MaterialXTrace/Tracing.h>
 
-#include <iostream>
 #include <queue>
 
 MATERIALX_NAMESPACE_BEGIN
@@ -1227,8 +1226,8 @@ void ShaderGraph::populateColorTransformMap(ColorManagementSystemPtr colorManage
             }
             else
             {
-                std::cerr << "Unsupported color space transform from " <<
-                              sourceColorSpace << " to " << targetColorSpace << std::endl;
+                throw ExceptionShaderGenError("Unsupported color space transform from '" +
+                                              sourceColorSpace + "' to '" + targetColorSpace + "'.");
             }
         }
     }

--- a/source/MaterialXGraphEditor/RenderView.cpp
+++ b/source/MaterialXGraphEditor/RenderView.cpp
@@ -587,6 +587,10 @@ void RenderView::reloadShaders()
             std::cerr << error << std::endl;
         }
     }
+    catch (std::exception& e)   // ExceptionShaderGenError, etc.
+    {
+        std::cerr << e.what() << std::endl;
+    }
 
     _materials.clear();
 }

--- a/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
+++ b/source/MaterialXTest/MaterialXGenMdl/GenMdl.h
@@ -76,7 +76,8 @@ class MdlShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     // Ignore certain .mtlx files
     void addSkipFiles() override
     {
-        // no additional files are skipped
+        // ocio_color_management.mtlx uses color spaces which require OCIO and is not supported by MDL.
+        _skipFiles.insert("ocio_color_management.mtlx");
         ShaderGeneratorTester::addSkipFiles();
     }
 

--- a/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
+++ b/source/MaterialXTest/MaterialXGenMsl/GenMsl.h
@@ -45,6 +45,7 @@ class MslShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     {
         // To skip specific files for this render target, add them as below:
         // _skipFiles.insert("example.mtlx");
+        ParentClass::addSkipFiles();
     }
 
     void setupDependentLibraries() override

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -741,6 +741,12 @@ void ShaderGeneratorTester::validate(const mx::GenOptions& generateOptions, cons
         context.getOptions().targetDistanceUnit = _defaultDistanceUnit;
     }
 
+    // Define target color space if required
+    if (context.getOptions().targetColorSpaceOverride.empty())
+    {
+        context.getOptions().targetColorSpaceOverride = "lin_rec709";
+    }
+
     // Check if a binding context has been set.
     bool bindingContextUsed = _userData.count(mx::HW::USER_DATA_BINDING_CONTEXT) > 0;
 

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.h
@@ -199,7 +199,13 @@ class ShaderGeneratorTester
     virtual void setTestStages() = 0;
 
     // Add files in to not examine
-    virtual void addSkipFiles() { };
+    virtual void addSkipFiles()
+    {
+#ifndef MATERIALX_BUILD_OCIO
+        // ocio_color_management.mtlx uses color spaces which require OCIO.
+        _skipFiles.insert("ocio_color_management.mtlx");
+#endif
+    };
 
     // Add nodedefs to not examine
     virtual void addSkipNodeDefs() { };

--- a/source/MaterialXTest/MaterialXGenSlang/GenSlang.h
+++ b/source/MaterialXTest/MaterialXGenSlang/GenSlang.h
@@ -30,6 +30,13 @@ class SlangShaderGeneratorTester : public GenShaderUtil::ShaderGeneratorTester
     }
 
     // Ignore trying to create shader code for displacementshaders
+    void addSkipFiles() override
+    {
+        // ocio_color_management.mtlx uses color spaces which require OCIO and is not supported by Slang.
+        _skipFiles.insert("ocio_color_management.mtlx");
+        ParentClass::addSkipFiles();
+    }
+
     void addSkipNodeDefs() override
     {
         _skipNodeDefs.insert("ND_displacement_float");

--- a/source/MaterialXTest/MaterialXRender/RenderUtil.h
+++ b/source/MaterialXTest/MaterialXRender/RenderUtil.h
@@ -274,7 +274,13 @@ class ShaderRenderTester
     void addAdditionalTestStreams(mx::MeshPtr mesh);
 
     // Add any paths to explicitly skip here
-    virtual void addSkipFiles() {}
+    virtual void addSkipFiles()
+    {
+#ifndef MATERIALX_BUILD_OCIO
+        // ocio_color_management.mtlx uses color spaces which require OCIO.
+        _skipFiles.insert("ocio_color_management.mtlx");
+#endif
+    }
 
     // Read test suite options and check if this target should run.
     bool loadOptions(const mx::FilePath& optionsFilePath, TestRunState& runState);

--- a/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
+++ b/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp
@@ -112,6 +112,8 @@ class OslShaderRenderTester : public RenderUtil::ShaderRenderTester
             _skipFiles.insert("vertical_layering.mtlx");
             _skipFiles.insert("mix_bsdf.mtlx");
         }
+
+        RenderUtil::ShaderRenderTester::addSkipFiles();
     }
 
     bool saveImage(const mx::FilePath& filePath, mx::ConstImagePtr image, bool /*verticalFlip*/) const override


### PR DESCRIPTION
Currently, if an unrecognized colorspace string is encountered in MaterialXGenShader, it prints a warning to std::cerr. This is not ideal for several reasons:
- The render proceeds and will have incorrect colors
- Printing to stderr is difficult for applications to deal with
- Raising an exception would be more in line with how MaterialX usually handles this type of situation

This PR  changes the behavior to raise ExceptionShaderGenError.

This change required omitting the test file ocio_color_management.mtlx from the MaterialXGenMdl tests. The test was previously succeeding (when compiled with MATERIALX_BUILD_OCIO=ON), although it should not have.

In addition, a change was made to improve the name of the color space conversion functions generated by the OcioColorManagementSystem. Previously the names only used the cacheIDs of the OCIO Processors, which was not very friendly to troubleshooting. Now the names are more similar to the "srcColorSpace_to_dstColorSpace" naming used by the DefaultColorManagmentSystem. This avoids a problem when MaterialX is compiled with the current OCIO main branch due to a change in the cacheID formatting.

While testing, I noticed that the MaterialX createValidName function sometimes creates names with double underscores. OCIO's shader generator avoids this since (although some drivers accept it) it is technically undefined behavior. I added a sanitizeName function locally to work around this.

As I worked further, I noticed that the GenShader tests were not actually testing color management, even though MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp explicitly tries to enable color management. The problem was that it was not ensuring that a targetColorSpace was set (as the rendering tests do). If that is empty, the color management shaders are never generated or tested. I ensured that is now being set. As a result, I needed to make sure the ocio_color_management.mtlx test file was omitted from the GenShader tests when OCIO is not enabled.

Finally, I fixed a bug with the DefaultColorManagementSystem where the conversion from "lin_rec709_scene" to "lin_rec709" was not handled properly as a no-op. I added a test case for this in color_management.mtlx.

Claude Code was used during the creation of this PR.