### PR TITLE
Fix inline source input variable names

### DIFF
--- a/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
+++ b/source/MaterialXGenShader/Nodes/SourceCodeNode.cpp
@@ -147,7 +147,7 @@ void SourceCodeNode::emitFunctionCall(const ShaderNode& node, GenContext& contex
                 }
                 else
                 {
-                    string variableName = node.getName() + "_" + input->getName() + "_tmp";
+                    string variableName = input->getVariable() + "_tmp";
                     if (!variableNames.count(variableName))
                     {
                         ShaderPort v(nullptr, input->getType(), variableName, input->getValue());


### PR DESCRIPTION
While implementing canonical shader variable names in a custom shader generator, I found that `SourceCodeNode` does not honor the variable name assigned to a `ShaderInput`.

`ShaderGraph::setVariableNames` constructs each input's full name from its node and port names, passes it through `Syntax::getVariableName`, and stores the resulting valid and unique target-language identifier on the input. Custom generators may subsequently assign a different variable name for their own emission requirements.

For unconnected inline-expression inputs, however, `SourceCodeNode` ignores the assigned variable and reconstructs a temporary identifier directly from the authored node and input names:

```cpp
node.getName() + "_" + input->getName() + "_tmp"
```

This happened to bypass my canonical names, but I believe it is a general bug: emission should use the shader variable already assigned to the input rather than independently reconstructing one from document names. This change derives the temporary from `ShaderInput::getVariable()` instead. For ordinary names the generated identifier remains unchanged, while target-language sanitization, uniqueness handling, and generator-specific naming are respected.

The issue can also produce invalid shader source without any custom generator. MaterialX permits colons in element names, and Maya uses `:` as the separator between namespaces and object names. Nested Maya namespaces can naturally produce names such as `asset:look:multiply`.

For example:

```xml
<materialx version="1.39">
  <nodegraph name="NG_namespaced">
    <multiply name="asset:look:multiply" type="color3">
      <input name="in1" type="color3" value="0.8, 0.6, 0.4" />
      <input name="in2" type="color3" value="0.5, 0.5, 0.5" />
    </multiply>
    <output
      name="out"
      type="color3"
      nodename="asset:look:multiply"
    />
  </nodegraph>
</materialx>
```

MaterialX's assigned shader variable is correctly sanitized to:

```text
asset_look_multiply_in1
```

The current `SourceCodeNode` implementation instead emits a temporary containing the authored colons:

```text
asset:look:multiply_in1_tmp
```

The MaterialX document is valid, but the generated shader is not, because `:` is not valid within the target-language identifier. Using the assigned input variable produces the valid `asset_look_multiply_in1_tmp` instead.