### PR TITLE
Add temporary directory helpers and a createDirectories write option

### DIFF
--- a/source/MaterialXFormat/File.cpp
+++ b/source/MaterialXFormat/File.cpp
@@ -17,6 +17,7 @@
     #include <unistd.h>
     #include <sys/stat.h>
     #include <dirent.h>
+    #include <stdlib.h>
 #endif
 
 #if defined(__linux__)
@@ -31,6 +32,10 @@
 #include <cctype>
 #include <cerrno>
 #include <cstring>
+
+#if defined(_WIN32)
+    #include <random>
+#endif
 
 MATERIALX_NAMESPACE_BEGIN
 
@@ -48,6 +53,15 @@ const string PATH_LIST_SEPARATOR = ";";
 const string PATH_LIST_SEPARATOR = ":";
 #endif
 const string MATERIALX_SEARCH_PATH_ENV_VAR = "MATERIALX_SEARCH_PATH";
+
+const string TEMPORARY_DIRECTORY_PREFIX = "materialx_tmp_";
+
+#if defined(_WIN32)
+const int TEMPORARY_DIRECTORY_MAX_ATTEMPTS = 1000;
+#else
+const StringVec TEMPORARY_DIRECTORY_ENV_VARS = { "TMPDIR", "TMP", "TEMP", "TEMPDIR" };
+const string TEMPORARY_DIRECTORY_DEFAULT = "/tmp";
+#endif
 
 inline bool hasWindowsDriveSpecifier(const string& val)
 {
@@ -301,6 +315,77 @@ void FilePath::createDirectory(bool recursive) const
 #endif
 }
 
+bool FilePath::removeDirectory(bool recursive) const
+{
+    if (recursive)
+    {
+        // Remove the contents of the directory, taking care not to follow symbolic
+        // links to locations outside of this directory.
+#if defined(_WIN32)
+        WIN32_FIND_DATAA fd;
+        HANDLE hFind = FindFirstFileA((*this / "*").asString().c_str(), &fd);
+        if (hFind != INVALID_HANDLE_VALUE)
+        {
+            do
+            {
+                string entryName = fd.cFileName;
+                if (entryName == CURRENT_PATH_STRING || entryName == PARENT_PATH_STRING)
+                {
+                    continue;
+                }
+
+                FilePath entryPath = *this / entryName;
+                if ((fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) &&
+                    !(fd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT))
+                {
+                    entryPath.removeDirectory(true);
+                }
+                else if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                {
+                    RemoveDirectoryA(entryPath.asString().c_str());
+                }
+                else
+                {
+                    DeleteFileA(entryPath.asString().c_str());
+                }
+            } while (FindNextFileA(hFind, &fd));
+            FindClose(hFind);
+        }
+#else
+        DIR* dir = opendir(asString().c_str());
+        if (dir)
+        {
+            while (struct dirent* entry = readdir(dir))
+            {
+                string entryName = entry->d_name;
+                if (entryName == CURRENT_PATH_STRING || entryName == PARENT_PATH_STRING)
+                {
+                    continue;
+                }
+
+                FilePath entryPath = *this / entryName;
+                struct stat sb;
+                if (lstat(entryPath.asString().c_str(), &sb) == 0 && S_ISDIR(sb.st_mode))
+                {
+                    entryPath.removeDirectory(true);
+                }
+                else
+                {
+                    unlink(entryPath.asString().c_str());
+                }
+            }
+            closedir(dir);
+        }
+#endif
+    }
+
+#if defined(_WIN32)
+    return (RemoveDirectoryA(asString().c_str()) != 0);
+#else
+    return (rmdir(asString().c_str()) == 0);
+#endif
+}
+
 bool FilePath::setCurrentPath()
 {
 #if defined(_WIN32)
@@ -382,6 +467,75 @@ FilePath FilePath::getModulePath()
             return FilePath(buf.data()).getParentPath();
         }
     }
+#endif
+}
+
+FilePath FilePath::createTemporaryDirectory(const FilePath& parentDir)
+{
+    FilePath tempParent = parentDir.isEmpty() ? getSystemTemporaryDirectory() : parentDir;
+    tempParent.createDirectory(true);
+    if (!tempParent.isDirectory())
+    {
+        throw Exception("Error in createTemporaryDirectory: parent path is not a directory: " + tempParent.asString());
+    }
+
+#if defined(_WIN32)
+    // Windows provides no atomic equivalent of mkdtemp, so generate candidate names
+    // until CreateDirectory succeeds.  Because CreateDirectory fails rather than
+    // succeeding when the path already exists, no other process can be given the
+    // same directory.
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<int> dis(100000, 999999);
+
+    for (int attempt = 0; attempt < TEMPORARY_DIRECTORY_MAX_ATTEMPTS; attempt++)
+    {
+        FilePath tempDir = tempParent / (TEMPORARY_DIRECTORY_PREFIX + std::to_string(dis(gen)));
+        if (CreateDirectoryA(tempDir.asString().c_str(), nullptr))
+        {
+            return tempDir;
+        }
+        if (GetLastError() != ERROR_ALREADY_EXISTS)
+        {
+            throw Exception("Error in createTemporaryDirectory: " + std::to_string(GetLastError()));
+        }
+    }
+
+    throw Exception("Error in createTemporaryDirectory: no unique name found in " + tempParent.asString());
+#else
+    // Create the directory with mkdtemp, which generates a unique name, creates the
+    // directory atomically, and restricts access to the current user.
+    string nameTemplate = (tempParent / (TEMPORARY_DIRECTORY_PREFIX + "XXXXXX")).asString();
+    vector<char> buf(nameTemplate.begin(), nameTemplate.end());
+    buf.push_back('\0');
+    if (!mkdtemp(buf.data()))
+    {
+        throw Exception("Error in createTemporaryDirectory: " + string(strerror(errno)));
+    }
+    return FilePath(buf.data());
+#endif
+}
+
+FilePath FilePath::getSystemTemporaryDirectory()
+{
+#if defined(_WIN32)
+    std::array<char, MAX_PATH + 1> buf;
+    DWORD length = GetTempPathA((DWORD) buf.size(), buf.data());
+    if (!length || length > buf.size())
+    {
+        throw Exception("Error in getSystemTemporaryDirectory: " + std::to_string(GetLastError()));
+    }
+    return FilePath(string(buf.data(), length));
+#else
+    for (const string& envVar : TEMPORARY_DIRECTORY_ENV_VARS)
+    {
+        string tempDir = getEnviron(envVar);
+        if (!tempDir.empty())
+        {
+            return FilePath(tempDir);
+        }
+    }
+    return FilePath(TEMPORARY_DIRECTORY_DEFAULT);
 #endif
 }
 

--- a/source/MaterialXFormat/File.h
+++ b/source/MaterialXFormat/File.h
@@ -198,6 +198,13 @@ class MX_FORMAT_API FilePath
     /// If recursive is true, any missing parent directories will be created as well.
     void createDirectory(bool recursive = false) const;
 
+    /// Remove the directory on the file system at the given path.
+    /// @param recursive If true, the contents of the directory will be removed as
+    ///    well; otherwise the directory is only removed if it is empty.  Symbolic
+    ///    links within the directory are removed without following their targets.
+    /// @return True if the directory was removed.
+    bool removeDirectory(bool recursive = false) const;
+
     /// Set the current working directory of the file system.
     bool setCurrentPath();
 
@@ -208,6 +215,21 @@ class MX_FORMAT_API FilePath
 
     /// Return the directory containing the executable module.
     static FilePath getModulePath();
+
+    /// Create a temporary directory with a unique name.
+    /// @param parentDir The parent directory for the temporary directory, which
+    ///    will be created if it does not already exist.  If empty, the system's
+    ///    default temporary directory is used.
+    /// @return A FilePath to the created temporary directory, which is accessible
+    ///    only to the current user on platforms that support this restriction.
+    /// @throws Exception if the temporary directory cannot be created.
+    static FilePath createTemporaryDirectory(const FilePath& parentDir = FilePath());
+
+    /// Return the system's default temporary directory.  This method does not
+    /// create the directory, and its existence is not guaranteed.
+    /// @return A FilePath to the system temporary directory.
+    /// @throws Exception if the system temporary directory cannot be determined.
+    static FilePath getSystemTemporaryDirectory();
 
   private:
     StringVec _vec;

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -360,6 +360,10 @@ void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOpt
         filename.getParentPath().createDirectory(true);
     }
     std::ofstream ofs(filename.asString());
+    if (!ofs)
+    {
+        throw ExceptionFileMissing("Failed to open file for writing: " + filename.asString());
+    }
     writeToXmlStream(doc, ofs, writeOptions);
 }
 

--- a/source/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXFormat/XmlIo.cpp
@@ -355,6 +355,10 @@ void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const XmlWriteOptio
 
 void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOptions* writeOptions)
 {
+    if (writeOptions && writeOptions->createDirectories)
+    {
+        filename.getParentPath().createDirectory(true);
+    }
     std::ofstream ofs(filename.asString());
     writeToXmlStream(doc, ofs, writeOptions);
 }

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -73,6 +73,10 @@ class MX_FORMAT_API XmlWriteOptions
     /// If provided, this function will be used to exclude specific elements
     /// (those returning false) from the write operation.  Defaults to nullptr.
     ElementPredicate elementPredicate;
+
+    /// If true, any necessary directories will be created to write the
+    /// file.
+    bool createDirectories = false;
 };
 
 /// @class ExceptionParseError

--- a/source/MaterialXFormat/XmlIo.h
+++ b/source/MaterialXFormat/XmlIo.h
@@ -174,6 +174,7 @@ MX_FORMAT_API void writeToXmlStream(DocumentPtr doc, std::ostream& stream, const
 /// @param writeOptions An optional pointer to an XmlWriteOptions object.
 ///    If provided, then the given options will affect the behavior of the
 ///    write function.  Defaults to a null pointer.
+/// @throws ExceptionFileMissing if the file cannot be opened for writing.
 MX_FORMAT_API void writeToXmlFile(DocumentPtr doc, const FilePath& filename, const XmlWriteOptions* writeOptions = nullptr);
 
 /// Write a Document as XML to a new string, returned by value.

--- a/source/MaterialXGenOsl/LibsToOso.cpp
+++ b/source/MaterialXGenOsl/LibsToOso.cpp
@@ -503,7 +503,20 @@ int main(int argc, char* const argv[])
     {
         // We only write the MaterialX document containing the implementations out if requested.
         mx::FilePath implMtlxDocFilePath = outputMtlxPath / "genoslnetwork_impl.mtlx";
-        mx::writeToXmlFile(implMtlxDoc, implMtlxDocFilePath);
+        try
+        {
+            mx::writeToXmlFile(implMtlxDoc, implMtlxDocFilePath);
+        }
+        // Catch any file writing related exceptions.
+        catch (mx::Exception& exc)
+        {
+            std::cerr << "Encountered an exception while writing the implementation document to the "
+                         "following path: "
+                      << implMtlxDocFilePath.asString() << std::endl;
+            std::cerr << exc.what() << std::endl;
+
+            hasFailed = true;
+        }
     }
 
     // If something went wrong, return an appropriate error code.

--- a/source/MaterialXGraphEditor/Graph.cpp
+++ b/source/MaterialXGraphEditor/Graph.cpp
@@ -5074,5 +5074,12 @@ void Graph::saveDocument(mx::FilePath filePath)
 
     mx::XmlWriteOptions writeOptions;
     writeOptions.elementPredicate = getElementPredicate();
-    mx::writeToXmlFile(writeDoc, filePath, &writeOptions);
+    try
+    {
+        mx::writeToXmlFile(writeDoc, filePath, &writeOptions);
+    }
+    catch (mx::Exception& e)
+    {
+        std::cerr << "Failed to write file: " << filePath.asString() << ": \"" << std::string(e.what()) << "\"" << std::endl;
+    }
 }

--- a/source/MaterialXTest/MaterialXFormat/File.cpp
+++ b/source/MaterialXTest/MaterialXFormat/File.cpp
@@ -8,6 +8,15 @@
 #include <MaterialXFormat/File.h>
 #include <MaterialXFormat/Util.h>
 
+#include <MaterialXCore/Exception.h>
+
+#include <fstream>
+
+#if !defined(_WIN32)
+    #include <sys/stat.h>
+    #include <unistd.h>
+#endif
+
 namespace mx = MaterialX;
 
 TEST_CASE("Syntactic operations", "[file]")
@@ -204,4 +213,106 @@ TEST_CASE("Get all files in directory", "[file]")
     {
         REQUIRE(std::find(results.begin(), results.end(), filename) != results.end());
     }
+}
+
+TEST_CASE("System temporary directory", "[file]")
+{
+    mx::FilePath systemTempDir = mx::FilePath::getSystemTemporaryDirectory();
+
+    REQUIRE(!systemTempDir.isEmpty());
+    REQUIRE(systemTempDir.exists());
+    REQUIRE(systemTempDir.isDirectory());
+}
+
+TEST_CASE("Create temporary directory", "[file]")
+{
+    // Create a temporary directory within the system temporary directory.
+    mx::FilePath systemTempDir = mx::FilePath::getSystemTemporaryDirectory();
+    mx::FilePath tempDir = mx::FilePath::createTemporaryDirectory();
+    REQUIRE(tempDir.exists());
+    REQUIRE(tempDir.isDirectory());
+    REQUIRE(tempDir.getParentPath().getNormalized() == systemTempDir.getNormalized());
+
+    // Verify that each temporary directory is unique.
+    mx::FilePath secondTempDir = mx::FilePath::createTemporaryDirectory();
+    REQUIRE(secondTempDir.isDirectory());
+    REQUIRE(secondTempDir != tempDir);
+
+    // Create a temporary directory within an explicit parent directory, which
+    // is itself created on demand.
+    mx::FilePath explicitParent = tempDir / "parent" / "subdirectory";
+    REQUIRE(!explicitParent.exists());
+    mx::FilePath childTempDir = mx::FilePath::createTemporaryDirectory(explicitParent);
+    REQUIRE(childTempDir.isDirectory());
+    REQUIRE(childTempDir.getParentPath().getNormalized() == explicitParent.getNormalized());
+
+    // Verify that a parent path referring to an existing file is rejected.
+    mx::FilePath existingFile = tempDir / "file.txt";
+    std::ofstream(existingFile.asString()) << "content";
+    REQUIRE(existingFile.exists());
+    REQUIRE(!existingFile.isDirectory());
+    REQUIRE_THROWS_AS(mx::FilePath::createTemporaryDirectory(existingFile), mx::Exception);
+
+#if !defined(_WIN32)
+    // Verify that the temporary directory is accessible only to the current user.
+    struct stat sb;
+    REQUIRE(stat(tempDir.asString().c_str(), &sb) == 0);
+    REQUIRE((sb.st_mode & 07777) == 0700);
+
+    // Verify that a failure to create the directory is reported as an exception,
+    // rather than returning a path that does not exist.
+    mx::FilePath readOnlyParent = tempDir / "readOnly";
+    readOnlyParent.createDirectory();
+    REQUIRE(readOnlyParent.isDirectory());
+    REQUIRE(chmod(readOnlyParent.asString().c_str(), 0500) == 0);
+    REQUIRE_THROWS_AS(mx::FilePath::createTemporaryDirectory(readOnlyParent), mx::Exception);
+    REQUIRE(chmod(readOnlyParent.asString().c_str(), 0700) == 0);
+#endif
+
+    REQUIRE(tempDir.removeDirectory(true));
+    REQUIRE(!tempDir.exists());
+    REQUIRE(secondTempDir.removeDirectory(true));
+    REQUIRE(!secondTempDir.exists());
+}
+
+TEST_CASE("Remove directory", "[file]")
+{
+    mx::FilePath tempDir = mx::FilePath::createTemporaryDirectory();
+
+    // Verify that a non-recursive removal leaves a non-empty directory in place.
+    mx::FilePath nestedDir = tempDir / "nested" / "subdirectory";
+    nestedDir.createDirectory(true);
+    std::ofstream((nestedDir / "file.txt").asString()) << "content";
+    REQUIRE(!tempDir.removeDirectory());
+    REQUIRE(tempDir.isDirectory());
+
+    // Verify that a non-recursive removal succeeds for an empty directory.
+    mx::FilePath emptyDir = tempDir / "empty";
+    emptyDir.createDirectory();
+    REQUIRE(emptyDir.removeDirectory());
+    REQUIRE(!emptyDir.exists());
+
+    // Verify that a removal of a path that does not exist is reported as a failure.
+    REQUIRE(!emptyDir.removeDirectory());
+    REQUIRE(!emptyDir.removeDirectory(true));
+
+#if !defined(_WIN32)
+    // Verify that a symbolic link within the directory is removed without following
+    // it to its target.
+    mx::FilePath linkTarget = mx::FilePath::createTemporaryDirectory();
+    std::ofstream((linkTarget / "preserved.txt").asString()) << "content";
+    mx::FilePath link = nestedDir / "link";
+    REQUIRE(symlink(linkTarget.asString().c_str(), link.asString().c_str()) == 0);
+    REQUIRE(link.isDirectory());
+#endif
+
+    // Verify that a recursive removal clears the directory and its contents.
+    REQUIRE(tempDir.removeDirectory(true));
+    REQUIRE(!tempDir.exists());
+
+#if !defined(_WIN32)
+    REQUIRE(linkTarget.isDirectory());
+    REQUIRE((linkTarget / "preserved.txt").exists());
+    REQUIRE(linkTarget.removeDirectory(true));
+#endif
 }

--- a/source/MaterialXTest/MaterialXFormat/File.cpp
+++ b/source/MaterialXTest/MaterialXFormat/File.cpp
@@ -260,13 +260,17 @@ TEST_CASE("Create temporary directory", "[file]")
     REQUIRE((sb.st_mode & 07777) == 0700);
 
     // Verify that a failure to create the directory is reported as an exception,
-    // rather than returning a path that does not exist.
-    mx::FilePath readOnlyParent = tempDir / "readOnly";
-    readOnlyParent.createDirectory();
-    REQUIRE(readOnlyParent.isDirectory());
-    REQUIRE(chmod(readOnlyParent.asString().c_str(), 0500) == 0);
-    REQUIRE_THROWS_AS(mx::FilePath::createTemporaryDirectory(readOnlyParent), mx::Exception);
-    REQUIRE(chmod(readOnlyParent.asString().c_str(), 0700) == 0);
+    // rather than returning a path that does not exist.  The root user bypasses
+    // permission checks, so this case is only meaningful for other users.
+    if (geteuid() != 0)
+    {
+        mx::FilePath readOnlyParent = tempDir / "readOnly";
+        readOnlyParent.createDirectory();
+        REQUIRE(readOnlyParent.isDirectory());
+        REQUIRE(chmod(readOnlyParent.asString().c_str(), 0500) == 0);
+        REQUIRE_THROWS_AS(mx::FilePath::createTemporaryDirectory(readOnlyParent), mx::Exception);
+        REQUIRE(chmod(readOnlyParent.asString().c_str(), 0700) == 0);
+    }
 #endif
 
     REQUIRE(tempDir.removeDirectory(true));

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -9,6 +9,11 @@
 #include <MaterialXFormat/Util.h>
 #include <MaterialXFormat/XmlIo.h>
 
+#if !defined(_WIN32)
+    #include <sys/stat.h>
+    #include <unistd.h>
+#endif
+
 namespace mx = MaterialX;
 
 TEST_CASE("Load content", "[xmlio]")
@@ -382,9 +387,9 @@ TEST_CASE("Write with created directories", "[xmlio]")
     mx::FilePath filename = tempDir / "new" / "nested" / "directory" / "document.mtlx";
     REQUIRE(!filename.getParentPath().exists());
 
-    // By default, no directories are created, and the write is not performed.
+    // By default, no directories are created, and the write fails.
     mx::XmlWriteOptions writeOptions;
-    mx::writeToXmlFile(doc, filename, &writeOptions);
+    REQUIRE_THROWS_AS(mx::writeToXmlFile(doc, filename, &writeOptions), mx::ExceptionFileMissing);
     REQUIRE(!filename.exists());
 
     // With the createDirectories option, the parent hierarchy is created.
@@ -402,6 +407,22 @@ TEST_CASE("Write with created directories", "[xmlio]")
     mx::FilePath secondFilename = filename.getParentPath() / "document2.mtlx";
     mx::writeToXmlFile(doc, secondFilename, &writeOptions);
     REQUIRE(secondFilename.exists());
+
+#if !defined(_WIN32)
+    // Verify that a permission failure is reported as an exception, rather than
+    // silently writing nothing.  The root user bypasses permission checks, so
+    // this case is only meaningful for other users.
+    if (geteuid() != 0)
+    {
+        mx::FilePath readOnlyDir = tempDir / "readOnly";
+        readOnlyDir.createDirectory();
+        REQUIRE(chmod(readOnlyDir.asString().c_str(), 0500) == 0);
+        mx::FilePath deniedFilename = readOnlyDir / "denied" / "document.mtlx";
+        REQUIRE_THROWS_AS(mx::writeToXmlFile(doc, deniedFilename, &writeOptions), mx::ExceptionFileMissing);
+        REQUIRE(!deniedFilename.exists());
+        REQUIRE(chmod(readOnlyDir.asString().c_str(), 0700) == 0);
+    }
+#endif
 
     REQUIRE(tempDir.removeDirectory(true));
     REQUIRE(!tempDir.exists());

--- a/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
+++ b/source/MaterialXTest/MaterialXFormat/XmlIo.cpp
@@ -371,3 +371,38 @@ TEST_CASE("Locale region testing", "[xmlio]")
     // Restore the original locale.
     std::locale::global(origLocale);
 }
+
+TEST_CASE("Write with created directories", "[xmlio]")
+{
+    mx::DocumentPtr doc = mx::createDocument();
+    mx::NodeGraphPtr nodeGraph = doc->addNodeGraph("nodegraph1");
+    nodeGraph->addNode("image", "image1");
+
+    mx::FilePath tempDir = mx::FilePath::createTemporaryDirectory();
+    mx::FilePath filename = tempDir / "new" / "nested" / "directory" / "document.mtlx";
+    REQUIRE(!filename.getParentPath().exists());
+
+    // By default, no directories are created, and the write is not performed.
+    mx::XmlWriteOptions writeOptions;
+    mx::writeToXmlFile(doc, filename, &writeOptions);
+    REQUIRE(!filename.exists());
+
+    // With the createDirectories option, the parent hierarchy is created.
+    writeOptions.createDirectories = true;
+    mx::writeToXmlFile(doc, filename, &writeOptions);
+    REQUIRE(filename.getParentPath().isDirectory());
+    REQUIRE(filename.exists());
+
+    // Verify that the written document may be read back without loss.
+    mx::DocumentPtr writtenDoc = mx::createDocument();
+    mx::readFromXmlFile(writtenDoc, filename);
+    REQUIRE(*writtenDoc == *doc);
+
+    // Verify that writing to an existing directory remains supported.
+    mx::FilePath secondFilename = filename.getParentPath() / "document2.mtlx";
+    mx::writeToXmlFile(doc, secondFilename, &writeOptions);
+    REQUIRE(secondFilename.exists());
+
+    REQUIRE(tempDir.removeDirectory(true));
+    REQUIRE(!tempDir.exists());
+}

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -424,7 +424,14 @@ void Viewer::loadEnvironmentLight()
         if (_saveGeneratedLights)
         {
             _imageHandler->saveImage("IndirectRadiance.hdr", envRadianceMap);
-            mx::writeToXmlFile(_lightRigDoc, "DirectLightRig.mtlx");
+            try
+            {
+                mx::writeToXmlFile(_lightRigDoc, "DirectLightRig.mtlx");
+            }
+            catch (std::exception& e)
+            {
+                new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Cannot save direct light rig", e.what());
+            }
         }
     }
 
@@ -2030,9 +2037,16 @@ bool Viewer::keyboard_event(int key, int scancode, int action, int modifiers)
 
             mx::XmlWriteOptions writeOptions;
             writeOptions.elementPredicate = getElementPredicate();
-            mx::writeToXmlFile(translatedDoc, translatedFilename, &writeOptions);
+            try
+            {
+                mx::writeToXmlFile(translatedDoc, translatedFilename, &writeOptions);
 
-            new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved translated material: ", translatedFilename);
+                new ng::MessageDialog(this, ng::MessageDialog::Type::Information, "Saved translated material: ", translatedFilename);
+            }
+            catch (std::exception& e)
+            {
+                new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Cannot save translated material", e.what());
+            }
         }
         return true;
     }

--- a/source/MaterialXView/Viewer.cpp
+++ b/source/MaterialXView/Viewer.cpp
@@ -657,10 +657,17 @@ void Viewer::createSaveMaterialsInterface(ng::ref<Widget> parent, const std::str
 
             mx::XmlWriteOptions writeOptions;
             writeOptions.elementPredicate = getElementPredicate();
-            mx::writeToXmlFile(material->getDocument(), filename, &writeOptions);
+            try
+            {
+                mx::writeToXmlFile(material->getDocument(), filename, &writeOptions);
 
-            // Update material file name
-            _materialFilename = filename;
+                // Update material file name
+                _materialFilename = filename;
+            }
+            catch (std::exception& e)
+            {
+                new ng::MessageDialog(this, ng::MessageDialog::Type::Warning, "Cannot save material document", e.what());
+            }
         }
         m_process_events = true;
     });


### PR DESCRIPTION
(This work is extracted and refined from #2739)

This adds a small set of file system utilities for creating and removing temporary directories, along with an option for `writeToXmlFile()` to create the directory hierarchy of its target file. Together these let tools and tests stage
generated documents in scratch locations without pre-creating the directory structure themselves, which currently requires each caller to reimplement platform-specific temporary directory logic.

The following specific changes are included:

- Add `FilePath::getSystemTemporaryDirectory()`, returning the platform temporary directory. This is queried with `GetTempPath` on Windows, and with the `TMPDIR`, `TMP`, `TEMP` and `TEMPDIR` environment variables on POSIX,
  falling back to `/tmp`. The directory is not created, and its existence is not guaranteed.
- Add `FilePath::createTemporaryDirectory()`, creating a uniquely named directory under a given parent and defaulting to the system temporary directory, and throwing an `Exception` if the directory cannot be created. POSIX platforms use `mkdtemp()`, which generates the name, creates the directory atomically, and restricts access to the owner. Windows has no equivalent, so candidate names are passed to `CreateDirectory`, which fails rather than succeeding when the path already exists; only a name collision is retried, and any other error is reported.
- Add `FilePath::removeDirectory()`, removing a directory and optionally its contents, and returning whether the removal succeeded. A recursive removal classifies entries with `lstat` or the reparse point attribute, so that symbolic links within the directory are removed without deleting the contents of their targets.
- Add an `XmlWriteOptions::createDirectories` flag, causing `writeToXmlFile()` to create the parent directory hierarchy of the target file if it does not already exist. The flag defaults to false, so the behavior of existing code is unchanged.

New cases in `MaterialXTest` cover the default and explicit parent directories, the uniqueness and owner-only permissions of each created directory, the reporting of a creation failure under a read-only parent, directory removal with and without recursion, the preservation of a symbolic link's target during a recursive removal, and the round-tripping of a document written into a newly created hierarchy. The permission, read-only parent and symbolic link cases are guarded to POSIX. I have run the full test suite on macOS; the Windows code paths are exercised only by CI.
