### PR TITLE
Add support for MDL 1.11

### DIFF
--- a/source/MaterialXGenMdl/MdlShaderGenerator.cpp
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.cpp
@@ -52,11 +52,13 @@ const string MDL_VERSION_1_7 = "1.7";
 const string MDL_VERSION_1_8 = "1.8";
 const string MDL_VERSION_1_9 = "1.9";
 const string MDL_VERSION_1_10 = "1.10";
+const string MDL_VERSION_1_11 = "1.11";
 const string MDL_VERSION_SUFFIX_1_6 = "1_6";
 const string MDL_VERSION_SUFFIX_1_7 = "1_7";
 const string MDL_VERSION_SUFFIX_1_8 = "1_8";
 const string MDL_VERSION_SUFFIX_1_9 = "1_9";
 const string MDL_VERSION_SUFFIX_1_10 = "1_10";
+const string MDL_VERSION_SUFFIX_1_11 = "1_11";
 
 } // anonymous namespace
 
@@ -752,10 +754,13 @@ void MdlShaderGenerator::emitMdlVersionNumber(GenContext& context, ShaderStage& 
         case GenMdlOptions::MdlVersion::MDL_1_9:
             emitString(MDL_VERSION_1_9, stage);
             break;
-        default:
-            // GenMdlOptions::MdlVersion::MDL_1_10
-            // GenMdlOptions::MdlVersion::MDL_LATEST
+        case GenMdlOptions::MdlVersion::MDL_1_10:
             emitString(MDL_VERSION_1_10, stage);
+            break;
+        default:
+            // GenMdlOptions::MdlVersion::MDL_1_11
+            // GenMdlOptions::MdlVersion::MDL_LATEST
+            emitString(MDL_VERSION_1_11, stage);
             break;
     }
     emitLineEnd(stage, true);
@@ -776,10 +781,12 @@ const string& MdlShaderGenerator::getMdlVersionFilenameSuffix(GenContext& contex
             return MDL_VERSION_SUFFIX_1_8;
         case GenMdlOptions::MdlVersion::MDL_1_9:
             return MDL_VERSION_SUFFIX_1_9;
-        default:
-            // GenMdlOptions::MdlVersion::MDL_1_10
-            // GenMdlOptions::MdlVersion::MDL_LATEST
+        case GenMdlOptions::MdlVersion::MDL_1_10:
             return MDL_VERSION_SUFFIX_1_10;
+        default:
+            // GenMdlOptions::MdlVersion::MDL_1_11
+            // GenMdlOptions::MdlVersion::MDL_LATEST
+            return MDL_VERSION_SUFFIX_1_11;
     }
 }
 

--- a/source/MaterialXGenMdl/MdlShaderGenerator.h
+++ b/source/MaterialXGenMdl/MdlShaderGenerator.h
@@ -27,7 +27,8 @@ class MX_GENMDL_API GenMdlOptions : public GenUserData
         MDL_1_8,
         MDL_1_9,
         MDL_1_10,
-        MDL_LATEST = MDL_1_10
+        MDL_1_11,
+        MDL_LATEST = MDL_1_11
     };
 
     /// Create MDL code generator options with default values.

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_11.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_11.mdl
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// MDL implementation of all types and nodes of
+//     MaterialX Physically-Based Shading Nodes
+//     Document version 1.39, June 29, 2024
+//     see www.materialx.org
+// in
+//     NVIDIA Material Definition Language 1.11
+//     Language Specification
+//     Document version 1.11, 2026
+//     www.nvidia.com/mdl
+
+mdl 1.11;
+
+// forward all unchanged definitions from the previous version
+export using .::pbrlib_1_10 import *;

--- a/source/MaterialXGenMdl/mdl/materialx/stdlib_1_11.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/stdlib_1_11.mdl
@@ -1,0 +1,18 @@
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
+// MDL implementation of all Standard Source Nodes of
+//     MaterialX: An Open Standard for Network-Based CG Object Looks
+//     Document version 1.39, September 15, 2024
+//     www.materialx.org
+// in
+//     NVIDIA Material Definition Language 1.11
+//     Language Specification
+//     Document version 1.11, 2026
+//     www.nvidia.com/mdl
+
+mdl 1.11;
+
+// forward all unchanged definitions from the previous version
+export using .::stdlib_1_10 import *;


### PR DESCRIPTION
This commit just adds the wiring for MDL 1.11. Support for retro-reflective will be added in a separate MR afterwards.