### PR TITLE
Fix XML validation check for mxformat script

### DIFF
--- a/python/Scripts/mxformat.py
+++ b/python/Scripts/mxformat.py
@@ -16,6 +16,7 @@ def is_well_formed(xml_string):
         ET.fromstring(xml_string)  
     except ET.ParseError as e:
         error = str(e)
+    return error
 
 def main():
     parser = argparse.ArgumentParser(description="Reformat a folder of MaterialX documents in place.")


### PR DESCRIPTION
## Change

Update #2956 

Fix so that XML validate returns an error condition. Would previously return nothing so would always pass.

## Tests

### Libraries

```
python python\Scripts\mxformat.py libraries -x -y
Found 56 MaterialX files in "libraries"
- Check XML syntax
Reformatted 56 documents
```

### Resources

```
python python\Scripts\mxformat.py resources -x -y
Found 205 MaterialX files in "resources"
- Check XML syntax
- Warning: Document resources\Materials\TestSuite\nprlib\toon_shade.mtlx is not well-formed XML: unbound prefix: line 19, column 2
- Warning: Document resources\Materials\TestSuite\stdlib\texture\udim.mtlx is not well-formed XML: not well-formed (invalid token): line 4, column 78
Reformatted 205 documents
```

Note that two XML errors are now found in resources files where none were found before.