### PR TITLE
Define Chiang BCSDF normalization

### DIFF
--- a/documents/Specification/MaterialX.PBRSpec.md
+++ b/documents/Specification/MaterialX.PBRSpec.md
@@ -787,14 +787,21 @@ In the equations below, the `tint_R`, `tint_TT`, and `tint_TRT` inputs correspon
 
 #### Chiang Hair Scattering Equations
 
-The Chiang hair model[^Chiang2016] treats a hair fiber as a dielectric cylinder with tilted cuticle scales. Directions at a point on the fiber are parameterized by inclination $\theta$ from the fiber's normal plane and azimuth $\phi$ around the fiber, differing from the surface-normal angles used by planar BSDF nodes. The BCSDF is a sum over four scattering lobes — R (surface reflection), TT (double transmission), TRT (internal reflection), and TRRT+ (higher-order paths):
+The Chiang hair model[^Chiang2016] treats a hair fiber as a dielectric cylinder with tilted cuticle scales. Directions at a point on the fiber are parameterized by inclination $\theta$ from the fiber's normal plane and azimuth $\phi$ around the fiber, differing from the surface-normal angles used by planar BSDF nodes. The BCSDF is a sum over four scattering lobes: R (surface reflection), TT (double transmission), TRT (internal reflection), and TRRT+ (higher-order paths):
 
 ```math
-f_c(\omega_i, \omega_o) = \frac{1}{\pi} \sum_{p \in \{R,TT,TRT,TRRT+\}} t_p A_p M_p N_p
+f_c(\omega_i, \omega_o) =
+\sum_{p \in \{R,TT,TRT,TRRT+\}} t_p A_p M_p N_p
 ```
 <p></p>
 
-where $M_p$ is the longitudinal scattering function, $N_p$ is the azimuthal scattering function, and $A_p$ is the attenuation factor combining Fresnel reflectance and volumetric absorption. The higher-order TRRT+ lobe shares the tint $t_{TRT}$ and the roughness values of the TRT lobe. The full definitions of these components are given in the [Chiang Hair Model](#chiang-hair-model) appendix.
+where $M_p$ is the longitudinal scattering function, $N_p$ is the azimuthal scattering function, and $A_p$ is the attenuation factor combining Fresnel reflectance and volumetric absorption. These one-dimensional distributions contain their own normalization factors, including $N_{TRRT+} = 1/(2\pi)$ for the uniform high-order lobe, so there is no additional global factor of $1/\pi$. The higher-order TRRT+ lobe shares the tint $t_{TRT}$ and the roughness values of the TRT lobe. The full definitions of these components are given in the [Chiang Hair Model](#chiang-hair-model) appendix.
+
+**Implementation notes:**
+
+- **GLSL:** Currently evaluates the same lobe sum and then applies an additional global factor of $1/\pi$, so its normalization differs from the normative equations above.
+- **OSL (`testrender`):** The path used by MaterialXTest does not register `chiang_hair_bsdf`, and the MaterialX OSL network test profile skips its Chiang hair fixture, so this target provides no implementation result for comparison.
+- **MDL:** The current NVIDIA MDL SDK implementation of `df::chiang_hair_bsdf` accumulates the normalized lobe products without the additional factor.
 
 
 ## EDF Nodes

--- a/documents/Specification/MaterialX.PBRSpec.md
+++ b/documents/Specification/MaterialX.PBRSpec.md
@@ -795,13 +795,7 @@ f_c(\omega_i, \omega_o) =
 ```
 <p></p>
 
-where $M_p$ is the longitudinal scattering function, $N_p$ is the azimuthal scattering function, and $A_p$ is the attenuation factor combining Fresnel reflectance and volumetric absorption. These one-dimensional distributions contain their own normalization factors, including $N_{TRRT+} = 1/(2\pi)$ for the uniform high-order lobe, so there is no additional global factor of $1/\pi$. The higher-order TRRT+ lobe shares the tint $t_{TRT}$ and the roughness values of the TRT lobe. The full definitions of these components are given in the [Chiang Hair Model](#chiang-hair-model) appendix.
-
-**Implementation notes:**
-
-- **GLSL:** Currently evaluates the same lobe sum and then applies an additional global factor of $1/\pi$, so its normalization differs from the normative equations above.
-- **OSL (`testrender`):** The path used by MaterialXTest does not register `chiang_hair_bsdf`, and the MaterialX OSL network test profile skips its Chiang hair fixture, so this target provides no implementation result for comparison.
-- **MDL:** The current NVIDIA MDL SDK implementation of `df::chiang_hair_bsdf` accumulates the normalized lobe products without the additional factor.
+where $M_p$ is the longitudinal scattering function, $N_p$ is the azimuthal scattering function, and $A_p$ is the attenuation factor combining Fresnel reflectance and volumetric absorption. The longitudinal and azimuthal distributions include the normalization required by the model, so the lobe products require no additional normalization. The higher-order TRRT+ lobe shares the tint $t_{TRT}$ and the roughness values of the TRT lobe. The full definitions of these components are given in the [Chiang Hair Model](#chiang-hair-model) appendix.
 
 
 ## EDF Nodes

--- a/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
@@ -264,6 +264,7 @@ void mx_chiang_hair_bsdf(ClosureData closureData, vec3 tint_R, vec3 tint_TT, vec
             F += Mp * Np * tint[i] * Ap[i];
         }
 
+        // TODO: Remove M_PI_INV to match the PBR specification.
         bsdf.response = F * closureData.occlusion * M_PI_INV;
     }
     else if (closureData.closureType == CLOSURE_TYPE_INDIRECT)


### PR DESCRIPTION
While reviewing the Chiang hair equations added in #2964, I found an additional global `1/pi` factor that is not present in the cited model. The longitudinal and azimuthal distributions already contain their normalization factors, including `1/(2*pi)` for the uniform high-order azimuthal lobe.

## Normalization argument

Consider a non-absorbing fiber (`T = 1`) with unit lobe tints. The attenuation terms in the specification become:

```math
A_R = F,\qquad
A_{TT} = (1-F)^2,\qquad
A_{TRT} = (1-F)^2F,\qquad
A_{TRRT+} = (1-F)F^2.
```

They account for all possible paths:

```math
A_R + A_{TT} + A_{TRT} + A_{TRRT+} = 1.
```

Consider the simplest case, with zero cuticle tilt, in a constant white environment. A non-absorbing material should return the same unit radiance in every direction: this is the usual white-furnace test. The attenuation terms above divide the incoming energy among the four scattering paths, and their weights add up to `1`. The normalized `M_p` and `N_p` distributions only determine where each path's share of the energy is scattered.

The familiar `1/pi` factor is needed for a constant Lambertian BRDF because its projected hemisphere integral is `pi`. It is not needed for these already-normalized directional distributions. Applying it to the complete Chiang response reduces the white-furnace result from `1` to `1/pi`, losing about 68% of the energy.

This is the normalization tested by the white-furnace result in Figure 5(e) of the original [Chiang et al. paper](https://media.disneyanimation.com/uploads/production/publication_asset/152/asset/eurographics2016Fur_Smaller.pdf).

## Specification change

The specification already denotes a BCSDF by `f_c`. Following equations 1 and 2 of the cited Chiang paper, this PR defines it directly as:

```math
f_c(\omega_i,\omega_o) =
\sum_p t_p A_p M_p N_p.
```

The existing `f_c` notation is retained, and this change does not add a general BCSDF transport convention. Renderer APIs may account for the curve projection factor separately, but that does not introduce a global `1/pi`. The PR changes the specification only; the current implementations are not changed.

## Implementation notes

- **GLSL:** Evaluates the same lobe sum and normalized azimuthal distributions, but then applies an additional [`M_PI_INV`](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ebc8cc8d89c056ba7d7bde0d6ef49bdc417e7de7/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl#L255-L267).
- **OSL (`testrender`):** The MaterialX wrapper emits [`chiang_hair_bsdf`](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ebc8cc8d89c056ba7d7bde0d6ef49bdc417e7de7/libraries/pbrlib/genosl/mx_chiang_hair_bsdf.osl#L1-L9), but `testrender` does not register this closure in its [built-in or BSDL closure sets](https://github.com/AcademySoftwareFoundation/OpenShadingLanguage/blob/f7ab6a7a5074e530d3ef9e107745a193cc811d90/src/testrender/shading.cpp#L184-L298). The MaterialX OSL network profile [skips the Chiang hair fixture](https://github.com/AcademySoftwareFoundation/MaterialX/blob/ebc8cc8d89c056ba7d7bde0d6ef49bdc417e7de7/source/MaterialXTest/MaterialXRenderOsl/RenderOsl.cpp#L100-L113), so this path has no normalization result to compare.
- **MDL:** The current NVIDIA MDL SDK defines [normalized azimuthal distributions](https://github.com/NVIDIA/MDL-SDK/blob/ebca383a932c94cdc9c965c283658637f251a587/src/mdl/jit/libbsdf/libbsdf_hair.h#L100-L151) and [accumulates the lobe products without a global `1/pi`](https://github.com/NVIDIA/MDL-SDK/blob/ebca383a932c94cdc9c965c283658637f251a587/src/mdl/jit/libbsdf/libbsdf_hair.h#L449-L567).

This follows the original [Chiang et al. model](https://media.disneyanimation.com/uploads/production/publication_asset/152/asset/eurographics2016Fur_Smaller.pdf), equations 1 and 2. [PBRT v4](https://github.com/mmp/pbrt-v4/blob/5f7a606806a4ac7b939131ded9d7a30ebd02416e/src/pbrt/bxdfs.cpp#L303-L365) accounts for its renderer-facing measure separately and likewise has no global `1/pi`.
