### PR TITLE
Support the `implname` attribute during shader generation

### DIFF
--- a/libraries/bxdf/genosl/bxdf_genosl_impl.mtlx
+++ b/libraries/bxdf/genosl/bxdf_genosl_impl.mtlx
@@ -1,0 +1,145 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <!--
+    Copyright Contributors to the MaterialX Project
+    SPDX-License-Identifier: Apache-2.0
+
+    Declarations for OSL implementations of the physically based shading nodes.
+
+    Each nodedef below is implemented by a nodegraph that is shared by every
+    target, so the port names that clash with OSL reserved words cannot be
+    remapped on that nodegraph. These target specific implementation elements
+    reference the same nodegraph and remap those names for OSL only.
+  -->
+
+  <implementation name="IM_disney_principled_genosl" nodedef="ND_disney_principled" nodegraph="NG_disney_principled" target="genosl">
+    <input name="sheen" type="float" implname="sheen_value" />
+    <input name="subsurface" type="float" implname="subsurface_value" />
+  </implementation>
+
+  <implementation name="IM_UsdPreviewSurface_surfaceshader_genosl" nodedef="ND_UsdPreviewSurface_surfaceshader" nodegraph="IMP_UsdPreviewSurface_surfaceshader" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_standard_surface_surfaceshader_genosl" nodedef="ND_standard_surface_surfaceshader" nodegraph="NG_standard_surface_surfaceshader_100" target="genosl">
+    <input name="subsurface" type="float" implname="subsurface_value" />
+    <input name="sheen" type="float" implname="sheen_value" />
+    <input name="emission" type="float" implname="emission_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_standard_surface_surfaceshader_100_genosl" nodedef="ND_standard_surface_surfaceshader_100" nodegraph="NG_standard_surface_surfaceshader_100" target="genosl">
+    <input name="subsurface" type="float" implname="subsurface_value" />
+    <input name="sheen" type="float" implname="sheen_value" />
+    <input name="emission" type="float" implname="emission_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_pbr_surfaceshader_genosl" nodedef="ND_gltf_pbr_surfaceshader" nodegraph="IMPL_gltf_pbr_surfaceshader" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_colorimage_genosl" nodedef="ND_gltf_colorimage" nodegraph="NG_gltf_colorimage" target="genosl">
+    <input name="default" type="color4" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+    <input name="color" type="color4" implname="color_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_image_color3_color3_1_0_genosl" nodedef="ND_gltf_image_color3_color3_1_0" nodegraph="NG_NG_gltf_image_color3_color3_1_0" target="genosl">
+    <input name="default" type="color3" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_image_color4_color4_1_0_genosl" nodedef="ND_gltf_image_color4_color4_1_0" nodegraph="NG_gltf_image_color4_color4_1_0" target="genosl">
+    <input name="default" type="color4" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_image_float_float_1_0_genosl" nodedef="ND_gltf_image_float_float_1_0" nodegraph="NG_gltf_image_float_float_1_0" target="genosl">
+    <input name="default" type="float" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_image_vector3_vector3_1_0_genosl" nodedef="ND_gltf_image_vector3_vector3_1_0" nodegraph="NG_gltf_image_vector3_vector3_1_0" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_normalmap_vector3_1_0_genosl" nodedef="ND_gltf_normalmap_vector3_1_0" nodegraph="NG_gltf_normalmap_vector3_1_0" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_iridescence_thickness_float_1_0_genosl" nodedef="ND_gltf_iridescence_thickness_float_1_0" nodegraph="NG_gltf_iridescence_thickness_float_1_0" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_gltf_anisotropy_image_genosl" nodedef="ND_gltf_anisotropy_image" nodegraph="NG_gltf_anisotropy_image_1_0" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_standard_surface_to_open_pbr_surface_genosl" nodedef="ND_standard_surface_to_open_pbr_surface" nodegraph="NG_standard_surface_to_open_pbr_surface" target="genosl">
+    <input name="subsurface" type="float" implname="subsurface_value" />
+    <input name="sheen" type="float" implname="sheen_value" />
+    <input name="emission" type="float" implname="emission_value" />
+  </implementation>
+
+  <implementation name="IM_standard_surface_to_UsdPreviewSurface_genosl" nodedef="ND_standard_surface_to_UsdPreviewSurface" nodegraph="NG_standard_surface_to_UsdPreviewSurface" target="genosl">
+    <input name="subsurface" type="float" implname="subsurface_value" />
+    <input name="emission" type="float" implname="emission_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_standard_surface_to_gltf_pbr_genosl" nodedef="ND_standard_surface_to_gltf_pbr" nodegraph="NG_standard_surface_to_gltf_pbr" target="genosl">
+    <input name="sheen" type="float" implname="sheen_value" />
+    <input name="emission" type="float" implname="emission_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_sheen_genosl" nodedef="ND_lama_sheen" nodegraph="IMPL_lama_sheen" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_sss_genosl" nodedef="ND_lama_sss" nodegraph="IMPL_lama_sss" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_dielectric_genosl" nodedef="ND_lama_dielectric" nodegraph="IMPL_lama_dielectric" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_diffuse_genosl" nodedef="ND_lama_diffuse" nodegraph="NG_lama_diffuse" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_mix_bsdf_genosl" nodedef="ND_lama_mix_bsdf" nodegraph="NG_lama_mix_bsdf" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+
+  <implementation name="IM_lama_mix_edf_genosl" nodedef="ND_lama_mix_edf" nodegraph="NG_lama_mix_edf" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+
+  <implementation name="IM_lama_conductor_genosl" nodedef="ND_lama_conductor" nodegraph="IMPL_lama_conductor" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_emission_genosl" nodedef="ND_lama_emission" nodegraph="IMPL_lama_emission" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+  </implementation>
+
+  <implementation name="IM_lama_generalized_schlick_genosl" nodedef="ND_lama_generalized_schlick" nodegraph="IMPL_lama_generalized_schlick" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_lama_translucent_genosl" nodedef="ND_lama_translucent" nodegraph="NG_lama_translucent" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+</materialx>

--- a/libraries/nprlib/genosl/nprlib_genosl_impl.mtlx
+++ b/libraries/nprlib/genosl/nprlib_genosl_impl.mtlx
@@ -14,4 +14,16 @@
   <!-- <viewdirection> -->
   <implementation name="IM_viewdirection_vector3_genosl" nodedef="ND_viewdirection_vector3" sourcecode="transform({{space}}, I)" target="genosl" />
 
+  <!-- ======================================================================== -->
+  <!-- Nodes with a nodegraph implementation                                    -->
+  <!--                                                                          -->
+  <!-- These nodedefs are implemented by a nodegraph shared by every target, so  -->
+  <!-- the port names that clash with OSL reserved words are remapped here.      -->
+  <!-- ======================================================================== -->
+
+  <implementation name="IM_facingratio_float_genosl" nodedef="ND_facingratio_float" nodegraph="NG_facingratio_float" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+    <input name="faceforward" type="boolean" implname="faceforward_value" />
+  </implementation>
+
 </materialx>

--- a/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
+++ b/libraries/pbrlib/genosl/pbrlib_genosl_impl.mtlx
@@ -2,37 +2,62 @@
 <materialx version="1.39">
 
   <!-- <oren_nayar_diffuse_bsdf> -->
-  <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" sourcecode="{{weight}} * oren_nayar_diffuse_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl" />
+  <implementation name="IM_oren_nayar_diffuse_bsdf_genosl" nodedef="ND_oren_nayar_diffuse_bsdf" sourcecode="{{weight}} * oren_nayar_diffuse_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <burley_diffuse_bsdf> -->
-  <implementation name="IM_burley_diffuse_bsdf_genosl" nodedef="ND_burley_diffuse_bsdf" sourcecode="{{weight}} * burley_diffuse_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl" />
+  <implementation name="IM_burley_diffuse_bsdf_genosl" nodedef="ND_burley_diffuse_bsdf" sourcecode="{{weight}} * burley_diffuse_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <translucent_bsdf> -->
-  <implementation name="IM_translucent_bsdf_genosl" nodedef="ND_translucent_bsdf" sourcecode="{{weight}} * translucent_bsdf({{normal}}, {{color}})" target="genosl" />
+  <implementation name="IM_translucent_bsdf_genosl" nodedef="ND_translucent_bsdf" sourcecode="{{weight}} * translucent_bsdf({{normal}}, {{color}})" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <dielectric_bsdf> -->
-  <implementation name="IM_dielectric_bsdf_genosl" nodedef="ND_dielectric_bsdf" file="mx_dielectric_bsdf.osl" function="mx_dielectric_bsdf" target="genosl" />
+  <implementation name="IM_dielectric_bsdf_genosl" nodedef="ND_dielectric_bsdf" file="mx_dielectric_bsdf.osl" function="mx_dielectric_bsdf" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <conductor_bsdf> -->
-  <implementation name="IM_conductor_bsdf_genosl" nodedef="ND_conductor_bsdf" sourcecode="{{weight}} * conductor_bsdf({{normal}}, {{tangent}}, {{roughness}}.x, {{roughness}}.y, {{ior}}, {{extinction}}, {{distribution}}, &quot;thinfilm_thickness&quot;, {{thinfilm_thickness}}, &quot;thinfilm_ior&quot;, {{thinfilm_ior}})" target="genosl" />
+  <implementation name="IM_conductor_bsdf_genosl" nodedef="ND_conductor_bsdf" sourcecode="{{weight}} * conductor_bsdf({{normal}}, {{tangent}}, {{roughness}}.x, {{roughness}}.y, {{ior}}, {{extinction}}, {{distribution}}, &quot;thinfilm_thickness&quot;, {{thinfilm_thickness}}, &quot;thinfilm_ior&quot;, {{thinfilm_ior}})" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <generalized_schlick_bsdf> -->
-  <implementation name="IM_generalized_schlick_bsdf_genosl" nodedef="ND_generalized_schlick_bsdf" file="mx_generalized_schlick_bsdf.osl" function="mx_generalized_schlick_bsdf" target="genosl" />
+  <implementation name="IM_generalized_schlick_bsdf_genosl" nodedef="ND_generalized_schlick_bsdf" file="mx_generalized_schlick_bsdf.osl" function="mx_generalized_schlick_bsdf" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <subsurface_bsdf> -->
-  <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl" />
+  <implementation name="IM_subsurface_bsdf_genosl" nodedef="ND_subsurface_bsdf" file="mx_subsurface_bsdf.osl" function="mx_subsurface_bsdf" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <chiang_hair_bsdf> -->
-  <implementation name="IM_chiang_hair_bsdf_genosl" nodedef="ND_chiang_hair_bsdf" file="mx_chiang_hair_bsdf.osl" function="mx_chiang_hair_bsdf" target="genosl" />
+  <implementation name="IM_chiang_hair_bsdf_genosl" nodedef="ND_chiang_hair_bsdf" file="mx_chiang_hair_bsdf.osl" function="mx_chiang_hair_bsdf" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <sheen_bsdf> -->
-  <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" sourcecode="{{weight}} * sheen_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl" />
+  <implementation name="IM_sheen_bsdf_genosl" nodedef="ND_sheen_bsdf" sourcecode="{{weight}} * sheen_bsdf({{normal}}, {{color}}, {{roughness}})" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <anisotropic_vdf> -->
   <implementation name="IM_anisotropic_vdf_genosl" nodedef="ND_anisotropic_vdf" file="mx_anisotropic_vdf.osl" function="mx_anisotropic_vdf" target="genosl" />
 
   <!-- <uniform_edf> -->
-  <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" sourcecode="uniform_edf({{color}})" target="genosl" />
+  <implementation name="IM_uniform_edf_genosl" nodedef="ND_uniform_edf" sourcecode="uniform_edf({{color}})" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+  </implementation>
 
   <!-- <generalized_schlick_edf> -->
   <implementation name="IM_generalized_schlick_edf_genosl" nodedef="ND_generalized_schlick_edf" file="mx_generalized_schlick_edf.osl" function="mx_generalized_schlick_edf" target="genosl" />
@@ -42,8 +67,12 @@
   <implementation name="IM_layer_vdf_genosl" nodedef="ND_layer_vdf" sourcecode="layer({{top}}, {{base}})" target="genosl" />
 
   <!-- <mix> -->
-  <implementation name="IM_mix_bsdf_genosl" nodedef="ND_mix_bsdf" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" target="genosl" />
-  <implementation name="IM_mix_edf_genosl" nodedef="ND_mix_edf" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" target="genosl" />
+  <implementation name="IM_mix_bsdf_genosl" nodedef="ND_mix_bsdf" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_edf_genosl" nodedef="ND_mix_edf" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <add> -->
   <implementation name="IM_add_bsdf_genosl" nodedef="ND_add_bsdf" sourcecode="({{in1}} + {{in2}})" target="genosl" />
@@ -78,7 +107,9 @@
   <implementation name="IM_deon_hair_absorption_from_melanin_genosl" nodedef="ND_deon_hair_absorption_from_melanin" sourcecode="vector(1.0)" target="genosl" />
 
   <!-- <chiang_hair_absorption_from_color> -->
-  <implementation name="IM_chiang_hair_absorption_from_color_genosl" nodedef="ND_chiang_hair_absorption_from_color" sourcecode="vector(1.0)" target="genosl" />
+  <implementation name="IM_chiang_hair_absorption_from_color_genosl" nodedef="ND_chiang_hair_absorption_from_color" sourcecode="vector(1.0)" target="genosl">
+    <input name="color" type="color3" implname="color_value" />
+  </implementation>
 
   <!-- <chiang_hair_roughness> -->
   <implementation name="IM_chiang_hair_roughness_genosl" nodedef="ND_chiang_hair_roughness" file="mx_chiang_hair_roughness.osl" function="mx_chiang_hair_roughness" target="genosl" />

--- a/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
+++ b/libraries/stdlib/genosl/stdlib_genosl_impl.mtlx
@@ -38,10 +38,15 @@
   <!-- ======================================================================== -->
 
   <!-- <surfacematerial> -->
-  <implementation name="IM_surfacematerial_genosl" nodedef="ND_surfacematerial" file="mx_surfacematerial.osl" function="mx_surfacematerial" target="genosl" />
+  <implementation name="IM_surfacematerial_genosl" nodedef="ND_surfacematerial" file="mx_surfacematerial.osl" function="mx_surfacematerial" target="genosl">
+    <input name="surfaceshader" type="surfaceshader" implname="surfaceshader_value" />
+    <input name="displacementshader" type="displacementshader" implname="displacementshader_value" />
+  </implementation>
 
   <!-- <surface_unlit> -->
-  <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl" />
+  <implementation name="IM_surface_unlit_genosl" nodedef="ND_surface_unlit" file="mx_surface_unlit.osl" function="mx_surface_unlit" target="genosl">
+    <input name="emission" type="float" implname="emission_value" />
+  </implementation>
 
   <!-- ======================================================================== -->
   <!-- Texture nodes                                                            -->
@@ -49,21 +54,27 @@
 
   <!-- <image> -->
   <implementation name="IM_image_float_genosl" nodedef="ND_image_float" file="mx_image_float.osl" function="mx_image_float" target="genosl">
+    <input name="layer" type="string" implname="layer_value" />
     <input name="default" type="float" implname="default_value" />
   </implementation>
   <implementation name="IM_image_color3_genosl" nodedef="ND_image_color3" file="mx_image_color3.osl" function="mx_image_color3" target="genosl">
+    <input name="layer" type="string" implname="layer_value" />
     <input name="default" type="color3" implname="default_value" />
   </implementation>
   <implementation name="IM_image_color4_genosl" nodedef="ND_image_color4" file="mx_image_color4.osl" function="mx_image_color4" target="genosl">
+    <input name="layer" type="string" implname="layer_value" />
     <input name="default" type="color4" implname="default_value" />
   </implementation>
   <implementation name="IM_image_vector2_genosl" nodedef="ND_image_vector2" file="mx_image_vector2.osl" function="mx_image_vector2" target="genosl">
+    <input name="layer" type="string" implname="layer_value" />
     <input name="default" type="vector2" implname="default_value" />
   </implementation>
   <implementation name="IM_image_vector3_genosl" nodedef="ND_image_vector3" file="mx_image_vector3.osl" function="mx_image_vector3" target="genosl">
+    <input name="layer" type="string" implname="layer_value" />
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
   <implementation name="IM_image_vector4_genosl" nodedef="ND_image_vector4" file="mx_image_vector4.osl" function="mx_image_vector4" target="genosl">
+    <input name="layer" type="string" implname="layer_value" />
     <input name="default" type="vector4" implname="default_value" />
   </implementation>
 
@@ -78,11 +89,16 @@
   <!-- <triplanarprojection> -->
 
   <!-- <normalmap> -->
-  <implementation name="IM_normalmap_float_genosl" nodedef="ND_normalmap_float" file="mx_normalmap.osl" function="mx_normalmap_float" target="genosl" />
-  <implementation name="IM_normalmap_vector2_genosl" nodedef="ND_normalmap_vector2" file="mx_normalmap.osl" function="mx_normalmap_vector2" target="genosl" />
+  <implementation name="IM_normalmap_float_genosl" nodedef="ND_normalmap_float" file="mx_normalmap.osl" function="mx_normalmap_float" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+  <implementation name="IM_normalmap_vector2_genosl" nodedef="ND_normalmap_vector2" file="mx_normalmap.osl" function="mx_normalmap_vector2" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <hextilednormalmap> -->
   <implementation name="IM_hextilednormalmap_vector3_genosl" nodedef="ND_hextilednormalmap_vector3" file="mx_hextilednormalmap_vector3.osl" function="mx_hextilednormalmap_vector3" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
     <input name="default" type="vector3" implname="default_value" />
   </implementation>
 
@@ -177,10 +193,14 @@
   <implementation name="IM_worleynoise3d_vector3_genosl" nodedef="ND_worleynoise3d_vector3" file="mx_worleynoise3d_vector3.osl" function="mx_worleynoise3d_vector3" target="genosl" />
 
   <!-- <flake2d> -->
-  <implementation name="IM_flake2d_genosl" nodedef="ND_flake2d" file="mx_flake2d.osl" function="mx_flake2d" target="genosl" />
+  <implementation name="IM_flake2d_genosl" nodedef="ND_flake2d" file="mx_flake2d.osl" function="mx_flake2d" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- <flake3d> -->
-  <implementation name="IM_flake3d_genosl" nodedef="ND_flake3d" file="mx_flake3d.osl" function="mx_flake3d" target="genosl" />
+  <implementation name="IM_flake3d_genosl" nodedef="ND_flake3d" file="mx_flake3d.osl" function="mx_flake3d" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
 
   <!-- ======================================================================== -->
   <!-- Geometric nodes                                                          -->
@@ -208,18 +228,38 @@
   <implementation name="IM_geomcolor_color4_genosl" nodedef="ND_geomcolor_color4" file="mx_geomcolor_color4.osl" function="mx_geomcolor_color4" target="genosl" />
 
   <!-- <geompropvalue> -->
-  <implementation name="IM_geompropvalue_integer_genosl" nodedef="ND_geompropvalue_integer" file="mx_geompropvalue_integer.osl" function="mx_geompropvalue_integer" target="genosl" />
-  <implementation name="IM_geompropvalue_boolean_genosl" nodedef="ND_geompropvalue_boolean" file="mx_geompropvalue_boolean.osl" function="mx_geompropvalue_boolean" target="genosl" />
-  <implementation name="IM_geompropvalue_float_genosl" nodedef="ND_geompropvalue_float" file="mx_geompropvalue_float.osl" function="mx_geompropvalue_float" target="genosl" />
-  <implementation name="IM_geompropvalue_color3_genosl" nodedef="ND_geompropvalue_color3" file="mx_geompropvalue_color3.osl" function="mx_geompropvalue_color" target="genosl" />
-  <implementation name="IM_geompropvalue_color4_genosl" nodedef="ND_geompropvalue_color4" file="mx_geompropvalue_color4.osl" function="mx_geompropvalue_color4" target="genosl" />
-  <implementation name="IM_geompropvalue_vector2_genosl" nodedef="ND_geompropvalue_vector2" file="mx_geompropvalue_vector2.osl" function="mx_geompropvalue_vector2" target="genosl" />
-  <implementation name="IM_geompropvalue_vector3_genosl" nodedef="ND_geompropvalue_vector3" file="mx_geompropvalue_vector3.osl" function="mx_geompropvalue_vector" target="genosl" />
-  <implementation name="IM_geompropvalue_vector4_genosl" nodedef="ND_geompropvalue_vector4" file="mx_geompropvalue_vector4.osl" function="mx_geompropvalue_vector4" target="genosl" />
+  <implementation name="IM_geompropvalue_integer_genosl" nodedef="ND_geompropvalue_integer" file="mx_geompropvalue_integer.osl" function="mx_geompropvalue_integer" target="genosl">
+    <input name="default" type="integer" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_boolean_genosl" nodedef="ND_geompropvalue_boolean" file="mx_geompropvalue_boolean.osl" function="mx_geompropvalue_boolean" target="genosl">
+    <input name="default" type="boolean" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_float_genosl" nodedef="ND_geompropvalue_float" file="mx_geompropvalue_float.osl" function="mx_geompropvalue_float" target="genosl">
+    <input name="default" type="float" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_color3_genosl" nodedef="ND_geompropvalue_color3" file="mx_geompropvalue_color3.osl" function="mx_geompropvalue_color" target="genosl">
+    <input name="default" type="color3" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_color4_genosl" nodedef="ND_geompropvalue_color4" file="mx_geompropvalue_color4.osl" function="mx_geompropvalue_color4" target="genosl">
+    <input name="default" type="color4" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_vector2_genosl" nodedef="ND_geompropvalue_vector2" file="mx_geompropvalue_vector2.osl" function="mx_geompropvalue_vector2" target="genosl">
+    <input name="default" type="vector2" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_vector3_genosl" nodedef="ND_geompropvalue_vector3" file="mx_geompropvalue_vector3.osl" function="mx_geompropvalue_vector" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_vector4_genosl" nodedef="ND_geompropvalue_vector4" file="mx_geompropvalue_vector4.osl" function="mx_geompropvalue_vector4" target="genosl">
+    <input name="default" type="vector4" implname="default_value" />
+  </implementation>
 
   <!-- <geompropvalueuniform> -->
-  <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalueuniform_string" file="mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl" />
-  <implementation name="IM_geompropvalue_filename_genosl" nodedef="ND_geompropvalueuniform_filename" file="mx_geompropvalue_filename.osl" function="mx_geompropvalue_filename" target="genosl" />
+  <implementation name="IM_geompropvalue_string_genosl" nodedef="ND_geompropvalueuniform_string" file="mx_geompropvalue_string.osl" function="mx_geompropvalue_string" target="genosl">
+    <input name="default" type="string" implname="default_value" />
+  </implementation>
+  <implementation name="IM_geompropvalue_filename_genosl" nodedef="ND_geompropvalueuniform_filename" file="mx_geompropvalue_filename.osl" function="mx_geompropvalue_filename" target="genosl">
+    <input name="default" type="filename" implname="default_value" />
+  </implementation>
 
   <!-- ======================================================================== -->
   <!-- Application nodes                                                        -->
@@ -571,52 +611,100 @@
   <implementation name="IM_unpremult_color4_genosl" nodedef="ND_unpremult_color4" file="mx_unpremult_color4.osl" function="mx_unpremult_color4" target="genosl" />
 
   <!-- <plus> -->
-  <implementation name="IM_plus_float_genosl" nodedef="ND_plus_float" target="genosl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_plus_color3_genosl" nodedef="ND_plus_color3" target="genosl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_plus_color4_genosl" nodedef="ND_plus_color4" target="genosl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
+  <implementation name="IM_plus_float_genosl" nodedef="ND_plus_float" target="genosl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_plus_color3_genosl" nodedef="ND_plus_color3" target="genosl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_plus_color4_genosl" nodedef="ND_plus_color4" target="genosl" sourcecode="({{mix}}*({{bg}} + {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <minus> -->
-  <implementation name="IM_minus_float_genosl" nodedef="ND_minus_float" target="genosl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_minus_color3_genosl" nodedef="ND_minus_color3" target="genosl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_minus_color4_genosl" nodedef="ND_minus_color4" target="genosl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
+  <implementation name="IM_minus_float_genosl" nodedef="ND_minus_float" target="genosl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_minus_color3_genosl" nodedef="ND_minus_color3" target="genosl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_minus_color4_genosl" nodedef="ND_minus_color4" target="genosl" sourcecode="({{mix}}*({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <difference> -->
-  <implementation name="IM_difference_float_genosl" nodedef="ND_difference_float" target="genosl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_difference_color3_genosl" nodedef="ND_difference_color3" target="genosl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_difference_color4_genosl" nodedef="ND_difference_color4" target="genosl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})" />
+  <implementation name="IM_difference_float_genosl" nodedef="ND_difference_float" target="genosl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_difference_color3_genosl" nodedef="ND_difference_color3" target="genosl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_difference_color4_genosl" nodedef="ND_difference_color4" target="genosl" sourcecode="({{mix}}*abs({{bg}} - {{fg}})) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <burn> -->
-  <implementation name="IM_burn_float_genosl" nodedef="ND_burn_float" file="mx_burn_float.osl" function="mx_burn_float" target="genosl" />
-  <implementation name="IM_burn_color3_genosl" nodedef="ND_burn_color3" file="mx_burn_color3.osl" function="mx_burn_color3" target="genosl" />
-  <implementation name="IM_burn_color4_genosl" nodedef="ND_burn_color4" file="mx_burn_color4.osl" function="mx_burn_color4" target="genosl" />
+  <implementation name="IM_burn_float_genosl" nodedef="ND_burn_float" file="mx_burn_float.osl" function="mx_burn_float" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_burn_color3_genosl" nodedef="ND_burn_color3" file="mx_burn_color3.osl" function="mx_burn_color3" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_burn_color4_genosl" nodedef="ND_burn_color4" file="mx_burn_color4.osl" function="mx_burn_color4" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <dodge> -->
-  <implementation name="IM_dodge_float_genosl" nodedef="ND_dodge_float" file="mx_dodge_float.osl" function="mx_dodge_float" target="genosl" />
-  <implementation name="IM_dodge_color3_genosl" nodedef="ND_dodge_color3" file="mx_dodge_color3.osl" function="mx_dodge_color3" target="genosl" />
-  <implementation name="IM_dodge_color4_genosl" nodedef="ND_dodge_color4" file="mx_dodge_color4.osl" function="mx_dodge_color4" target="genosl" />
+  <implementation name="IM_dodge_float_genosl" nodedef="ND_dodge_float" file="mx_dodge_float.osl" function="mx_dodge_float" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_dodge_color3_genosl" nodedef="ND_dodge_color3" file="mx_dodge_color3.osl" function="mx_dodge_color3" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_dodge_color4_genosl" nodedef="ND_dodge_color4" file="mx_dodge_color4.osl" function="mx_dodge_color4" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <screen> -->
-  <implementation name="IM_screen_float_genosl" nodedef="ND_screen_float" target="genosl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_screen_color3_genosl" nodedef="ND_screen_color3" target="genosl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})" />
-  <implementation name="IM_screen_color4_genosl" nodedef="ND_screen_color4" target="genosl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})" />
+  <implementation name="IM_screen_float_genosl" nodedef="ND_screen_float" target="genosl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_screen_color3_genosl" nodedef="ND_screen_color3" target="genosl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_screen_color4_genosl" nodedef="ND_screen_color4" target="genosl" sourcecode="({{mix}}*((1.0 - (1.0 - {{fg}}) * (1 - {{bg}})))) + ((1.0-{{mix}})*{{bg}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <disjointover> -->
-  <implementation name="IM_disjointover_color4_genosl" nodedef="ND_disjointover_color4" file="mx_disjointover_color4.osl" function="mx_disjointover_color4" target="genosl" />
+  <implementation name="IM_disjointover_color4_genosl" nodedef="ND_disjointover_color4" file="mx_disjointover_color4.osl" function="mx_disjointover_color4" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <in> -->
-  <implementation name="IM_in_color4_genosl" nodedef="ND_in_color4" target="genosl" sourcecode="({{fg}}*{{bg}}.a  * {{mix}}) + ({{bg}} * (1.0-{{mix}}))" />
+  <implementation name="IM_in_color4_genosl" nodedef="ND_in_color4" target="genosl" sourcecode="({{fg}}*{{bg}}.a  * {{mix}}) + ({{bg}} * (1.0-{{mix}}))">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <mask> -->
-  <implementation name="IM_mask_color4_genosl" nodedef="ND_mask_color4" target="genosl" sourcecode="({{bg}}*{{fg}}.a  * {{mix}}) + ({{bg}} * (1.0-{{mix}}));" />
+  <implementation name="IM_mask_color4_genosl" nodedef="ND_mask_color4" target="genosl" sourcecode="({{bg}}*{{fg}}.a  * {{mix}}) + ({{bg}} * (1.0-{{mix}}));">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <matte> -->
-  <implementation name="IM_matte_color4_genosl" nodedef="ND_matte_color4" target="genosl" sourcecode="color4({{fg}}.rgb*{{fg}}.a + {{bg}}.rgb*(1.0-{{fg}}.a), {{fg}}.a + ({{bg}}.a*(1.0-{{fg}}.a)) ) * {{mix}} + ({{bg}} * (1.0-{{mix}}))" />
+  <implementation name="IM_matte_color4_genosl" nodedef="ND_matte_color4" target="genosl" sourcecode="color4({{fg}}.rgb*{{fg}}.a + {{bg}}.rgb*(1.0-{{fg}}.a), {{fg}}.a + ({{bg}}.a*(1.0-{{fg}}.a)) ) * {{mix}} + ({{bg}} * (1.0-{{mix}}))">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <out> -->
-  <implementation name="IM_out_color4_genosl" nodedef="ND_out_color4" target="genosl" sourcecode="({{fg}}*(1.0-{{bg}}.a)  * {{mix}}) + ({{bg}} * (1.0-{{mix}}))" />
+  <implementation name="IM_out_color4_genosl" nodedef="ND_out_color4" target="genosl" sourcecode="({{fg}}*(1.0-{{bg}}.a)  * {{mix}}) + ({{bg}} * (1.0-{{mix}}))">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <over> -->
-  <implementation name="IM_over_color4_genosl" nodedef="ND_over_color4" target="genosl" sourcecode="({{fg}} + ({{bg}}*(1.0-{{fg}}.a))) * {{mix}} + {{bg}} * (1.0-{{mix}})" />
+  <implementation name="IM_over_color4_genosl" nodedef="ND_over_color4" target="genosl" sourcecode="({{fg}} + ({{bg}}*(1.0-{{fg}}.a))) * {{mix}} + {{bg}} * (1.0-{{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- <inside> -->
   <implementation name="IM_inside_float_genosl" nodedef="ND_inside_float" target="genosl" sourcecode="{{in}} * {{mask}}" />
@@ -629,18 +717,42 @@
   <implementation name="IM_outside_color4_genosl" nodedef="ND_outside_color4" target="genosl" sourcecode="{{in}} * (1.0 - {{mask}})" />
 
   <!-- <mix> -->
-  <implementation name="IM_mix_float_genosl" nodedef="ND_mix_float" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color3_genosl" nodedef="ND_mix_color3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color3_color3_genosl" nodedef="ND_mix_color3_color3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color4_genosl" nodedef="ND_mix_color4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_color4_color4_genosl" nodedef="ND_mix_color4_color4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector2_genosl" nodedef="ND_mix_vector2" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector2_vector2_genosl" nodedef="ND_mix_vector2_vector2" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector3_genosl" nodedef="ND_mix_vector3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector3_vector3_genosl" nodedef="ND_mix_vector3_vector3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector4_genosl" nodedef="ND_mix_vector4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_vector4_vector4_genosl" nodedef="ND_mix_vector4_vector4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})" />
-  <implementation name="IM_mix_surfaceshader_genosl" nodedef="ND_mix_surfaceshader" file="mx_mix_surfaceshader.osl" function="mx_mix_surfaceshader" target="genosl" />
+  <implementation name="IM_mix_float_genosl" nodedef="ND_mix_float" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_color3_genosl" nodedef="ND_mix_color3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_color3_color3_genosl" nodedef="ND_mix_color3_color3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="color3" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_color4_genosl" nodedef="ND_mix_color4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_color4_color4_genosl" nodedef="ND_mix_color4_color4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="color4" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_vector2_genosl" nodedef="ND_mix_vector2" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_vector2_vector2_genosl" nodedef="ND_mix_vector2_vector2" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="vector2" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_vector3_genosl" nodedef="ND_mix_vector3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_vector3_vector3_genosl" nodedef="ND_mix_vector3_vector3" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="vector3" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_vector4_genosl" nodedef="ND_mix_vector4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_vector4_vector4_genosl" nodedef="ND_mix_vector4_vector4" target="genosl" sourcecode="mix({{bg}}, {{fg}}, {{mix}})">
+    <input name="mix" type="vector4" implname="mix_value" />
+  </implementation>
+  <implementation name="IM_mix_surfaceshader_genosl" nodedef="ND_mix_surfaceshader" file="mx_mix_surfaceshader.osl" function="mx_mix_surfaceshader" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
 
   <!-- ======================================================================== -->
   <!-- Conditional nodes                                                        -->
@@ -794,4 +906,112 @@
   <implementation name="IM_dot_displacementshader_genosl" nodedef="ND_dot_displacementshader" target="genosl" sourcecode="{{in}}" />
   <implementation name="IM_dot_volumeshader_genosl" nodedef="ND_dot_volumeshader" target="genosl" sourcecode="{{in}}" />
   <implementation name="IM_dot_lightshader_genosl" nodedef="ND_dot_lightshader" target="genosl" sourcecode="{{in}}" />
+
+  <!-- ======================================================================== -->
+  <!-- Nodes with a nodegraph implementation                                    -->
+  <!--                                                                          -->
+  <!-- These nodedefs are implemented by a nodegraph shared by every target, so  -->
+  <!-- the port names that clash with OSL reserved words are remapped here.      -->
+  <!-- ======================================================================== -->
+
+  <implementation name="IM_tiledimage_float_genosl" nodedef="ND_tiledimage_float" nodegraph="NG_tiledimage_float" target="genosl">
+    <input name="default" type="float" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_tiledimage_color3_genosl" nodedef="ND_tiledimage_color3" nodegraph="NG_tiledimage_color3" target="genosl">
+    <input name="default" type="color3" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_tiledimage_color4_genosl" nodedef="ND_tiledimage_color4" nodegraph="NG_tiledimage_color4" target="genosl">
+    <input name="default" type="color4" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_tiledimage_vector2_genosl" nodedef="ND_tiledimage_vector2" nodegraph="NG_tiledimage_vector2" target="genosl">
+    <input name="default" type="vector2" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_tiledimage_vector3_genosl" nodedef="ND_tiledimage_vector3" nodegraph="NG_tiledimage_vector3" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_tiledimage_vector4_genosl" nodedef="ND_tiledimage_vector4" nodegraph="NG_tiledimage_vector4" target="genosl">
+    <input name="default" type="vector4" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_latlongimage_genosl" nodedef="ND_latlongimage" nodegraph="NG_latlongimage" target="genosl">
+    <input name="default" type="color3" implname="default_value" />
+  </implementation>
+
+  <implementation name="IM_triplanarprojection_float_genosl" nodedef="ND_triplanarprojection_float" nodegraph="NG_triplanarprojection_float" target="genosl">
+    <input name="default" type="float" implname="default_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_triplanarprojection_color3_genosl" nodedef="ND_triplanarprojection_color3" nodegraph="NG_triplanarprojection_color3" target="genosl">
+    <input name="default" type="color3" implname="default_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_triplanarprojection_color4_genosl" nodedef="ND_triplanarprojection_color4" nodegraph="NG_triplanarprojection_color4" target="genosl">
+    <input name="default" type="color4" implname="default_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_triplanarprojection_vector2_genosl" nodedef="ND_triplanarprojection_vector2" nodegraph="NG_triplanarprojection_vector2" target="genosl">
+    <input name="default" type="vector2" implname="default_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_triplanarprojection_vector3_genosl" nodedef="ND_triplanarprojection_vector3" nodegraph="NG_triplanarprojection_vector3" target="genosl">
+    <input name="default" type="vector3" implname="default_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_triplanarprojection_vector4_genosl" nodedef="ND_triplanarprojection_vector4" nodegraph="NG_triplanarprojection_vector4" target="genosl">
+    <input name="default" type="vector4" implname="default_value" />
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_ramp_genosl" nodedef="ND_ramp" nodegraph="NG_ramp" target="genosl">
+    <input name="color4" type="color4" implname="color4_value" />
+  </implementation>
+
+  <implementation name="IM_randomfloat_float_genosl" nodedef="ND_randomfloat_float" nodegraph="NG_randomfloat_float" target="genosl">
+    <input name="min" type="float" implname="min_value" />
+    <input name="max" type="float" implname="max_value" />
+  </implementation>
+
+  <implementation name="IM_randomfloat_integer_genosl" nodedef="ND_randomfloat_integer" nodegraph="NG_randomfloat_integer" target="genosl">
+    <input name="min" type="float" implname="min_value" />
+    <input name="max" type="float" implname="max_value" />
+  </implementation>
+
+  <implementation name="IM_bump_vector3_genosl" nodedef="ND_bump_vector3" nodegraph="NG_bump_vector3" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_place2d_vector2_genosl" nodedef="ND_place2d_vector2" nodegraph="NG_place2d_vector2" target="genosl">
+    <input name="rotate" type="float" implname="rotate_value" />
+  </implementation>
+
+  <implementation name="IM_reflect_vector3_genosl" nodedef="ND_reflect_vector3" nodegraph="NG_reflect_vector3" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_refract_vector3_genosl" nodedef="ND_refract_vector3" nodegraph="NG_refract_vector3" target="genosl">
+    <input name="normal" type="vector3" implname="normal_value" />
+  </implementation>
+
+  <implementation name="IM_overlay_float_genosl" nodedef="ND_overlay_float" nodegraph="NG_overlay_float" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+
+  <implementation name="IM_overlay_color3_genosl" nodedef="ND_overlay_color3" nodegraph="NG_overlay_color3" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+
+  <implementation name="IM_overlay_color4_genosl" nodedef="ND_overlay_color4" nodegraph="NG_overlay_color4" target="genosl">
+    <input name="mix" type="float" implname="mix_value" />
+  </implementation>
+
 </materialx>

--- a/resources/Materials/TestSuite/bxdf/gltf_images.mtlx
+++ b/resources/Materials/TestSuite/bxdf/gltf_images.mtlx
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <!--
+  Unit tests for the glTF PBR image nodes that are not exercised by the
+  glTF PBR examples.
+  -->
+  <nodegraph name="gltf_image_float">
+    <gltf_image name="gltf_image1" type="float">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+      <input name="factor" type="float" value="0.5" />
+      <input name="rotate" type="float" value="45.0" />
+    </gltf_image>
+    <output name="out" type="float" nodename="gltf_image1" />
+  </nodegraph>
+  <nodegraph name="gltf_iridescence_thickness">
+    <gltf_iridescence_thickness name="gltf_iridescence_thickness1" type="float">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+      <input name="default" type="vector3" value="0.0, 0.5, 0.0" />
+      <input name="rotate" type="float" value="45.0" />
+    </gltf_iridescence_thickness>
+    <output name="out" type="float" nodename="gltf_iridescence_thickness1" />
+  </nodegraph>
+  <nodegraph name="gltf_anisotropy_image">
+    <gltf_anisotropy_image name="gltf_anisotropy_image1" type="multioutput">
+      <input name="file" type="filename" value="resources/Images/grid.png" />
+      <input name="anisotropy_strength" type="float" value="0.5" />
+      <input name="anisotropy_rotation" type="float" value="0.25" />
+    </gltf_anisotropy_image>
+    <output name="strength_out" type="float" nodename="gltf_anisotropy_image1" output="anisotropy_strength_out" />
+    <output name="rotation_out" type="float" nodename="gltf_anisotropy_image1" output="anisotropy_rotation_out" />
+  </nodegraph>
+</materialx>

--- a/resources/Materials/TestSuite/bxdf/translation.mtlx
+++ b/resources/Materials/TestSuite/bxdf/translation.mtlx
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <!--
+  Unit tests for the shader translation graphs. The shader translator adds a
+  node instance of one of these to the document being translated, so they can
+  be shader generated like any other node with a nodegraph implementation.
+  -->
+  <nodegraph name="standard_surface_to_UsdPreviewSurface">
+    <standard_surface_to_UsdPreviewSurface name="translate1" type="multioutput">
+      <input name="base_color" type="color3" value="0.8, 0.4, 0.2" />
+      <input name="specular_roughness" type="float" value="0.3" />
+      <input name="emission" type="float" value="0.5" />
+      <input name="subsurface" type="float" value="0.25" />
+    </standard_surface_to_UsdPreviewSurface>
+    <output name="diffuseColor_out" type="color3" nodename="translate1" output="diffuseColor_out" />
+    <output name="roughness_out" type="float" nodename="translate1" output="roughness_out" />
+    <output name="normal_out" type="vector3" nodename="translate1" output="normal_out" />
+  </nodegraph>
+  <nodegraph name="standard_surface_to_gltf_pbr">
+    <standard_surface_to_gltf_pbr name="translate1" type="multioutput">
+      <input name="base_color" type="color3" value="0.8, 0.4, 0.2" />
+      <input name="specular_roughness" type="float" value="0.3" />
+      <input name="emission" type="float" value="0.5" />
+      <input name="sheen" type="float" value="0.25" />
+    </standard_surface_to_gltf_pbr>
+    <output name="base_color_out" type="color3" nodename="translate1" output="base_color_out" />
+    <output name="roughness_out" type="float" nodename="translate1" output="roughness_out" />
+  </nodegraph>
+  <nodegraph name="standard_surface_to_open_pbr_surface">
+    <standard_surface_to_open_pbr_surface name="translate1" type="multioutput">
+      <input name="base_color" type="color3" value="0.8, 0.4, 0.2" />
+      <input name="specular_roughness" type="float" value="0.3" />
+      <input name="emission" type="float" value="0.5" />
+      <input name="subsurface" type="float" value="0.25" />
+    </standard_surface_to_open_pbr_surface>
+    <output name="base_color_out" type="color3" nodename="translate1" output="base_color_out" />
+    <output name="specular_roughness_out" type="float" nodename="translate1" output="specular_roughness_out" />
+  </nodegraph>
+</materialx>

--- a/resources/Materials/TestSuite/stdlib/compositing/compositing.mtlx
+++ b/resources/Materials/TestSuite/stdlib/compositing/compositing.mtlx
@@ -17,6 +17,7 @@
   - inside
   - outside
   - mix
+  - overlay
   - premult
   - unpremult
 -->
@@ -369,5 +370,29 @@
       <input name="mix" type="float" value="0.5000" />
     </matte>
     <output name="out" type="color4" nodename="matte1" />
+  </nodegraph>
+  <nodegraph name="overlay_float">
+    <overlay name="overlay1" type="float">
+      <input name="fg" type="float" value="0.4000" />
+      <input name="bg" type="float" value="0.3000" />
+      <input name="mix" type="float" value="0.5000" />
+    </overlay>
+    <output name="out" type="float" nodename="overlay1" />
+  </nodegraph>
+  <nodegraph name="overlay_color3">
+    <overlay name="overlay1" type="color3">
+      <input name="fg" type="color3" value="0.4000, 0.3000, 0.2000" />
+      <input name="bg" type="color3" value="0.3000, 0.2000, 0.1000" />
+      <input name="mix" type="float" value="0.5000" />
+    </overlay>
+    <output name="out" type="color3" nodename="overlay1" />
+  </nodegraph>
+  <nodegraph name="overlay_color4">
+    <overlay name="overlay1" type="color4">
+      <input name="fg" type="color4" value="0.4000, 0.3000, 0.2000, 1.0000" />
+      <input name="bg" type="color4" value="0.3000, 0.2000, 0.1000, 1.0000" />
+      <input name="mix" type="float" value="0.5000" />
+    </overlay>
+    <output name="out" type="color4" nodename="overlay1" />
   </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/geometric/bump.mtlx
+++ b/resources/Materials/TestSuite/stdlib/geometric/bump.mtlx
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <!--
+  Basic bump mapping unit test. The bump node perturbs the surface normal by a
+  height value, and is intended to be connected to a shader's 'normal' input.
+  -->
+  <nodegraph name="bump_vector3">
+    <fractal3d name="height" type="float">
+      <input name="octaves" type="integer" value="4" />
+    </fractal3d>
+    <bump name="bump1" type="vector3">
+      <input name="height" type="float" nodename="height" />
+      <input name="scale" type="float" value="0.1" />
+    </bump>
+    <output name="out" type="vector3" nodename="bump1" />
+  </nodegraph>
+</materialx>

--- a/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
+++ b/resources/Materials/TestSuite/stdlib/math/vector_math.mtlx
@@ -199,4 +199,11 @@
     </mincomponent>
     <output name="out" type="float" nodename="mincomponent1" />
   </nodegraph>
+  <nodegraph name="refract_vector3">
+    <refract name="refract1" type="vector3">
+      <input name="in" type="vector3" value="1.0000, 0.5000, 0.0" />
+      <input name="ior" type="float" value="1.5000" />
+    </refract>
+    <output name="out" type="vector3" nodename="refract1" />
+  </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/noise/procedural.mtlx
+++ b/resources/Materials/TestSuite/stdlib/noise/procedural.mtlx
@@ -104,4 +104,22 @@
       <input name="in2" type="vector2" value="50.0000, 50.0000" />
     </multiply>
   </nodegraph>
+  <nodegraph name="randomfloat_float">
+    <randomfloat name="randomfloat1" type="float">
+      <input name="in" type="float" value="0.5000" />
+      <input name="min" type="float" value="0.2500" />
+      <input name="max" type="float" value="0.7500" />
+      <input name="seed" type="integer" value="1" />
+    </randomfloat>
+    <output name="out" type="float" nodename="randomfloat1" />
+  </nodegraph>
+  <nodegraph name="randomfloat_integer">
+    <randomfloat name="randomfloat1" type="float">
+      <input name="in" type="integer" value="3" />
+      <input name="min" type="float" value="0.2500" />
+      <input name="max" type="float" value="0.7500" />
+      <input name="seed" type="integer" value="1" />
+    </randomfloat>
+    <output name="out" type="float" nodename="randomfloat1" />
+  </nodegraph>
 </materialx>

--- a/resources/Materials/TestSuite/stdlib/texture/latlongimage.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/latlongimage.mtlx
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<materialx version="1.39">
+  <!--
+  Basic latitude-longitude environment image unit test.
+  -->
+  <output name="latlongimage_default_output" type="color3" nodename="latlongimage_default" />
+  <latlongimage name="latlongimage_default" type="color3">
+    <input name="file" type="filename" value="resources/Images/grid.png" />
+  </latlongimage>
+  <output name="latlongimage_rotated_output" type="color3" nodename="latlongimage_rotated" />
+  <latlongimage name="latlongimage_rotated" type="color3">
+    <input name="file" type="filename" value="resources/Images/grid.png" />
+    <input name="default" type="color3" value="0.5, 0.5, 0.5" />
+    <input name="viewdir" type="vector3" value="0.0, 0.0, 1.0" />
+    <input name="rotation" type="float" value="90.0" />
+  </latlongimage>
+</materialx>

--- a/resources/Materials/TestSuite/stdlib/texture/ramp.mtlx
+++ b/resources/Materials/TestSuite/stdlib/texture/ramp.mtlx
@@ -5,6 +5,7 @@
   - Ramp (left-to-right)
   - Ramp (top-to-bottom)
   - Ramp (four corner)
+  - Ramp (multi interval)
   -->
 
   <!-- Left-to-right tests -->
@@ -131,4 +132,24 @@
     <input name="valuebr" type="vector2" value="0.0, 1.0" />
     <input name="valuebl" type="vector2" value="0.0, 0.0" />
   </ramp4>
+
+  <!-- Multi-interval ramp tests -->
+  <output name="ramp_standard_output" type="color4" nodename="ramp_standard" />
+  <ramp name="ramp_standard" type="color4">
+    <input name="num_intervals" type="integer" value="3" />
+    <input name="interval1" type="float" value="0.0" />
+    <input name="color1" type="color4" value="1.0, 0.0, 0.0, 1.0" />
+    <input name="interval2" type="float" value="0.5" />
+    <input name="color2" type="color4" value="0.0, 1.0, 0.0, 1.0" />
+    <input name="interval3" type="float" value="1.0" />
+    <input name="color3" type="color4" value="0.0, 0.0, 1.0, 1.0" />
+  </ramp>
+  <output name="ramp_radial_output" type="color4" nodename="ramp_radial" />
+  <ramp name="ramp_radial" type="color4">
+    <input name="type" type="integer" value="1" />
+    <input name="interpolation" type="integer" value="2" />
+    <input name="color1" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="color2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+  </ramp>
+
 </materialx>

--- a/source/MaterialXGenOsl/LibsToOso.cpp
+++ b/source/MaterialXGenOsl/LibsToOso.cpp
@@ -481,6 +481,33 @@ int main(int argc, char* const argv[])
                 impl->setFunction(oslShaderName);
                 impl->setAttribute("sourcecode", "dummy");
                 impl->setTarget(target);
+
+                // Carry over the port name remappings declared by the source implementation.
+                // The parameters of the compiled oso are named by their 'implname', so this
+                // implementation has to declare them too for consumers of the oso to bind
+                // against the right names.
+                for (const mx::InputPtr& implInput : nodeImpl->getActiveInputs())
+                {
+                    if (!implInput->hasImplementationName())
+                    {
+                        continue;
+                    }
+                    mx::InputPtr nodeDefInput = nodeDef->getActiveInput(implInput->getName());
+                    const std::string& inputType = nodeDefInput ? nodeDefInput->getType() : implInput->getType();
+                    mx::InputPtr input = impl->addInput(implInput->getName(), inputType);
+                    input->setImplementationName(implInput->getImplementationName());
+                }
+                for (const mx::OutputPtr& implOutput : nodeImpl->getActiveOutputs())
+                {
+                    if (!implOutput->hasImplementationName())
+                    {
+                        continue;
+                    }
+                    mx::OutputPtr nodeDefOutput = nodeDef->getActiveOutput(implOutput->getName());
+                    const std::string& outputType = nodeDefOutput ? nodeDefOutput->getType() : implOutput->getType();
+                    mx::OutputPtr output = impl->addOutput(implOutput->getName(), outputType);
+                    output->setImplementationName(implOutput->getImplementationName());
+                }
             }
         }
         // Catch any codegen/compilation related exceptions.

--- a/source/MaterialXGenOsl/OslNetworkShaderGenerator.cpp
+++ b/source/MaterialXGenOsl/OslNetworkShaderGenerator.cpp
@@ -67,7 +67,10 @@ ShaderPtr OslNetworkShaderGenerator::generate(const string& name, ElementPtr ele
 
         for (auto&& input : node->getInputs())
         {
-            string inputName = input->getName();
+            // The emitted 'param' and 'connect' statements bind by name against the
+            // compiled oso for this node, so the port's implementation name is used
+            // rather than the name given in the nodedef.
+            string inputName = node->getPortName(input->getName());
             _syntax->makeValidName(inputName);
 
             const ShaderOutput* connection = input->getConnection();
@@ -112,7 +115,7 @@ ShaderPtr OslNetworkShaderGenerator::generate(const string& name, ElementPtr ele
             }
             else
             {
-                string connName = connection->getName();
+                string connName = connection->getNode()->getPortName(connection->getName());
                 _syntax->makeValidName(connName);
 
                 string connect = connectString(connection->getNode()->getName(), connName, nodeName, inputName);

--- a/source/MaterialXGenShader/Nodes/CompoundNode.cpp
+++ b/source/MaterialXGenShader/Nodes/CompoundNode.cpp
@@ -48,7 +48,7 @@ void CompoundNode::initialize(const InterfaceElement& element, GenContext& conte
     // so always use the reduced interface for this graph.
     const ShaderInterfaceType oldShaderInterfaceType = context.getOptions().shaderInterfaceType;
     context.getOptions().shaderInterfaceType = SHADER_INTERFACE_REDUCED;
-    _rootGraph = ShaderGraph::create(nullptr, graph, context);
+    _rootGraph = ShaderGraph::create(nullptr, graph, context, &getPortImplNames());
     context.getOptions().shaderInterfaceType = oldShaderInterfaceType;
 
     // Set hash using the function name.

--- a/source/MaterialXGenShader/ShaderGenerator.cpp
+++ b/source/MaterialXGenShader/ShaderGenerator.cpp
@@ -359,6 +359,18 @@ ShaderNodeImplPtr ShaderGenerator::getImplementation(const NodeDef& nodedef, Gen
         return nullptr;
     }
 
+    // Transfer the port name remappings declared by the 'implname' attributes before
+    // initializing, since a nodegraph implementation applies them while building its
+    // graph. They are read from the implementation element, and then from the element
+    // that declared it if that is a distinct <implementation> pointing at a nodegraph,
+    // so that a target-specific declaration takes precedence.
+    addPortImplementationNames(implElement, *impl);
+    InterfaceElementPtr declElement = nodedef.getImplementation(getTarget(), false);
+    if (declElement && declElement != implElement)
+    {
+        addPortImplementationNames(declElement, *impl);
+    }
+
     impl->initialize(*implElement, context);
 
     // Cache it.

--- a/source/MaterialXGenShader/ShaderGenerator.h
+++ b/source/MaterialXGenShader/ShaderGenerator.h
@@ -282,6 +282,32 @@ class MX_GENSHADER_API ShaderGenerator
     friend ShaderGraph;
 };
 
+/// Transfer the port name remappings declared by the 'implname' attributes on an
+/// implementation element to the given destination, which may be either a
+/// ShaderNodeImpl or a ShaderGraph.
+template <typename T>
+void addPortImplementationNames(ConstInterfaceElementPtr implElement, T& dest)
+{
+    if (implElement)
+    {
+        for (const auto& port : implElement->getActiveInputs())
+        {
+            if (port->hasImplementationName())
+            {
+                dest.addPortImplName(port->getName(), port->getImplementationName());
+            }
+        }
+
+        for (const auto& port : implElement->getActiveOutputs())
+        {
+            if (port->hasImplementationName())
+            {
+                dest.addPortImplName(port->getName(), port->getImplementationName());
+            }
+        }
+    }
+}
+
 MATERIALX_NAMESPACE_END
 
 #endif // MATERIALX_SHADERGENERATOR_H

--- a/source/MaterialXGenShader/ShaderGraph.cpp
+++ b/source/MaterialXGenShader/ShaderGraph.cpp
@@ -436,7 +436,7 @@ void ShaderGraph::addUnitTransformNode(ShaderOutput* output, const UnitTransform
     }
 }
 
-ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context)
+ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const NodeGraph& nodeGraph, GenContext& context, const StringMap* portImplNames)
 {
     NodeDefPtr nodeDef = nodeGraph.getNodeDef();
     if (!nodeDef)
@@ -456,6 +456,17 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const NodeGraph& n
 
     // Create output sockets from the nodegraph
     graph->addOutputSockets(nodeGraph, context);
+
+    // Apply the port name remappings declared by this implementation before the
+    // graph is finalized, since finalizing assigns the variable names that become
+    // the parameter names of the generated function.
+    if (portImplNames)
+    {
+        for (const auto& portImplName : *portImplNames)
+        {
+            graph->addPortImplName(portImplName.first, portImplName.second);
+        }
+    }
 
     // Traverse all outputs and create all internal nodes
     for (OutputPtr graphOutput : nodeGraph.getActiveOutputs())
@@ -551,6 +562,27 @@ ShaderGraphPtr ShaderGraph::create(const ShaderGraph* parent, const string& name
 
         // Create this shader node in the graph.
         ShaderNode* newNode = graph->createNode(node->getName(), node->getNamePath(), nodeDef, context);
+
+        // This graph is a shader for a single node, so the graph interface is the
+        // interface of that node's implementation. Publish the sockets under the
+        // names declared by its 'implname' attributes, so that the parameters of
+        // the generated shader match the names the implementation uses.
+        for (const ShaderInput* nodeInput : newNode->getInputs())
+        {
+            const string& implName = newNode->getPortName(nodeInput->getName());
+            if (implName != nodeInput->getName())
+            {
+                graph->addPortImplName(nodeInput->getName(), implName);
+            }
+        }
+        for (const ShaderOutput* nodeOutput : newNode->getOutputs())
+        {
+            const string& implName = newNode->getPortName(nodeOutput->getName());
+            if (implName != nodeOutput->getName())
+            {
+                graph->addPortImplName(nodeOutput->getName(), implName);
+            }
+        }
 
         // Share metadata.
         graph->setMetadata(newNode->getMetadata());
@@ -823,8 +855,13 @@ ShaderNode* ShaderGraph::inlineNodeBeforeOutput(ShaderGraphOutputSocket* output,
     {
         throw ExceptionShaderGenError("Error while creating node '"+newNodeName+"' of type '"+nodeDefName+"'");
     }
+
+    // This runs after the graph has been finalized, so setVariableNames() has already
+    // assigned the variables of every other node and will not run again. The ports of
+    // the node we are inserting must therefore be named here, using the same formula
+    // so that any 'implname' remapping is applied consistently.
     auto newNodeOutput = newNode->getOutput(outputName);
-    newNodeOutput->setVariable(newNodeOutput->getFullName());
+    newNodeOutput->setVariable(newNode->getPortVariableName(outputName));
     output->makeConnection(newNodeOutput);
 
     // update the type of the graph output port to match the new node output
@@ -838,7 +875,7 @@ ShaderNode* ShaderGraph::inlineNodeBeforeOutput(ShaderGraphOutputSocket* output,
         // update the variable name for the input and connect the original upstream
         // we already validated the types match above.
         auto newNodeInput = newNode->getInput(inputName);
-        newNodeInput->setVariable(newNodeInput->getFullName());
+        newNodeInput->setVariable(newNode->getPortVariableName(inputName));
 
         originalUpstream->makeConnection(newNodeInput);
     }
@@ -1166,25 +1203,25 @@ void ShaderGraph::setVariableNames(GenContext& context)
 
     for (ShaderGraphInputSocket* inputSocket : getInputSockets())
     {
-        const string variable = syntax.getVariableName(inputSocket->getName(), inputSocket->getType(), _identifiers);
+        const string variable = syntax.getVariableName(getPortName(inputSocket->getName()), inputSocket->getType(), _identifiers);
         inputSocket->setVariable(variable);
     }
     for (ShaderGraphOutputSocket* outputSocket : getOutputSockets())
     {
-        const string variable = syntax.getVariableName(outputSocket->getName(), outputSocket->getType(), _identifiers);
+        const string variable = syntax.getVariableName(getPortName(outputSocket->getName()), outputSocket->getType(), _identifiers);
         outputSocket->setVariable(variable);
     }
     for (ShaderNode* node : getNodes())
     {
         for (ShaderInput* input : node->getInputs())
         {
-            string variable = input->getFullName();
+            string variable = node->getPortVariableName(input->getName());
             variable = syntax.getVariableName(variable, input->getType(), _identifiers);
             input->setVariable(variable);
         }
         for (ShaderOutput* output : node->getOutputs())
         {
-            string variable = output->getFullName();
+            string variable = node->getPortVariableName(output->getName());
             variable = syntax.getVariableName(variable, output->getType(), _identifiers);
             output->setVariable(variable);
         }
@@ -1298,6 +1335,22 @@ void ShaderGraph::populateUnitTransformMap(UnitSystemPtr unitSystem, ShaderPort*
             }
         }
     }
+}
+
+void ShaderGraph::addPortImplName(const string& portName, const string& implName)
+{
+    _portImplNames[portName] = implName;
+}
+
+const string& ShaderGraph::getPortName(const string& portName) const
+{
+    if (_impl)
+    {
+        return _impl->getPortName(portName);
+    }
+
+    auto it = _portImplNames.find(portName);
+    return it != _portImplNames.end() ? it->second : portName;
 }
 
 namespace

--- a/source/MaterialXGenShader/ShaderGraph.h
+++ b/source/MaterialXGenShader/ShaderGraph.h
@@ -57,8 +57,11 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
                                  GenContext& context);
 
     /// Create a new shader graph from a nodegraph.
+    /// The optional portImplNames are the port name remappings declared by the
+    /// implementation this nodegraph provides, which may be declared either on the
+    /// nodegraph itself or on an <implementation> element referencing it.
     static ShaderGraphPtr create(const ShaderGraph* parent, const NodeGraph& nodeGraph,
-                                 GenContext& context);
+                                 GenContext& context, const StringMap* portImplNames = nullptr);
 
     /// Return true if this node is a graph.
     bool isAGraph() const override { return true; }
@@ -144,6 +147,17 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     /// Rewire all downstream connections from one output to another.
     void replaceOutput(ShaderOutput* oldOutput, ShaderOutput* newOutput);
 
+    /// Record that the port named portName in the interface element this graph was
+    /// created from is called implName in the graph, as declared by an 'implname'
+    /// attribute. This is used by generators that build a graph directly from a
+    /// nodedef, where the graph itself carries the implementation interface.
+    void addPortImplName(const string& portName, const string& implName);
+
+    /// Return the name used for the given port by this graph. The implementation
+    /// of this graph is consulted first, falling back to the names recorded by
+    /// addPortImplName().
+    const string& getPortName(const string& portName) const override;
+
   protected:
     /// Create node connections corresponding to the connection between a pair of elements.
     /// @param downstreamElement Element representing the node to connect to.
@@ -215,6 +229,9 @@ class MX_GENSHADER_API ShaderGraph : public ShaderNode
     std::vector<std::pair<ShaderOutput*, ColorSpaceTransform>> _outputColorTransformMap;
     // Temporary storage for outputs that require unit transformations
     std::vector<std::pair<ShaderOutput*, UnitTransform>> _outputUnitTransformMap;
+
+  private:
+    std::unordered_map<string, string> _portImplNames;
 };
 
 /// @class ShaderGraphEdge

--- a/source/MaterialXGenShader/ShaderNode.cpp
+++ b/source/MaterialXGenShader/ShaderNode.cpp
@@ -561,4 +561,14 @@ ShaderOutput* ShaderNode::addOutput(const string& name, TypeDesc type)
     return output.get();
 }
 
+const string& ShaderNode::getPortName(const string& portName) const
+{
+    return _impl ? _impl->getPortName(portName) : portName;
+}
+
+string ShaderNode::getPortVariableName(const string& portName) const
+{
+    return _name + "_" + getPortName(portName);
+}
+
 MATERIALX_NAMESPACE_END

--- a/source/MaterialXGenShader/ShaderNode.h
+++ b/source/MaterialXGenShader/ShaderNode.h
@@ -497,6 +497,18 @@ class MX_GENSHADER_API ShaderNode
         return (!_impl || _impl->isEditable(input));
     }
 
+    /// Return the name used for the given port by this node's implementation,
+    /// as declared by an 'implname' attribute. If there is no remapping for the
+    /// port the given portName is returned, in which case the returned reference
+    /// aliases the argument and callers must not pass a temporary.
+    virtual const string& getPortName(const string& portName) const;
+
+    /// Return the base name to use when naming variables for the given port of
+    /// this node, which is the node name combined with the port's implementation
+    /// name. This is the single source of truth for variable naming, and must be
+    /// used by any code that assigns port variables.
+    string getPortVariableName(const string& portName) const;
+
   protected:
     /// Create metadata from the nodedef according to registered metadata.
     void createMetadata(const NodeDef& nodeDef, GenContext& context);

--- a/source/MaterialXGenShader/ShaderNodeImpl.cpp
+++ b/source/MaterialXGenShader/ShaderNodeImpl.cpp
@@ -34,6 +34,17 @@ void ShaderNodeImpl::initialize(const InterfaceElement& element, GenContext&)
     _hash = std::hash<string>{}(_name);
 }
 
+void ShaderNodeImpl::addPortImplName(const string& portName, const string& implName)
+{
+    _portImplNames[portName] = implName;
+}
+
+const string& ShaderNodeImpl::getPortName(const string& portName) const
+{
+    auto it = _portImplNames.find(portName);
+    return it != _portImplNames.end() ? it->second : portName;
+}
+
 void ShaderNodeImpl::addInputs(ShaderNode&, GenContext&) const
 {
 }

--- a/source/MaterialXGenShader/ShaderNodeImpl.h
+++ b/source/MaterialXGenShader/ShaderNodeImpl.h
@@ -97,6 +97,16 @@ class MX_GENSHADER_API ShaderNodeImpl
         return true;
     }
 
+    /// Record that the port named portName in the nodedef is called implName
+    /// in this implementation, as declared by an 'implname' attribute.
+    void addPortImplName(const string& portName, const string& implName);
+
+    /// Return the name used for the given port by this implementation.
+    /// If the port has no 'implname' remapping the given portName is returned,
+    /// in which case the returned reference aliases the argument and callers
+    /// must not pass a temporary.
+    const string& getPortName(const string& portName) const;
+
   protected:
     /// Protected constructor
     ShaderNodeImpl();
@@ -106,9 +116,15 @@ class MX_GENSHADER_API ShaderNodeImpl
     /// the appropriate shader code.
     bool nodeOutputIsClosure(const ShaderNode& node) const;
 
+    /// Return all port name remappings declared for this implementation.
+    const StringMap& getPortImplNames() const { return _portImplNames; }
+
   protected:
     string _name;
     size_t _hash;
+
+  private:
+    StringMap _portImplNames;
 };
 
 /// A no operation node, to be used for organizational nodes that has no code to execute.

--- a/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
+++ b/source/MaterialXTest/MaterialXGenOsl/GenOsl.cpp
@@ -100,6 +100,59 @@ TEST_CASE("GenShader: OSL Unique Names", "[genosl]")
     GenShaderUtil::testUniqueNames(context, mx::Stage::PIXEL);
 }
 
+// The OSL generator implicitly inserts a <surfacematerial> node when a material outputs a
+// single surfaceshader. That node is inserted after the graph has been finalized, so it names
+// its own port variables, and must apply the same 'implname' remapping that finalizing does.
+// The standard libraries declare that the 'surfaceshader' input of <surfacematerial> is called
+// 'surfaceshader_value' in the OSL implementation.
+TEST_CASE("GenShader: OSL Implicit Surfacematerial Port Names", "[genosl]")
+{
+    const std::string testDocumentString =
+    "<?xml version=\"1.0\"?> \
+      <materialx version=\"1.39\"> \
+      <standard_surface name=\"standard_surface1\" type=\"surfaceshader\" /> \
+    </materialx>";
+
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr libraries = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, libraries);
+
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::readFromXmlString(doc, testDocumentString);
+    doc->setDataLibrary(libraries);
+
+    mx::ElementPtr element = doc->getChild("standard_surface1");
+    REQUIRE(element);
+
+    mx::GenContext context(mx::OslShaderGenerator::create());
+    context.registerSourceCodeSearchPath(searchPath);
+    REQUIRE(context.getOptions().oslImplicitSurfaceShaderConversion);
+
+    mx::ShaderPtr shader = context.getShaderGenerator().generate("test", element, context);
+    REQUIRE(shader);
+
+    // Find the implicitly inserted surfacematerial node, which is the only node in the graph
+    // carrying a 'surfaceshader' input.
+    mx::ShaderNode* surfaceMaterialNode = nullptr;
+    for (mx::ShaderNode* node : shader->getGraph().getNodes())
+    {
+        if (node->getInput("surfaceshader"))
+        {
+            surfaceMaterialNode = node;
+        }
+    }
+    REQUIRE(surfaceMaterialNode);
+
+    // The port is remapped by its 'implname', and the variable assigned when the node was
+    // inserted must reflect that remapping.
+    CHECK(surfaceMaterialNode->getPortName("surfaceshader") == "surfaceshader_value");
+
+    mx::ShaderInput* input = surfaceMaterialNode->getInput("surfaceshader");
+    REQUIRE(input);
+    CHECK(input->getVariable() == surfaceMaterialNode->getPortVariableName("surfaceshader"));
+    CHECK(mx::stringEndsWith(input->getVariable(), "_surfaceshader_value"));
+}
+
 TEST_CASE("GenShader: OSL Metadata", "[genosl]")
 {
     mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();

--- a/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShader.cpp
@@ -605,3 +605,102 @@ TEST_CASE("GenShader: User-Facing Color Space Names", "[genshader]")
     }
 #endif
 }
+
+// Check that the 'implname' attributes declared on an implementation element are
+// respected when naming the variables of the corresponding node in generated code.
+// The standard libraries declare that the 'default' input of the <image> node is
+// called 'default_value' in the implementations of all our source code targets.
+void checkImplementationNames(mx::DocumentPtr libraries, mx::GenContext& context)
+{
+    const std::string testDocumentString =
+    "<?xml version=\"1.0\"?> \
+      <materialx version=\"1.39\"> \
+      <image name=\"image1\" type=\"color3\" > \
+        <input name=\"default\" type=\"color3\" value=\"0.1, 0.2, 0.3\" /> \
+      </image> \
+      <standard_surface name=\"standard_surface1\" type=\"surfaceshader\" > \
+        <input name=\"base_color\" type=\"color3\" nodename=\"image1\" /> \
+      </standard_surface> \
+      <surfacematerial name=\"surfacematerial1\" type=\"material\" > \
+        <input name=\"surfaceshader\" type=\"surfaceshader\" nodename=\"standard_surface1\" /> \
+      </surfacematerial> \
+    </materialx>";
+
+    const mx::string testElement = "surfacematerial1";
+
+    mx::DocumentPtr testDoc = mx::createDocument();
+    mx::readFromXmlString(testDoc, testDocumentString);
+    testDoc->setDataLibrary(libraries);
+
+    mx::ElementPtr element = testDoc->getChild(testElement);
+    REQUIRE(element);
+
+    mx::ShaderPtr shader = context.getShaderGenerator().generate(testElement, element, context);
+    REQUIRE(shader);
+
+    mx::ShaderNode* imageNode = nullptr;
+    for (mx::ShaderNode* node : shader->getGraph().getNodes())
+    {
+        if (node->getName() == "image1")
+        {
+            imageNode = node;
+        }
+    }
+    REQUIRE(imageNode);
+
+    // The remapped input is named by its 'implname', while an input with no
+    // 'implname' keeps the name given in the nodedef.
+    CHECK(imageNode->getPortName("default") == "default_value");
+    CHECK(imageNode->getPortName("texcoord") == "texcoord");
+
+    mx::ShaderInput* defaultInput = imageNode->getInput("default");
+    REQUIRE(defaultInput);
+    CHECK(defaultInput->getVariable() == "image1_default_value");
+
+    mx::ShaderInput* texcoordInput = imageNode->getInput("texcoord");
+    REQUIRE(texcoordInput);
+    CHECK(texcoordInput->getVariable() == "image1_texcoord");
+}
+
+TEST_CASE("GenShader: Implementation Names", "[genshader]")
+{
+    mx::FileSearchPath searchPath = mx::getDefaultDataSearchPath();
+    mx::DocumentPtr libraries = mx::createDocument();
+    mx::loadLibraries({ "libraries" }, searchPath, libraries);
+
+#ifdef MATERIALX_BUILD_GEN_GLSL
+    {
+        mx::GenContext context(mx::GlslShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkImplementationNames(libraries, context);
+    }
+#endif
+#ifdef MATERIALX_BUILD_GEN_OSL
+    {
+        mx::GenContext context(mx::OslShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkImplementationNames(libraries, context);
+    }
+#endif
+#ifdef MATERIALX_BUILD_GEN_MDL
+    {
+        mx::GenContext context(mx::MdlShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkImplementationNames(libraries, context);
+    }
+#endif
+#ifdef MATERIALX_BUILD_GEN_MSL
+    {
+        mx::GenContext context(mx::MslShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkImplementationNames(libraries, context);
+    }
+#endif
+#ifdef MATERIALX_BUILD_GEN_SLANG
+    {
+        mx::GenContext context(mx::SlangShaderGenerator::create());
+        context.registerSourceCodeSearchPath(searchPath);
+        checkImplementationNames(libraries, context);
+    }
+#endif
+}

--- a/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
+++ b/source/MaterialXTest/MaterialXGenShader/GenShaderUtil.cpp
@@ -438,6 +438,7 @@ void ShaderGeneratorTester::checkImplementationUsage(const mx::StringSet& usedIm
 
     unsigned int implementationUseCount = 0;
     mx::StringVec skippedImplementations;
+    mx::StringVec nodeGraphImplementations;
     mx::StringVec missedImplementations;
     for (const auto& targetImpl : targetImpls)
     {
@@ -460,22 +461,31 @@ void ShaderGeneratorTester::checkImplementationUsage(const mx::StringSet& usedIm
             continue;
         }
 
-        if (usedImpls.count(implName))
-        {
-            implementationUseCount++;
-            continue;
-        }
+        // An implementation that references a nodegraph is resolved to that nodegraph
+        // before shader generation sees it, so it is the nodegraph that gets recorded
+        // as used. Test such an implementation through the nodegraph it references.
+        const bool viaNodeGraph = targetImpl->hasNodeGraph();
+        const std::string& usageName = viaNodeGraph ? targetImpl->getNodeGraph() : implName;
 
-        if (context.findNodeImplementation(implName))
+        if (usedImpls.count(usageName) || context.findNodeImplementation(usageName))
         {
             implementationUseCount++;
+            if (viaNodeGraph)
+            {
+                nodeGraphImplementations.push_back(implName + " (nodegraph " + usageName + ")");
+            }
             continue;
         }
-        missedImplementations.push_back(implName);
+        missedImplementations.push_back(viaNodeGraph ? implName + " (nodegraph " + usageName + ")" : implName);
     }
 
     size_t count = targetImpls.size();
     stream << "Tested: " << implementationUseCount << " out of: " << count << " library implementations." << std::endl;
+    stream << "Tested via a nodegraph: " << nodeGraphImplementations.size() << " implementations." << std::endl;
+    for (const auto& implName : nodeGraphImplementations)
+    {
+        stream << "\t" << implName << std::endl;
+    }
     stream << "Skipped: " << skippedImplementations.size() << " implementations." << std::endl;
     if (skippedImplementations.size())
     {


### PR DESCRIPTION
(This work is extracted and refined from #2739)

### Summary

The `implname` attribute lets an `<implementation>` declare that a port defined in the `<nodedef>` is called something else in the implementation's code. The [specification](https://github.com/AcademySoftwareFoundation/MaterialX/blob/main/documents/Specification/MaterialX.Specification.md) describes it as a way to avoid clashes with reserved words in the target shading language, and the data libraries already used it — every `<image>` implementation declares that the nodedef's `default` input is called `default_value` — but shader generation ignored it entirely.

Ports whose names clash with a reserved word were instead disambiguated by appending a counter, so the `mix` input of `<mix>` became `mix1` and the `normal` input of a BSDF became `normal1`: names that carry no meaning, and that shift if the reserved word list changes, and is also dependent on network topology in some cases.

This PR makes shader generation honor `implname`, declares it for the genosl inputs that clash, and applies it in the one place where a port name crosses a real interface boundary — the OSL network target.

### Shader generation

Port name remappings are read from the implementation element and applied when naming variables in generated code.

- `ShaderNodeImpl` stores the remappings declared by its implementation element and exposes them through a new `getPortName()`.
- `ShaderNode::getPortName()` forwards to its implementation, and `ShaderGraph` overrides it with its own set, for generators that build a graph directly from a nodedef rather than from a node. `ShaderNode::getPortVariableName()` is the single source of truth for the variable naming formula and is used at every site that names a port.
- `ShaderGenerator::getImplementation()` populates the remappings once per implementation element before it is cached. It reads both the resolved element and the unresolved declaration: an `<implementation>` that references a nodegraph is resolved to that nodegraph before shader generation sees it, so an `implname` on the `<implementation>` itself was being discarded. Reading both, with the declaration taking precedence, allows a nodegraph shared by every target to be given target-specific port names.
- `CompoundNode` forwards its remappings to `ShaderGraph::create()`, which applies them before finalizing the graph, since finalizing is what assigns the variable names that become a function's parameter names.
- A shader generated for a single node is the implementation of that node's nodedef, so its interface is published under that implementation's names as well.
- Nodes inserted by `inlineNodeBeforeOutput()` are created after `finalize()` has run and named their own port variables, bypassing the remapping. They now use the same formula.

Variable names remain unique, as they still pass through `Syntax::getVariableName()`.

### Data libraries

I audited every genosl `<implementation>`, checking each input name of its `<nodedef>` against the reserved words registered by `OslSyntax` — the OSL keywords and types, the OSL standard library function names, and the type name that registering a type syntax reserves.

Only the 9 `default` inputs of the image and hextiled nodes were declared. 163 more are added here, each declaring an `implname` of the input name with a `_value` suffix, following the convention already established by `default` → `default_value`. We can evolve these to other names as we move forward if desired

For nodedefs whose implementation is a `<nodegraph>`, that nodegraph's interface is shared by every target, so the declaration cannot go on the nodegraph itself. Each is declared instead on a new target-specific `<implementation>`
that references the existing nodegraph, leaving the nodegraph untouched and every other target unaffected. 

Only genosl is covered, as currently this is the only language with a node-based output where is it important these names are consistent. The other source code targets are untouched, and the same treatment could follow for them if that's wanted.

### OSL network target

The OSL network generator emits `param` and `connect` statements that bind by name against
the compiled oso for each node, making it the one place where a port name crosses a real
interface boundary. Both sides of a binding are now resolved through `getPortName()`.

`LibsToOso` generates the `<implementation>` elements for the genoslnetwork target, and these
carried none of the port remappings declared by the genosl implementation they are derived
from.

### Tests

`GenShader: Implementation Names` checks that a remapped input is named by its `implname`
while an input without one keeps the nodedef name, for every source code target.
`GenShader: OSL Implicit Surfacematerial Port Names` covers the node that the OSL generator
inserts after finalization.

The implementation coverage check now tests an `<implementation>` that references a nodegraph
through that nodegraph, since it is the nodegraph that gets recorded as used, and logs each
one together with the nodegraph so that the indirection is visible in the report rather than
silently trusted.

Test suite coverage is added for nodes that no material exercised
* `<overlay>`
* `<ramp>`
* `<randomfloat>`
* `<bump>` 
* `<refract>`
* `<latlongimage>`
