### PR TITLE
Preserve opacity correlation in surface shader mixes

### DIFF
--- a/documents/Specification/MaterialX.StandardNodes.md
+++ b/documents/Specification/MaterialX.StandardNodes.md
@@ -2380,6 +2380,13 @@ The scalar signature displaces along the surface normal direction, while the vec
 ### `mix`
 A linear blend between two surface/displacement/volumeshader closures.
 
+For surface shaders, `mix` linearly blends the opacity-scaled BSDF and EDF
+contributions defined by the
+[Surface Shading Equation](./MaterialX.PBRSpec.md#surface-shading-equation). The
+output opacity is the linear blend of the input opacities. Implementations that
+store the BSDF and EDF separately from opacity must divide the blended
+contributions by the output opacity when it is nonzero.
+
 |Port  |Description                                           |Type         |Default|
 |------|------------------------------------------------------|-------------|-------|
 |`bg`  |The background surface closure                        |surfaceshader|       |

--- a/libraries/stdlib/genosl/mx_mix_surfaceshader.osl
+++ b/libraries/stdlib/genosl/mx_mix_surfaceshader.osl
@@ -1,6 +1,8 @@
 void mx_mix_surfaceshader(surfaceshader fg, surfaceshader bg, float w, output surfaceshader result)
 {
-    result.bsdf = mix(bg.bsdf, fg.bsdf, w);
-    result.edf = mix(bg.edf, fg.edf, w);
     result.opacity = mix(bg.opacity, fg.opacity, w);
+    // Condition the represented surface response on the interaction not being cut out.
+    float conditional_mix = result.opacity > 0.0 ? w * fg.opacity / result.opacity : 0.0;
+    result.bsdf = mix(bg.bsdf, fg.bsdf, conditional_mix);
+    result.edf = mix(bg.edf, fg.edf, conditional_mix);
 }


### PR DESCRIPTION
While comparing surface opacity handling between GLSL and OSL, I found that
OSL mixes the surface closure and its cutout opacity independently. I don't
think this is correct: a fully cutout surface should not contribute either
scattering or emission.

Consider this shader:

```xml
<?xml version="1.0"?>
<materialx version="1.39">
  <surface_unlit name="opaque_red" type="surfaceshader">
    <input name="emission" type="float" value="1.0" />
    <input name="emission_color" type="color3" value="1.0, 0.0, 0.0" />
    <input name="opacity" type="float" value="1.0" />
  </surface_unlit>

  <surface_unlit name="cutout_blue" type="surfaceshader">
    <input name="emission" type="float" value="1.0" />
    <input name="emission_color" type="color3" value="0.0, 0.0, 1.0" />
    <input name="opacity" type="float" value="0.0" />
  </surface_unlit>

  <mix name="mixed_surface" type="surfaceshader">
    <input name="bg" type="surfaceshader" nodename="opaque_red" />
    <input name="fg" type="surfaceshader" nodename="cutout_blue" />
    <input name="mix" type="float" value="0.5" />
  </mix>

  <surfacematerial name="material" type="material">
    <input name="surfaceshader" type="surfaceshader" nodename="mixed_surface" />
  </surfacematerial>
</materialx>
```

This mixes an opaque red emissive surface with a fully cutout blue emissive
surface. The result should have opacity `0.5` and opacity-weighted emission
`(0.5, 0, 0)`.

The current OSL implementation first mixes the emission to purple, and
separately mixes the opacity to `0.5`. Applying that opacity gives
`(0.25, 0, 0.25)`, so the blue surface still emits despite being fully cutout.
GLSL already gives the expected result because `surface_unlit` premultiplies
the surface color by opacity before the mix.

I believe surface shader mixing should follow the same semantics as mixing
premultiplied-alpha colors. OSL stores the closure separately from opacity,
effectively in straight-alpha form, so the mixed closure needs to be
unpremultiplied by the mixed opacity before it is stored. In the example
above, the fully cutout blue surface therefore gets no closure weight.

This PR clarifies the behavior of `mix` for surface shaders in the standard
node specification and fixes the OSL BSDF and EDF mixing accordingly. I did
not change the hardware implementation, as it already has the intended
premultiplied behavior.

The MDL target also keeps cutout opacity separate from the represented
material response, so it may have the same issue. I will discuss with our MDL
guys to see what to do about it.