### PR TITLE
Use maxcomponent/mincomponent in glTF PBR and OpenPBR Surface

### DIFF
--- a/libraries/bxdf/gltf_pbr.mtlx
+++ b/libraries/bxdf/gltf_pbr.mtlx
@@ -230,30 +230,9 @@
     <!-- Sheen layer -->
 
     <!-- Compute sheen intensity = max(sheen_color.r, sheen_color.g, sheen_color.b) -->
-    <extract name="sheen_color_r" type="float">
+    <maxcomponent name="sheen_intensity" type="float">
       <input name="in" type="color3" interfacename="sheen_color" />
-      <input name="index" type="integer" value="0" />
-    </extract>
-
-    <extract name="sheen_color_g" type="float">
-      <input name="in" type="color3" interfacename="sheen_color" />
-      <input name="index" type="integer" value="1" />
-    </extract>
-
-    <extract name="sheen_color_b" type="float">
-      <input name="in" type="color3" interfacename="sheen_color" />
-      <input name="index" type="integer" value="2" />
-    </extract>
-
-    <max name="sheen_color_max_rg" type="float">
-      <input name="in1" type="float" nodename="sheen_color_r" />
-      <input name="in2" type="float" nodename="sheen_color_g" />
-    </max>
-
-    <max name="sheen_intensity" type="float">
-      <input name="in1" type="float" nodename="sheen_color_max_rg" />
-      <input name="in2" type="float" nodename="sheen_color_b" />
-    </max>
+    </maxcomponent>
 
     <multiply name="sheen_roughness_sq" type="float">
       <input name="in1" type="float" interfacename="sheen_roughness" />

--- a/libraries/bxdf/open_pbr_surface.mtlx
+++ b/libraries/bxdf/open_pbr_surface.mtlx
@@ -243,26 +243,9 @@
       <input name="in1" type="vector3" nodename="extinction_coeff" />
       <input name="in2" type="vector3" nodename="scattering_coeff" />
     </subtract>
-    <extract name="absorption_coeff_x" type="float">
+    <mincomponent name="absorption_coeff_min" type="float">
       <input name="in" type="vector3" nodename="absorption_coeff" />
-      <input name="index" type="integer" value="0" />
-    </extract>
-    <extract name="absorption_coeff_y" type="float">
-      <input name="in" type="vector3" nodename="absorption_coeff" />
-      <input name="index" type="integer" value="1" />
-    </extract>
-    <extract name="absorption_coeff_z" type="float">
-      <input name="in" type="vector3" nodename="absorption_coeff" />
-      <input name="index" type="integer" value="2" />
-    </extract>
-    <min name="absorption_coeff_min_x_y" type="float">
-      <input name="in1" type="float" nodename="absorption_coeff_x" />
-      <input name="in2" type="float" nodename="absorption_coeff_y" />
-    </min>
-    <min name="absorption_coeff_min" type="float">
-      <input name="in1" type="float" nodename="absorption_coeff_min_x_y" />
-      <input name="in2" type="float" nodename="absorption_coeff_z" />
-    </min>
+    </mincomponent>
     <convert name="absorption_coeff_min_vector" type="vector3">
       <input name="in" type="float" nodename="absorption_coeff_min" />
     </convert>


### PR DESCRIPTION
## Summary

Simplify `gltf_pbr.mtlx` and `open_pbr_surface.mtlx` by using the new `maxcomponent` and `mincomponent` nodes, replacing verbose extract+reduce patterns.

Closes #2802

No behavioral change.