### PR TITLE
Align UsdUVTexture wrap modes with USD specification

### DIFF
--- a/libraries/bxdf/usd_preview_surface.mtlx
+++ b/libraries/bxdf/usd_preview_surface.mtlx
@@ -38,9 +38,8 @@
   <nodedef name="ND_UsdUVTexture_23" node="UsdUVTexture" nodegroup="texture2d" version="2.3" isdefaultversion="true">
     <input name="file" type="filename" value="" uniform="true" />
     <input name="st" type="vector2" defaultgeomprop="UV0" />
-    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
-    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" uniform="true" />
-    <input name="fallback" type="color4" value="0, 0, 0, 1" />
+    <input name="wrapS" type="string" value="periodic" enum="black,clamp,periodic,mirror" enumvalues="0,1,2,3" uniform="true" />
+    <input name="wrapT" type="string" value="periodic" enum="black,clamp,periodic,mirror" enumvalues="0,1,2,3" uniform="true" />
     <input name="scale" type="color4" value="1, 1, 1, 1" uniform="true" />
     <input name="bias" type="color4" value="0, 0, 0, 0" uniform="true" />
     <output name="r" type="float" />
@@ -315,7 +314,6 @@
   <nodegraph name="IMP_UsdUVTexture_22" nodedef="ND_UsdUVTexture">
     <image name="image_reader" type="color4">
       <input name="file" type="filename" interfacename="file" />
-      <input name="default" type="color4" interfacename="fallback" />
       <input name="texcoord" type="vector2" interfacename="st" />
       <input name="uaddressmode" type="string" interfacename="wrapS" />
       <input name="vaddressmode" type="string" interfacename="wrapT" />
@@ -345,7 +343,6 @@
   <nodegraph name="IMP_UsdUVTexture_23" nodedef="ND_UsdUVTexture_23">
     <image name="image_reader" type="color4">
       <input name="file" type="filename" interfacename="file" />
-      <input name="default" type="color4" interfacename="fallback" />
       <input name="texcoord" type="vector2" interfacename="st" />
       <input name="uaddressmode" type="string" interfacename="wrapS" />
       <input name="vaddressmode" type="string" interfacename="wrapT" />

--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -128,8 +128,8 @@
     <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
     <input name="default" type="float" value="0.0" uiname="Default Color" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode U" uniform="true" />
+    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode V" uniform="true" />
     <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
     <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
     <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
@@ -141,8 +141,8 @@
     <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
     <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode U" uniform="true" />
+    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode V" uniform="true" />
     <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
     <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
     <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
@@ -152,23 +152,23 @@
   <nodedef name="ND_image_color4" node="image" nodegroup="texture2d">
     <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
     <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color" />
+    <input name="default" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Default Color" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode U" uniform="true" />
+    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode V" uniform="true" />
     <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
     <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
     <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
     <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
+    <output name="out" type="color4" default="0.0, 0.0, 0.0, 1.0" />
   </nodedef>
   <nodedef name="ND_image_vector2" node="image" nodegroup="texture2d">
     <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
     <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
     <input name="default" type="vector2" value="0.0, 0.0" uiname="Default Color" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode U" uniform="true" />
+    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode V" uniform="true" />
     <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
     <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
     <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
@@ -180,8 +180,8 @@
     <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
     <input name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default Color" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode U" uniform="true" />
+    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode V" uniform="true" />
     <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
     <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
     <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
@@ -191,15 +191,15 @@
   <nodedef name="ND_image_vector4" node="image" nodegroup="texture2d">
     <input name="file" type="filename" value="" uiname="Filename" uniform="true" />
     <input name="layer" type="string" value="" uiname="Layer" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default Color" />
+    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 1.0" uiname="Default Color" />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
-    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode U" uniform="true" />
-    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" uiname="Address Mode V" uniform="true" />
+    <input name="uaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode U" uniform="true" />
+    <input name="vaddressmode" type="string" value="periodic" enum="constant,clamp,periodic,mirror" enumvalues="0,1,2,3" uiname="Address Mode V" uniform="true" />
     <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uiname="Filter Type" uniform="true" />
     <input name="framerange" type="string" value="" uiname="Frame Range" uniform="true" />
     <input name="frameoffset" type="integer" value="0" uiname="Frame Offset" uniform="true" />
     <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uiname="Frame End Action" uniform="true" />
-    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
+    <output name="out" type="vector4" default="0.0, 0.0, 0.0, 1.0" />
   </nodedef>
 
   <!--


### PR DESCRIPTION
Closes #2899

The wrap mode enum values for `ND_UsdUVTexture_23` did not match those used by `UsdUVTexture` in OpenUSD, making round-trip interchange lossy. This PR aligns the names, defaults, and fallback behavior with the USD specification.

## Changes

**`libraries/bxdf/usd_preview_surface.mtlx`**
- Renamed enum values `periodic` → `repeat` and `black` is now explicitly included (was previously named `constant`)
- Changed the default for `wrapS`/`wrapT` from `periodic` to `useMetaData`, matching the USD default

**`source/MaterialXRender/ImageHandler.h`**
- Renamed `AddressMode` enum values: `CONSTANT` → `BLACK`, `PERIODIC` → `REPEAT` to match USD terminology

**GL / Metal / Slang texture handlers**
- Updated all references to the renamed enum values
- Changed the default (unspecified) address mode fallback from `REPEAT` (GL: `GL_REPEAT`, Metal: `MTLSamplerAddressModeRepeat`) to `BLACK` (GL: `GL_CLAMP_TO_BORDER`, Metal: `MTLSamplerAddressModeClampToBorderColor`), matching USD's fallback from `useMetaData` when no metadata is present

## Not yet addressed

`useMetaData` is now accepted as the default enum value in the nodedef, but reading wrap modes from texture file metadata is not yet implemented — a follow-up is noted with a `TODO (#2899)` comment in both the nodedef and the `AddressMode` enum.