### PR TITLE
Add uiname attributes to stdlib_defs.mtlx

### DIFF
--- a/libraries/stdlib/stdlib_defs.mtlx
+++ b/libraries/stdlib/stdlib_defs.mtlx
@@ -85,15 +85,15 @@
 
   <!-- Surface material -->
   <nodedef name="ND_surfacematerial" node="surfacematerial" nodegroup="material">
-    <input name="surfaceshader" type="surfaceshader" value="" />
-    <input name="backsurfaceshader" type="surfaceshader" value="" />
-    <input name="displacementshader" type="displacementshader" value="" />
+    <input name="surfaceshader" type="surfaceshader" value="" uiname="Surface Shader" />
+    <input name="backsurfaceshader" type="surfaceshader" value="" uiname="Back Surface Shader" />
+    <input name="displacementshader" type="displacementshader" value="" uiname="Displacement Shader" />
     <output name="out" type="material" />
   </nodedef>
 
   <!-- Volume material -->
   <nodedef name="ND_volumematerial" node="volumematerial" nodegroup="material">
-    <input name="volumeshader" type="volumeshader" value="" />
+    <input name="volumeshader" type="volumeshader" value="" uiname="Volume Shader" />
     <output name="out" type="material" />
   </nodedef>
 
@@ -107,11 +107,11 @@
     but does not receive illumination from light sources or other surfaces.
   -->
   <nodedef name="ND_surface_unlit" node="surface_unlit" nodegroup="shader" doc="Construct a surface shader from emission and transmission values.">
-    <input name="emission" type="float" value="1.0" doc="Surface emission amount." />
-    <input name="emission_color" type="color3" value="1,1,1" doc="Surface emission color." />
-    <input name="transmission" type="float" value="0.0" doc="Surface transmission amount." />
-    <input name="transmission_color" type="color3" value="1,1,1" doc="Surface transmission color." />
-    <input name="opacity" type="float" value="1.0" doc="Surface cutout opacity." />
+    <input name="emission" type="float" value="1.0" doc="Surface emission amount." uiname="Emission" />
+    <input name="emission_color" type="color3" value="1,1,1" doc="Surface emission color." uiname="Emission Color" />
+    <input name="transmission" type="float" value="0.0" doc="Surface transmission amount." uiname="Transmission" />
+    <input name="transmission_color" type="color3" value="1,1,1" doc="Surface transmission color." uiname="Transmission Color" />
+    <input name="opacity" type="float" value="1.0" doc="Surface cutout opacity." uiname="Opacity" />
     <output name="out" type="surfaceshader" />
   </nodedef>
 
@@ -208,87 +208,87 @@
     across uv space.
   -->
   <nodedef name="ND_tiledimage_float" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="float" value="0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Image Size" />
+    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Tile Size" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_tiledimage_color3" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Image Size" />
+    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Tile Size" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_tiledimage_color4" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Image Size" />
+    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Tile Size" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_tiledimage_vector2" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="vector2" value="0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Image Size" />
+    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Tile Size" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_tiledimage_vector3" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Image Size" />
+    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Tile Size" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_tiledimage_vector4" node="tiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="realworldimagesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Image Size" />
+    <input name="realworldtilesize" type="vector2" value="1.0, 1.0" unittype="distance" uiname="Real World Tile Size" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -300,7 +300,7 @@
     <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
     <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default Color" />
     <input name="viewdir" type="vector3" value="0.0, 0.0, 1.0" uiname="View Direction" />
-    <input name="rotation" type="float" value="0.0" unittype="angle" unit="degree" uimin="0" uimax="360" uiname="Longitude Offset" />
+ <input name="rotation" type="float" value="0.0" unittype="angle" unit="degree" uiname="Longitude Offset" uimin="0" uimax="360" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -310,35 +310,35 @@
     across uv space.
   -->
   <nodedef name="ND_hextiledimage_color3" node="hextiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="tiling" type="vector2" value="1.0, 1.0" />
-    <input name="rotation" type="float" value="1.0" />
-    <input name="rotationrange" type="vector2" value="0.0, 360.0" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="scalerange" type="vector2" value="0.5, 2.0" />
-    <input name="offset" type="float" value="1.0" />
-    <input name="offsetrange" type="vector2" value="0.0, 1.0" />
-    <input name="falloff" type="float" value="0.5" />
-    <input name="falloffcontrast" type="float" value="0.5" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="tiling" type="vector2" value="1.0, 1.0" uiname="Tiling" />
+    <input name="rotation" type="float" value="1.0" uiname="Rotation" />
+    <input name="rotationrange" type="vector2" value="0.0, 360.0" uiname="Rotation Range" />
+    <input name="scale" type="float" value="1.0" uiname="Scale" />
+    <input name="scalerange" type="vector2" value="0.5, 2.0" uiname="Scale Range" />
+    <input name="offset" type="float" value="1.0" uiname="Offset" />
+    <input name="offsetrange" type="vector2" value="0.0, 1.0" uiname="Offset Range" />
+    <input name="falloff" type="float" value="0.5" uiname="Falloff" />
+    <input name="falloffcontrast" type="float" value="0.5" uiname="Falloff Contrast" />
+    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" uiname="Luma Coefficients" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_hextiledimage_color4" node="hextiledimage" nodegroup="texture2d">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="tiling" type="vector2" value="1.0, 1.0" />
-    <input name="rotation" type="float" value="1.0" />
-    <input name="rotationrange" type="vector2" value="0.0, 360.0" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="scalerange" type="vector2" value="0.5, 2.0" />
-    <input name="offset" type="float" value="1.0" />
-    <input name="offsetrange" type="vector2" value="0.0, 1.0" />
-    <input name="falloff" type="float" value="0.5" />
-    <input name="falloffcontrast" type="float" value="0.5" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="tiling" type="vector2" value="1.0, 1.0" uiname="Tiling" />
+    <input name="rotation" type="float" value="1.0" uiname="Rotation" />
+    <input name="rotationrange" type="vector2" value="0.0, 360.0" uiname="Rotation Range" />
+    <input name="scale" type="float" value="1.0" uiname="Scale" />
+    <input name="scalerange" type="vector2" value="0.5, 2.0" uiname="Scale Range" />
+    <input name="offset" type="float" value="1.0" uiname="Offset" />
+    <input name="offsetrange" type="vector2" value="0.0, 1.0" uiname="Offset Range" />
+    <input name="falloff" type="float" value="0.5" uiname="Falloff" />
+    <input name="falloffcontrast" type="float" value="0.5" uiname="Falloff Contrast" />
+    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" uiname="Luma Coefficients" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -349,111 +349,111 @@
     an adjustable weighted blend of the three samples using the geometric normal.
   -->
   <nodedef name="ND_triplanarprojection_float" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="filex" type="filename" value="" uniform="true" uiname="File X" />
+    <input name="filey" type="filename" value="" uniform="true" uiname="File Y" />
+    <input name="filez" type="filename" value="" uniform="true" uiname="File Z" />
+    <input name="layerx" type="string" value="" uniform="true" uiname="Layer X" />
+    <input name="layery" type="string" value="" uniform="true" uiname="Layer Y" />
+    <input name="layerz" type="string" value="" uniform="true" uiname="Layer Z" />
+    <input name="default" type="float" value="0.0" uiname="Default" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nobject" uiname="Normal" />
+    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" uiname="Up Axis" />
+    <input name="blend" type="float" value="1.0" uiname="Blend" uimin="0.0" uimax="1.0" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_triplanarprojection_color3" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="filex" type="filename" value="" uniform="true" uiname="File X" />
+    <input name="filey" type="filename" value="" uniform="true" uiname="File Y" />
+    <input name="filez" type="filename" value="" uniform="true" uiname="File Z" />
+    <input name="layerx" type="string" value="" uniform="true" uiname="Layer X" />
+    <input name="layery" type="string" value="" uniform="true" uiname="Layer Y" />
+    <input name="layerz" type="string" value="" uniform="true" uiname="Layer Z" />
+    <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nobject" uiname="Normal" />
+    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" uiname="Up Axis" />
+    <input name="blend" type="float" value="1.0" uiname="Blend" uimin="0.0" uimax="1.0" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_triplanarprojection_color4" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="filex" type="filename" value="" uniform="true" uiname="File X" />
+    <input name="filey" type="filename" value="" uniform="true" uiname="File Y" />
+    <input name="filez" type="filename" value="" uniform="true" uiname="File Z" />
+    <input name="layerx" type="string" value="" uniform="true" uiname="Layer X" />
+    <input name="layery" type="string" value="" uniform="true" uiname="Layer Y" />
+    <input name="layerz" type="string" value="" uniform="true" uiname="Layer Z" />
+    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nobject" uiname="Normal" />
+    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" uiname="Up Axis" />
+    <input name="blend" type="float" value="1.0" uiname="Blend" uimin="0.0" uimax="1.0" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_triplanarprojection_vector2" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="filex" type="filename" value="" uniform="true" uiname="File X" />
+    <input name="filey" type="filename" value="" uniform="true" uiname="File Y" />
+    <input name="filez" type="filename" value="" uniform="true" uiname="File Z" />
+    <input name="layerx" type="string" value="" uniform="true" uiname="Layer X" />
+    <input name="layery" type="string" value="" uniform="true" uiname="Layer Y" />
+    <input name="layerz" type="string" value="" uniform="true" uiname="Layer Z" />
+    <input name="default" type="vector2" value="0.0, 0.0" uiname="Default" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nobject" uiname="Normal" />
+    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" uiname="Up Axis" />
+    <input name="blend" type="float" value="1.0" uiname="Blend" uimin="0.0" uimax="1.0" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_triplanarprojection_vector3" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="filex" type="filename" value="" uniform="true" uiname="File X" />
+    <input name="filey" type="filename" value="" uniform="true" uiname="File Y" />
+    <input name="filez" type="filename" value="" uniform="true" uiname="File Z" />
+    <input name="layerx" type="string" value="" uniform="true" uiname="Layer X" />
+    <input name="layery" type="string" value="" uniform="true" uiname="Layer Y" />
+    <input name="layerz" type="string" value="" uniform="true" uiname="Layer Z" />
+    <input name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nobject" uiname="Normal" />
+    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" uiname="Up Axis" />
+    <input name="blend" type="float" value="1.0" uiname="Blend" uimin="0.0" uimax="1.0" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_triplanarprojection_vector4" node="triplanarprojection" nodegroup="texture3d">
-    <input name="filex" type="filename" value="" uniform="true" />
-    <input name="filey" type="filename" value="" uniform="true" />
-    <input name="filez" type="filename" value="" uniform="true" />
-    <input name="layerx" type="string" value="" uniform="true" />
-    <input name="layery" type="string" value="" uniform="true" />
-    <input name="layerz" type="string" value="" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="normal" type="vector3" defaultgeomprop="Nobject" />
-    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" />
-    <input name="blend" type="float" value="1.0" uimin="0.0" uimax="1.0" />
-    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" />
-    <input name="framerange" type="string" value="" uniform="true" />
-    <input name="frameoffset" type="integer" value="0" uniform="true" />
-    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" />
+    <input name="filex" type="filename" value="" uniform="true" uiname="File X" />
+    <input name="filey" type="filename" value="" uniform="true" uiname="File Y" />
+    <input name="filez" type="filename" value="" uniform="true" uiname="File Z" />
+    <input name="layerx" type="string" value="" uniform="true" uiname="Layer X" />
+    <input name="layery" type="string" value="" uniform="true" uiname="Layer Y" />
+    <input name="layerz" type="string" value="" uniform="true" uiname="Layer Z" />
+    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nobject" uiname="Normal" />
+    <input name="upaxis" type="integer" value="2" enum="X,Y,Z" enumvalues="0,1,2" uniform="true" uiname="Up Axis" />
+    <input name="blend" type="float" value="1.0" uiname="Blend" uimin="0.0" uimax="1.0" />
+    <input name="filtertype" type="string" value="linear" enum="closest,linear,cubic" uniform="true" uiname="Filter Type" />
+    <input name="framerange" type="string" value="" uniform="true" uiname="Frame Range" />
+    <input name="frameoffset" type="integer" value="0" uniform="true" uiname="Frame Offset" />
+    <input name="frameendaction" type="string" value="constant" enum="constant,clamp,periodic,mirror" uniform="true" uiname="Frame End Action" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -467,51 +467,51 @@
     value that can be accessed in multiple places in the opgraph.
   -->
   <nodedef name="ND_constant_float" node="constant" nodegroup="procedural">
-    <input name="value" type="float" value="0.0" />
+    <input name="value" type="float" value="0.0" uiname="Value" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_constant_color3" node="constant" nodegroup="procedural">
-    <input name="value" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value" type="color3" value="0.0, 0.0, 0.0" uiname="Value" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_constant_color4" node="constant" nodegroup="procedural">
-    <input name="value" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_constant_vector2" node="constant" nodegroup="procedural">
-    <input name="value" type="vector2" value="0.0, 0.0" />
+    <input name="value" type="vector2" value="0.0, 0.0" uiname="Value" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_constant_vector3" node="constant" nodegroup="procedural">
-    <input name="value" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value" type="vector3" value="0.0, 0.0, 0.0" uiname="Value" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_constant_vector4" node="constant" nodegroup="procedural">
-    <input name="value" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_constant_boolean" node="constant" nodegroup="procedural">
-    <input name="value" type="boolean" value="false" />
+    <input name="value" type="boolean" value="false" uiname="Value" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_constant_integer" node="constant" nodegroup="procedural">
-    <input name="value" type="integer" value="0" />
+    <input name="value" type="integer" value="0" uiname="Value" />
     <output name="out" type="integer" default="0" />
   </nodedef>
   <nodedef name="ND_constant_matrix33" node="constant" nodegroup="procedural">
-    <input name="value" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="value" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Value" />
     <output name="out" type="matrix33" default="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
   </nodedef>
   <nodedef name="ND_constant_matrix44" node="constant" nodegroup="procedural">
-    <input name="value" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="value" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Value" />
     <output name="out" type="matrix44" default="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
   </nodedef>
   <nodedef name="ND_constant_string" node="constant" nodegroup="procedural">
-    <input name="value" type="string" value="" uniform="true" />
+    <input name="value" type="string" value="" uniform="true" uiname="Value" />
     <output name="out" type="string" default="" />
   </nodedef>
   <nodedef name="ND_constant_filename" node="constant" nodegroup="procedural">
-    <input name="value" type="filename" value="" uniform="true" />
+    <input name="value" type="filename" value="" uniform="true" uiname="Value" />
     <output name="out" type="filename" default="" />
   </nodedef>
 
@@ -520,30 +520,30 @@
     A ramp that supports up to 10 control points.
   -->
   <nodedef name="ND_ramp" node="ramp" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="type" type="integer" value="0" enum="standard,radial,circular,box" enumvalues="0,1,2,3" />
-    <input name="interpolation" type="integer" value="1" enum="linear,smooth,step" enumvalues="0,1,2" />
-    <input name="num_intervals" type="integer" value="2" uimin="2" uimax="10" />
-    <input name="interval1" type="float" value="0" uimin="0" uimax="1" />
-    <input name="color1" type="color4" value="0,0,0,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval2" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color2" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval3" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color3" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval4" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color4" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval5" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color5" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval6" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color6" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval7" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color7" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval8" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color8" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval9" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color9" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval10" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color10" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="type" type="integer" value="0" enum="standard,radial,circular,box" enumvalues="0,1,2,3" uiname="Type" />
+    <input name="interpolation" type="integer" value="1" enum="linear,smooth,step" enumvalues="0,1,2" uiname="Interpolation" />
+    <input name="num_intervals" type="integer" value="2" uiname="Number of Intervals" uimin="2" uimax="10" />
+    <input name="interval1" type="float" value="0" uiname="Interval 1" uimin="0" uimax="1" />
+    <input name="color1" type="color4" value="0,0,0,1" uiname="Color 1" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval2" type="float" value="1" uiname="Interval 2" uimin="0" uimax="1" />
+    <input name="color2" type="color4" value="1,1,1,1" uiname="Color 2" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval3" type="float" value="1" uiname="Interval 3" uimin="0" uimax="1" />
+    <input name="color3" type="color4" value="1,1,1,1" uiname="Color 3" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval4" type="float" value="1" uiname="Interval 4" uimin="0" uimax="1" />
+    <input name="color4" type="color4" value="1,1,1,1" uiname="Color 4" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval5" type="float" value="1" uiname="Interval 5" uimin="0" uimax="1" />
+    <input name="color5" type="color4" value="1,1,1,1" uiname="Color 5" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval6" type="float" value="1" uiname="Interval 6" uimin="0" uimax="1" />
+    <input name="color6" type="color4" value="1,1,1,1" uiname="Color 6" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval7" type="float" value="1" uiname="Interval 7" uimin="0" uimax="1" />
+    <input name="color7" type="color4" value="1,1,1,1" uiname="Color 7" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval8" type="float" value="1" uiname="Interval 8" uimin="0" uimax="1" />
+    <input name="color8" type="color4" value="1,1,1,1" uiname="Color 8" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval9" type="float" value="1" uiname="Interval 9" uimin="0" uimax="1" />
+    <input name="color9" type="color4" value="1,1,1,1" uiname="Color 9" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval10" type="float" value="1" uiname="Interval 10" uimin="0" uimax="1" />
+    <input name="color10" type="color4" value="1,1,1,1" uiname="Color 10" uimin="0,0,0,0" uimax="1,1,1,1" />
     <output name="out" type="color4" />
   </nodedef>
 
@@ -552,15 +552,15 @@
     A helper node that handles a single control point within a <ramp>.
   -->
   <nodedef name="ND_ramp_gradient" node="ramp_gradient" nodegroup="procedural2d">
-    <input name="x" type="float" value="0" uimin="0" uimax="1" />
-    <input name="interval1" type="float" value="0" uimin="0" uimax="1" />
-    <input name="interval2" type="float" value="1" uimin="0" uimax="1" />
-    <input name="color1" type="color4" value="0,0,0,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="color2" type="color4" value="1,1,1,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interpolation" type="integer" value="1" enum="linear,smooth,step" enumvalues="0,1,2" />
-    <input name="prev_color" type="color4" value="0,0,0,1" uimin="0,0,0,0" uimax="1,1,1,1" />
-    <input name="interval_num" type="integer" value="1" />
-    <input name="num_intervals" type="integer" value="2" />
+    <input name="x" type="float" value="0" uiname="X" uimin="0" uimax="1" />
+    <input name="interval1" type="float" value="0" uiname="Interval 1" uimin="0" uimax="1" />
+    <input name="interval2" type="float" value="1" uiname="Interval 2" uimin="0" uimax="1" />
+    <input name="color1" type="color4" value="0,0,0,1" uiname="Color 1" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="color2" type="color4" value="1,1,1,1" uiname="Color 2" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interpolation" type="integer" value="1" enum="linear,smooth,step" enumvalues="0,1,2" uiname="Interpolation" />
+    <input name="prev_color" type="color4" value="0,0,0,1" uiname="Previous Color" uimin="0,0,0,0" uimax="1,1,1,1" />
+    <input name="interval_num" type="integer" value="1" uiname="Interval Number" />
+    <input name="num_intervals" type="integer" value="2" uiname="Number of Intervals" />
     <output name="out" type="color4" />
   </nodedef>
 
@@ -569,39 +569,39 @@
     A left-to-right bilinear value ramp.
   -->
   <nodedef name="ND_ramplr_float" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="float" value="0.0" />
-    <input name="valuer" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuel" type="float" value="0.0" uiname="Value Left" />
+    <input name="valuer" type="float" value="0.0" uiname="Value Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_ramplr_color3" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuer" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuel" type="color3" value="0.0, 0.0, 0.0" uiname="Value Left" />
+    <input name="valuer" type="color3" value="0.0, 0.0, 0.0" uiname="Value Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramplr_color4" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Left" />
+    <input name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramplr_vector2" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="vector2" value="0.0, 0.0" />
-    <input name="valuer" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuel" type="vector2" value="0.0, 0.0" uiname="Value Left" />
+    <input name="valuer" type="vector2" value="0.0, 0.0" uiname="Value Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramplr_vector3" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuer" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuel" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Left" />
+    <input name="valuer" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramplr_vector4" node="ramplr" nodegroup="procedural2d">
-    <input name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Left" />
+    <input name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -610,39 +610,39 @@
     A top-to-bottom bilinear value ramp.
   -->
   <nodedef name="ND_ramptb_float" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="float" value="0.0" />
-    <input name="valueb" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuet" type="float" value="0.0" uiname="Value Top" />
+    <input name="valueb" type="float" value="0.0" uiname="Value Bottom" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_ramptb_color3" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valueb" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuet" type="color3" value="0.0, 0.0, 0.0" uiname="Value Top" />
+    <input name="valueb" type="color3" value="0.0, 0.0, 0.0" uiname="Value Bottom" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramptb_color4" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Top" />
+    <input name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Bottom" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramptb_vector2" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="vector2" value="0.0, 0.0" />
-    <input name="valueb" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuet" type="vector2" value="0.0, 0.0" uiname="Value Top" />
+    <input name="valueb" type="vector2" value="0.0, 0.0" uiname="Value Bottom" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramptb_vector3" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valueb" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuet" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Top" />
+    <input name="valueb" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Bottom" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramptb_vector4" node="ramptb" nodegroup="procedural2d">
-    <input name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Top" />
+    <input name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Bottom" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -651,51 +651,51 @@
     A 4-corner bilinear value ramp.
   -->
   <nodedef name="ND_ramp4_float" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="float" value="0.0" />
-    <input name="valuetr" type="float" value="0.0" />
-    <input name="valuebl" type="float" value="0.0" />
-    <input name="valuebr" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuetl" type="float" value="0.0" uiname="Value Top Left" />
+    <input name="valuetr" type="float" value="0.0" uiname="Value Top Right" />
+    <input name="valuebl" type="float" value="0.0" uiname="Value Bottom Left" />
+    <input name="valuebr" type="float" value="0.0" uiname="Value Bottom Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_ramp4_color3" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuetr" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuebl" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="valuebr" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuetl" type="color3" value="0.0, 0.0, 0.0" uiname="Value Top Left" />
+    <input name="valuetr" type="color3" value="0.0, 0.0, 0.0" uiname="Value Top Right" />
+    <input name="valuebl" type="color3" value="0.0, 0.0, 0.0" uiname="Value Bottom Left" />
+    <input name="valuebr" type="color3" value="0.0, 0.0, 0.0" uiname="Value Bottom Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramp4_color4" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuetr" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebl" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebr" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuetl" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Top Left" />
+    <input name="valuetr" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Top Right" />
+    <input name="valuebl" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Bottom Left" />
+    <input name="valuebr" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Bottom Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramp4_vector2" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="vector2" value="0.0, 0.0" />
-    <input name="valuetr" type="vector2" value="0.0, 0.0" />
-    <input name="valuebl" type="vector2" value="0.0, 0.0" />
-    <input name="valuebr" type="vector2" value="0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuetl" type="vector2" value="0.0, 0.0" uiname="Value Top Left" />
+    <input name="valuetr" type="vector2" value="0.0, 0.0" uiname="Value Top Right" />
+    <input name="valuebl" type="vector2" value="0.0, 0.0" uiname="Value Bottom Left" />
+    <input name="valuebr" type="vector2" value="0.0, 0.0" uiname="Value Bottom Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramp4_vector3" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuetr" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuebl" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="valuebr" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuetl" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Top Left" />
+    <input name="valuetr" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Top Right" />
+    <input name="valuebl" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Bottom Left" />
+    <input name="valuebr" type="vector3" value="0.0, 0.0, 0.0" uiname="Value Bottom Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_ramp4_vector4" node="ramp4" nodegroup="procedural2d">
-    <input name="valuetl" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuetr" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebl" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="valuebr" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="valuetl" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Top Left" />
+    <input name="valuetr" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Top Right" />
+    <input name="valuebl" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Bottom Left" />
+    <input name="valuebr" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Value Bottom Right" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -707,42 +707,42 @@
     <input name="valuel" type="float" value="0.0" uiname="Left" />
     <input name="valuer" type="float" value="0.0" uiname="Right" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_splitlr_color3" node="splitlr" nodegroup="procedural2d">
     <input name="valuel" type="color3" value="0.0, 0.0, 0.0" uiname="Left" />
     <input name="valuer" type="color3" value="0.0, 0.0, 0.0" uiname="Right" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splitlr_color4" node="splitlr" nodegroup="procedural2d">
     <input name="valuel" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Left" />
     <input name="valuer" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Right" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splitlr_vector2" node="splitlr" nodegroup="procedural2d">
     <input name="valuel" type="vector2" value="0.0, 0.0" uiname="Left" />
     <input name="valuer" type="vector2" value="0.0, 0.0" uiname="Right" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splitlr_vector3" node="splitlr" nodegroup="procedural2d">
     <input name="valuel" type="vector3" value="0.0, 0.0, 0.0" uiname="Left" />
     <input name="valuer" type="vector3" value="0.0, 0.0, 0.0" uiname="Right" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splitlr_vector4" node="splitlr" nodegroup="procedural2d">
     <input name="valuel" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Left" />
     <input name="valuer" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Right" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <!--
@@ -753,42 +753,42 @@
     <input name="valuet" type="float" value="0.0" uiname="Top" />
     <input name="valueb" type="float" value="0.0" uiname="Bottom" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_splittb_color3" node="splittb" nodegroup="procedural2d">
     <input name="valuet" type="color3" value="0.0, 0.0, 0.0" uiname="Top" />
     <input name="valueb" type="color3" value="0.0, 0.0, 0.0" uiname="Bottom" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splittb_color4" node="splittb" nodegroup="procedural2d">
     <input name="valuet" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Top" />
     <input name="valueb" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splittb_vector2" node="splittb" nodegroup="procedural2d">
     <input name="valuet" type="vector2" value="0.0, 0.0" uiname="Top" />
     <input name="valueb" type="vector2" value="0.0, 0.0" uiname="Bottom" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splittb_vector3" node="splittb" nodegroup="procedural2d">
     <input name="valuet" type="vector3" value="0.0, 0.0, 0.0" uiname="Top" />
     <input name="valueb" type="vector3" value="0.0, 0.0, 0.0" uiname="Bottom" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_splittb_vector4" node="splittb" nodegroup="procedural2d">
     <input name="valuet" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Top" />
     <input name="valueb" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Bottom" />
     <input name="center" type="float" value="0.5" uiname="Center" uimin="0.0" uimax="1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -797,69 +797,69 @@
     2D Perlin noise in 1, 2, 3 or 4 channels.
   -->
   <nodedef name="ND_noise2d_float" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_color3" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_color4" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_vector2" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector2" value="1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_vector3" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_vector4" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_color3FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_color4FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_vector2FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_vector3FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise2d_vector4FA" node="noise2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -868,69 +868,69 @@
     3D Perlin noise in 1, 2, 3 or 4 channels.
   -->
   <nodedef name="ND_noise3d_float" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_color3" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_color4" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_vector2" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector2" value="1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_vector3" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_vector4" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_color3FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_color4FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_vector2FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_vector3FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_noise3d_vector4FA" node="noise3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.0" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="pivot" type="float" value="0.0" uiname="Pivot" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -939,91 +939,91 @@
     2D Fractal noise in 1, 2, 3 or 4 channels.
   -->
   <nodedef name="ND_fractal2d_float" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_color3" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_color4" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_vector2" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector2" value="1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_vector3" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_vector4" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_color3FA" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_color4FA" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_vector2FA" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_vector3FA" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal2d_vector4FA" node="fractal2d" nodegroup="procedural2d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1032,91 +1032,91 @@
     3D Fractal noise in 1, 2, 3 or 4 channels.
   -->
   <nodedef name="ND_fractal3d_float" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_color3" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_color4" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_vector2" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector2" value="1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector2" value="1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_vector3" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector3" value="1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_vector4" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_color3FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_color4FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_vector2FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_vector3FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_fractal3d_vector4FA" node="fractal3d" nodegroup="procedural3d">
-    <input name="amplitude" type="float" value="1.0" />
-    <input name="octaves" type="integer" value="3" />
-    <input name="lacunarity" type="float" value="2.0" />
-    <input name="diminish" type="float" value="0.5" />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="amplitude" type="float" value="1.0" uiname="Amplitude" />
+    <input name="octaves" type="integer" value="3" uiname="Octaves" />
+    <input name="lacunarity" type="float" value="2.0" uiname="Lacunarity" />
+    <input name="diminish" type="float" value="0.5" uiname="Diminish" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1125,7 +1125,7 @@
     2D cellular noise in 1 channel.
   -->
   <nodedef name="ND_cellnoise2d_float" node="cellnoise2d" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -1134,7 +1134,7 @@
     3D cellular noise in 1 channel.
   -->
   <nodedef name="ND_cellnoise3d_float" node="cellnoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -1143,20 +1143,20 @@
     2D Worley (voronoi) noise in 1, 2 or 3 channels.
   -->
   <nodedef name="ND_worleynoise2d_float" node="worleynoise2d" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="jitter" type="float" value="1.0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="jitter" type="float" value="1.0" uiname="Jitter" />
     <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_worleynoise2d_vector2" node="worleynoise2d" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="jitter" type="float" value="1.0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="jitter" type="float" value="1.0" uiname="Jitter" />
     <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_worleynoise2d_vector3" node="worleynoise2d" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="jitter" type="float" value="1.0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="jitter" type="float" value="1.0" uiname="Jitter" />
     <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
@@ -1166,20 +1166,20 @@
     3D Worley (voronoi) noise in 1, 2 or 3 channels.
   -->
   <nodedef name="ND_worleynoise3d_float" node="worleynoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="jitter" type="float" value="1.0" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="jitter" type="float" value="1.0" uiname="Jitter" />
     <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_worleynoise3d_vector2" node="worleynoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="jitter" type="float" value="1.0" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="jitter" type="float" value="1.0" uiname="Jitter" />
     <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_worleynoise3d_vector3" node="worleynoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" defaultgeomprop="Pobject" />
-    <input name="jitter" type="float" value="1.0" />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" uiname="Position" />
+    <input name="jitter" type="float" value="1.0" uiname="Jitter" />
     <input name="style" uiname="Cell Style" type="integer" value="0" enum="Distance,Solid" enumvalues="0,1" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
@@ -1202,7 +1202,7 @@
     The output is 1 channel, with controls to adjust the output range.
   -->
   <nodedef name="ND_unifiednoise2d_float" node="unifiednoise2d" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" uifolder="Common" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." />
+    <input name="texcoord" type="vector2" uiname="Texture Coordinates" uifolder="Common" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." />
     <input name="freq" type="vector2" uiname="Frequency" uifolder="Common" value="1, 1" doc="Adjusts the noise frequency, with higher values producing smaller noise shapes. Default is (1,1)." />
     <input name="offset" type="vector2" uiname="Offset" uifolder="Common" value="0, 0" doc="Shift the noise in 2d space. Default is (0,0)." />
     <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjust uniformity of Worley noise; for other noise types jitters the results." />
@@ -1222,7 +1222,7 @@
     The 3d flavor of <unifiednoise2d>.
   -->
   <nodedef name="ND_unifiednoise3d_float" node="unifiednoise3d" nodegroup="procedural3d">
-    <input name="position" type="vector3" uifolder="Common" defaultgeomprop="Pobject" doc="The input 3d space. Default is position in object-space." />
+    <input name="position" type="vector3" uiname="Position" uifolder="Common" defaultgeomprop="Pobject" doc="The input 3d space. Default is position in object-space." />
     <input name="freq" type="vector3" uiname="Frequency" uifolder="Common" value="1, 1, 1" doc="Adjusts the noise frequency, with higher values producing smaller noise shapes. Default is (1,1,1)." />
     <input name="offset" type="vector3" uiname="Offset" uifolder="Common" value="0, 0, 0" doc="Shift the noise in 3d space. Default is (0,0,0)." />
     <input name="jitter" type="float" uiname="Jitter" uifolder="Common" uisoftmin="0.0" uisoftmax="1.0" value="1" doc="Adjust uniformity of Worley noise; for other noise types jitters the results." />
@@ -1242,13 +1242,13 @@
     2D flake pattern generator.
   -->
   <nodedef name="ND_flake2d" node="flake2d" nodegroup="procedural2d">
-    <input name="size" type="float" value="0.01" doc="Size of individual flakes." />
-    <input name="roughness" type="float" value="0.1" uimin="0.0" uimax="1.0" doc="Roughness of the flake normal distribution." />
-    <input name="coverage" type="float" value="0.5" uimin="0.0" uimax="1.0" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
-    <input name="tangent" type="vector3" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />
-    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" doc="Surface bitangent vector, defaults to the current world-space bitangent vector." />
+    <input name="size" type="float" value="0.01" doc="Size of individual flakes." uiname="Size" />
+    <input name="roughness" type="float" value="0.1" uiname="Roughness" uimin="0.0" uimax="1.0" doc="Roughness of the flake normal distribution." />
+    <input name="coverage" type="float" value="0.5" uiname="Coverage" uimin="0.0" uimax="1.0" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" doc="The input 2d space. Default is the first texture coordinates." uiname="Texture Coordinates" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." uiname="Normal" />
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." uiname="Tangent" />
+    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" doc="Surface bitangent vector, defaults to the current world-space bitangent vector." uiname="Bitangent" />
     <output name="id" type="integer" default="0" doc="Stable pseudo-random integer label for the selected flake, not guaranteed to be unique (0 for no flake)." />
     <output name="rand" type="float" default="0.0" doc="Random value per flake for additional variation (0 for no flake)." />
     <output name="presence" type="float" default="0.0" doc="Depth-based presence value per flake for additional variation (0 for no flake)." />
@@ -1260,13 +1260,13 @@
     3D flake pattern generator.
   -->
   <nodedef name="ND_flake3d" node="flake3d" nodegroup="procedural3d">
-    <input name="size" type="float" value="0.01" doc="Size of individual flakes." />
-    <input name="roughness" type="float" value="0.1" uimin="0.0" uimax="1.0" doc="Roughness of the flake normal distribution." />
-    <input name="coverage" type="float" value="0.5" uimin="0.0" uimax="1.0" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
-    <input name="position" type="vector3" defaultgeomprop="Pobject" doc="The input 3d space. Default is position in object-space." />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." />
-    <input name="tangent" type="vector3" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." />
-    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" doc="Surface bitangent vector, defaults to the current world-space bitangent vector." />
+    <input name="size" type="float" value="0.01" doc="Size of individual flakes." uiname="Size" />
+    <input name="roughness" type="float" value="0.1" uiname="Roughness" uimin="0.0" uimax="1.0" doc="Roughness of the flake normal distribution." />
+    <input name="coverage" type="float" value="0.5" uiname="Coverage" uimin="0.0" uimax="1.0" doc="Density of flake coverage (0 = no flakes, 1 = full coverage)." />
+    <input name="position" type="vector3" defaultgeomprop="Pobject" doc="The input 3d space. Default is position in object-space." uiname="Position" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal; defaults to the current world-space normal." uiname="Normal" />
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld" doc="Surface tangent vector, defaults to the current world-space tangent vector." uiname="Tangent" />
+    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" doc="Surface bitangent vector, defaults to the current world-space bitangent vector." uiname="Bitangent" />
     <output name="id" type="integer" default="0" doc="Stable pseudo-random integer label for the selected flake, not guaranteed to be unique (0 for no flake)." />
     <output name="rand" type="float" default="0.0" doc="Random value per flake for additional variation (0 for no flake)." />
     <output name="presence" type="float" default="0.0" doc="Depth-based presence value per flake for additional variation (0 for no flake)." />
@@ -1339,11 +1339,11 @@
     Uses formulas from Inigo Quilez SDF samples (iquilezles.org)
   -->
   <nodedef name="ND_line_float" node="line" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="center" type="vector2" value="0, 0" />
-    <input name="radius" type="float" value="0.1" />
-    <input name="point1" type="vector2" value="0.25, 0.25" />
-    <input name="point2" type="vector2" value="0.75, 0.75" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="center" type="vector2" value="0, 0" uiname="Center" />
+    <input name="radius" type="float" value="0.1" uiname="Radius" />
+    <input name="point1" type="vector2" value="0.25, 0.25" uiname="Point 1" />
+    <input name="point2" type="vector2" value="0.75, 0.75" uiname="Point 2" />
     <output name="out" type="float" />
   </nodedef>
 
@@ -1352,9 +1352,9 @@
     Returns 1 if texcoord is inside a circle defined by center and radius; otherwise returns 0.
   -->
   <nodedef name="ND_circle_float" node="circle" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="center" type="vector2" value="0, 0" />
-    <input name="radius" type="float" value="0.5" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="center" type="vector2" value="0, 0" uiname="Center" />
+    <input name="radius" type="float" value="0.5" uiname="Radius" />
     <output name="out" type="float" />
   </nodedef>
 
@@ -1363,9 +1363,9 @@
     Returns 1 if texcoord is inside a cloverleaf shape inscribed by a circle defined by center and radius; otherwise returns 0.
   -->
   <nodedef name="ND_cloverleaf_float" node="cloverleaf" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="center" type="vector2" value="0, 0" />
-    <input name="radius" type="float" value="0.5" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="center" type="vector2" value="0, 0" uiname="Center" />
+    <input name="radius" type="float" value="0.5" uiname="Radius" />
     <output name="out" type="float" />
   </nodedef>
 
@@ -1375,9 +1375,9 @@
     Uses formulas from Inigo Quilez SDF samples (iquilezles.org)
   -->
   <nodedef name="ND_hexagon_float" node="hexagon" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="center" type="vector2" value="0, 0" />
-    <input name="radius" type="float" value="0.5" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="center" type="vector2" value="0, 0" uiname="Center" />
+    <input name="radius" type="float" value="0.5" uiname="Radius" />
     <output name="out" type="float" />
   </nodedef>
 
@@ -1387,11 +1387,11 @@
     Pattern can be regular or staggered.
   -->
   <nodedef name="ND_grid_color3" node="grid" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="thickness" type="float" value="0.05" />
-    <input name="staggered" type="boolean" value="false" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="thickness" type="float" value="0.05" uiname="Thickness" />
+    <input name="staggered" type="boolean" value="false" uiname="Staggered" />
     <output name="out" type="color3" />
   </nodedef>
 
@@ -1401,11 +1401,11 @@
     Pattern can be regular or staggered.
   -->
   <nodedef name="ND_crosshatch_color3" node="crosshatch" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="thickness" type="float" value="0.05" />
-    <input name="staggered" type="boolean" value="false" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="thickness" type="float" value="0.05" uiname="Thickness" />
+    <input name="staggered" type="boolean" value="false" uiname="Staggered" />
     <output name="out" type="color3" />
   </nodedef>
 
@@ -1415,11 +1415,11 @@
     Pattern can be regular or staggered.
   -->
   <nodedef name="ND_tiledcircles_color3" node="tiledcircles" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="size" type="float" value="0.5" />
-    <input name="staggered" type="boolean" value="false" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="size" type="float" value="0.5" uiname="Size" />
+    <input name="staggered" type="boolean" value="false" uiname="Staggered" />
     <output name="out" type="color3" />
   </nodedef>
 
@@ -1429,11 +1429,11 @@
     Pattern can be regular or staggered.
   -->
   <nodedef name="ND_tiledcloverleafs_color3" node="tiledcloverleafs" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="size" type="float" value="0.5" />
-    <input name="staggered" type="boolean" value="false" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="size" type="float" value="0.5" uiname="Size" />
+    <input name="staggered" type="boolean" value="false" uiname="Staggered" />
     <output name="out" type="color3" />
   </nodedef>
 
@@ -1443,11 +1443,11 @@
     Pattern can be regular or staggered.
   -->
   <nodedef name="ND_tiledhexagons_color3" node="tiledhexagons" nodegroup="procedural2d">
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="uvtiling" type="vector2" value="1.0, 1.0" />
-    <input name="uvoffset" type="vector2" value="0.0, 0.0" />
-    <input name="size" type="float" value="0.5" />
-    <input name="staggered" type="boolean" value="false" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="uvtiling" type="vector2" value="1.0, 1.0" uiname="UV Tiling" />
+    <input name="uvoffset" type="vector2" value="0.0, 0.0" uiname="UV Offset" />
+    <input name="size" type="float" value="0.5" uiname="Size" />
+    <input name="staggered" type="boolean" value="false" uiname="Staggered" />
     <output name="out" type="color3" />
   </nodedef>
 
@@ -1461,7 +1461,7 @@
     as defined in a specific coordinate space.
   -->
   <nodedef name="ND_position_vector3" node="position" nodegroup="geometric">
-    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" />
+    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" uiname="Space" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1471,7 +1471,7 @@
     as defined in a specific coordinate space.
   -->
   <nodedef name="ND_normal_vector3" node="normal" nodegroup="geometric">
-    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" />
+    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" uiname="Space" />
     <output name="out" type="vector3" default="0.0, 1.0, 0.0" />
   </nodedef>
 
@@ -1481,8 +1481,8 @@
     as defined in a specific coordinate space.
   -->
   <nodedef name="ND_tangent_vector3" node="tangent" nodegroup="geometric">
-    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" />
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" uiname="Space" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="vector3" default="1.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1492,8 +1492,8 @@
     as defined in a specific coordinate space.
   -->
   <nodedef name="ND_bitangent_vector3" node="bitangent" nodegroup="geometric">
-    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" />
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="space" type="string" value="object" enum="model,object,world" uniform="true" uiname="Space" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="vector3" default="0.0, 0.0, 1.0" />
   </nodedef>
 
@@ -1502,11 +1502,11 @@
     The full 2D or 3D texture coordinates associated with the currently processed data.
   -->
   <nodedef name="ND_texcoord_vector2" node="texcoord" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_texcoord_vector3" node="texcoord" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1516,15 +1516,15 @@
     bound via per-vertex color values.
   -->
   <nodedef name="ND_geomcolor_float" node="geomcolor" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_geomcolor_color3" node="geomcolor" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_geomcolor_color4" node="geomcolor" nodegroup="geometric">
-    <input name="index" type="integer" value="0" uniform="true" />
+    <input name="index" type="integer" value="0" uniform="true" uiname="Index" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1533,43 +1533,43 @@
     The value of the specified geometric property for the current geometry.
   -->
   <nodedef name="ND_geompropvalue_integer" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="integer" value="0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="integer" value="0" uiname="Default" />
     <output name="out" type="integer" default="0" />
   </nodedef>
   <nodedef name="ND_geompropvalue_boolean" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="boolean" value="false" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="boolean" value="false" uiname="Default" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_geompropvalue_float" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="float" value="0.0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="float" value="0.0" uiname="Default" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_geompropvalue_color3" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="color3" value="0.0, 0.0, 0.0" uiname="Default" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_geompropvalue_color4" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_geompropvalue_vector2" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="vector2" value="0.0, 0.0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="vector2" value="0.0, 0.0" uiname="Default" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_geompropvalue_vector3" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="vector3" value="0.0, 0.0, 0.0" uiname="Default" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_geompropvalue_vector4" node="geompropvalue" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Default" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -1578,13 +1578,13 @@
     The uniform, non-varying value of the specified geometric property for the current geometry.
   -->
   <nodedef name="ND_geompropvalueuniform_string" node="geompropvalueuniform" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="string" value="" uniform="true" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="string" value="" uniform="true" uiname="Default" />
     <output name="out" type="string" default="" uniform="true" />
   </nodedef>
   <nodedef name="ND_geompropvalueuniform_filename" node="geompropvalueuniform" nodegroup="geometric">
-    <input name="geomprop" type="string" value="" uniform="true" />
-    <input name="default" type="filename" value="" uniform="true" />
+    <input name="geomprop" type="string" value="" uniform="true" uiname="Geometry Property" />
+    <input name="default" type="filename" value="" uniform="true" uiname="Default" />
     <output name="out" type="filename" default="" uniform="true" />
   </nodedef>
 
@@ -1619,7 +1619,7 @@
     The current time in seconds as defined by the host environment.
   -->
   <nodedef name="ND_time_float" node="time" nodegroup="application">
-    <input name="fps" type="float" value="24.0" />
+    <input name="fps" type="float" value="24.0" uiname="FPS" />
     <!-- An unused input, to be removed in a future specification version -->
     <output name="out" type="float" default="0.0" />
   </nodedef>
@@ -1633,83 +1633,83 @@
     Add "in2" value/stream to the incoming float/integer/color/vector/matrix.
   -->
   <nodedef name="ND_add_float" node="add" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_integer" node="add" nodegroup="math">
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color3" node="add" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color4" node="add" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector2" node="add" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector3" node="add" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector4" node="add" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix33" node="add" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" />
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix44" node="add" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" />
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color3FA" node="add" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_color4FA" node="add" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector2FA" node="add" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector3FA" node="add" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_vector4FA" node="add" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix33FA" node="add" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_add_matrix44FA" node="add" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
 
@@ -1718,83 +1718,83 @@
     Subtract "in2" value/stream from the incoming float/integer/color/vector/matrix.
   -->
   <nodedef name="ND_subtract_float" node="subtract" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_integer" node="subtract" nodegroup="math">
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color3" node="subtract" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color4" node="subtract" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector2" node="subtract" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector3" node="subtract" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector4" node="subtract" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix33" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" />
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0,0.0,0.0, 0.0,0.0,0.0, 0.0,0.0,0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix44" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" />
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0, 0.0,0.0,0.0,0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color3FA" node="subtract" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_color4FA" node="subtract" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector2FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector3FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_vector4FA" node="subtract" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix33FA" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_subtract_matrix44FA" node="subtract" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
 
@@ -1804,68 +1804,68 @@
     two matrices.
   -->
   <nodedef name="ND_multiply_float" node="multiply" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color3" node="multiply" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color4" node="multiply" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector2" node="multiply" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector3" node="multiply" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector4" node="multiply" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_matrix33" node="multiply" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_matrix44" node="multiply" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color3FA" node="multiply" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_color4FA" node="multiply" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector2FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector3FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_multiply_vector4FA" node="multiply" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -1876,68 +1876,68 @@
     inverse of a second matrix.
   -->
   <nodedef name="ND_divide_float" node="divide" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color3" node="divide" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color4" node="divide" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector2" node="divide" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector3" node="divide" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector4" node="divide" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_matrix33" node="divide" nodegroup="math">
-    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in1" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_matrix44" node="divide" nodegroup="math">
-    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in1" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color3FA" node="divide" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_color4FA" node="divide" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector2FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector3FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_divide_vector4FA" node="divide" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -1947,58 +1947,58 @@
     subtracting the integer portion. The modula "in2" value cannot be 0.
   -->
   <nodedef name="ND_modulo_float" node="modulo" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_color3" node="modulo" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_color4" node="modulo" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_vector2" node="modulo" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_vector3" node="modulo" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_vector4" node="modulo" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_color3FA" node="modulo" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_color4FA" node="modulo" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_vector2FA" node="modulo" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_vector3FA" node="modulo" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_modulo_vector4FA" node="modulo" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -2007,27 +2007,27 @@
     The fraction of a float or vector.
   -->
   <nodedef name="ND_fract_float" node="fract" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_fract_color3" node="fract" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_fract_color4" node="fract" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_fract_vector2" node="fract" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_fract_vector3" node="fract" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_fract_vector4" node="fract" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2037,58 +2037,58 @@
     outputting: amount - in.
   -->
   <nodedef name="ND_invert_float" node="invert" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <input name="amount" type="float" value="1.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_color3" node="invert" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="color3" value="1.0, 1.0, 1.0" uiname="Amount" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_color4" node="invert" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Amount" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_vector2" node="invert" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="vector2" value="1.0, 1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector2" value="1.0, 1.0" uiname="Amount" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_vector3" node="invert" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector3" value="1.0, 1.0, 1.0" uiname="Amount" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_vector4" node="invert" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amount" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_color3FA" node="invert" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_color4FA" node="invert" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_vector2FA" node="invert" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_vector3FA" node="invert" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invert_vector4FA" node="invert" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2097,27 +2097,27 @@
     The per-channel absolute value of the incoming float/color/vector.
   -->
   <nodedef name="ND_absval_float" node="absval" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_absval_color3" node="absval" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_absval_color4" node="absval" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_absval_vector2" node="absval" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_absval_vector3" node="absval" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_absval_vector4" node="absval" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2126,31 +2126,31 @@
     Find the nearest integer less than or equal to the parameter.
   -->
   <nodedef name="ND_floor_float" node="floor" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_floor_color3" node="floor" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_floor_color4" node="floor" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_floor_vector2" node="floor" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_floor_vector3" node="floor" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_floor_vector4" node="floor" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_floor_integer" node="floor" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="integer" defaultinput="in" />
   </nodedef>
 
@@ -2159,31 +2159,31 @@
     Find the nearest integer greater than or equal to the parameter.
   -->
   <nodedef name="ND_ceil_float" node="ceil" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ceil_color3" node="ceil" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ceil_color4" node="ceil" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ceil_vector2" node="ceil" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ceil_vector3" node="ceil" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ceil_vector4" node="ceil" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ceil_integer" node="ceil" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="integer" defaultinput="in" />
   </nodedef>
 
@@ -2192,31 +2192,31 @@
     Round incoming float/color/vector values.
   -->
   <nodedef name="ND_round_float" node="round" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_round_color3" node="round" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_round_color4" node="round" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_round_vector2" node="round" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_round_vector3" node="round" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_round_vector4" node="round" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_round_integer" node="round" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="integer" defaultinput="in" />
   </nodedef>
 
@@ -2225,58 +2225,58 @@
     Raise incoming float/color/vector values to the "in2" power.
   -->
   <nodedef name="ND_power_float" node="power" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_color3" node="power" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_color4" node="power" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_vector2" node="power" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_vector3" node="power" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_vector4" node="power" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_color3FA" node="power" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_color4FA" node="power" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_vector2FA" node="power" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_vector3FA" node="power" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_power_vector4FA" node="power" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -2286,58 +2286,58 @@
     Negative "in1" values will result in negative output values. ie. out = sign(in1)*pow(abs(in1),in2)
   -->
   <nodedef name="ND_safepower_float" node="safepower" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_color3" node="safepower" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_color4" node="safepower" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_vector2" node="safepower" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="1.0, 1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_vector3" node="safepower" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_vector4" node="safepower" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_color3FA" node="safepower" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_color4FA" node="safepower" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_vector2FA" node="safepower" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_vector3FA" node="safepower" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_safepower_vector4FA" node="safepower" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="1.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="1.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -2346,103 +2346,103 @@
     Standard trigonometric functions; angles are given in radians.
   -->
   <nodedef name="ND_sin_float" node="sin" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_cos_float" node="cos" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_tan_float" node="tan" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_asin_float" node="asin" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_acos_float" node="acos" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_float" node="atan2" nodegroup="math">
-    <input name="iny" type="float" value="0.0" />
-    <input name="inx" type="float" value="1.0" />
+    <input name="iny" type="float" value="0.0" uiname="Input Y" />
+    <input name="inx" type="float" value="1.0" uiname="Input X" />
     <output name="out" type="float" defaultinput="iny" />
   </nodedef>
   <nodedef name="ND_sin_vector2" node="sin" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_cos_vector2" node="cos" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_tan_vector2" node="tan" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_asin_vector2" node="asin" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_acos_vector2" node="acos" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_vector2" node="atan2" nodegroup="math">
-    <input name="iny" type="vector2" value="0.0, 0.0" />
-    <input name="inx" type="vector2" value="1.0, 1.0" />
+    <input name="iny" type="vector2" value="0.0, 0.0" uiname="Input Y" />
+    <input name="inx" type="vector2" value="1.0, 1.0" uiname="Input X" />
     <output name="out" type="vector2" defaultinput="iny" />
   </nodedef>
   <nodedef name="ND_sin_vector3" node="sin" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_cos_vector3" node="cos" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_tan_vector3" node="tan" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_asin_vector3" node="asin" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_acos_vector3" node="acos" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_vector3" node="atan2" nodegroup="math">
-    <input name="iny" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inx" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="iny" type="vector3" value="0.0, 0.0, 0.0" uiname="Input Y" />
+    <input name="inx" type="vector3" value="1.0, 1.0, 1.0" uiname="Input X" />
     <output name="out" type="vector3" defaultinput="iny" />
   </nodedef>
   <nodedef name="ND_sin_vector4" node="sin" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_cos_vector4" node="cos" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_tan_vector4" node="tan" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_asin_vector4" node="asin" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_acos_vector4" node="acos" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_atan2_vector4" node="atan2" nodegroup="math">
-    <input name="iny" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inx" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="iny" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input Y" />
+    <input name="inx" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input X" />
     <output name="out" type="vector4" defaultinput="iny" />
   </nodedef>
 
@@ -2451,51 +2451,51 @@
     Standard math functions.
   -->
   <nodedef name="ND_sqrt_float" node="sqrt" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ln_float" node="ln" nodegroup="math">
-    <input name="in" type="float" value="1.0" />
+    <input name="in" type="float" value="1.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_exp_float" node="exp" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sqrt_vector2" node="sqrt" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ln_vector2" node="ln" nodegroup="math">
-    <input name="in" type="vector2" value="1.0, 1.0" />
+    <input name="in" type="vector2" value="1.0, 1.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_exp_vector2" node="exp" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sqrt_vector3" node="sqrt" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ln_vector3" node="ln" nodegroup="math">
-    <input name="in" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="vector3" value="1.0, 1.0, 1.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_exp_vector3" node="exp" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sqrt_vector4" node="sqrt" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_ln_vector4" node="ln" nodegroup="math">
-    <input name="in" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_exp_vector4" node="exp" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2504,27 +2504,27 @@
     Sign of eachinput channel: -1, 0 or +1
   -->
   <nodedef name="ND_sign_float" node="sign" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sign_color3" node="sign" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sign_color4" node="sign" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sign_vector2" node="sign" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sign_vector3" node="sign" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_sign_vector4" node="sign" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2533,69 +2533,69 @@
     Clamp incoming value to a specified range of values.
   -->
   <nodedef name="ND_clamp_float" node="clamp" nodegroup="math">
-    <input name="in" type="float" value="0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_color3" node="clamp" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="color3" value="0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="color3" value="1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_color4" node="clamp" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_vector2" node="clamp" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="vector2" value="0.0, 0.0" />
-    <input name="high" type="vector2" value="1.0, 1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="low" type="vector2" value="0.0, 0.0" uiname="Low" />
+    <input name="high" type="vector2" value="1.0, 1.0" uiname="High" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_vector3" node="clamp" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="vector3" value="0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="vector3" value="1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_vector4" node="clamp" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_color3FA" node="clamp" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_color4FA" node="clamp" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_vector2FA" node="clamp" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_vector3FA" node="clamp" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_clamp_vector4FA" node="clamp" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2604,58 +2604,58 @@
     Select the minimum among incoming values.
   -->
   <nodedef name="ND_min_float" node="min" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_color3" node="min" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_color4" node="min" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_vector2" node="min" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_vector3" node="min" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_vector4" node="min" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_color3FA" node="min" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_color4FA" node="min" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_vector2FA" node="min" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_vector3FA" node="min" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_min_vector4FA" node="min" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -2664,58 +2664,58 @@
     Select the maximum among incoming values.
   -->
   <nodedef name="ND_max_float" node="max" nodegroup="math">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_color3" node="max" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_color4" node="max" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_vector2" node="max" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_vector3" node="max" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_vector4" node="max" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_color3FA" node="max" nodegroup="math">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_color4FA" node="max" nodegroup="math">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_vector2FA" node="max" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_vector3FA" node="max" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_max_vector4FA" node="max" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
 
@@ -2724,23 +2724,23 @@
     Output the minimum component of the incoming vector or color stream.
   -->
   <nodedef name="ND_mincomponent_color3" node="mincomponent" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_mincomponent_color4" node="mincomponent" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_mincomponent_vector2" node="mincomponent" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_mincomponent_vector3" node="mincomponent" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_mincomponent_vector4" node="mincomponent" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -2749,23 +2749,23 @@
     Output the maximum component of the incoming vector or color stream.
   -->
   <nodedef name="ND_maxcomponent_color3" node="maxcomponent" nodegroup="math">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_maxcomponent_color4" node="maxcomponent" nodegroup="math">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_maxcomponent_vector2" node="maxcomponent" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_maxcomponent_vector3" node="maxcomponent" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_maxcomponent_vector4" node="maxcomponent" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -2774,15 +2774,15 @@
     Outputs the normalized vector from the incoming vector stream.
   -->
   <nodedef name="ND_normalize_vector2" node="normalize" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_normalize_vector3" node="normalize" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_normalize_vector4" node="normalize" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2791,15 +2791,15 @@
     Outputs the float magnitude (vector length) of the incoming vector stream.
   -->
   <nodedef name="ND_magnitude_vector2" node="magnitude" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_magnitude_vector3" node="magnitude" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_magnitude_vector4" node="magnitude" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -2828,18 +2828,18 @@
     Perform a dot product of two 2-4 channel vectors
   -->
   <nodedef name="ND_dotproduct_vector2" node="dotproduct" nodegroup="math">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_dotproduct_vector3" node="dotproduct" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_dotproduct_vector4" node="dotproduct" nodegroup="math">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -2848,8 +2848,8 @@
     Perform a cross product of two vectors
   -->
   <nodedef name="ND_crossproduct_vector3" node="crossproduct" nodegroup="math">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
 
@@ -2858,9 +2858,9 @@
     Transform a vector3 coordinate from one named space to another.
   -->
   <nodedef name="ND_transformpoint_vector3" node="transformpoint" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="fromspace" type="string" value="" uniform="true" />
-    <input name="tospace" type="string" value="" uniform="true" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="fromspace" type="string" value="" uniform="true" uiname="From Space" />
+    <input name="tospace" type="string" value="" uniform="true" uiname="To Space" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
 
@@ -2869,9 +2869,9 @@
     Transform a vector from one named space to another.
   -->
   <nodedef name="ND_transformvector_vector3" node="transformvector" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="fromspace" type="string" value="" uniform="true" />
-    <input name="tospace" type="string" value="" uniform="true" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="fromspace" type="string" value="" uniform="true" uiname="From Space" />
+    <input name="tospace" type="string" value="" uniform="true" uiname="To Space" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <!--
@@ -2879,9 +2879,9 @@
     Transform a normal vector from one named space to another.
   -->
   <nodedef name="ND_transformnormal_vector3" node="transformnormal" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 1.0" />
-    <input name="fromspace" type="string" value="" uniform="true" />
-    <input name="tospace" type="string" value="" uniform="true" />
+    <input name="in" type="vector3" value="0.0, 0.0, 1.0" uiname="Input" />
+    <input name="fromspace" type="string" value="" uniform="true" uiname="From Space" />
+    <input name="tospace" type="string" value="" uniform="true" uiname="To Space" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
 
@@ -2890,23 +2890,23 @@
     Transform a vector by a matrix.
   -->
   <nodedef name="ND_transformmatrix_vector2M3" node="transformmatrix" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Matrix" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_transformmatrix_vector3" node="transformmatrix" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mat" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Matrix" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_transformmatrix_vector3M4" node="transformmatrix" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Matrix" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_transformmatrix_vector4" node="transformmatrix" nodegroup="math">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mat" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Matrix" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -2915,19 +2915,19 @@
     Transform a normal vector from object or tangent space into "world" space.
   -->
   <nodedef name="ND_normalmap_float" node="normalmap" nodegroup="math">
-    <input name="in" type="vector3" value="0.5, 0.5, 1.0" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" />
-    <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
-    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" />
+    <input name="in" type="vector3" value="0.5, 0.5, 1.0" uiname="Input" />
+    <input name="scale" type="float" value="1.0" uiname="Scale" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" />
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld" uiname="Tangent" />
+    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" uiname="Bitangent" />
     <output name="out" type="vector3" defaultinput="normal" />
   </nodedef>
   <nodedef name="ND_normalmap_vector2" node="normalmap" nodegroup="math">
-    <input name="in" type="vector3" value="0.5, 0.5, 1.0" />
-    <input name="scale" type="vector2" value="1.0, 1.0" />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" />
-    <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
-    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" />
+    <input name="in" type="vector3" value="0.5, 0.5, 1.0" uiname="Input" />
+    <input name="scale" type="vector2" value="1.0, 1.0" uiname="Scale" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" />
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld" uiname="Tangent" />
+    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" uiname="Bitangent" />
     <output name="out" type="vector3" defaultinput="normal" />
   </nodedef>
 
@@ -2937,22 +2937,22 @@
     across uv space.
   -->
   <nodedef name="ND_hextilednormalmap_vector3" node="hextilednormalmap" nodegroup="math">
-    <input name="file" type="filename" value="" uniform="true" />
-    <input name="default" type="vector3" value="0.5, 0.5, 1.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
-    <input name="tiling" type="vector2" value="1.0, 1.0" />
-    <input name="rotation" type="float" value="1.0" />
-    <input name="rotationrange" type="vector2" value="0.0, 360.0" />
-    <input name="scale" type="float" value="1.0" />
-    <input name="scalerange" type="vector2" value="0.5, 2.0" />
-    <input name="offset" type="float" value="1.0" />
-    <input name="offsetrange" type="vector2" value="0.0, 1.0" />
-    <input name="falloff" type="float" value="0.5" />
-    <input name="strength" type="float" value="1.0" />
-    <input name="flip_g" type="boolean" value="false" />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" />
-    <input name="tangent" type="vector3" defaultgeomprop="Tworld" />
-    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" />
+    <input name="file" type="filename" value="" uniform="true" uiname="Filename" />
+    <input name="default" type="vector3" value="0.5, 0.5, 1.0" uiname="Default" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
+    <input name="tiling" type="vector2" value="1.0, 1.0" uiname="Tiling" />
+    <input name="rotation" type="float" value="1.0" uiname="Rotation" />
+    <input name="rotationrange" type="vector2" value="0.0, 360.0" uiname="Rotation Range" />
+    <input name="scale" type="float" value="1.0" uiname="Scale" />
+    <input name="scalerange" type="vector2" value="0.5, 2.0" uiname="Scale Range" />
+    <input name="offset" type="float" value="1.0" uiname="Offset" />
+    <input name="offsetrange" type="vector2" value="0.0, 1.0" uiname="Offset Range" />
+    <input name="falloff" type="float" value="0.5" uiname="Falloff" />
+    <input name="strength" type="float" value="1.0" uiname="Strength" />
+    <input name="flip_g" type="boolean" value="false" uiname="Flip Green" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" />
+    <input name="tangent" type="vector3" defaultgeomprop="Tworld" uiname="Tangent" />
+    <input name="bitangent" type="vector3" defaultgeomprop="Bworld" uiname="Bitangent" />
     <output name="out" type="vector3" default="0.5, 0.5, 1.0" />
   </nodedef>
 
@@ -2961,11 +2961,11 @@
     Output the transpose of the incoming matrix.
   -->
   <nodedef name="ND_transpose_matrix33" node="transpose" nodegroup="math">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input" />
     <output name="out" type="matrix33" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_transpose_matrix44" node="transpose" nodegroup="math">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input" />
     <output name="out" type="matrix44" defaultinput="in" />
   </nodedef>
 
@@ -2974,11 +2974,11 @@
     Output the determinant of the incoming matrix.
   -->
   <nodedef name="ND_determinant_matrix33" node="determinant" nodegroup="math">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input" />
     <output name="out" type="float" default="1.0" />
   </nodedef>
   <nodedef name="ND_determinant_matrix44" node="determinant" nodegroup="math">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input" />
     <output name="out" type="float" default="1.0" />
   </nodedef>
 
@@ -2987,11 +2987,11 @@
     Invert an incoming matrix.
   -->
   <nodedef name="ND_invertmatrix_matrix33" node="invertmatrix" nodegroup="math">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input" />
     <output name="out" type="matrix33" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_invertmatrix_matrix44" node="invertmatrix" nodegroup="math">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input" />
     <output name="out" type="matrix44" defaultinput="in" />
   </nodedef>
 
@@ -3000,8 +3000,8 @@
     Rotate a vector2 value about the origin.
   -->
   <nodedef name="ND_rotate2d_vector2" node="rotate2d" nodegroup="math">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="float" value="0.0" unittype="angle" unit="degree" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="0.0" unittype="angle" unit="degree" uiname="Amount" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
 
@@ -3010,9 +3010,9 @@
     Rotate a vector3 value about a specified unit axis vector
   -->
   <nodedef name="ND_rotate3d_vector3" node="rotate3d" nodegroup="math">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="0.0" unittype="angle" unit="degree" />
-    <input name="axis" type="vector3" value="0.0, 1.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="0.0" unittype="angle" unit="degree" uiname="Amount" />
+    <input name="axis" type="vector3" value="0.0, 1.0, 0.0" uiname="Axis" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
 
@@ -3026,12 +3026,12 @@
     Default is 0 "SRT" for backward compatibility.
   -->
   <nodedef name="ND_place2d_vector2" node="place2d" nodegroup="math">
-    <input name="texcoord" type="vector2" value="0.0, 0.0" />
-    <input name="pivot" type="vector2" value="0.0,0.0" />
-    <input name="scale" type="vector2" value="1.0,1.0" />
-    <input name="rotate" type="float" value="0.0" unittype="angle" unit="degree" />
-    <input name="offset" type="vector2" value="0.0,0.0" />
-    <input name="operationorder" type="integer" value="0" enum="SRT, TRS" enumvalues="0, 1" />
+    <input name="texcoord" type="vector2" value="0.0, 0.0" uiname="Texture Coordinates" />
+    <input name="pivot" type="vector2" value="0.0,0.0" uiname="Pivot" />
+    <input name="scale" type="vector2" value="1.0,1.0" uiname="Scale" />
+    <input name="rotate" type="float" value="0.0" unittype="angle" unit="degree" uiname="Rotate" />
+    <input name="offset" type="vector2" value="0.0,0.0" uiname="Offset" />
+    <input name="operationorder" type="integer" value="0" enum="SRT, TRS" enumvalues="0, 1" uiname="Operation Order" />
     <output name="out" type="vector2" defaultinput="texcoord" />
   </nodedef>
 
@@ -3041,7 +3041,7 @@
     The generated wave ranges from zero to one and repeats on integer boundaries.
   -->
   <nodedef name="ND_trianglewave_float" node="trianglewave" nodegroup="math">
-    <input name="in" type="float" value="0" />
+    <input name="in" type="float" value="0" uiname="Input" />
     <output name="out" type="float" />
   </nodedef>
 
@@ -3050,8 +3050,8 @@
     Compute the reflection vector given an incident vector and unit surface normal.
   -->
   <nodedef name="ND_reflect_vector3" node="reflect" nodegroup="math" doc="Compute the reflection vector">
-    <input name="in" type="vector3" value="1.0, 0.0, 0.0" doc="Incident vector" />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal" />
+    <input name="in" type="vector3" value="1.0, 0.0, 0.0" doc="Incident vector" uiname="Input" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal" uiname="Normal" />
     <output name="out" type="vector3" />
   </nodedef>
 
@@ -3061,9 +3061,9 @@
     and index of refraction.
   -->
   <nodedef name="ND_refract_vector3" node="refract" nodegroup="math" doc="Compute the refraction vector">
-    <input name="in" type="vector3" value="1.0, 0.0, 0.0" doc="Incident vector" />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal" />
-    <input name="ior" type="float" value="1.0" doc="Index of refraction" />
+    <input name="in" type="vector3" value="1.0, 0.0, 0.0" doc="Incident vector" uiname="Input" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" doc="Surface normal" uiname="Normal" />
+    <input name="ior" type="float" value="1.0" doc="Index of refraction" uiname="IOR" />
     <output name="out" type="vector3" />
   </nodedef>
 
@@ -3076,91 +3076,91 @@
     Remap a value from one range of float/color/vector values to another.
   -->
   <nodedef name="ND_remap_float" node="remap" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_color3" node="remap" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="color3" value="0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="outlow" type="color3" value="0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" uiname="Output High" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_color4" node="remap" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Output High" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_vector2" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="vector2" value="0.0, 0.0" />
-    <input name="inhigh" type="vector2" value="1.0, 1.0" />
-    <input name="outlow" type="vector2" value="0.0, 0.0" />
-    <input name="outhigh" type="vector2" value="1.0, 1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="vector2" value="0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="vector2" value="1.0, 1.0" uiname="Input High" />
+    <input name="outlow" type="vector2" value="0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="vector2" value="1.0, 1.0" uiname="Output High" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_vector3" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" uiname="Output High" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_vector4" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Output High" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_color3FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_color4FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_vector2FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_vector3FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_remap_vector4FA" node="remap" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -3170,69 +3170,69 @@
     to output 0-1.
   -->
   <nodedef name="ND_smoothstep_float" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_color3" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="color3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="color3" value="0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="color3" value="1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_color4" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_vector2" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="vector2" value="0.0, 0.0" />
-    <input name="high" type="vector2" value="1.0, 1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="low" type="vector2" value="0.0, 0.0" uiname="Low" />
+    <input name="high" type="vector2" value="1.0, 1.0" uiname="High" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_vector3" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="high" type="vector3" value="1.0, 1.0, 1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="vector3" value="0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="vector3" value="1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_vector4" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Low" />
+    <input name="high" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="High" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_color3FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_color4FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_vector2FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_vector3FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_smoothstep_vector4FA" node="smoothstep" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="low" type="float" value="0.0" />
-    <input name="high" type="float" value="1.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="low" type="float" value="0.0" uiname="Low" />
+    <input name="high" type="float" value="1.0" uiname="High" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -3242,13 +3242,13 @@
     the alpha channel is left unchanged if present.
   -->
   <nodedef name="ND_luminance_color3" node="luminance" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" uiname="Luma Coefficients" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_luminance_color4" node="luminance" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" uiname="Luma Coefficients" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3257,19 +3257,19 @@
     Convert an incoming color between RGB and HSV space, with H and S ranging from 0-1.
   -->
   <nodedef name="ND_rgbtohsv_color3" node="rgbtohsv" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_rgbtohsv_color4" node="rgbtohsv" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_hsvtorgb_color3" node="hsvtorgb" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_hsvtorgb_color4" node="hsvtorgb" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3278,69 +3278,69 @@
     Increase or decrease contrast of a float/color value using a linear slope multiplier.
   -->
   <nodedef name="ND_contrast_float" node="contrast" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="pivot" type="float" value="0.5" uiname="Pivot" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_color3" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="color3" value="0.5, 0.5, 0.5" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="color3" value="1.0, 1.0, 1.0" uiname="Amount" />
+    <input name="pivot" type="color3" value="0.5, 0.5, 0.5" uiname="Pivot" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_color4" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="color4" value="0.5, 0.5, 0.5, 0.5" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Amount" />
+    <input name="pivot" type="color4" value="0.5, 0.5, 0.5, 0.5" uiname="Pivot" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_vector2" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="vector2" value="1.0, 1.0" />
-    <input name="pivot" type="vector2" value="0.5, 0.5" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector2" value="1.0, 1.0" uiname="Amount" />
+    <input name="pivot" type="vector2" value="0.5, 0.5" uiname="Pivot" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_vector3" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="pivot" type="vector3" value="0.5, 0.5, 0.5" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector3" value="1.0, 1.0, 1.0" uiname="Amount" />
+    <input name="pivot" type="vector3" value="0.5, 0.5, 0.5" uiname="Pivot" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_vector4" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Amount" />
+    <input name="pivot" type="vector4" value="0.5, 0.5, 0.5, 0.5" uiname="Pivot" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_color3FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="pivot" type="float" value="0.5" uiname="Pivot" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_color4FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="pivot" type="float" value="0.5" uiname="Pivot" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_vector2FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="pivot" type="float" value="0.5" uiname="Pivot" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_vector3FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="pivot" type="float" value="0.5" uiname="Pivot" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_contrast_vector4FA" node="contrast" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="pivot" type="float" value="0.5" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="pivot" type="float" value="0.5" uiname="Pivot" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -3350,113 +3350,113 @@
     applying a gamma correction in the middle, and optionally clamping output values.
   -->
   <nodedef name="ND_range_float" node="range" nodegroup="adjustment">
-    <input name="in" type="float" value="0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="gamma" type="float" value="1.0" uiname="Gamma" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_color3" node="range" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="gamma" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="color3" value="0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="color3" value="1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="gamma" type="color3" value="1.0, 1.0, 1.0" uiname="Gamma" />
+    <input name="outlow" type="color3" value="0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="color3" value="1.0, 1.0, 1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_color4" node="range" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="gamma" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="gamma" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Gamma" />
+    <input name="outlow" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="color4" value="1.0, 1.0, 1.0, 1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_vector2" node="range" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="vector2" value="0.0, 0.0" />
-    <input name="inhigh" type="vector2" value="1.0, 1.0" />
-    <input name="gamma" type="vector2" value="1.0, 1.0" />
-    <input name="outlow" type="vector2" value="0.0, 0.0" />
-    <input name="outhigh" type="vector2" value="1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="vector2" value="0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="vector2" value="1.0, 1.0" uiname="Input High" />
+    <input name="gamma" type="vector2" value="1.0, 1.0" uiname="Gamma" />
+    <input name="outlow" type="vector2" value="0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="vector2" value="1.0, 1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_vector3" node="range" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="gamma" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="vector3" value="0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="vector3" value="1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="gamma" type="vector3" value="1.0, 1.0, 1.0" uiname="Gamma" />
+    <input name="outlow" type="vector3" value="0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="vector3" value="1.0, 1.0, 1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_vector4" node="range" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="gamma" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input Low" />
+    <input name="inhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Input High" />
+    <input name="gamma" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Gamma" />
+    <input name="outlow" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Output Low" />
+    <input name="outhigh" type="vector4" value="1.0, 1.0, 1.0, 1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_color3FA" node="range" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="gamma" type="float" value="1.0" uiname="Gamma" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_color4FA" node="range" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="gamma" type="float" value="1.0" uiname="Gamma" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_vector2FA" node="range" nodegroup="adjustment">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="gamma" type="float" value="1.0" uiname="Gamma" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_vector3FA" node="range" nodegroup="adjustment">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="gamma" type="float" value="1.0" uiname="Gamma" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_range_vector4FA" node="range" nodegroup="adjustment">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="inlow" type="float" value="0.0" />
-    <input name="inhigh" type="float" value="1.0" />
-    <input name="gamma" type="float" value="1.0" />
-    <input name="outlow" type="float" value="0.0" />
-    <input name="outhigh" type="float" value="1.0" />
-    <input name="doclamp" type="boolean" value="false" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="inlow" type="float" value="0.0" uiname="Input Low" />
+    <input name="inhigh" type="float" value="1.0" uiname="Input High" />
+    <input name="gamma" type="float" value="1.0" uiname="Gamma" />
+    <input name="outlow" type="float" value="0.0" uiname="Output Low" />
+    <input name="outhigh" type="float" value="1.0" uiname="Output High" />
+    <input name="doclamp" type="boolean" value="false" uiname="Do Clamp" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -3467,13 +3467,13 @@
     multiplying the value by amount.z, then converting back to RGB.
   -->
   <nodedef name="ND_hsvadjust_color3" node="hsvadjust" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="0.0, 1.0, 1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector3" value="0.0, 1.0, 1.0" uiname="Amount" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_hsvadjust_color4" node="hsvadjust" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="vector3" value="0.0, 1.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="vector3" value="0.0, 1.0, 1.0" uiname="Amount" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3484,15 +3484,15 @@
     coefficients; the alpha channel will be unchanged if present.
   -->
   <nodedef name="ND_saturate_color3" node="saturate" nodegroup="adjustment">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" uiname="Luma Coefficients" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_saturate_color4" node="saturate" nodegroup="adjustment">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="amount" type="float" value="1.0" />
-    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="amount" type="float" value="1.0" uiname="Amount" />
+    <input name="lumacoeffs" type="color3" value="0.2722287, 0.6740818, 0.0536895" enum="acescg, rec709, rec2020, rec2100" enumvalues="0.2722287,0.6740818,0.0536895, 0.2126,0.7152,0.0722, 0.2627,0.6780,0.0593, 0.2627,0.6780,0.0593" uiname="Luma Coefficients" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3535,7 +3535,7 @@
     Multiply the R or RGB channels of the input by the Alpha channel of the input.
   -->
   <nodedef name="ND_premult_color4" node="premult" nodegroup="compositing">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3545,7 +3545,7 @@
     If the Alpha value is zero, it is passed through unchanged.
   -->
   <nodedef name="ND_unpremult_color4" node="unpremult" nodegroup="compositing">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3554,21 +3554,21 @@
     Add two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
   <nodedef name="ND_plus_float" node="plus" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_plus_color3" node="plus" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_plus_color4" node="plus" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3577,21 +3577,21 @@
     Subtract two 1-4 channel inputs, with optional mixing between the bg input and the result.
   -->
   <nodedef name="ND_minus_float" node="minus" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_minus_color3" node="minus" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_minus_color4" node="minus" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3601,21 +3601,21 @@
     the bg input and the result.
   -->
   <nodedef name="ND_difference_float" node="difference" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_difference_color3" node="difference" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_difference_color4" node="difference" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3624,21 +3624,21 @@
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-B)/F
   -->
   <nodedef name="ND_burn_float" node="burn" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_burn_color3" node="burn" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_burn_color4" node="burn" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3647,21 +3647,21 @@
     Take two 1-4 channel inputs and apply the same operator to all channels: B/(1-F)
   -->
   <nodedef name="ND_dodge_float" node="dodge" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_dodge_color3" node="dodge" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_dodge_color4" node="dodge" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3670,21 +3670,21 @@
     Take two 1-4 channel inputs and apply the same operator to all channels: 1-(1-F)*(1-B)
   -->
   <nodedef name="ND_screen_float" node="screen" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_screen_color3" node="screen" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_screen_color4" node="screen" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3695,21 +3695,21 @@
       1-2(1-F)(1-B) if B>=0.5
   -->
   <nodedef name="ND_overlay_float" node="overlay" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_overlay_color3" node="overlay" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_overlay_color4" node="overlay" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3722,9 +3722,9 @@
       alpha: min(f+b,1)
   -->
   <nodedef name="ND_disjointover_color4" node="disjointover" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3734,9 +3734,9 @@
     channel(s) to control the compositing of the fg and bg inputs: Fb  (alpha: fb)
   -->
   <nodedef name="ND_in_color4" node="in" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3746,9 +3746,9 @@
     channel(s) to control the compositing of the fg and bg inputs: Bf  (alpha: bf)
   -->
   <nodedef name="ND_mask_color4" node="mask" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3758,9 +3758,9 @@
     channel(s) to control the compositing of the fg and bg inputs: Ff+B(1-f)  (alpha: f+b(1-f))
   -->
   <nodedef name="ND_matte_color4" node="matte" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3770,9 +3770,9 @@
     channel(s) to control the compositing of the fg and bg inputs: F(1-b)  (alpha: f(1-b))
   -->
   <nodedef name="ND_out_color4" node="out" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3782,9 +3782,9 @@
     channel(s) to control the compositing of the fg and bg inputs: F+B(1-f)  (alpha: f+b(1-f))
   -->
   <nodedef name="ND_over_color4" node="over" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="1.0" uiname="Mix" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
 
@@ -3794,18 +3794,18 @@
     operator to all channels: in * mask
   -->
   <nodedef name="ND_inside_float" node="inside" nodegroup="compositing">
-    <input name="in" type="float" value="0.0" />
-    <input name="mask" type="float" value="1.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="mask" type="float" value="1.0" uiname="Mask" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_inside_color3" node="inside" nodegroup="compositing">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="1.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mask" type="float" value="1.0" uiname="Mask" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_inside_color4" node="inside" nodegroup="compositing">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mask" type="float" value="1.0" uiname="Mask" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3815,18 +3815,18 @@
     operator to all channels: in * (1-mask)
   -->
   <nodedef name="ND_outside_float" node="outside" nodegroup="compositing">
-    <input name="in" type="float" value="0.0" />
-    <input name="mask" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="mask" type="float" value="0.0" uiname="Mask" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_outside_color3" node="outside" nodegroup="compositing">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mask" type="float" value="0.0" uiname="Mask" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_outside_color4" node="outside" nodegroup="compositing">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mask" type="float" value="0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="mask" type="float" value="0.0" uiname="Mask" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
 
@@ -3835,87 +3835,87 @@
     Mix two inputs according to an input mix amount.
   -->
   <nodedef name="ND_mix_float" node="mix" nodegroup="compositing">
-    <input name="fg" type="float" value="0.0" />
-    <input name="bg" type="float" value="0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="float" value="0.0" uiname="Foreground" />
+    <input name="bg" type="float" value="0.0" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="float" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_color3" node="mix" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_color3_color3" node="mix" nodegroup="compositing">
-    <input name="fg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="color3" value="0.0, 0.0, 0.0" uisoftmin="0,0,0" uisoftmax="1,1,1" />
+    <input name="fg" type="color3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="color3" value="0.0, 0.0, 0.0" uiname="Mix" uisoftmin="0,0,0" uisoftmax="1,1,1" />
     <output name="out" type="color3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_color4" node="mix" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_color4_color4" node="mix" nodegroup="compositing">
-    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="color4" value="0.0, 0.0, 0.0, 0.0" uisoftmin="0,0,0,0" uisoftmax="1,1,1,1" />
+    <input name="fg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Mix" uisoftmin="0,0,0,0" uisoftmax="1,1,1,1" />
     <output name="out" type="color4" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_vector2" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector2" value="0.0, 0.0" />
-    <input name="bg" type="vector2" value="0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="vector2" value="0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="vector2" value="0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="vector2" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_vector2_vector2" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector2" value="0.0, 0.0" />
-    <input name="bg" type="vector2" value="0.0, 0.0" />
-    <input name="mix" type="vector2" value="0.0, 0.0" uisoftmin="0,0" uisoftmax="1,1" />
+    <input name="fg" type="vector2" value="0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="vector2" value="0.0, 0.0" uiname="Background" />
+    <input name="mix" type="vector2" value="0.0, 0.0" uiname="Mix" uisoftmin="0,0" uisoftmax="1,1" />
     <output name="out" type="vector2" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_vector3" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="vector3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="vector3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="vector3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_vector3_vector3" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="bg" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="mix" type="vector3" value="0.0, 0.0, 0.0" uisoftmin="0,0,0" uisoftmax="1,1,1" />
+    <input name="fg" type="vector3" value="0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="vector3" value="0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="vector3" value="0.0, 0.0, 0.0" uiname="Mix" uisoftmin="0,0,0" uisoftmax="1,1,1" />
     <output name="out" type="vector3" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_vector4" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="vector4" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_vector4_vector4" node="mix" nodegroup="compositing">
-    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="mix" type="vector4" value="0.0, 0.0, 0.0, 0.0" uisoftmin="0,0,0,0" uisoftmax="1,1,1,1" />
+    <input name="fg" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Foreground" />
+    <input name="bg" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Background" />
+    <input name="mix" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Mix" uisoftmin="0,0,0,0" uisoftmax="1,1,1,1" />
     <output name="out" type="vector4" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_surfaceshader" node="mix" nodegroup="compositing">
-    <input name="fg" type="surfaceshader" value="" />
-    <input name="bg" type="surfaceshader" value="" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="surfaceshader" value="" uiname="Foreground" />
+    <input name="bg" type="surfaceshader" value="" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="surfaceshader" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_displacementshader" node="mix" nodegroup="compositing">
-    <input name="fg" type="displacementshader" value="" />
-    <input name="bg" type="displacementshader" value="" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="displacementshader" value="" uiname="Foreground" />
+    <input name="bg" type="displacementshader" value="" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="displacementshader" defaultinput="bg" />
   </nodedef>
   <nodedef name="ND_mix_volumeshader" node="mix" nodegroup="compositing">
-    <input name="fg" type="volumeshader" value="" />
-    <input name="bg" type="volumeshader" value="" />
-    <input name="mix" type="float" value="0.0" uisoftmin="0.0" uisoftmax="1.0" />
+    <input name="fg" type="volumeshader" value="" uiname="Foreground" />
+    <input name="bg" type="volumeshader" value="" uiname="Background" />
+    <input name="mix" type="float" value="0.0" uiname="Mix" uisoftmin="0.0" uisoftmax="1.0" />
     <output name="out" type="volumeshader" defaultinput="bg" />
   </nodedef>
 
@@ -3928,139 +3928,139 @@
     Output the value of in1 if value1>value2, or the value of in2 if value1<=value2.
   -->
   <nodedef name="ND_ifgreater_float" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_integer" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_color3" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_color4" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_vector2" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_vector3" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_vector4" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_matrix33" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_matrix44" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_boolean" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_ifgreater_floatI" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_integerI" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_color3I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_color4I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_vector2I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_vector3I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_vector4I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_matrix33I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_matrix44I" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreater_booleanI" node="ifgreater" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
 
@@ -4069,139 +4069,139 @@
     Output the value of in1 if value1>=value2, or the value of in2 if value1<value2.
   -->
   <nodedef name="ND_ifgreatereq_float" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_integer" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_color3" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_color4" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_vector2" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_vector3" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_vector4" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_matrix33" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_matrix44" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_boolean" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_floatI" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_integerI" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_color3I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_color4I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_vector2I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_vector3I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_vector4I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_matrix33I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_matrix44I" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifgreatereq_booleanI" node="ifgreatereq" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
 
@@ -4210,207 +4210,207 @@
     Output the value of in1 if value1==value2, or the value of in2 if value1!=value2.
   -->
   <nodedef name="ND_ifequal_float" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_integer" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_color3" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_color4" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector2" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector3" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector4" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_matrix33" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_matrix44" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="0.0" />
-    <input name="value2" type="float" value="0.0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="float" value="0.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_boolean" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="float" value="1.0" />
-    <input name="value2" type="float" value="0.0" />
+    <input name="value1" type="float" value="1.0" uiname="Value 1" />
+    <input name="value2" type="float" value="0.0" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_ifequal_floatI" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_integerI" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_color3I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_color4I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector2I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector3I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector4I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_matrix33I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_matrix44I" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="0" />
-    <input name="value2" type="integer" value="0" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="integer" value="0" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_booleanI" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="integer" value="1" />
-    <input name="value2" type="integer" value="0" />
+    <input name="value1" type="integer" value="1" uiname="Value 1" />
+    <input name="value2" type="integer" value="0" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
   <nodedef name="ND_ifequal_floatB" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_integerB" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="integer" value="0" />
-    <input name="in2" type="integer" value="0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="integer" value="0" uiname="Input 1" />
+    <input name="in2" type="integer" value="0" uiname="Input 2" />
     <output name="out" type="integer" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_color3B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_color4B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector2B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector3B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_vector4B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_matrix33B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_matrix44B" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_ifequal_booleanB" node="ifequal" nodegroup="conditional">
-    <input name="value1" type="boolean" value="false" />
-    <input name="value2" type="boolean" value="false" />
+    <input name="value1" type="boolean" value="false" uiname="Value 1" />
+    <input name="value2" type="boolean" value="false" uiname="Value 2" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
 
@@ -4419,227 +4419,227 @@
     Pass on the value of one of five input streams, according to the value of a selector parameter.
   -->
   <nodedef name="ND_switch_float" node="switch" nodegroup="conditional">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
-    <input name="in5" type="float" value="0.0" />
-    <input name="in6" type="float" value="0.0" />
-    <input name="in7" type="float" value="0.0" />
-    <input name="in8" type="float" value="0.0" />
-    <input name="in9" type="float" value="0.0" />
-    <input name="in10" type="float" value="0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
+    <input name="in3" type="float" value="0.0" uiname="Input 3" />
+    <input name="in4" type="float" value="0.0" uiname="Input 4" />
+    <input name="in5" type="float" value="0.0" uiname="Input 5" />
+    <input name="in6" type="float" value="0.0" uiname="Input 6" />
+    <input name="in7" type="float" value="0.0" uiname="Input 7" />
+    <input name="in8" type="float" value="0.0" uiname="Input 8" />
+    <input name="in9" type="float" value="0.0" uiname="Input 9" />
+    <input name="in10" type="float" value="0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_color3" node="switch" nodegroup="conditional">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="color3" value="0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="color3" value="0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="color3" value="0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="color3" value="0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="color3" value="0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="color3" value="0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="color3" value="0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="color3" value="0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_color4" node="switch" nodegroup="conditional">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_vector2" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <input name="in3" type="vector2" value="0.0, 0.0" />
-    <input name="in4" type="vector2" value="0.0, 0.0" />
-    <input name="in5" type="vector2" value="0.0, 0.0" />
-    <input name="in6" type="vector2" value="0.0, 0.0" />
-    <input name="in7" type="vector2" value="0.0, 0.0" />
-    <input name="in8" type="vector2" value="0.0, 0.0" />
-    <input name="in9" type="vector2" value="0.0, 0.0" />
-    <input name="in10" type="vector2" value="0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector2" value="0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector2" value="0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="vector2" value="0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="vector2" value="0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="vector2" value="0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="vector2" value="0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="vector2" value="0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="vector2" value="0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_vector3" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_vector4" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_matrix33" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_matrix44" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="float" value="0.0" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="float" value="0.0" uiname="Which" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_floatI" node="switch" nodegroup="conditional">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
-    <input name="in5" type="float" value="0.0" />
-    <input name="in6" type="float" value="0.0" />
-    <input name="in7" type="float" value="0.0" />
-    <input name="in8" type="float" value="0.0" />
-    <input name="in9" type="float" value="0.0" />
-    <input name="in10" type="float" value="0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
+    <input name="in3" type="float" value="0.0" uiname="Input 3" />
+    <input name="in4" type="float" value="0.0" uiname="Input 4" />
+    <input name="in5" type="float" value="0.0" uiname="Input 5" />
+    <input name="in6" type="float" value="0.0" uiname="Input 6" />
+    <input name="in7" type="float" value="0.0" uiname="Input 7" />
+    <input name="in8" type="float" value="0.0" uiname="Input 8" />
+    <input name="in9" type="float" value="0.0" uiname="Input 9" />
+    <input name="in10" type="float" value="0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="float" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_color3I" node="switch" nodegroup="conditional">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color3" value="0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="color3" value="0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="color3" value="0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="color3" value="0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="color3" value="0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="color3" value="0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="color3" value="0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="color3" value="0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="color3" value="0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="color3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_color4I" node="switch" nodegroup="conditional">
-    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="color4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_vector2I" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
-    <input name="in3" type="vector2" value="0.0, 0.0" />
-    <input name="in4" type="vector2" value="0.0, 0.0" />
-    <input name="in5" type="vector2" value="0.0, 0.0" />
-    <input name="in6" type="vector2" value="0.0, 0.0" />
-    <input name="in7" type="vector2" value="0.0, 0.0" />
-    <input name="in8" type="vector2" value="0.0, 0.0" />
-    <input name="in9" type="vector2" value="0.0, 0.0" />
-    <input name="in10" type="vector2" value="0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector2" value="0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector2" value="0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="vector2" value="0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="vector2" value="0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="vector2" value="0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="vector2" value="0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="vector2" value="0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="vector2" value="0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="vector2" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_vector3I" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in3" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in5" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in6" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in7" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in8" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in9" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in10" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="vector3" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_vector4I" node="switch" nodegroup="conditional">
-    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="vector4" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_matrix33I" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="matrix33" defaultinput="in1" />
   </nodedef>
   <nodedef name="ND_switch_matrix44I" node="switch" nodegroup="conditional">
-    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in3" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in4" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in5" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in6" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in7" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in8" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in9" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="in10" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="which" type="integer" value="0" />
+    <input name="in1" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 4" />
+    <input name="in5" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 5" />
+    <input name="in6" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 6" />
+    <input name="in7" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 7" />
+    <input name="in8" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 8" />
+    <input name="in9" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 9" />
+    <input name="in10" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input 10" />
+    <input name="which" type="integer" value="0" uiname="Which" />
     <output name="out" type="matrix44" defaultinput="in1" />
   </nodedef>
 
@@ -4653,199 +4653,199 @@
     types are supported.
   -->
   <nodedef name="ND_convert_float_color3" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_float_color4" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_float_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_float_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_float_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="float" value="0.0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
   <nodedef name="ND_convert_color3_color4" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_color3_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_color3_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_color3_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
   <nodedef name="ND_convert_color4_color3" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_color4_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_color4_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_color4_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
   <nodedef name="ND_convert_vector2_color3" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector2_color4" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector2_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector2_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
   <nodedef name="ND_convert_vector3_color3" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector3_color4" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector3_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector3_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
   <nodedef name="ND_convert_vector4_color3" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector4_color4" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector4_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_vector4_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
 
   <nodedef name="ND_convert_boolean_float" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_convert_boolean_color3" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_boolean_color4" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_boolean_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_boolean_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_boolean_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_boolean_integer" node="convert" nodegroup="channel">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="integer" default="0" />
   </nodedef>
 
   <nodedef name="ND_convert_integer_float" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_convert_integer_color3" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_integer_color4" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_integer_vector2" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_integer_vector3" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_integer_vector4" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_convert_integer_boolean" node="convert" nodegroup="channel">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="boolean" default="false" />
   </nodedef>
 
   <nodedef name="ND_convert_color3_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert color3 to shader">
-    <input name="in" type="color3" value="0, 0, 0" />
+    <input name="in" type="color3" value="0, 0, 0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_color4_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert color4  to shader">
-    <input name="in" type="color4" value="0, 0, 0, 0" />
+    <input name="in" type="color4" value="0, 0, 0, 0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_float_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert float to shader">
-    <input name="in" type="float" value="0" />
+    <input name="in" type="float" value="0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_vector2_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert vector2 to shader">
-    <input name="in" type="vector2" value="0, 0" />
+    <input name="in" type="vector2" value="0, 0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_vector3_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert vector2 to shader">
-    <input name="in" type="vector3" value="0, 0, 0" />
+    <input name="in" type="vector3" value="0, 0, 0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_vector4_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert vector4 to shader">
-    <input name="in" type="vector4" value="0, 0, 0, 0" />
+    <input name="in" type="vector4" value="0, 0, 0, 0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_integer_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert integer to shader">
-    <input name="in" type="integer" value="0" />
+    <input name="in" type="integer" value="0" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
   <nodedef name="ND_convert_boolean_surfaceshader" node="convert" version="1.0" isdefaultversion="true" nodegroup="shader" doc="Convert boolean to shader">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="surfaceshader" />
   </nodedef>
 
@@ -4855,23 +4855,23 @@
     single output stream of a specified compatible type.
   -->
   <nodedef name="ND_combine2_vector2" node="combine2" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector2" default="0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_combine2_color4CF" node="combine2" nodegroup="channel">
-    <input name="in1" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="color3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_combine2_vector4VF" node="combine2" nodegroup="channel">
-    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="in2" type="float" value="0.0" />
+    <input name="in1" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_combine2_vector4VV" node="combine2" nodegroup="channel">
-    <input name="in1" type="vector2" value="0.0, 0.0" />
-    <input name="in2" type="vector2" value="0.0, 0.0" />
+    <input name="in1" type="vector2" value="0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector2" value="0.0, 0.0" uiname="Input 2" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -4881,15 +4881,15 @@
     single output stream of a specified compatible type.
   -->
   <nodedef name="ND_combine3_color3" node="combine3" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
+    <input name="in3" type="float" value="0.0" uiname="Input 3" />
     <output name="out" type="color3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_combine3_vector3" node="combine3" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
+    <input name="in3" type="float" value="0.0" uiname="Input 3" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -4899,17 +4899,17 @@
     single output stream of a specified compatible type.
   -->
   <nodedef name="ND_combine4_color4" node="combine4" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
+    <input name="in3" type="float" value="0.0" uiname="Input 3" />
+    <input name="in4" type="float" value="0.0" uiname="Input 4" />
     <output name="out" type="color4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_combine4_vector4" node="combine4" nodegroup="channel">
-    <input name="in1" type="float" value="0.0" />
-    <input name="in2" type="float" value="0.0" />
-    <input name="in3" type="float" value="0.0" />
-    <input name="in4" type="float" value="0.0" />
+    <input name="in1" type="float" value="0.0" uiname="Input 1" />
+    <input name="in2" type="float" value="0.0" uiname="Input 2" />
+    <input name="in3" type="float" value="0.0" uiname="Input 3" />
+    <input name="in4" type="float" value="0.0" uiname="Input 4" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -4918,25 +4918,25 @@
     Combine the the three vectors3 from stream into a matrix 33.
   -->
   <nodedef name="ND_creatematrix_vector3_matrix33" node="creatematrix" nodegroup="math">
-    <input name="in1" type="vector3" value="1.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 1.0, 0.0" />
-    <input name="in3" type="vector3" value="0.0, 0.0, 1.0" />
+    <input name="in1" type="vector3" value="1.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 1.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector3" value="0.0, 0.0, 1.0" uiname="Input 3" />
     <output name="out" type="matrix33" default="1.0, 0.0, 0.0,  0.0, 1.0, 0.0,  0.0, 0.0, 1.0" />
   </nodedef>
 
   <nodedef name="ND_creatematrix_vector3_matrix44" node="creatematrix" nodegroup="math">
-    <input name="in1" type="vector3" value="1.0, 0.0, 0.0" />
-    <input name="in2" type="vector3" value="0.0, 1.0, 0.0" />
-    <input name="in3" type="vector3" value="0.0, 0.0, 1.0" />
-    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in1" type="vector3" value="1.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector3" value="0.0, 1.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector3" value="0.0, 0.0, 1.0" uiname="Input 3" />
+    <input name="in4" type="vector3" value="0.0, 0.0, 0.0" uiname="Input 4" />
     <output name="out" type="matrix44" default="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
   </nodedef>
 
   <nodedef name="ND_creatematrix_vector4_matrix44" node="creatematrix" nodegroup="math">
-    <input name="in1" type="vector4" value="1.0, 0.0, 0.0, 0.0" />
-    <input name="in2" type="vector4" value="0.0, 1.0, 0.0, 0.0" />
-    <input name="in3" type="vector4" value="0.0, 0.0, 1.0, 0.0" />
-    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in1" type="vector4" value="1.0, 0.0, 0.0, 0.0" uiname="Input 1" />
+    <input name="in2" type="vector4" value="0.0, 1.0, 0.0, 0.0" uiname="Input 2" />
+    <input name="in3" type="vector4" value="0.0, 0.0, 1.0, 0.0" uiname="Input 3" />
+    <input name="in4" type="vector4" value="0.0, 0.0, 0.0, 1.0" uiname="Input 4" />
     <output name="out" type="matrix44" default="1.0, 0.0, 0.0, 0.0,  0.0, 1.0, 0.0, 0.0,  0.0, 0.0, 1.0, 0.0,  0.0, 0.0, 0.0, 1.0" />
   </nodedef>
 
@@ -4945,38 +4945,38 @@
     Extract a single channel from a colorN or vectorN stream, outputting a float.
   -->
   <nodedef name="ND_extract_color3" node="extract" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="2" uniform="true" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_extract_color4" node="extract" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="3" uniform="true" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_extract_vector2" node="extract" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="1" uniform="true" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="1" uniform="true" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_extract_vector3" node="extract" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="2" uniform="true" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_extract_vector4" node="extract" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="3" uniform="true" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_extract_matrix33" node="extract" nodegroup="channel">
-    <input name="in" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="2" uniform="true" />
+    <input name="in" type="matrix33" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="2" uniform="true" />
     <output name="out" type="vector3" default="0.0, 0.0, 0.0" />
   </nodedef>
   <nodedef name="ND_extract_matrix44" node="extract" nodegroup="channel">
-    <input name="in" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" />
-    <input name="index" type="integer" value="0" uimin="0" uimax="3" uniform="true" />
+    <input name="in" type="matrix44" value="0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="index" type="integer" value="0" uiname="Index" uimin="0" uimax="3" uniform="true" />
     <output name="out" type="vector4" default="0.0, 0.0, 0.0, 0.0" />
   </nodedef>
 
@@ -4985,31 +4985,31 @@
     Output each of the channels of a color/vector stream as a separate float output.
   -->
   <nodedef name="ND_separate2_vector2" node="separate2" nodegroup="channel">
-    <input name="in" type="vector2" value="0.0, 0.0" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
     <output name="outx" type="float" default="0.0" />
     <output name="outy" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_separate3_color3" node="separate3" nodegroup="channel">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="outr" type="float" default="0.0" />
     <output name="outg" type="float" default="0.0" />
     <output name="outb" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_separate3_vector3" node="separate3" nodegroup="channel">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="outx" type="float" default="0.0" />
     <output name="outy" type="float" default="0.0" />
     <output name="outz" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_separate4_color4" node="separate4" nodegroup="channel">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="outr" type="float" default="0.0" />
     <output name="outg" type="float" default="0.0" />
     <output name="outb" type="float" default="0.0" />
     <output name="outa" type="float" default="0.0" />
   </nodedef>
   <nodedef name="ND_separate4_vector4" node="separate4" nodegroup="channel">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
     <output name="outx" type="float" default="0.0" />
     <output name="outy" type="float" default="0.0" />
     <output name="outz" type="float" default="0.0" />
@@ -5025,39 +5025,39 @@
     A gaussian-falloff blur.
   -->
   <nodedef name="ND_blur_float" node="blur" nodegroup="convolution2d">
-    <input name="in" type="float" value="0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="size" type="float" value="0.0" uiname="Size" />
+    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" uiname="Filter Type" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_blur_color3" node="blur" nodegroup="convolution2d">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="size" type="float" value="0.0" uiname="Size" />
+    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" uiname="Filter Type" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_blur_color4" node="blur" nodegroup="convolution2d">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="size" type="float" value="0.0" uiname="Size" />
+    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" uiname="Filter Type" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_blur_vector2" node="blur" nodegroup="convolution2d">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="size" type="float" value="0.0" uiname="Size" />
+    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" uiname="Filter Type" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_blur_vector3" node="blur" nodegroup="convolution2d">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="size" type="float" value="0.0" uiname="Size" />
+    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" uiname="Filter Type" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_blur_vector4" node="blur" nodegroup="convolution2d">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="size" type="float" value="0.0" />
-    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="size" type="float" value="0.0" uiname="Size" />
+    <input name="filtertype" type="string" value="box" enum="box,gaussian" uniform="true" uiname="Filter Type" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
 
@@ -5066,9 +5066,9 @@
     Convert a scalar height map to a normal map of type vector3.
   -->
   <nodedef name="ND_heighttonormal_vector3" node="heighttonormal" nodegroup="convolution2d">
-    <input name="in" type="float" value="0.0" />
-    <input name="scale" type="float" value="1.0" uimin="0.0" uisoftmax="5.0" />
-    <input name="texcoord" type="vector2" defaultgeomprop="UV0" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="scale" type="float" value="1.0" uiname="Scale" uimin="0.0" uisoftmax="5.0" />
+    <input name="texcoord" type="vector2" defaultgeomprop="UV0" uiname="Texture Coordinates" />
     <output name="out" type="vector3" default="0.5, 0.5, 1.0" />
   </nodedef>
 
@@ -5081,8 +5081,8 @@
     Logical And operation for two boolean values.
   -->
   <nodedef name="ND_logical_and" node="and" nodegroup="conditional">
-    <input name="in1" type="boolean" value="false" />
-    <input name="in2" type="boolean" value="false" />
+    <input name="in1" type="boolean" value="false" uiname="Input 1" />
+    <input name="in2" type="boolean" value="false" uiname="Input 2" />
     <output name="out" type="boolean" defaultinput="in1" />
   </nodedef>
 
@@ -5091,8 +5091,8 @@
     Logical Inclusive Or operation for two boolean values.
   -->
   <nodedef name="ND_logical_or" node="or" nodegroup="conditional">
-    <input name="in1" type="boolean" value="false" />
-    <input name="in2" type="boolean" value="false" />
+    <input name="in1" type="boolean" value="false" uiname="Input 1" />
+    <input name="in2" type="boolean" value="false" uiname="Input 2" />
     <output name="out" type="boolean" defaultinput="in1" />
   </nodedef>
 
@@ -5101,8 +5101,8 @@
     Logical Exclusive Or operation for two boolean values.
   -->
   <nodedef name="ND_logical_xor" node="xor" nodegroup="conditional">
-    <input name="in1" type="boolean" value="false" />
-    <input name="in2" type="boolean" value="false" />
+    <input name="in1" type="boolean" value="false" uiname="Input 1" />
+    <input name="in2" type="boolean" value="false" uiname="Input 2" />
     <output name="out" type="boolean" defaultinput="in1" />
   </nodedef>
 
@@ -5111,7 +5111,7 @@
     Returns logical Not of input.
   -->
   <nodedef name="ND_logical_not" node="not" nodegroup="conditional">
-    <input name="in" type="boolean" value="false" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
     <output name="out" type="boolean" default="true" />
   </nodedef>
 
@@ -5124,83 +5124,83 @@
     No-op; passes its input to the output unchanged.
   -->
   <nodedef name="ND_dot_float" node="dot" nodegroup="organization">
-    <input name="in" type="float" value="0.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="float" value="0.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="float" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_color3" node="dot" nodegroup="organization">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="color3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_color4" node="dot" nodegroup="organization">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="color4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_vector2" node="dot" nodegroup="organization">
-    <input name="in" type="vector2" value="0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="vector2" value="0.0, 0.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="vector2" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_vector3" node="dot" nodegroup="organization">
-    <input name="in" type="vector3" value="0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="vector3" value="0.0, 0.0, 0.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="vector3" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_vector4" node="dot" nodegroup="organization">
-    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="vector4" value="0.0, 0.0, 0.0, 0.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="vector4" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_boolean" node="dot" nodegroup="organization">
-    <input name="in" type="boolean" value="false" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="boolean" value="false" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="boolean" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_integer" node="dot" nodegroup="organization">
-    <input name="in" type="integer" value="0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="integer" value="0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="integer" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_matrix33" node="dot" nodegroup="organization">
-    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="matrix33" value="1.0,0.0,0.0, 0.0,1.0,0.0, 0.0,0.0,1.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="matrix33" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_matrix44" node="dot" nodegroup="organization">
-    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="matrix44" value="1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="matrix44" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_string" node="dot" nodegroup="organization">
-    <input name="in" type="string" value="" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="string" value="" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="string" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_filename" node="dot" nodegroup="organization">
-    <input name="in" type="filename" value="" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="filename" value="" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="filename" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_surfaceshader" node="dot" nodegroup="organization">
-    <input name="in" type="surfaceshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="surfaceshader" value="" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="surfaceshader" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_displacementshader" node="dot" nodegroup="organization">
-    <input name="in" type="displacementshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="displacementshader" value="" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="displacementshader" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_volumeshader" node="dot" nodegroup="organization">
-    <input name="in" type="volumeshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="volumeshader" value="" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="volumeshader" defaultinput="in" />
   </nodedef>
   <nodedef name="ND_dot_lightshader" node="dot" nodegroup="organization">
-    <input name="in" type="lightshader" value="" />
-    <input name="note" type="string" value="" uniform="true" />
+    <input name="in" type="lightshader" value="" uiname="Input" />
+    <input name="note" type="string" value="" uniform="true" uiname="Note" />
     <output name="out" type="lightshader" defaultinput="in" />
   </nodedef>
 


### PR DESCRIPTION
> This continues the series of PRs, started with PR #3024, that will address all of the "library" nodedef's.
>
>See the PR above for a list of terms used in the replacement for easy review and discussion.

Add `uiname` attributes to all `<input>` elements of the `libraries/stdlib/stdlib_defs.mtlx` nodedefs.

Note: The `<output>` elements are not modified because they currently do not permit the use of `uiname` attributes in the spec which should be addressed separately first.