### PR TITLE
Fix prefilter env tangent-frame seam and add mx_isinf wrapper

### DIFF
--- a/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
+++ b/libraries/pbrlib/genglsl/lib/mx_generate_prefilter_env.glsl
@@ -29,7 +29,13 @@ vec3 mx_generate_prefilter_env()
     // Compute derived properties.
     vec2 uv = gl_FragCoord.xy * pow(2.0, $envPrefilterMip) / vec2(textureSize($envRadianceSampler2D, 0));
     vec3 worldN = mx_latlong_map_projection_inverse(uv);
-    mat3 tangentToWorld = mx_orthonormal_basis(worldN);
+
+    // Build a continuous tangent frame from the latlong parameterization,
+    // avoiding the tangent-frame flip in mx_orthonormal_basis at N.z == 0.
+    float longitude = (uv.x - 0.5) * M_PI * 2.0;
+    vec3 T = normalize(vec3(-mx_cos(longitude), 0.0, -mx_sin(longitude)));
+    vec3 B = cross(worldN, T);
+    mat3 tangentToWorld = mat3(T, B, worldN);
     float alpha = mx_latlong_lod_to_alpha(float($envPrefilterMip));
     float G1V = mx_ggx_smith_G1(NdotV, alpha);
 

--- a/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
+++ b/libraries/pbrlib/genglsl/mx_chiang_hair_bsdf.glsl
@@ -145,7 +145,7 @@ float mx_hair_azimuthal_scattering(  // Np
         return float(0.5 / M_PI);
 
     float dphi = phi - mx_hair_phi(p, gammaO, gammaT);
-    if (isinf(dphi))
+    if (mx_isinf(dphi))
         return float(0.5 / M_PI);
 
     while (dphi > M_PI)    dphi -= (2.0 * M_PI);

--- a/libraries/stdlib/genglsl/lib/mx_math.glsl
+++ b/libraries/stdlib/genglsl/lib/mx_math.glsl
@@ -13,6 +13,8 @@
 #define mx_radians radians
 #define mx_float_bits_to_int floatBitsToInt
 
+bool mx_isinf(float x) { return isinf(x); }
+
 vec2 mx_matrix_mul(vec2 v, mat2 m) { return v * m; }
 vec3 mx_matrix_mul(vec3 v, mat3 m) { return v * m; }
 vec4 mx_matrix_mul(vec4 v, mat4 m) { return v * m; }

--- a/libraries/stdlib/genmsl/lib/mx_math.metal
+++ b/libraries/stdlib/genmsl/lib/mx_math.metal
@@ -6,6 +6,7 @@
 #define mx_tan metal::tan
 #define mx_asin metal::asin
 #define mx_acos metal::acos
+#define mx_isinf metal::isinf
 #define mx_float_bits_to_int as_type<int>
 
 float2 mx_matrix_mul(float2 v, float2x2 m) { return v * m; }

--- a/libraries/stdlib/genslang/lib/mx_math.slang
+++ b/libraries/stdlib/genslang/lib/mx_math.slang
@@ -7,6 +7,7 @@
 #define mx_asin asin
 #define mx_acos acos
 #define mx_radians radians
+#define mx_isinf isinf
 #define mx_float_bits_to_int asint
 
 /// The GLSL we are piggybacking on has all its matrices transposed compared to Slang and the MaterialX spec.


### PR DESCRIPTION
Fixes a tangent-frame seam in mx_generate_prefilter_env by building the frame from the latlong parameterization instead of calling mx_orthonormal_basis, which flips discontinuously where N.z crosses zero at longitude ±90°.

Also adds an mx_isinf wrapper to the GLSL/MSL/Slang math libraries and updates mx_chiang_hair_bsdf.glsl to use it. This is required because wgsl does not support it.

Validated with before/after GLSL renders using --envMethod 1 (prefiltered environment maps).
[mx_orthonormal_basis_comparison.html.pdf](https://github.com/user-attachments/files/30761472/mx_orthonormal_basis_comparison.html.pdf)
