### PR TITLE
Align OSL image alpha with texture conventions

### DIFF
--- a/documents/Specification/MaterialX.StandardNodes.md
+++ b/documents/Specification/MaterialX.StandardNodes.md
@@ -80,7 +80,7 @@ Standard Texture nodes:
 
 Samples data from a single image, or from a layer within a multi-layer image.  When used in the context of rendering a geometry, the image is mapped onto the geometry based on geometry UV coordinates, with the lower-left corner of an image mapping to the (0,0) UV coordinate (or to the fractional (0,0) UV coordinate for tiled images).
 
-The type of the &lt;image> node determines the number of channels output, which may be less than the number of channels in the image file, outputting the first N channels from the image file.  So a `float` &lt;image> would return the Red channel of an RGB image, and a `color3` &lt;image> would return the RGB channels of an RGBA image.  If the type of the &lt;image> node has more channels than the referenced image file, then the output will contain zero values in all channels beyond the N channels of the image file.
+The type of the &lt;image> node determines the number of channels output, which may be less than the number of channels in the image file, outputting the first N channels from the image file.  So a `float` &lt;image> would return the Red channel of an RGB image, and a `color3` &lt;image> would return the RGB channels of an RGBA image.  If the type of the &lt;image> node has more channels than the referenced image file, then the output will contain zero values in all channels beyond the N channels of the image file, aside from the fourth channel which is populated with 1.
 
 The `file` input value can include one or more substitutions to change the file name that is accessed, as described in the [Filename Substitutions](./MaterialX.Specification.md#filename-substitutions) section in the main Specification document.
 

--- a/libraries/stdlib/genosl/mx_hextiledimage_color4.osl
+++ b/libraries/stdlib/genosl/mx_hextiledimage_color4.osl
@@ -56,4 +56,11 @@ void mx_hextiledimage_color4(
     // Blend colors
     result.rgb = w[0] * c[0] + w[1] * c[1] + w[2] * c[2];
     result.a = aw[0] * alpha[0] + aw[1] * alpha[1] + aw[2] * alpha[2];
+
+    // Default a missing fourth channel to one, following the MaterialX specification.
+    int channels = 0;
+    if (gettextureinfo(file.filename, "channels", channels) && channels < 4)
+    {
+        result.a = 1.0;
+    }
 }

--- a/libraries/stdlib/genosl/mx_image_color4.osl
+++ b/libraries/stdlib/genosl/mx_image_color4.osl
@@ -23,5 +23,12 @@ void mx_image_color4(textureresource file, string layer, color4 default_value, v
 #endif
                         );
 
+    // Default a missing fourth channel to one, following the MaterialX specification.
+    int channels = 0;
+    if (gettextureinfo(file.filename, "channels", channels) && channels < 4)
+    {
+        alpha = 1.0;
+    }
+
     out = color4(rgb, alpha);
 }

--- a/libraries/stdlib/genosl/mx_image_vector4.osl
+++ b/libraries/stdlib/genosl/mx_image_vector4.osl
@@ -19,5 +19,12 @@ void mx_image_vector4(textureresource file, string layer, vector4 default_value,
                         "missingcolor", missingColor, "missingalpha", missingAlpha,
                         "swrap", uaddressmode, "twrap", vaddressmode);
 
+    // Default a missing fourth channel to one, following the MaterialX specification.
+    int channels = 0;
+    if (gettextureinfo(file.filename, "channels", channels) && channels < 4)
+    {
+        alpha = 1.0;
+    }
+
     out = vector4(rgb[0], rgb[1], rgb[2], alpha);
 }


### PR DESCRIPTION
This changelist fixes the alpha output of the OSL `image` and `hextiledimage` nodes when sampling a file with fewer than four channels.  The OSL `texture` function returns zero for channels not present in the file, so a `color4` or `vector4` `image` reading an RGB file returned a transparent rather than opaque result.  The fix queries the channel count with `gettextureinfo` and sets the output alpha to one when fewer than four channels are present, matching the GLSL and MSL backends.

More broadly, this change aligns the `image` node with the established convention that a missing fourth channel resolves to one, as already followed by the MaterialX `convert` node, the OpenUSD `UsdUVTexture` node, and standard GPU texture sampling.  The specification text for the `image` node, previously ambiguous on this point, has been clarified to note the fourth-channel exception.