### PR TITLE
Add initial `CODE_OF_CONDUCT` document

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Code of Conduct
+
+MaterialX is a project of the [Academy Software Foundation](https://www.aswf.io/)
+and abides by the Linux Foundation's
+[Code of Conduct](https://lfprojects.org/policies/code-of-conduct).
+
+As a community of contributors and maintainers, we are committed to making
+participation in MaterialX a respectful and harassment-free experience for
+everyone. Our covenant includes:
+
+- Treat each other with respect, professionalism, fairness, and sensitivity to
+  our many differences and strengths, including in situations of high pressure
+  and urgency.
+
+- Never harass or bully anyone verbally, physically, or sexually.
+
+- Never discriminate on the basis of personal characteristics or group
+  membership.
+
+- Communicate constructively and avoid demeaning or insulting behavior or
+  language.
+
+- Seek, accept, and offer objective work criticism, and acknowledge properly the
+  contributions of others.
+
+- Be honest about your own qualifications, and about any circumstances that might
+  lead to conflicts of interest.
+
+- Respect the privacy of others and the confidentiality of data you access.
+
+- With respect to cultural differences, be conservative in what you do and
+  liberal in what you accept from others, but not to the point of accepting
+  disrespectful, unprofessional, unfair, or unwelcome behavior or advances.
+
+- Promote the rules of this Code and take action (especially if you are in a
+  leadership position) to bring the discussion back to a more civil level
+  whenever inappropriate behaviors are observed.
+
+- Stay on topic: make sure that you are posting to the correct channel and avoid
+  off-topic discussions. Remember that when you update an issue or respond to a
+  message, you are potentially reaching a large number of people.
+
+- Step down considerately: participants in every project come and go, and
+  MaterialX is no different. When you leave or disengage from the project, in
+  whole or in part, we ask that you do so in a way that minimizes disruption to
+  the project. This means you should tell people you are leaving and take the
+  proper steps to ensure that others can pick up where you left off.
+
+To report incidents or to appeal reports of incidents, send email to the
+Manager of LF Projects at <manager@lfprojects.org>.


### PR DESCRIPTION
This changelist adds an initial `CODE_OF_CONDUCT` document for the MaterialX project, adopting the broader Code of Conduct from the Linux Foundation (https://lfprojects.org/policies/code-of-conduct), and borrowing presentation conventions from our sibling projects under the ASWF.