### PR TITLE
Correct anisotropic Smith masking equation

### DIFF
--- a/documents/Specification/MaterialX.PBRSpec.md
+++ b/documents/Specification/MaterialX.PBRSpec.md
@@ -325,14 +325,31 @@ The pair $(\alpha_x, \alpha_y)$ is supplied directly by the `roughness` input of
 
 #### Height-Correlated Smith Masking-Shadowing
 
-The joint masking-shadowing function is the height-correlated form of the Smith function[^Heitz2014]:
+The joint masking-shadowing function is the height-correlated form of the Smith function[^Heitz2014]. Define the direction-dependent stretched-vector length:
 
 ```math
-G_2(\omega_i, \omega_o) = \frac{2 \cos\theta_i \cos\theta_o}{\lambda_o \cos\theta_i + \lambda_i \cos\theta_o}
+L(\omega) = \sqrt{\alpha_x^2\omega_x^2 + \alpha_y^2\omega_y^2 + \omega_z^2}
 ```
 <p></p>
 
-where $\lambda_i = \lambda(\cos\theta_i)$, $\lambda_o = \lambda(\cos\theta_o)$, $\lambda(\cos\theta) = \sqrt{\alpha^2 + (1 - \alpha^2) \cos^2\theta}$, and $\alpha = \sqrt{\alpha_x \alpha_y}$ when the roughness is anisotropic.
+Then:
+
+```math
+G_2(\omega_i, \omega_o) =
+\frac{2|\omega_{i,z}||\omega_{o,z}|}
+{|\omega_{i,z}|L(\omega_o) + |\omega_{o,z}|L(\omega_i)}
+```
+<p></p>
+
+This is equivalent to evaluating the Smith $\Lambda$ function with the roughness projected independently onto each direction, as given by Heitz[^Heitz2014]. In the isotropic case, $\alpha_x = \alpha_y = \alpha$, this reduces to the usual scalar-roughness expression.
+
+**Implementation notes:**
+
+- **GLSL:** Currently evaluates this term with the scalar approximation $\alpha = \sqrt{\alpha_x\alpha_y}$, which removes its anisotropic azimuthal dependence.
+- **OSL (`testrender`):** The path used by MaterialXTest registers the MaterialX dielectric closure through BSDL, whose GGX implementation evaluates the anisotropic height-correlated form above.
+- **MDL:** Passes both roughness axes to `df::microfacet_ggx_smith_bsdf`, but the current NVIDIA MDL SDK combines its anisotropic masking terms as the separable product $G_1(\omega_i)G_1(\omega_o)$ rather than as height-correlated $G_2$.
+
+These target-specific differences do not redefine the normative equation above.
 
 
 ### Directional Albedo and Energy Conservation

--- a/documents/Specification/MaterialX.PBRSpec.md
+++ b/documents/Specification/MaterialX.PBRSpec.md
@@ -343,15 +343,6 @@ G_2(\omega_i, \omega_o) =
 
 This is equivalent to evaluating the Smith $\Lambda$ function with the roughness projected independently onto each direction, as given by Heitz[^Heitz2014]. In the isotropic case, $\alpha_x = \alpha_y = \alpha$, this reduces to the usual scalar-roughness expression.
 
-**Implementation notes:**
-
-- **GLSL:** Currently evaluates this term with the scalar approximation $\alpha = \sqrt{\alpha_x\alpha_y}$, which removes its anisotropic azimuthal dependence.
-- **OSL (`testrender`):** The path used by MaterialXTest registers the MaterialX dielectric closure through BSDL, whose GGX implementation evaluates the anisotropic height-correlated form above.
-- **MDL:** Passes both roughness axes to `df::microfacet_ggx_smith_bsdf`, but the current NVIDIA MDL SDK combines its anisotropic masking terms as the separable product $G_1(\omega_i)G_1(\omega_o)$ rather than as height-correlated $G_2$.
-
-These target-specific differences do not redefine the normative equation above.
-
-
 ### Directional Albedo and Energy Conservation
 
 The **directional albedo** $E_o$ of a BSDF is its integral over all incident directions, for a fixed exitant direction $\omega_o$:

--- a/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_microfacet_specular.glsl
@@ -79,6 +79,7 @@ float mx_ggx_smith_G1(float cosTheta, float alpha)
 // Height-correlated Smith masking-shadowing
 // http://jcgt.org/published/0003/02/03/paper.pdf
 // Equations 72 and 99
+// TODO: Add an anisotropic form to match the PBR specification.
 float mx_ggx_smith_G2(float NdotL, float NdotV, float alpha)
 {
     float alpha2 = mx_square(alpha);


### PR DESCRIPTION
While reviewing https://github.com/AcademySoftwareFoundation/MaterialX/pull/2964, I found that the anisotropic GGX masking-shadowing equation first reduces `alpha_x` and `alpha_y` to their geometric mean. This removes the azimuthal dependence from `G2`, even though the NDF immediately above it is anisotropic.

This PR updates the specification to use the direction-dependent projected roughness from Heitz 2014 and the corresponding height-correlated Smith term, following the OSL testrender and the current state of the art. It reduces to the existing scalar equation when `alpha_x = alpha_y`.

For `alpha_x = 0.1`, `alpha_y = 0.8`, and incident and outgoing directions 60 degrees from the normal:

| Incident/outgoing azimuth | Geometric-mean `G2` | Anisotropic correlated `G2` |
| --- | ---: | ---: |
| x / x | 0.898027 | 0.985329 |
| x / y | 0.898027 | 0.734298 |
| y / y | 0.898027 | 0.585206 |

This does not change any of the actual implementations, and adds an implementation note to the spec:

- **GLSL:** [Uses `sqrt(alpha_x * alpha_y)`](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ebc8cc8d89c056ba7d7bde0d6ef49bdc417e7de7/libraries/pbrlib/genglsl/mx_dielectric_bsdf.glsl#L28-L45), matching the current specification but discarding the anisotropic azimuth.
- **OSL (`testrender`):** MaterialX delegates to a [native dielectric closure](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ebc8cc8d89c056ba7d7bde0d6ef49bdc417e7de7/libraries/pbrlib/genosl/mx_dielectric_bsdf.osl#L1-L5). The BSDL implementation used by `testrender` evaluates [anisotropic height-correlated Smith masking](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/f7ab6a7a5074e530d3ef9e107745a193cc811d90/src/libbsdl/include/BSDL/microfacet_tools_impl.h#L31-L48), matching the proposed equation.
- **MDL:** MaterialX passes both roughness axes to [`df::microfacet_ggx_smith_bsdf`](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ebc8cc8d89c056ba7d7bde0d6ef49bdc417e7de7/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_11.mdl#L168-L205). The current NVIDIA MDL SDK preserves the anisotropic dependence but uses the separable product [`G1(wi) * G1(wo)`](https://github.com/NVIDIA/MDL-SDK/blob/ebca383a932c94cdc9c965c283658637f251a587/src/mdl/jit/libbsdf/libbsdf.cpp#L3386-L3405), rather than height-correlated `G2`.

[Heitz, *Understanding the Masking-Shadowing Function in Microfacet-Based BRDFs*](https://jcgt.org/published/0003/02/03/paper.pdf), equations 80, 86, and 99.
