### PR TITLE
Improvements to text and pin display in Graph Editor

### DIFF
--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -24,6 +24,9 @@ const ImVec2 DEFAULT_NODE_SIZE = ImVec2(138, 116);
 
 const int DEFAULT_ALPHA = 255;
 const int FILTER_ALPHA = 50;
+const float BASE_UI_FONT_SIZE = 18.0f;
+const float BASE_PIN_ICON_SIZE = 36.0f;
+const float MIN_PIN_ICON_SIZE = 20.0f;
 
 const std::array<std::string, 22> NODE_GROUP_ORDER = {
     "texture2d",
@@ -114,6 +117,12 @@ static void DisableSRGBCallback(const ImDrawList*, const ImDrawCmd*)
     glDisable(GL_FRAMEBUFFER_SRGB);
 }
 
+static float getUiScaleFromFont()
+{
+    const float fontSize = ImGui::GetFontSize();
+    return (fontSize > 0.0f) ? (fontSize / BASE_UI_FONT_SIZE) : 1.0f;
+}
+
 } // anonymous namespace
 
 //
@@ -143,7 +152,6 @@ Graph::Graph(const std::string& materialFilename,
     _isCut(false),
     _autoLayout(false),
     _frameCount(INT_MIN),
-    _fontScale(1.0f),
     _previewSize(previewWidth),
     _saveNodePositions(true)
 {
@@ -540,7 +548,7 @@ void Graph::applyLayout(const std::vector<int>& outputNodeIndices)
     }
 
     // Compute layout directly from UI types.
-    LayoutResults results = _layout.compute(_state.nodes, _state.edges, outputNodeIds, _fontScale);
+    LayoutResults results = _layout.compute(_state.nodes, _state.edges, outputNodeIds, getUiScaleFromFont());
 
     // Apply results to nodes.
     for (const UiNodePtr& node : _state.nodes)
@@ -856,7 +864,9 @@ void Graph::showPropertyEditorValue(UiNodePtr node, mx::InputPtr input, const mx
             ImGui::ColorEdit3("##color", &temp[0], ImGuiColorEditFlags_Uint8);
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
             {
-                ImGui::SetTooltip("Color is selected and rendered to Viewer in sRGB display space, \nbut written to .mtlx file in linear format.");
+                ImGui::BeginTooltip();
+                ImGui::TextUnformatted("Color is selected and rendered to Viewer in sRGB display space, \nbut written to .mtlx file in linear format.");
+                ImGui::EndTooltip();
             }
 
             // Set input value and update materials if different from previous value
@@ -889,7 +899,9 @@ void Graph::showPropertyEditorValue(UiNodePtr node, mx::InputPtr input, const mx
             ImGui::ColorEdit4("##color", &temp[0], ImGuiColorEditFlags_Uint8);
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
             {
-                ImGui::SetTooltip("Color is selected and rendered to Viewer in sRGB display space, \nbut written to .mtlx file in linear format.");
+                ImGui::BeginTooltip();
+                ImGui::TextUnformatted("Color is selected and rendered to Viewer in sRGB display space, \nbut written to .mtlx file in linear format.");
+                ImGui::EndTooltip();
             }
 
             // Set input value and update materials if different from previous value
@@ -1917,9 +1929,8 @@ UiPinPtr Graph::getPin(ed::PinId pinId)
     return nullPin;
 }
 
-void Graph::drawPinIcon(const std::string& type, bool connected, int alpha)
+void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset)
 {
-    ax::Drawing::IconType iconType = ax::Drawing::IconType::Flow;
     ImColor color = ImColor(0, 0, 0, 255);
     if (_pinColor.find(type) != _pinColor.end())
     {
@@ -1928,7 +1939,35 @@ void Graph::drawPinIcon(const std::string& type, bool connected, int alpha)
 
     color.Value.w = alpha / 255.0f;
 
-    ax::Widgets::Icon(ImVec2(24, 24), iconType, connected, color, ImColor(32, 32, 32, alpha));
+    const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+
+    // Draw a plain circle directly via the draw list — no external library needed,
+    // and no directional arrow is rendered.
+    ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
+    ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
+    ImVec2 center  = (iconMin + iconMax) * 0.5f;
+    const float radius       = iconSize * 0.25f;
+    const float outlineScale = iconSize / BASE_PIN_ICON_SIZE;
+    const int   segments     = 12 + static_cast<int>(2 * outlineScale);
+    ImDrawList* drawList     = ImGui::GetWindowDrawList();
+
+    if (connected)
+    {
+        drawList->AddCircleFilled(center, radius, ImColor(color));
+    }
+    else
+    {
+        drawList->AddCircleFilled(center, radius, ImColor(32, 32, 32, alpha));
+        drawList->AddCircle(center, radius, ImColor(color), segments, 2.0f * outlineScale);
+    }
+
+    ImGui::Dummy(ImVec2(iconSize, iconSize));
+
+    if (xOffset != 0.0f)
+    {
+        // Override pin bounds so hover/click area and link endpoint match the shifted icon.
+        ed::PinRect(iconMin, iconMax);
+    }
 }
 
 void Graph::buildGroupNode(UiNodePtr node)
@@ -2003,7 +2042,9 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
     }
 
     // Create output pins with extra right padding
-    const float outputPinExtraPad = 20.0f;
+    const float outputPinExtraPad = 20.0f * getUiScaleFromFont();
+    const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+    const float pinOffset = ed::GetStyle().NodePadding.z + iconSize * 0.5f;
     float nodeWidth = ImGui::CalcTextSize(longestLabel.c_str()).x + outputPinExtraPad;
     for (UiPinPtr pin : node->getOutputPins())
     {
@@ -2016,11 +2057,11 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
         bool connected = pin->getConnected();
         if (!_pinFilterType.empty())
         {
-            drawPinIcon(pin->getType(), connected, _pinFilterType == pin->getType() ? DEFAULT_ALPHA : FILTER_ALPHA);
+            drawPinIcon(pin->getType(), connected, _pinFilterType == pin->getType() ? DEFAULT_ALPHA : FILTER_ALPHA, pinOffset);
         }
         else
         {
-            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA);
+            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset);
         }
 
         ed::EndPin();
@@ -2030,6 +2071,9 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
 
 void Graph::drawInputPin(UiPinPtr pin)
 {
+    const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+    const float pinOffset = -(ed::GetStyle().NodePadding.x + iconSize * 0.5f);
+
     ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
     ImGui::PushID(int(pin->getPinId().Get()));
     bool connected = pin->getConnected();
@@ -2037,21 +2081,21 @@ void Graph::drawInputPin(UiPinPtr pin)
     {
         if (_pinFilterType == pin->getType())
         {
-            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA);
+            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset);
         }
         else
         {
-            drawPinIcon(pin->getType(), connected, FILTER_ALPHA);
+            drawPinIcon(pin->getType(), connected, FILTER_ALPHA, pinOffset);
         }
     }
     else
     {
-        drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA);
+        drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset);
     }
     ImGui::PopID();
     ed::EndPin();
 
-    ImGui::SameLine(0, 5.0f);
+    ImGui::SameLine(0, 5.0f * getUiScaleFromFont());
     ImGui::TextUnformatted(pin->getName().c_str());
 }
 
@@ -2120,7 +2164,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
             {
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-hdrPadL, -hdrPadT),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - hdrPadL - 2.f * hdrInset, ImGui::GetTextLineHeight() + hdrPadB),
@@ -2132,7 +2175,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                 ImGui::Indent(hdrTextIndent);
                 ImGui::Text("%s", node->getName().c_str());
                 ImGui::Unindent(hdrTextIndent);
-                ImGui::SetWindowFontScale(_fontScale);
                 ImGui::Dummy(ImVec2(0, hdrBottomSpacing));
 
                 std::string longestInputLabel = node->getName();
@@ -2191,7 +2233,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
 
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-hdrPadL, -hdrPadT),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - hdrPadL - 2.f * hdrInset, ImGui::GetTextLineHeight() + hdrPadB),
@@ -2203,7 +2244,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                 ImGui::Indent(hdrTextIndent);
                 ImGui::Text("%s", node->getName().c_str());
                 ImGui::Unindent(hdrTextIndent);
-                ImGui::SetWindowFontScale(_fontScale);
                 ImGui::Dummy(ImVec2(0, hdrBottomSpacing));
 
                 outputType = node->getInput()->getType();
@@ -2232,26 +2272,30 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                         }
                         pin->setConnected(true);
                     }
-                    ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
-                    if (!_pinFilterType.empty())
                     {
-                        if (_pinFilterType == pin->getType())
+                        const float iconSz = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+                        const float pinOff = -(ed::GetStyle().NodePadding.x + iconSz * 0.5f);
+                        ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
+                        if (!_pinFilterType.empty())
                         {
-                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA);
+                            if (_pinFilterType == pin->getType())
+                            {
+                                drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
+                            }
+                            else
+                            {
+                                drawPinIcon(pin->getType(), true, FILTER_ALPHA, pinOff);
+                            }
                         }
                         else
                         {
-                            drawPinIcon(pin->getType(), true, FILTER_ALPHA);
+                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
                         }
-                    }
-                    else
-                    {
-                        drawPinIcon(pin->getType(), true, DEFAULT_ALPHA);
-                    }
 
-                    ImGui::SameLine();
-                    ImGui::TextUnformatted("value");
-                    ed::EndPin();
+                        ImGui::SameLine();
+                        ImGui::TextUnformatted("value");
+                        ed::EndPin();
+                    }
 
                     if (pin->getName().size() > longestInputLabel.size())
                         longestInputLabel = pin->getName();
@@ -2264,7 +2308,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
 
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-hdrPadL, -hdrPadT),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - hdrPadL - 2.f * hdrInset, ImGui::GetTextLineHeight() + hdrPadB),
@@ -2276,7 +2319,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                 ImGui::Indent(hdrTextIndent);
                 ImGui::Text("%s", node->getName().c_str());
                 ImGui::Unindent(hdrTextIndent);
-                ImGui::SetWindowFontScale(_fontScale);
                 ImGui::Dummy(ImVec2(0, hdrBottomSpacing));
 
                 outputType = node->getOutput()->getType();
@@ -2306,26 +2348,30 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                         }
                     }
 
-                    ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
-                    if (!_pinFilterType.empty())
                     {
-                        if (_pinFilterType == pin->getType())
+                        const float iconSz = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+                        const float pinOff = -(ed::GetStyle().NodePadding.x + iconSz * 0.5f);
+                        ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
+                        if (!_pinFilterType.empty())
                         {
-                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA);
+                            if (_pinFilterType == pin->getType())
+                            {
+                                drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
+                            }
+                            else
+                            {
+                                drawPinIcon(pin->getType(), true, FILTER_ALPHA, pinOff);
+                            }
                         }
                         else
                         {
-                            drawPinIcon(pin->getType(), true, FILTER_ALPHA);
+                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
                         }
-                    }
-                    else
-                    {
-                        drawPinIcon(pin->getType(), true, DEFAULT_ALPHA);
-                    }
-                    ImGui::SameLine();
-                    ImGui::TextUnformatted("input");
+                        ImGui::SameLine();
+                        ImGui::TextUnformatted("input");
 
-                    ed::EndPin();
+                        ed::EndPin();
+                    }
 
                     if (pin->getName().size() > longestInputLabel.size())
                         longestInputLabel = pin->getName();
@@ -2342,7 +2388,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
 
                 ed::BeginNode(node->getId());
                 ImGui::PushID(node->getId());
-                ImGui::SetWindowFontScale(1.2f * _fontScale);
                 ImGui::GetWindowDrawList()->AddRectFilled(
                     ImGui::GetCursorScreenPos() + ImVec2(-hdrPadL, -hdrPadT),
                     ImGui::GetCursorScreenPos() + ImVec2(ed::GetNodeSize(node->getId()).x - hdrPadL - 2.f * hdrInset, ImGui::GetTextLineHeight() + hdrPadB),
@@ -2354,7 +2399,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                 ImGui::Indent(hdrTextIndent);
                 ImGui::Text("%s", node->getName().c_str());
                 ImGui::Unindent(hdrTextIndent);
-                ImGui::SetWindowFontScale(_fontScale);
                 ImGui::Dummy(ImVec2(0, hdrBottomSpacing));
                 for (UiPinPtr pin : node->getInputPins())
                 {
@@ -2378,7 +2422,6 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                 ed::PopStyleColor();
         }
     }
-    ImGui::SetWindowFontScale(_fontScale);
     return outputNum;
 }
 
@@ -3065,7 +3108,6 @@ void Graph::loadGeometry()
 void Graph::graphButtons()
 {
     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(.15f, .15f, .15f, 1.0f));
-    ImGui::SetWindowFontScale(_fontScale);
 
     if (ImGui::BeginMenuBar())
     {
@@ -3285,7 +3327,6 @@ void Graph::showPropertyEditorOutputConnections(UiNodePtr node)
             bool haveTable = ImGui::BeginTable("outputs_node_table", 2, tableFlags, tableSize);
             if (haveTable)
             {
-                ImGui::SetWindowFontScale(_fontScale);
                 for (UiPinPtr outputPin : node->getOutputPins())
                 {
                     bool firstPin = true;
@@ -3342,7 +3383,6 @@ void Graph::showPropertyEditorOutputConnections(UiNodePtr node)
                     }
                 }
                 ImGui::EndTable();
-                ImGui::SetWindowFontScale(1.0f);
             }
         }
     }
@@ -3554,7 +3594,9 @@ void Graph::propertyEditor()
             }
             if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
             {
-                ImGui::SetTooltip("%s", _currUiNode->getNode()->getNodeDef()->getDocString().c_str());
+                ImGui::BeginTooltip();
+                ImGui::TextUnformatted(_currUiNode->getNode()->getNodeDef()->getDocString().c_str());
+                ImGui::EndTooltip();
             }
 
             bool showAllInputs = _currUiNode->getShowAllInputs();
@@ -3597,7 +3639,6 @@ void Graph::propertyEditor()
                 bool haveTable = ImGui::BeginTable("inputs_node_table", 2, tableFlags, tableSize);
                 if (haveTable)
                 {
-                    ImGui::SetWindowFontScale(_fontScale);
                     for (UiPinPtr input : _currUiNode->getInputPins())
                     {
                         if (_currUiNode->getShowAllInputs() || (input->getConnected() || _currUiNode->getNode()->getInput(input->getName())))
@@ -3650,7 +3691,6 @@ void Graph::propertyEditor()
                     }
 
                     ImGui::EndTable();
-                    ImGui::SetWindowFontScale(1.0f);
                 }
             }
 
@@ -3669,7 +3709,6 @@ void Graph::propertyEditor()
                                                    ImVec2(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, count)));
                 if (haveTable)
                 {
-                    ImGui::SetWindowFontScale(_fontScale);
                     for (size_t i = 0; i < inputs.size(); i++)
                     {
                         ImGui::TableNextRow();
@@ -3698,7 +3737,6 @@ void Graph::propertyEditor()
                         ImGui::PopID();
                     }
                     ImGui::EndTable();
-                    ImGui::SetWindowFontScale(1.0f);
                 }
             }
 
@@ -3739,7 +3777,6 @@ void Graph::propertyEditor()
                                                    ImVec2(0.0f, TEXT_BASE_HEIGHT * std::min(SCROLL_LINE_COUNT, count)));
                 if (haveTable)
                 {
-                    ImGui::SetWindowFontScale(_fontScale);
                     for (UiPinPtr input : inputs)
                     {
                         if (_currUiNode->getShowAllInputs() || (input->getConnected() || _currUiNode->getNodeGraph()->getInput(input->getName())))
@@ -3772,7 +3809,6 @@ void Graph::propertyEditor()
                         }
                     }
                     ImGui::EndTable();
-                    ImGui::SetWindowFontScale(1.0f);
                 }
             }
 
@@ -3792,7 +3828,6 @@ void Graph::propertyEditor()
             // Use `ImGuiTableFlags_SizingFixedFit` to set default column width to fit content
             if (ImGui::BeginTable("tokens_node_table", 4, tableFlags | ImGuiTableFlags_SizingFixedFit, tableHeight))
             {
-                ImGui::SetWindowFontScale(_fontScale);
 
                 ImGui::TableSetupColumn("Name");
                 ImGui::TableSetupColumn("Value");
@@ -3834,7 +3869,6 @@ void Graph::propertyEditor()
                 }
 
                 ImGui::EndTable();
-                ImGui::SetWindowFontScale(1.0f); // Restore font scale
             }
         }
 
@@ -3848,9 +3882,7 @@ void Graph::propertyEditor()
 
         if (ImGui::BeginPopup("docstring"))
         {
-            ImGui::SetWindowFontScale(_fontScale);
             ImGui::Text("%s", docString.c_str());
-            ImGui::SetWindowFontScale(1.0f);
             ImGui::EndPopup();
         }
     }
@@ -4002,7 +4034,6 @@ void Graph::addNodePopup(bool cursor)
                 ImGui::SetNextWindowSizeConstraints(ImVec2(100, 10), ImVec2(-1, 300));
                 if (ImGui::BeginMenu(node.getGroup().c_str()))
                 {
-                    ImGui::SetWindowFontScale(_fontScale);
                     std::string name = node.getName();
                     std::string prefix = "ND_";
                     if (name.compare(0, prefix.size(), prefix) == 0 && name.compare(prefix.size(), std::string::npos, node.getCategory()) == 0)
@@ -4107,7 +4138,9 @@ void Graph::addPinPopup()
             value = "\nValue: " + pin->getInput()->getValueString();
         }
         const std::string message("Name: " + pin->getName() + "\nType: " + pin->getType() + value + connected);
-        ImGui::SetTooltip("%s", message.c_str());
+        ImGui::BeginTooltip();
+        ImGui::TextUnformatted(message.c_str());
+        ImGui::EndTooltip();
         ed::Resume();
     }
 }

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -25,8 +25,8 @@ const ImVec2 DEFAULT_NODE_SIZE = ImVec2(138, 116);
 const int DEFAULT_ALPHA = 255;
 const int FILTER_ALPHA = 50;
 const float BASE_UI_FONT_SIZE = 18.0f;
-const float BASE_PIN_ICON_SIZE = 36.0f;
-const float MIN_PIN_ICON_SIZE = 20.0f;
+const float BASE_PIN_ICON_SIZE = 18.0f;
+const float MIN_PIN_ICON_SIZE = 18.0f;
 
 const std::array<std::string, 22> NODE_GROUP_ORDER = {
     "texture2d",
@@ -1929,45 +1929,39 @@ UiPinPtr Graph::getPin(ed::PinId pinId)
     return nullPin;
 }
 
-void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset)
+void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset, bool isOutput)
 {
     ImColor color = ImColor(0, 0, 0, 255);
     if (_pinColor.find(type) != _pinColor.end())
-    {
         color = _pinColor[type];
-    }
-
     color.Value.w = alpha / 255.0f;
 
     const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
 
-    // Draw a plain circle directly via the draw list — no external library needed,
-    // and no directional arrow is rendered.
     ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
     ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
-    ImVec2 center  = (iconMin + iconMax) * 0.5f;
-    const float radius       = iconSize * 0.25f;
+    ImVec2 center = (iconMin + iconMax) * 0.5f;
+    const float radius = iconSize * 0.25f;
     const float outlineScale = iconSize / BASE_PIN_ICON_SIZE;
-    const int   segments     = 12 + static_cast<int>(2 * outlineScale);
-    ImDrawList* drawList     = ImGui::GetWindowDrawList();
+    const int segments = 12 + static_cast<int>(2 * outlineScale);
+    ImDrawList* drawList = ImGui::GetWindowDrawList();
 
     if (connected)
-    {
         drawList->AddCircleFilled(center, radius, ImColor(color));
-    }
     else
     {
         drawList->AddCircleFilled(center, radius, ImColor(32, 32, 32, alpha));
         drawList->AddCircle(center, radius, ImColor(color), segments, 2.0f * outlineScale);
     }
 
-    ImGui::Dummy(ImVec2(iconSize, iconSize));
+    // Reserve dummy space only for input pins (they sit inside the node).
+    // Output pins protrude outside and must not affect layout width.
+    float dummyWidth = 0.0f;
+    if (!isOutput)
+        dummyWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
+    ImGui::Dummy(ImVec2(dummyWidth, iconSize));
 
-    if (xOffset != 0.0f)
-    {
-        // Override pin bounds so hover/click area and link endpoint match the shifted icon.
-        ed::PinRect(iconMin, iconMax);
-    }
+    ed::PinRect(iconMin, iconMax);
 }
 
 void Graph::buildGroupNode(UiNodePtr node)
@@ -2034,38 +2028,51 @@ bool Graph::readOnly()
 
 void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
 {
-    std::string longestLabel = longestInputLabel;
+    // 1. Find the widest label among input and output pins.
+    float maxLabelWidth = ImGui::CalcTextSize(longestInputLabel.c_str()).x;
     for (UiPinPtr pin : node->getOutputPins())
     {
-        if (pin->getName().size() > longestLabel.size())
-            longestLabel = pin->getName();
+        float w = ImGui::CalcTextSize(pin->getName().c_str()).x;
+        if (w > maxLabelWidth) maxLabelWidth = w;
     }
 
-    // Create output pins with extra right padding
-    const float outputPinExtraPad = 20.0f * getUiScaleFromFont();
+    // Content width = max label width (paddings are handled by the editor)
+    const float contentWidth = maxLabelWidth;
+
     const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
-    const float pinOffset = ed::GetStyle().NodePadding.z + iconSize * 0.5f;
-    float nodeWidth = ImGui::CalcTextSize(longestLabel.c_str()).x + outputPinExtraPad;
+    const float rightPadding = ed::GetStyle().NodePadding.z;
+
+    // 2. Draw each output pin.
     for (UiPinPtr pin : node->getOutputPins())
     {
-        const float indent = nodeWidth - ImGui::CalcTextSize(pin->getName().c_str()).x;
-        ImGui::Indent(indent);
+        float textWidth = ImGui::CalcTextSize(pin->getName().c_str()).x;
+
+        // Indent so that text ends at the right edge of the content area.
+        const float indent = contentWidth - textWidth;
+        if (indent > 0) ImGui::Indent(indent);
         ImGui::TextUnformatted(pin->getName().c_str());
+        if (indent > 0) ImGui::Unindent(indent);
+
+        // The cursor is now at the right edge of the text.
         ImGui::SameLine();
+
+        // Offset the icon so its center lands on the node's right edge.
+        // Node's right edge = contentWidth + rightPadding.
+        // We want icon center = contentWidth + rightPadding.
+        // Icon left = center - iconSize/2.
+        // Cursor is at contentWidth, so xOffset = (contentWidth + rightPadding - iconSize/2) - contentWidth
+        // = rightPadding - iconSize/2.
+        const float pinOffset = rightPadding - iconSize * 0.5f;
 
         ed::BeginPin(pin->getPinId(), ed::PinKind::Output);
         bool connected = pin->getConnected();
         if (!_pinFilterType.empty())
-        {
-            drawPinIcon(pin->getType(), connected, _pinFilterType == pin->getType() ? DEFAULT_ALPHA : FILTER_ALPHA, pinOffset);
-        }
+            drawPinIcon(pin->getType(), connected,
+                _pinFilterType == pin->getType() ? DEFAULT_ALPHA : FILTER_ALPHA,
+                pinOffset, true);   // isOutput = true
         else
-        {
-            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset);
-        }
-
+            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset, true);
         ed::EndPin();
-        ImGui::Unindent(indent);
     }
 }
 

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1950,10 +1950,11 @@ void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, floa
 
     const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
 
+    ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
+    ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
+
     if (_pinIconShape == (unsigned int)ax::Drawing::IconType::Circle)
     {
-        ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
-        ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
         ImVec2 center = (iconMin + iconMax) * 0.5f;
         const float radius = iconSize * 0.25f;
         const float outlineScale = iconSize / BASE_PIN_ICON_SIZE;
@@ -1970,21 +1971,29 @@ void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, floa
             drawList->AddCircle(center, radius, ImColor(color), segments, 2.0f * outlineScale);
         }
 
-        // Reserve dummy space only for input pins (they sit inside the node).
-        // Output pins protrude outside and must not affect layout width.
-        float dummyWidth = 0.0f;
-        if (!isOutput)
-        {
-            dummyWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
-        }
-        ImGui::Dummy(ImVec2(dummyWidth, iconSize));
-
-        ed::PinRect(iconMin, iconMax);
     }
     else if (_pinIconShape == (unsigned int)ax::Drawing::IconType::Flow)
     {
-        ax::Widgets::Icon(ImVec2(iconSize, iconSize), ax::Drawing::IconType::Flow, connected, color, ImColor(32, 32, 32, alpha));
+        ax::Drawing::DrawIcon(
+            ImGui::GetWindowDrawList(),
+            iconMin,
+            iconMax,
+            ax::Drawing::IconType::Flow,
+            connected,
+            color,
+            ImColor(32, 32, 32, alpha));
     }
+
+    // Reserve dummy space only for input pins (they sit inside the node).
+    // Output pins protrude outside and must not affect layout width.
+    float dummyWidth = 0.0f;
+    if (!isOutput)
+    {
+        dummyWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
+    }
+    ImGui::Dummy(ImVec2(dummyWidth, iconSize));
+
+    ed::PinRect(iconMin, iconMax);
 }
 
 void Graph::buildGroupNode(UiNodePtr node)

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -1938,7 +1938,7 @@ UiPinPtr Graph::getPin(ed::PinId pinId)
     return nullPin;
 }
 
-void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset, bool isOutput)
+void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset, bool offsetInY)
 {
     ImColor color = ImColor(0, 0, 0, 255);
     if (_pinColor.find(type) != _pinColor.end())
@@ -1948,7 +1948,7 @@ void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, floa
 
     color.Value.w = alpha / 255.0f;
 
-    const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+    const float iconSize = computeIconSize();
 
     ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
     ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
@@ -1984,14 +1984,13 @@ void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, floa
             ImColor(32, 32, 32, alpha));
     }
 
-    // Reserve dummy space only for input pins (they sit inside the node).
-    // Output pins protrude outside and must not affect layout width.
-    float dummyWidth = 0.0f;
-    if (!isOutput)
+    // Offset pins horizontally inwards in layout.
+    float offsetWidth = 0.0f;
+    if (!offsetInY)
     {
-        dummyWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
+        offsetWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
     }
-    ImGui::Dummy(ImVec2(dummyWidth, iconSize));
+    ImGui::Dummy(ImVec2(offsetWidth, iconSize));
 
     ed::PinRect(iconMin, iconMax);
 }
@@ -2058,6 +2057,24 @@ bool Graph::readOnly()
     return !_state.graphElem->belongsToContentDocument();
 }
 
+float Graph::computeIconSize()
+{
+    return std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
+}
+
+
+float Graph::computePinOffset(bool righAligned)
+{
+    float iconSize = computeIconSize();
+    if (righAligned)
+    {
+        // Center the icon on the node's right border (drawn after a right-aligned label).
+        return ed::GetStyle().NodePadding.z - iconSize * 0.5f;
+    }
+    // Center the icon on the node's left border (drawn before the label).
+    return -(ed::GetStyle().NodePadding.x + iconSize * 0.5f);
+}
+
 void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
 {
     // 1. Find the widest label among input and output pins.
@@ -2071,8 +2088,9 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
     // Content width = max label width (paddings are handled by the editor)
     const float contentWidth = maxLabelWidth;
 
-    const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
-    const float rightPadding = ed::GetStyle().NodePadding.z;
+    // Offset the icon so its center lands on the node's right edge
+    // if pin on border option is enabled. 
+    const float pinOffset = _pinsOnBorder ? computePinOffset(true) : 0.0f;
 
     // 2. Draw each output pin.
     for (UiPinPtr pin : node->getOutputPins())
@@ -2086,10 +2104,6 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
         if (indent > 0) ImGui::Unindent(indent);
 
         ImGui::SameLine();
-
-        // Offset the icon so its center lands on the node's right edge
-        // if pin on border option is enabled. 
-        const float pinOffset = _pinsOnBorder ? rightPadding - iconSize * 0.5f : 0.0f;
 
         ed::BeginPin(pin->getPinId(), ed::PinKind::Output);
         bool connected = pin->getConnected();
@@ -2108,9 +2122,7 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
 
 void Graph::drawInputPin(UiPinPtr pin)
 {
-    const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
-    const float pinOffset = _pinsOnBorder ?
-        -(ed::GetStyle().NodePadding.x + iconSize * 0.5f) : 0.0f;
+    const float pinOffset = _pinsOnBorder ? computePinOffset() : 0.0f;
 
     ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
     ImGui::PushID(int(pin->getPinId().Get()));
@@ -2311,23 +2323,22 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                         pin->setConnected(true);
                     }
                     {
-                        const float iconSz = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
-                        const float pinOff = -(ed::GetStyle().NodePadding.x + iconSz * 0.5f);
+                        const float pinOffset = computePinOffset();
                         ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
                         if (!_pinFilterType.empty())
                         {
                             if (_pinFilterType == pin->getType())
                             {
-                                drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
+                                drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOffset);
                             }
                             else
                             {
-                                drawPinIcon(pin->getType(), true, FILTER_ALPHA, pinOff);
+                                drawPinIcon(pin->getType(), true, FILTER_ALPHA, pinOffset);
                             }
                         }
                         else
                         {
-                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
+                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOffset);
                         }
 
                         ImGui::SameLine();
@@ -2387,23 +2398,22 @@ std::vector<int> Graph::createNodes(bool nodegraph)
                     }
 
                     {
-                        const float iconSz = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
-                        const float pinOff = -(ed::GetStyle().NodePadding.x + iconSz * 0.5f);
+                        const float pinOffset = computePinOffset();
                         ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
                         if (!_pinFilterType.empty())
                         {
                             if (_pinFilterType == pin->getType())
                             {
-                                drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
+                                drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOffset);
                             }
                             else
                             {
-                                drawPinIcon(pin->getType(), true, FILTER_ALPHA, pinOff);
+                                drawPinIcon(pin->getType(), true, FILTER_ALPHA, pinOffset);
                             }
                         }
                         else
                         {
-                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOff);
+                            drawPinIcon(pin->getType(), true, DEFAULT_ALPHA, pinOffset);
                         }
                         ImGui::SameLine();
                         ImGui::TextUnformatted("input");

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -135,7 +135,9 @@ Graph::Graph(const std::string& materialFilename,
              const mx::FilePathVec& libraryFolders,
              int viewWidth,
              int viewHeight,
-             float previewWidth) :
+             float previewWidth,
+             bool pinsOnBorder,
+             const std::string& pinShape) :
     _materialFilename(materialFilename),
     _searchPath(searchPath),
     _libraryFolders(libraryFolders),
@@ -152,9 +154,16 @@ Graph::Graph(const std::string& materialFilename,
     _isCut(false),
     _autoLayout(false),
     _frameCount(INT_MIN),
+    _pinsOnBorder(pinsOnBorder),
     _previewSize(previewWidth),
     _saveNodePositions(true)
 {
+    _pinIconShape = (unsigned int) ax::Drawing::IconType::Circle;
+    if (pinShape == "flow")
+    {
+        _pinIconShape = (unsigned int)ax::Drawing::IconType::Flow;
+    }
+
     loadStandardLibraries();
     setPinColor();
 
@@ -1933,35 +1942,49 @@ void Graph::drawPinIcon(const std::string& type, bool connected, int alpha, floa
 {
     ImColor color = ImColor(0, 0, 0, 255);
     if (_pinColor.find(type) != _pinColor.end())
+    {
         color = _pinColor[type];
+    }
+
     color.Value.w = alpha / 255.0f;
 
     const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
 
-    ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
-    ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
-    ImVec2 center = (iconMin + iconMax) * 0.5f;
-    const float radius = iconSize * 0.25f;
-    const float outlineScale = iconSize / BASE_PIN_ICON_SIZE;
-    const int segments = 12 + static_cast<int>(2 * outlineScale);
-    ImDrawList* drawList = ImGui::GetWindowDrawList();
-
-    if (connected)
-        drawList->AddCircleFilled(center, radius, ImColor(color));
-    else
+    if (_pinIconShape == (unsigned int)ax::Drawing::IconType::Circle)
     {
-        drawList->AddCircleFilled(center, radius, ImColor(32, 32, 32, alpha));
-        drawList->AddCircle(center, radius, ImColor(color), segments, 2.0f * outlineScale);
+        ImVec2 iconMin = ImGui::GetCursorScreenPos() + ImVec2(xOffset, 0.0f);
+        ImVec2 iconMax = iconMin + ImVec2(iconSize, iconSize);
+        ImVec2 center = (iconMin + iconMax) * 0.5f;
+        const float radius = iconSize * 0.25f;
+        const float outlineScale = iconSize / BASE_PIN_ICON_SIZE;
+        const int segments = 12 + static_cast<int>(2 * outlineScale);
+        ImDrawList* drawList = ImGui::GetWindowDrawList();
+
+        if (connected)
+        {
+            drawList->AddCircleFilled(center, radius, ImColor(color));
+        }
+        else
+        {
+            drawList->AddCircleFilled(center, radius, ImColor(32, 32, 32, alpha));
+            drawList->AddCircle(center, radius, ImColor(color), segments, 2.0f * outlineScale);
+        }
+
+        // Reserve dummy space only for input pins (they sit inside the node).
+        // Output pins protrude outside and must not affect layout width.
+        float dummyWidth = 0.0f;
+        if (!isOutput)
+        {
+            dummyWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
+        }
+        ImGui::Dummy(ImVec2(dummyWidth, iconSize));
+
+        ed::PinRect(iconMin, iconMax);
     }
-
-    // Reserve dummy space only for input pins (they sit inside the node).
-    // Output pins protrude outside and must not affect layout width.
-    float dummyWidth = 0.0f;
-    if (!isOutput)
-        dummyWidth = (xOffset < 0.0f) ? std::max(0.0f, iconSize + xOffset) : iconSize;
-    ImGui::Dummy(ImVec2(dummyWidth, iconSize));
-
-    ed::PinRect(iconMin, iconMax);
+    else if (_pinIconShape == (unsigned int)ax::Drawing::IconType::Flow)
+    {
+        ax::Widgets::Icon(ImVec2(iconSize, iconSize), ax::Drawing::IconType::Flow, connected, color, ImColor(32, 32, 32, alpha));
+    }
 }
 
 void Graph::buildGroupNode(UiNodePtr node)
@@ -2053,25 +2076,23 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
         ImGui::TextUnformatted(pin->getName().c_str());
         if (indent > 0) ImGui::Unindent(indent);
 
-        // The cursor is now at the right edge of the text.
         ImGui::SameLine();
 
-        // Offset the icon so its center lands on the node's right edge.
-        // Node's right edge = contentWidth + rightPadding.
-        // We want icon center = contentWidth + rightPadding.
-        // Icon left = center - iconSize/2.
-        // Cursor is at contentWidth, so xOffset = (contentWidth + rightPadding - iconSize/2) - contentWidth
-        // = rightPadding - iconSize/2.
-        const float pinOffset = rightPadding - iconSize * 0.5f;
+        // Offset the icon so its center lands on the node's right edge
+        // if pin on border option is enabled. 
+        const float pinOffset = _pinsOnBorder ? rightPadding - iconSize * 0.5f : 0.0f;
 
         ed::BeginPin(pin->getPinId(), ed::PinKind::Output);
         bool connected = pin->getConnected();
         if (!_pinFilterType.empty())
-            drawPinIcon(pin->getType(), connected,
-                _pinFilterType == pin->getType() ? DEFAULT_ALPHA : FILTER_ALPHA,
-                pinOffset, true);   // isOutput = true
+        {
+            drawPinIcon(pin->getType(), connected, _pinFilterType == pin->getType() ? DEFAULT_ALPHA : FILTER_ALPHA, pinOffset, _pinsOnBorder);
+        }
         else
-            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset, true);
+        {
+            drawPinIcon(pin->getType(), connected, DEFAULT_ALPHA, pinOffset, _pinsOnBorder);
+        }
+
         ed::EndPin();
     }
 }
@@ -2079,7 +2100,8 @@ void Graph::drawOutputPins(UiNodePtr node, const std::string& longestInputLabel)
 void Graph::drawInputPin(UiPinPtr pin)
 {
     const float iconSize = std::max(MIN_PIN_ICON_SIZE, BASE_PIN_ICON_SIZE * getUiScaleFromFont());
-    const float pinOffset = -(ed::GetStyle().NodePadding.x + iconSize * 0.5f);
+    const float pinOffset = _pinsOnBorder ?
+        -(ed::GetStyle().NodePadding.x + iconSize * 0.5f) : 0.0f;
 
     ed::BeginPin(pin->getPinId(), ed::PinKind::Input);
     ImGui::PushID(int(pin->getPinId().Get()));

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -119,11 +119,6 @@ class Graph
         return _renderer;
     }
 
-    void setFontScale(float val)
-    {
-        _fontScale = val;
-    }
-
   private:
     mx::ElementPredicate getElementPredicate() const;
     void loadStandardLibraries();
@@ -185,7 +180,7 @@ class Graph
     void setPinColor();
 
     // Based on the pin icon function in the ImGui Node Editor blueprints-example.cpp
-    void drawPinIcon(const std::string& type, bool connected, int alpha);
+    void drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset = 0.0f);
 
     UiPinPtr getPin(ed::PinId id);
     void drawInputPin(UiPinPtr pin);
@@ -300,8 +295,9 @@ class Graph
 
     // A compile-time constant member variable that corresponds to the function below. Defined in header as visibility is desirable here.
     static constexpr char HELP_MARKER_TEXT[] = "(?)";
-    // Static helper function to draw a marker via ImGui which shows a tooltip when hovered
-    static void drawHelpMarker(const char* content);
+    // Helper function to draw a marker via ImGui which shows a tooltip when hovered.
+    // Uses instance font scaling for tooltip readability.
+    void drawHelpMarker(const char* content);
 
     // Static helper function to display tooltips for headers in an ImGui table
     template <std::size_t N> static void drawTableHeadersRowWithTooltips(const std::array<const char*, N>& tooltips)
@@ -399,9 +395,6 @@ class Graph
     // used for auto connecting pins if a node is added by drawing a link from a pin
     ed::PinId _pinIdToLinkFrom;
     ed::PinId _pinIdToLinkTo;
-
-    // DPI scaling for fonts
-    float _fontScale;
 
     // Layout engine
     Layout _layout;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -180,7 +180,7 @@ class Graph
     void setPinColor();
 
     // Based on the pin icon function in the ImGui Node Editor blueprints-example.cpp
-    void drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset = 0.0f);
+    void drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset = 0.0f, bool isOutput = false);
 
     UiPinPtr getPin(ed::PinId id);
     void drawInputPin(UiPinPtr pin);

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -108,7 +108,9 @@ class Graph
           const mx::FilePathVec& libraryFolders,
           int viewWidth,
           int viewHeight,
-          float previewWidth);
+          float previewWidth,
+          bool pinsOnBorder,
+          const std::string& pinShape);
     ~Graph() = default;
 
     mx::DocumentPtr loadDocument(const mx::FilePath& filename);
@@ -395,6 +397,10 @@ class Graph
     // used for auto connecting pins if a node is added by drawing a link from a pin
     ed::PinId _pinIdToLinkFrom;
     ed::PinId _pinIdToLinkTo;
+    // Offset pin placement to be on border of node vs inside.
+    bool _pinsOnBorder;
+    // Pin icon shape
+    unsigned int _pinIconShape;
 
     // Layout engine
     Layout _layout;

--- a/source/MaterialXGraphEditor/Graph.h
+++ b/source/MaterialXGraphEditor/Graph.h
@@ -181,8 +181,13 @@ class Graph
     // Return pin color based on the type of the value of that pin
     void setPinColor();
 
+    // Compute icon size
+    static float computeIconSize();
+    // Compute pin offset based on icon size and aligment (left vs right)
+    static float computePinOffset(bool rightAligned = false);
+
     // Based on the pin icon function in the ImGui Node Editor blueprints-example.cpp
-    void drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset = 0.0f, bool isOutput = false);
+    void drawPinIcon(const std::string& type, bool connected, int alpha, float xOffset = 0.0f, bool offsetInY = false);
 
     UiPinPtr getPin(ed::PinId id);
     void drawInputPin(UiPinPtr pin);
@@ -299,7 +304,7 @@ class Graph
     static constexpr char HELP_MARKER_TEXT[] = "(?)";
     // Helper function to draw a marker via ImGui which shows a tooltip when hovered.
     // Uses instance font scaling for tooltip readability.
-    void drawHelpMarker(const char* content);
+    static void drawHelpMarker(const char* content);
 
     // Static helper function to display tooltips for headers in an ImGui table
     template <std::size_t N> static void drawTableHeadersRowWithTooltips(const std::array<const char*, N>& tooltips)

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -30,7 +30,7 @@ const std::string options =
     "    --mesh [FILENAME]              Specify the filename of the OBJ or glTF mesh to be displayed in the graph editor\n"
     "    --path [FILEPATH]              Specify an additional data search path location (e.g. '/projects/MaterialX').  This absolute path will be queried when locating data libraries, XInclude references, and referenced images.\n"
     "    --library [FILEPATH]           Specify an additional data library folder (e.g. 'vendorlib', 'studiolib').  This relative path will be appended to each location in the data search path when loading data libraries.\n"
-    "    --uiScale [FACTOR]             Manually specify a UI scaling factor\n"
+    "    --uiScale [FACTOR]             Additional UI scale multiplier applied on top of detected device scale\n"
     "    --font [FILENAME]              Specify the name of the custom font file to use.  If not specified the default font will be used.\n"
     "    --fontSize [SIZE]              Specify font size to use for the custom font.  If not specified a default of 18 will be used.\n"
     "    --captureFilename [FILENAME]   Specify the filename to which the first rendered frame should be written\n"
@@ -70,7 +70,7 @@ int main(int argc, char* const argv[])
     mx::FilePathVec libraryFolders;
     int viewWidth = 256;
     int viewHeight = 256;
-    float uiScale = 0.0f;
+    float uiScale = 1.0f;
     std::string fontFilename;
     int fontSize = 18;
     float previewWidth = 256.0f;
@@ -198,10 +198,17 @@ int main(int argc, char* const argv[])
     io.IniFilename = NULL;
     io.LogFilename = NULL;
 
+    // Derive a single effective UI scale from device DPI and optional CLI multiplier.
+    float xscale = 1.0f, yscale = 1.0f;
+    glfwGetWindowContentScale(window, &xscale, &yscale);
+    const float deviceScale = (xscale > yscale) ? xscale : yscale;
+    const float effectiveUiScale = deviceScale * ((uiScale > 0.0f) ? uiScale : 1.0f);
+    const float scaledFontSize = std::max(1.0f, fontSize * effectiveUiScale);
+
     ImFont* customFont = nullptr;
     if (!fontFilename.empty())
     {
-        customFont = io.Fonts->AddFontFromFileTTF(fontFilename.c_str(), fontSize);
+        customFont = io.Fonts->AddFontFromFileTTF(fontFilename.c_str(), scaledFontSize);
     }
     if (!customFont)
     {
@@ -209,7 +216,7 @@ int main(int argc, char* const argv[])
         mx::FilePath resolvedFontPath = searchPath.find(defaultFontFile);
         if (!resolvedFontPath.isEmpty())
         {
-            customFont = io.Fonts->AddFontFromFileTTF(resolvedFontPath.asString().c_str(), fontSize);
+            customFont = io.Fonts->AddFontFromFileTTF(resolvedFontPath.asString().c_str(), scaledFontSize);
         }
     }
     if (!customFont)
@@ -238,24 +245,9 @@ int main(int argc, char* const argv[])
         graph->getRenderer()->requestExit();
     }
 
-    // Handle DPI scaling
-    // Note that ScaleAllSizes() only handles things like spacing of elements.
-    // Fonts are not handled, so a global font scale factor is set.
-    // There appears to be no multi-monitor solution so use the primary monitor
-    // for now.
-    GLFWmonitor* monitor = glfwGetPrimaryMonitor();
-    if (monitor)
-    {
-        float xscale = 1.0f, yscale = 1.0f;
-        glfwGetMonitorContentScale(monitor, &xscale, &yscale);
-        ImGuiStyle& style = ImGui::GetStyle();
-        if (uiScale <= 0.0f)
-        {
-            uiScale = (xscale > yscale) ? xscale : yscale;
-        }
-        style.ScaleAllSizes(uiScale);
-        graph->setFontScale(uiScale);
-    }
+    // Handle DPI scaling for ImGui style metrics.
+    ImGuiStyle& style = ImGui::GetStyle();
+    style.ScaleAllSizes(effectiveUiScale);
 
     // Create editor config and context.
     ed::Config config;
@@ -268,8 +260,9 @@ int main(int argc, char* const argv[])
     }
     ed::SetCurrentEditor(editorContext);
     ed::Style& editorStyle = ed::GetStyle();
-    editorStyle.NodeRounding  = 5.0f;
+    editorStyle.NodeRounding  = 8.0f;
     editorStyle.PinRounding   = 2.0f;
+    editorStyle.PinArrowSize = 0.0f;
     editorStyle.GroupRounding = 3.0f;
     editorStyle.LinkStrength  = 125.0f;
 

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -35,6 +35,8 @@ const std::string options =
     "    --fontSize [SIZE]              Specify font size to use for the custom font.  If not specified a default of 18 will be used.\n"
     "    --captureFilename [FILENAME]   Specify the filename to which the first rendered frame should be written\n"
     "    --previewWidth [WIDTH]         Specify the width for image previews\n"
+    "    --pinsOnBorder [true|false]    Specify whether node pins should be drawn on the border of nodes (true) or inside the node (false).  Default is true.\n"
+    "    --pinShape [circle|square]     Specify the shape of node pins (circle, flow).  Default is circle.\n"
     "    --help                         Display the complete list of command-line options\n";
 
 template <class T> void parseToken(std::string token, std::string type, T& res)
@@ -75,6 +77,8 @@ int main(int argc, char* const argv[])
     int fontSize = 18;
     float previewWidth = 256.0f;
     std::string captureFilename;
+    bool pinsOnBorder = true;
+    std::string pinShape = "circle";
 
     for (size_t i = 0; i < tokens.size(); i++)
     {
@@ -124,6 +128,14 @@ int main(int argc, char* const argv[])
         else if (token == "--captureFilename")
         {
             parseToken(nextToken, "string", captureFilename);
+        }
+        else if (token == "--pinsOnBorder")
+        {
+            parseToken(nextToken, "boolean", pinsOnBorder);
+        }
+        else if (token == "--pinShape")
+        {
+            parseToken(nextToken, "string", pinShape);
         }
         else if (token == "--help")
         {
@@ -238,7 +250,9 @@ int main(int argc, char* const argv[])
                              libraryFolders,
                              viewWidth,
                              viewHeight,
-                             previewWidth);
+                             previewWidth,
+                             pinsOnBorder,
+                             pinShape);
     if (!captureFilename.empty())
     {
         graph->getRenderer()->requestFrameCapture(captureFilename);

--- a/source/MaterialXGraphEditor/Main.cpp
+++ b/source/MaterialXGraphEditor/Main.cpp
@@ -36,7 +36,7 @@ const std::string options =
     "    --captureFilename [FILENAME]   Specify the filename to which the first rendered frame should be written\n"
     "    --previewWidth [WIDTH]         Specify the width for image previews\n"
     "    --pinsOnBorder [true|false]    Specify whether node pins should be drawn on the border of nodes (true) or inside the node (false).  Default is true.\n"
-    "    --pinShape [circle|square]     Specify the shape of node pins (circle, flow).  Default is circle.\n"
+    "    --pinShape [circle|flow]       Specify the shape of node pins (circle, flow).  Default is circle.\n"
     "    --help                         Display the complete list of command-line options\n";
 
 template <class T> void parseToken(std::string token, std::string type, T& res)

--- a/source/MaterialXGraphEditor/UiNode.cpp
+++ b/source/MaterialXGraphEditor/UiNode.cpp
@@ -149,7 +149,13 @@ void UiNode::buildUiTokenMap()
 
         std::string inputValue = input->getValueString();
         if (inputValue.empty() && input->hasInterfaceName())
-            inputValue = input->getInterfaceInput()->getValueString(); // Get value from referenced interface
+        {
+            mx::InputPtr interfaceInput = input->getInterfaceInput();
+            if (interfaceInput)
+            {
+                inputValue = interfaceInput->getValueString(); // Get value from referenced interface
+            }
+        }
 
         for (const auto& entry : inputTokens)
         {


### PR DESCRIPTION
## Changes

### Fixes
Fix up issues related to font changes.

- Fix up inconsistent text scaling throughout all UI.
- Consider font size for placement and scaling all UI.
  - All nodes should have no scaling as this blurs the fonts. 
  - All other UI considers optional (existing) UI scale command line option
- Move pins / plugs / ports to straddle border of node 
- Fix text placement for pin labels
- Fix unrelate crash in interface code.

#### Command Line Options
- Pins on border (`--pinsOnBorder`). Default is true.
- Pin Shape (`--pinShape`). Default is "circle". Options are "circle" and "flow" (previous) for now.

### Results 

- All results shown display with high DPI (4k, 2x scale) -- used to be all different sizes for fonts.

#### Consistent Text Scaling

<img alt="image" src="https://github.com/user-attachments/assets/8d64a3de-5cea-47dc-90bb-f3099c45c5fa" />

<img alt="image" src="https://github.com/user-attachments/assets/195276b8-9393-4179-ab79-f75a8483d3cf" />

<img width="1938" height="1520" alt="image" src="https://github.com/user-attachments/assets/1ab5a593-33e2-4b00-aef8-a1dd2cb91cb9" />

<img width="1938" height="1520" alt="image" src="https://github.com/user-attachments/assets/77fc7976-0393-486d-8d42-34d07b0cad75" />

<img width="1938" height="1520" alt="image" src="https://github.com/user-attachments/assets/a42a9d3d-20a9-4b97-aaaa-c31d6387f412" />

<img width="1938" height="1520" alt="image" src="https://github.com/user-attachments/assets/72b3f855-e58f-49ee-9178-1b043585901b" />

- Sample with 4K, 1x scale. User option of 1.5x (* font size) scale.

<img width="2796" height="2206" alt="image" src="https://github.com/user-attachments/assets/3fe25304-242b-4e45-99db-9756d2233797" />

#### Plug Placement 

- Circle icons for plugs (could be other available ones)
- Fixed min / max size relative to current font size
- Hot-spot placement centered
- Text alignment fixes

<img width="2100" height="1520" alt="image" src="https://github.com/user-attachments/assets/72d1a8b4-7ea5-41cc-9558-fc8b4be3e83d" />

<img width="2100" height="1520" alt="image" src="https://github.com/user-attachments/assets/e0b84de4-8230-4a93-88e9-9cf52c6a60a8" />

<img width="2100" height="1518" alt="image" src="https://github.com/user-attachments/assets/b073fdf8-57c5-4a50-813c-8c33800b147a" />

##### 

Previous plug layout possible using options:

| Option | Example | 
| :--: | :--: |
| Inset + Flow | <img alt="image" src="https://github.com/user-attachments/assets/5e4081e2-0834-4d9f-a402-432f9ac3c577" /> |
| Border + Flow |  <img alt="image" src="https://github.com/user-attachments/assets/27f62273-2bb4-4590-a126-0e7b5a5a2e2a" /> |
| Inset + Circle |  <img alt="image" src="https://github.com/user-attachments/assets/d4b7fd4d-1e78-4cc0-ba4e-daaa5f9b984a" /> |

