### PR TITLE
Remove deprecated `Syntax::typeSupported` method

### DIFF
--- a/source/MaterialXGenGlsl/GlslSyntax.cpp
+++ b/source/MaterialXGenGlsl/GlslSyntax.cpp
@@ -356,11 +356,6 @@ GlslSyntax::GlslSyntax(TypeSystemPtr typeSystem) :
             "#define material surfaceshader"));
 }
 
-bool GlslSyntax::typeSupported(const TypeDesc* type) const
-{
-    return *type != Type::STRING;
-}
-
 bool GlslSyntax::remapEnumeration(const string& value, TypeDesc type, const string& enumNames, std::pair<TypeDesc, ValuePtr>& result) const
 {
     // Early out if not an enum input.

--- a/source/MaterialXGenGlsl/GlslSyntax.h
+++ b/source/MaterialXGenGlsl/GlslSyntax.h
@@ -29,8 +29,6 @@ class MX_GENGLSL_API GlslSyntax : public Syntax
     const string& getUniformQualifier() const override { return UNIFORM_QUALIFIER; };
     const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
 
-    bool typeSupported(const TypeDesc* type) const override;
-
     /// Given an input specification attempt to remap this to an enumeration which is accepted by
     /// the shader generator. The enumeration may be converted to a different type than the input.
     bool remapEnumeration(const string& value, TypeDesc type, const string& enumNames, std::pair<TypeDesc, ValuePtr>& result) const override;

--- a/source/MaterialXGenMsl/MslSyntax.cpp
+++ b/source/MaterialXGenMsl/MslSyntax.cpp
@@ -343,11 +343,6 @@ string MslSyntax::getOutputTypeName(TypeDesc type) const
     return "thread " + syntax.getName() + "&";
 }
 
-bool MslSyntax::typeSupported(const TypeDesc* type) const
-{
-    return *type != Type::STRING;
-}
-
 bool MslSyntax::remapEnumeration(const string& value, TypeDesc type, const string& enumNames, std::pair<TypeDesc, ValuePtr>& result) const
 {
     // Early out if not an enum input.

--- a/source/MaterialXGenMsl/MslSyntax.h
+++ b/source/MaterialXGenMsl/MslSyntax.h
@@ -32,8 +32,6 @@ class MX_GENMSL_API MslSyntax : public Syntax
 
     string getOutputTypeName(TypeDesc type) const override;
 
-    bool typeSupported(const TypeDesc* type) const override;
-
     /// Given an input specification attempt to remap this to an enumeration which is accepted by
     /// the shader generator. The enumeration may be converted to a different type than the input.
     bool remapEnumeration(const string& value, TypeDesc type, const string& enumNames, std::pair<TypeDesc, ValuePtr>& result) const override;

--- a/source/MaterialXGenShader/Syntax.cpp
+++ b/source/MaterialXGenShader/Syntax.cpp
@@ -121,11 +121,6 @@ const string& Syntax::getTypeDefinition(TypeDesc type) const
     return syntax.getTypeDefinition();
 }
 
-bool Syntax::typeSupported(const TypeDesc*) const
-{
-    return true;
-}
-
 string Syntax::getArrayVariableSuffix(TypeDesc type, const Value& value) const
 {
     if (type.isArray())

--- a/source/MaterialXGenShader/Syntax.h
+++ b/source/MaterialXGenShader/Syntax.h
@@ -167,10 +167,6 @@ class MX_GENSHADER_API Syntax
     virtual string getArrayVariableSuffix(TypeDesc type, const Value& value) const;
     [[deprecated]] string getArrayVariableSuffix(const TypeDesc* type, const Value& value) const { return getArrayVariableSuffix(*type, value); }
 
-    /// Query if given type is supported in the syntax.
-    /// By default all types are assumed to be supported.
-    [[deprecated]] virtual bool typeSupported(const TypeDesc* type) const;
-
     /// Modify the given name string to remove any invalid characters or tokens.
     virtual void makeValidName(string& name) const;
 

--- a/source/MaterialXGenSlang/SlangSyntax.cpp
+++ b/source/MaterialXGenSlang/SlangSyntax.cpp
@@ -356,11 +356,6 @@ SlangSyntax::SlangSyntax(TypeSystemPtr typeSystem) :
             "#define material surfaceshader"));
 }
 
-bool SlangSyntax::typeSupported(const TypeDesc* type) const
-{
-    return *type != Type::STRING;
-}
-
 void SlangSyntax::makeValidName(string& name) const
 {
     Syntax::makeValidName(name);

--- a/source/MaterialXGenSlang/SlangSyntax.h
+++ b/source/MaterialXGenSlang/SlangSyntax.h
@@ -29,8 +29,6 @@ class MX_GENSLANG_API SlangSyntax : public Syntax
     const string& getUniformQualifier() const override { return UNIFORM_QUALIFIER; };
     const string& getSourceFileExtension() const override { return SOURCE_FILE_EXTENSION; };
 
-    bool typeSupported(const TypeDesc* type) const override;
-
     void makeValidName(string& name) const override;
 
     /// Given an input specification attempt to remap this to an enumeration which is accepted by


### PR DESCRIPTION
This changelist removes the deprecated `Syntax::typeSupported` method, along with its `GlslSyntax`, `MslSyntax`, and `SlangSyntax` overrides, from the shader generation modules.

The method was marked `[[deprecated]]` during 1.39.0 development and has since been left without any callers in the codebase, making it unused code maintained only to preserve the deprecation cycle.  Removing it resolves warnings on newer compilers, including MSVC in Visual Studio 2026, which flag overrides of a deprecated virtual function as warnings and, under our warnings-as-errors build, promote them to build failures.