### PR TITLE
Add uimin/uimax for roughness and coverage in flake nodes

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -1243,8 +1243,8 @@
   -->
   <nodedef name="ND_flake2d" node="flake2d" nodegroup="procedural2d">
     <input name="size" type="float" value="0.01" doc="Size of individual flakes." />
-    <input name="roughness" type="float" value="0.1" doc="Roughness of the flake normal distribution." />
-    <input name="coverage" type="float" value="0.5" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
+    <input name="roughness" type="float" value="0.1" uimin="0.0" uimax="1.0" doc="Roughness of the flake normal distribution." />
+    <input name="coverage" type="float" value="0.5" uimin="0.0" uimax="1.0" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
     <input name="texcoord" type="vector2" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
     <input name="tangent" type="vector3" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />
@@ -1261,8 +1261,8 @@
   -->
   <nodedef name="ND_flake3d" node="flake3d" nodegroup="procedural3d">
     <input name="size" type="float" value="0.01" doc="Size of individual flakes." />
-    <input name="roughness" type="float" value="0.1" doc="Roughness of the flake normal distribution." />
-    <input name="coverage" type="float" value="0.5" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
+    <input name="roughness" type="float" value="0.1" uimin="0.0" uimax="1.0" doc="Roughness of the flake normal distribution." />
+    <input name="coverage" type="float" value="0.5" uimin="0.0" uimax="1.0" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
     <input name="position" type="vector3" defaultgeomprop="Pobject" doc="The input 3d space. Default is position in object-space." />
     <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
     <input name="tangent" type="vector3" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />


### PR DESCRIPTION
I just recently noticed the awesome new Flake shaders were missing uimin/uimax for roughness and coverage.

Does this look alright @msuzuki-nvidia ? I'm pretty sure it's correct for these to be clamped, but I guess we could use the 'soft' versions if necessary too.

Thanks!