### PR TITLE
Validate glTF data in `CgltfLoader`

### DIFF
--- a/source/MaterialXRender/CgltfLoader.cpp
+++ b/source/MaterialXRender/CgltfLoader.cpp
@@ -149,8 +149,10 @@ bool CgltfLoader::load(const FilePath& filePath, MeshList& meshList, bool texcoo
     {
         return false;
     }
-    if (cgltf_load_buffers(&options, data, input_filename.c_str()) != cgltf_result_success)
+    if (cgltf_load_buffers(&options, data, input_filename.c_str()) != cgltf_result_success ||
+        cgltf_validate(data) != cgltf_result_success)
     {
+        cgltf_free(data);
         return false;
     }
 


### PR DESCRIPTION
This changelist adds a `cgltf_validate` step to `CgltfLoader`, rejecting invalid glTF files before their contents are used to construct meshes.

The cgltf parser is intentionally permissive, and does not verify that accessor ranges, buffer view extents, and object references are internally consistent.  Validating the parsed data after buffer loading guards downstream mesh construction code against out-of-bounds reads when an invalid asset is loaded.

This changelist additionally fixes a memory leak in `CgltfLoader`, where a failure in buffer loading or validation would previously return without freeing the data allocated by `cgltf_parse_file`.