### PR TITLE
Clamp PBR surface opacity before shader construction

### DIFF
--- a/documents/Specification/MaterialX.PBRSpec.md
+++ b/documents/Specification/MaterialX.PBRSpec.md
@@ -1008,7 +1008,7 @@ If the `edf` input is left unconnected, no emission will occur from the surface.
 |`thin_walled`|Set to true to make the surface thin-walled   |boolean      |false   |
 |`out`        |Output: the computed surface shader           |surfaceshader|        |
 
-In the equations below, the `bsdf` input corresponds to $f$, the `edf` input corresponds to $L_e$, and the `opacity` input corresponds to $O$.
+In the equations below, the `bsdf` input corresponds to $f$, the `edf` input corresponds to $L_e$, and the cutout opacity is $O = \mathrm{clamp}(\mathrm{opacity}, 0, 1)$. Input values below 0 are treated as 0, and input values above 1 are treated as 1, before the surface shader is constructed.
 
 #### Surface Shading Equation
 

--- a/libraries/pbrlib/pbrlib_defs.mtlx
+++ b/libraries/pbrlib/pbrlib_defs.mtlx
@@ -243,7 +243,7 @@
   <nodedef name="ND_surface" node="surface" nodegroup="pbr" doc="A constructor node for the surfaceshader type.">
     <input name="bsdf" type="BSDF" value="" doc="Distribution function for surface scattering." />
     <input name="edf" type="EDF" value="" doc="Distribution function for surface emission." />
-    <input name="opacity" type="float" value="1.0" doc="Surface cutout opacity" />
+    <input name="opacity" type="float" value="1.0" uimin="0.0" uimax="1.0" doc="Surface cutout opacity, clamped to the range [0, 1]." />
     <input name="thin_walled" type="boolean" value="false" uniform="true" doc="Option to make the surface thin-walled." />
     <output name="out" type="surfaceshader" />
   </nodedef>

--- a/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
+++ b/source/MaterialXGenHw/Nodes/HwSurfaceNode.cpp
@@ -135,8 +135,9 @@ void HwSurfaceNode::emitFunctionCall(const ShaderNode& node, GenContext& context
             if (const ShaderNode* bsdf = bsdfInput->getConnectedSibling())
             {
                 shadergen.emitLineBegin(stage);
-                shadergen.emitString("float surfaceOpacity = ", stage);
+                shadergen.emitString("float surfaceOpacity = clamp(", stage);
                 shadergen.emitInput(node.getInput(getOpacityInputName()), context, stage);
+                shadergen.emitString(", 0.0, 1.0)", stage);
                 shadergen.emitLineEnd(stage);
                 shadergen.emitLineBreak(stage);
 

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_6.mdl
@@ -612,7 +612,7 @@ export material mx_surface(
     ior: mxp_transmission_ior > 0.0 ? color(mxp_transmission_ior) : mxp_bsdf.ior,
     volume: bsdf_volume,
     geometry: material_geometry(
-        cutout_opacity: mxp_opacity
+        cutout_opacity: math::clamp(mxp_opacity, 0.0, 1.0)
     )
 );
 

--- a/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_9.mdl
+++ b/source/MaterialXGenMdl/mdl/materialx/pbrlib_1_9.mdl
@@ -389,6 +389,6 @@ export material mx_surface(
     ior: mxp_transmission_ior > 0.0 ? color(mxp_transmission_ior) : mxp_bsdf.ior,
     volume: bsdf_volume,
     geometry: material_geometry(
-        cutout_opacity: mxp_opacity
+        cutout_opacity: math::clamp(mxp_opacity, 0.0, 1.0)
     )
 );

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -100,6 +100,48 @@ TEST_CASE("GenShader: GLSL Unique Names", "[genglsl]")
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
+TEST_CASE("GenShader: GLSL Surface Opacity Clamp", "[genglsl]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr doc = mx::createDocument();
+    loadLibraries({ "libraries" }, searchPath, doc);
+
+    mx::NodeDefPtr bsdfDef = doc->getNodeDef("ND_oren_nayar_diffuse_bsdf");
+    mx::NodeDefPtr surfaceDef = doc->getNodeDef("ND_surface");
+    mx::NodeDefPtr mixDef = doc->getNodeDef("ND_mix_surfaceshader");
+    REQUIRE(bsdfDef != nullptr);
+    REQUIRE(surfaceDef != nullptr);
+    REQUIRE(mixDef != nullptr);
+
+    mx::NodePtr bsdf = doc->addNodeInstance(bsdfDef, "diffuse");
+
+    mx::NodePtr background = doc->addNodeInstance(surfaceDef, "background");
+    background->setConnectedNode("bsdf", bsdf);
+    background->setInputValue("opacity", 0.2f);
+
+    mx::NodePtr foreground = doc->addNodeInstance(surfaceDef, "foreground");
+    foreground->setConnectedNode("bsdf", bsdf);
+    foreground->setInputValue("opacity", 2.0f);
+
+    mx::NodePtr mix = doc->addNodeInstance(mixDef, "surface_mix");
+    mix->setConnectedNode("bg", background);
+    mix->setConnectedNode("fg", foreground);
+    mix->setInputValue("mix", 0.25f);
+
+    REQUIRE(doc->validate());
+
+    mx::GenContext context(mx::GlslShaderGenerator::create());
+    context.registerSourceCodeSearchPath(searchPath);
+    mx::ShaderPtr shader = context.getShaderGenerator().generate(mix->getName(), mix, context);
+    REQUIRE(shader != nullptr);
+
+    const std::string sourceCode = shader->getSourceCode(mx::Stage::PIXEL);
+    const std::string opacityClamp = "float surfaceOpacity = clamp(";
+    const size_t firstClamp = sourceCode.find(opacityClamp);
+    REQUIRE(firstClamp != std::string::npos);
+    REQUIRE(sourceCode.find(opacityClamp, firstClamp + opacityClamp.size()) != std::string::npos);
+}
+
 TEST_CASE("GenShader: GLSL Light Shaders", "[genglsl]")
 {
     mx::DocumentPtr doc = mx::createDocument();

--- a/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
+++ b/source/MaterialXTest/MaterialXGenGlsl/GenGlsl.cpp
@@ -100,48 +100,6 @@ TEST_CASE("GenShader: GLSL Unique Names", "[genglsl]")
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
-TEST_CASE("GenShader: GLSL Surface Opacity Clamp", "[genglsl]")
-{
-    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
-    mx::DocumentPtr doc = mx::createDocument();
-    loadLibraries({ "libraries" }, searchPath, doc);
-
-    mx::NodeDefPtr bsdfDef = doc->getNodeDef("ND_oren_nayar_diffuse_bsdf");
-    mx::NodeDefPtr surfaceDef = doc->getNodeDef("ND_surface");
-    mx::NodeDefPtr mixDef = doc->getNodeDef("ND_mix_surfaceshader");
-    REQUIRE(bsdfDef != nullptr);
-    REQUIRE(surfaceDef != nullptr);
-    REQUIRE(mixDef != nullptr);
-
-    mx::NodePtr bsdf = doc->addNodeInstance(bsdfDef, "diffuse");
-
-    mx::NodePtr background = doc->addNodeInstance(surfaceDef, "background");
-    background->setConnectedNode("bsdf", bsdf);
-    background->setInputValue("opacity", 0.2f);
-
-    mx::NodePtr foreground = doc->addNodeInstance(surfaceDef, "foreground");
-    foreground->setConnectedNode("bsdf", bsdf);
-    foreground->setInputValue("opacity", 2.0f);
-
-    mx::NodePtr mix = doc->addNodeInstance(mixDef, "surface_mix");
-    mix->setConnectedNode("bg", background);
-    mix->setConnectedNode("fg", foreground);
-    mix->setInputValue("mix", 0.25f);
-
-    REQUIRE(doc->validate());
-
-    mx::GenContext context(mx::GlslShaderGenerator::create());
-    context.registerSourceCodeSearchPath(searchPath);
-    mx::ShaderPtr shader = context.getShaderGenerator().generate(mix->getName(), mix, context);
-    REQUIRE(shader != nullptr);
-
-    const std::string sourceCode = shader->getSourceCode(mx::Stage::PIXEL);
-    const std::string opacityClamp = "float surfaceOpacity = clamp(";
-    const size_t firstClamp = sourceCode.find(opacityClamp);
-    REQUIRE(firstClamp != std::string::npos);
-    REQUIRE(sourceCode.find(opacityClamp, firstClamp + opacityClamp.size()) != std::string::npos);
-}
-
 TEST_CASE("GenShader: GLSL Light Shaders", "[genglsl]")
 {
     mx::DocumentPtr doc = mx::createDocument();


### PR DESCRIPTION
The PBR specification defines surface cutout opacity \(O\) over the range `[0, 1]`, but does not specify how values outside that range are handled.

Consider this shader:

```xml
<?xml version="1.0"?>
<materialx version="1.39">
  <oren_nayar_diffuse_bsdf name="diffuse" type="BSDF" />

  <surface name="background" type="surfaceshader">
    <input name="bsdf" type="BSDF" nodename="diffuse" />
    <input name="opacity" type="float" value="0.2" />
  </surface>

  <surface name="foreground" type="surfaceshader">
    <input name="bsdf" type="BSDF" nodename="diffuse" />
    <input name="opacity" type="float" value="2.0" />
  </surface>

  <mix name="surface_mix" type="surfaceshader">
    <input name="bg" type="surfaceshader" nodename="background" />
    <input name="fg" type="surfaceshader" nodename="foreground" />
    <input name="mix" type="float" value="0.25" />
  </mix>

  <surfacematerial name="material" type="material">
    <input
      name="surfaceshader"
      type="surfaceshader"
      nodename="surface_mix"
    />
  </surfacematerial>
</materialx>
```

OSL clamps opacity at each leaf surface, giving:

`mix(clamp(0.2, 0, 1), clamp(2.0, 0, 1), 0.25) = 0.4`

GLSL and MDL effectively clamp only the final result, giving:

`clamp(mix(0.2, 2.0, 0.25), 0, 1) = 0.65`

Clamping at each `surface` node is preferable because opacity represents coverage in `[0, 1]`. A surface with opacity `2.0` has no meaningful coverage interpretation, and allowing that invalid value to participate in later surface operations can produce valid-looking but unintuitive downstream results.

This PR:

- Defines the cutout opacity as `O = clamp(opacity, 0, 1)` before the surface shader is constructed.
- Adds matching `[0, 1]` UI bounds and documentation to `ND_surface`.
- Applies the clamp in the common hardware implementation used by GLSL, MSL, and Slang.
- Applies the same behavior to the MDL implementation, aligning it with the existing OSL behavior.

If clamping is not the intended policy, the specification should instead explicitly declare out-of-range opacity inputs undefined. In either case, the current disagreement between backends should be resolved or documented.