### PR TITLE
Fix window focus check for `addNodePopup` in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -3878,7 +3878,7 @@ void Graph::showHelp() const
 
 void Graph::addNodePopup(bool cursor)
 {
-    bool open_AddPopup = (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootWindow) && ImGui::IsKeyReleased(ImGuiKey_Tab)) ||
+    bool open_AddPopup = (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) && ImGui::IsKeyReleased(ImGuiKey_Tab)) ||
                          (_pinFilterType != mx::EMPTY_STRING && ImGui::IsMouseReleased(0));
     static char input[32]{ "" };
     if (open_AddPopup)


### PR DESCRIPTION
This changelist fixes a Graph Editor bug that appeared on some platforms, where the TAB-triggered add-node popup would open only once per session.

The root cause is that `addNodePopup` used `ImGuiFocusedFlags_RootWindow` to guard the TAB shortcut, which requires the ImGui NavWindow to be exactly the top-level root window.

On application startup, this condition holds because the root window has initial focus, but on dismissing the popup, ImGui restores focus to the popup's source window, causing the check to fail for subsequent TAB presses.