### PR TITLE
Add uiname attributes to cmlib_defs.mtlx

### DIFF
--- a/libraries/cmlib/cmlib_defs.mtlx
+++ b/libraries/cmlib/cmlib_defs.mtlx
@@ -8,102 +8,102 @@
   -->
 
   <nodedef name="ND_g18_rec709_to_lin_rec709_color3" node="g18_rec709_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_g18_rec709_to_lin_rec709_color4" node="g18_rec709_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_g22_rec709_to_lin_rec709_color3" node="g22_rec709_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_g22_rec709_to_lin_rec709_color4" node="g22_rec709_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_rec709_display_to_lin_rec709_color3" node="rec709_display_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_rec709_display_to_lin_rec709_color4" node="rec709_display_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_acescg_to_lin_rec709_color3" node="acescg_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_acescg_to_lin_rec709_color4" node="acescg_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_g22_ap1_to_lin_rec709_color3" node="g22_ap1_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_g22_ap1_to_lin_rec709_color4" node="g22_ap1_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_srgb_texture_to_lin_rec709_color3" node="srgb_texture_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_srgb_texture_to_lin_rec709_color4" node="srgb_texture_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_lin_adobergb_to_lin_rec709_color3" node="lin_adobergb_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_lin_adobergb_to_lin_rec709_color4" node="lin_adobergb_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_adobergb_to_lin_rec709_color3" node="adobergb_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_adobergb_to_lin_rec709_color4" node="adobergb_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_srgb_displayp3_to_lin_rec709_color3" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_srgb_displayp3_to_lin_rec709_color4" node="srgb_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 
   <nodedef name="ND_lin_displayp3_to_lin_rec709_color3" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color3" value="0.0, 0.0, 0.0" />
+    <input name="in" type="color3" value="0.0, 0.0, 0.0" uiname="Input" />
     <output name="out" type="color3" />
   </nodedef>
 
   <nodedef name="ND_lin_displayp3_to_lin_rec709_color4" node="lin_displayp3_to_lin_rec709" nodegroup="colortransform">
-    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" />
+    <input name="in" type="color4" value="0.0, 0.0, 0.0, 1.0" uiname="Input" />
     <output name="out" type="color4" />
   </nodedef>
 


### PR DESCRIPTION
> This continues the series of PRs, started with PR #3024, that will address all of the "library" nodedef's.
>
>See the PR above for a list of terms used in the replacement for easy review and discussion.

Add `uiname` attributes to all `<input>` elements of the `libraries/cmlib/cmlib_defs.mtlx` nodedefs.

Note: The `<output>` elements are not modified because they currently do not permit the use of `uiname` attributes in the spec which should be addressed separately first.