### PR TITLE
Add uiname attributes to nprlib_defs.mtlx

### DIFF
--- a/libraries/nprlib/nprlib_defs.mtlx
+++ b/libraries/nprlib/nprlib_defs.mtlx
@@ -22,7 +22,7 @@
     The current scene view direction, as defined by the shading environment.
   -->
   <nodedef name="ND_viewdirection_vector3" node="viewdirection" nodegroup="npr">
-    <input name="space" type="string" value="world" enum="model,object,world" uniform="true" />
+    <input name="space" type="string" value="world" enum="model,object,world" uniform="true" uiname="Space" />
     <output name="out" type="vector3" default="0.0, 0.0, 1.0" />
   </nodedef>
 
@@ -32,10 +32,10 @@
     view direction and geometric normal.
   -->
   <nodedef name="ND_facingratio_float" node="facingratio" nodegroup="npr">
-    <input name="viewdirection" type="vector3" defaultgeomprop="Vworld" />
-    <input name="normal" type="vector3" defaultgeomprop="Nworld" />
-    <input name="faceforward" type="boolean" value="true" />
-    <input name="invert" type="boolean" value="false" />
+    <input name="viewdirection" type="vector3" defaultgeomprop="Vworld" uiname="View Direction" />
+    <input name="normal" type="vector3" defaultgeomprop="Nworld" uiname="Normal" />
+    <input name="faceforward" type="boolean" value="true" uiname="Face Forward" />
+    <input name="invert" type="boolean" value="false" uiname="Invert" />
     <output name="out" type="float" default="0.0" />
   </nodedef>
 
@@ -46,9 +46,9 @@
   <nodedef name="ND_gooch_shade" node="gooch_shade" nodegroup="npr" doc="Compute Gooch shading">
     <input name="warm_color" type="color3" value="0.8, 0.8, 0.7" uiname="Warm Color" doc="Warm color" />
     <input name="cool_color" type="color3" value="0.3, 0.3, 0.8" uiname="Cool Color" doc="Cool color" />
-    <input name="specular_intensity" type="float" value="1" uimin="0" uimax="1" uiname="Specular Intensity" doc="Specular Intensity" />
-    <input name="shininess" type="float" value="64" uimin="1" uisoftmax="256" uiname="Shininess" doc="Specular Power" />
-    <input name="light_direction" type="vector3" value="1, -0.5, -0.5" uimin="-1, -1, -1" uimax="1, 1, 1" uiname="Light Direction" doc="Light vector in world space" />
+ <input name="specular_intensity" type="float" value="1" uiname="Specular Intensity" uimin="0" uimax="1" doc="Specular Intensity" />
+ <input name="shininess" type="float" value="64" uiname="Shininess" uimin="1" uisoftmax="256" doc="Specular Power" />
+ <input name="light_direction" type="vector3" value="1, -0.5, -0.5" uiname="Light Direction" uimin="-1, -1, -1" uimax="1, 1, 1" doc="Light vector in world space" />
     <output name="out" type="color3" />
   </nodedef>
 


### PR DESCRIPTION
> This continues the series of PRs, started with PR #3024, that will address all of the "library" nodedef's.
>
>See the PR above for a list of terms used in the replacement for easy review and discussion.

Add `uiname` attributes to all `<input>` elements of the `libraries/nprlib/nprlib_defs.mtlx` nodedefs.

Note: The `<output>` elements are not modified because they currently do not permit the use of `uiname` attributes in the spec which should be addressed separately first.
